### PR TITLE
feat(gateway): extract providers module with key rotation

### DIFF
--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -23,51 +23,25 @@ from llm_rosetta.auto_detect import ProviderType
 from llm_rosetta.converters.base.stream_context import StreamContext
 
 from .banner import print_banner
-from .config import PATHS_TO_TRY, GatewayConfig, discover_config, load_config, load_config_raw
+from .config import (
+    PATHS_TO_TRY,
+    GatewayConfig,
+    discover_config,
+    load_config,
+    load_config_raw,
+)
+from .providers import (
+    ProviderInfo,
+    get_default_base_url,
+    get_default_api_key_env,
+    known_provider_types,
+)
 
 logger = logging.getLogger("llm-rosetta-gateway")
 
 # ---------------------------------------------------------------------------
 # Upstream request building
 # ---------------------------------------------------------------------------
-
-_UPSTREAM_URL_TEMPLATES = {
-    "openai_chat": "{base_url}/chat/completions",
-    "openai_responses": "{base_url}/responses",
-    "anthropic": "{base_url}/v1/messages",
-    "google": "{base_url}/v1beta/models/{model}:generateContent",
-    "google_stream": "{base_url}/v1beta/models/{model}:streamGenerateContent?alt=sse",
-}
-
-
-def _build_auth_headers(provider_type: ProviderType, api_key: str) -> dict[str, str]:
-    """Return provider-specific authentication headers."""
-    if provider_type in ("openai_chat", "openai_responses"):
-        return {"Authorization": f"Bearer {api_key}"}
-    elif provider_type == "anthropic":
-        return {
-            "x-api-key": api_key,
-            "anthropic-version": "2023-06-01",
-        }
-    elif provider_type == "google":
-        return {"x-goog-api-key": api_key}
-    return {}
-
-
-def _build_upstream_url(
-    provider_type: ProviderType,
-    provider_cfg: dict[str, str],
-    model: str,
-    *,
-    stream: bool,
-) -> str:
-    """Construct the full upstream URL for a provider."""
-    base_url = provider_cfg["base_url"].rstrip("/")
-    if provider_type == "google" and stream:
-        template = _UPSTREAM_URL_TEMPLATES["google_stream"]
-    else:
-        template = _UPSTREAM_URL_TEMPLATES[provider_type]
-    return template.format(base_url=base_url, model=model)
 
 
 def _fixup_google_body(provider_request: dict[str, Any]) -> dict[str, Any]:
@@ -117,17 +91,17 @@ def _fixup_google_body(provider_request: dict[str, Any]) -> dict[str, Any]:
 
 def _prepare_upstream(
     target_provider: ProviderType,
-    provider_cfg: dict[str, str],
+    provider_info: ProviderInfo,
     provider_request: dict[str, Any],
     model: str,
     *,
     stream: bool,
 ) -> tuple[str, dict[str, str], dict[str, Any]]:
     """Return (url, headers, body) ready for the upstream HTTP call."""
-    url = _build_upstream_url(target_provider, provider_cfg, model, stream=stream)
+    url = provider_info.upstream_url(model, stream=stream)
     headers = {
         "Content-Type": "application/json",
-        **_build_auth_headers(target_provider, provider_cfg["api_key"]),
+        **provider_info.auth_headers(),
     }
 
     # Provider-specific body fixups
@@ -294,7 +268,7 @@ def _get_client() -> httpx.AsyncClient:
 async def _handle_non_streaming(
     source_provider: ProviderType,
     target_provider: ProviderType,
-    provider_cfg: dict[str, str],
+    provider_info: ProviderInfo,
     body: dict[str, Any],
     model: str,
 ) -> Response:
@@ -322,7 +296,7 @@ async def _handle_non_streaming(
 
     # 3. Build upstream request
     url, headers, upstream_body = _prepare_upstream(
-        target_provider, provider_cfg, target_body, model, stream=False
+        target_provider, provider_info, target_body, model, stream=False
     )
 
     # 4. Forward to upstream
@@ -365,7 +339,7 @@ async def _handle_non_streaming(
 async def _handle_streaming(
     source_provider: ProviderType,
     target_provider: ProviderType,
-    provider_cfg: dict[str, str],
+    provider_info: ProviderInfo,
     body: dict[str, Any],
     model: str,
 ) -> Response:
@@ -393,7 +367,7 @@ async def _handle_streaming(
 
     # 3. Build upstream request (with stream=True)
     url, headers, upstream_body = _prepare_upstream(
-        target_provider, provider_cfg, target_body, model, stream=True
+        target_provider, provider_info, target_body, model, stream=True
     )
 
     format_sse = _SSE_FORMATTERS[source_provider]
@@ -501,7 +475,7 @@ async def _proxy_handler(
 
     # Resolve target provider
     try:
-        target_provider, provider_cfg = _config.resolve_model(model)
+        target_provider, provider_info = _config.resolve_model(model)
     except KeyError:
         configured = ", ".join(sorted(_config.models.keys()))
         return _error_response_for_source(
@@ -523,11 +497,11 @@ async def _proxy_handler(
 
     if is_stream:
         return await _handle_streaming(
-            source_provider, target_provider, provider_cfg, body, model
+            source_provider, target_provider, provider_info, body, model
         )
     else:
         return await _handle_non_streaming(
-            source_provider, target_provider, provider_cfg, body, model
+            source_provider, target_provider, provider_info, body, model
         )
 
 
@@ -632,7 +606,10 @@ def _open_in_editor(config_path: str | None = None) -> None:
                 except FileNotFoundError:
                     continue
                 except Exception as exc:
-                    print(f"Error: failed to open {editor} for {path}: {exc}", file=sys.stderr)
+                    print(
+                        f"Error: failed to open {editor} for {path}: {exc}",
+                        file=sys.stderr,
+                    )
                     sys.exit(1)
 
     print("Error: no config file found to edit. Searched:", file=sys.stderr)
@@ -645,19 +622,7 @@ def _open_in_editor(config_path: str | None = None) -> None:
 # CLI: ``add`` subcommand helpers
 # ---------------------------------------------------------------------------
 
-_KNOWN_PROVIDERS: list[str] = [
-    "openai_chat",
-    "openai_responses",
-    "anthropic",
-    "google",
-]
-
-_DEFAULT_BASE_URLS: dict[str, str] = {
-    "openai_chat": "https://api.openai.com/v1",
-    "openai_responses": "https://api.openai.com/v1",
-    "anthropic": "https://api.anthropic.com",
-    "google": "https://generativelanguage.googleapis.com",
-}
+_KNOWN_PROVIDERS = known_provider_types()
 
 _CONFIG_TEMPLATE: dict[str, Any] = {
     "providers": {},
@@ -687,14 +652,16 @@ def _cmd_add_provider(args: argparse.Namespace) -> None:
     data, path = _load_or_create_config(config_path)
 
     name: str = args.name
-    default_key = f"${{{name.upper()}_API_KEY}}"
-    default_url = _DEFAULT_BASE_URLS.get(name, "")
+    default_key = f"${{{get_default_api_key_env(name)}}}"
+    default_url = get_default_base_url(name)
 
     # api_key: CLI flag > interactive > auto-default
     api_key: str = args.api_key or ""
     if not api_key:
         if sys.stdin.isatty():
-            api_key = input(f"API key env placeholder for '{name}' [{default_key}]: ").strip()
+            api_key = input(
+                f"API key env placeholder for '{name}' [{default_key}]: "
+            ).strip()
         if not api_key:
             api_key = default_key
 
@@ -704,9 +671,11 @@ def _cmd_add_provider(args: argparse.Namespace) -> None:
         if default_url:
             base_url = default_url  # known provider — use default silently
         elif sys.stdin.isatty():
-            base_url = input(f"Base URL (required): ").strip()
+            base_url = input("Base URL (required): ").strip()
     if not base_url:
-        print("Error: --base-url is required for non-standard providers.", file=sys.stderr)
+        print(
+            "Error: --base-url is required for non-standard providers.", file=sys.stderr
+        )
         sys.exit(1)
 
     data.setdefault("providers", {})[name] = {"api_key": api_key, "base_url": base_url}
@@ -732,7 +701,10 @@ def _cmd_add_model(args: argparse.Namespace) -> None:
         print("Error: provider is required.", file=sys.stderr)
         sys.exit(1)
     if provider not in providers:
-        print(f"Warning: provider '{provider}' not yet in config. Add it with: llm-rosetta-gateway add provider {provider}", file=sys.stderr)
+        print(
+            f"Warning: provider '{provider}' not yet in config. Add it with: llm-rosetta-gateway add provider {provider}",
+            file=sys.stderr,
+        )
 
     data.setdefault("models", {})[model_name] = provider
     _write_jsonc(path, data)
@@ -788,7 +760,9 @@ def main() -> None:
 
     prov_parser = add_sub.add_parser("provider", help="Add a provider entry")
     prov_parser.add_argument("name", help="Provider name (e.g. openai_chat, anthropic)")
-    prov_parser.add_argument("--api-key", default=None, help="API key or ${ENV_VAR} placeholder")
+    prov_parser.add_argument(
+        "--api-key", default=None, help="API key or ${ENV_VAR} placeholder"
+    )
     prov_parser.add_argument("--base-url", default=None, help="Provider base URL")
 
     model_parser = add_sub.add_parser("model", help="Add a model routing entry")
@@ -809,7 +783,7 @@ def main() -> None:
         elif args.add_type == "model":
             _cmd_add_model(args)
         else:
-            sub.choices["add"].print_help()  # type: ignore[union-attr]
+            sub.choices["add"].print_help()
         return
 
     # --- normal server startup ---

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -10,6 +10,8 @@ from typing import Any
 
 from llm_rosetta.auto_detect import ProviderType
 
+from .providers import ProviderInfo, build_provider_info
+
 logger = logging.getLogger("llm-rosetta-gateway")
 
 # ---------------------------------------------------------------------------
@@ -101,25 +103,31 @@ class GatewayConfig:
     """Parsed and validated gateway configuration."""
 
     def __init__(self, raw: dict[str, Any]) -> None:
-        self.providers: dict[str, dict[str, str]] = raw.get("providers", {})
+        self._raw_providers: dict[str, dict[str, str]] = raw.get("providers", {})
         self.models: dict[str, ProviderType] = raw.get("models", {})
         self.host: str = raw.get("server", {}).get("host", "0.0.0.0")
         self.port: int = raw.get("server", {}).get("port", 8765)
         self._validate()
 
+        # Build ProviderInfo objects (with key rotation support)
+        self.providers: dict[str, ProviderInfo] = {
+            name: build_provider_info(name, cfg)
+            for name, cfg in self._raw_providers.items()
+        }
+
     def _validate(self) -> None:
-        if not self.providers:
+        if not self._raw_providers:
             raise ValueError("config: 'providers' section is empty")
         if not self.models:
             raise ValueError("config: 'models' section is empty")
         for model, provider in self.models.items():
-            if provider not in self.providers:
+            if provider not in self._raw_providers:
                 raise ValueError(
                     f"config: model '{model}' references unknown provider '{provider}'"
                 )
 
-    def resolve_model(self, model: str) -> tuple[ProviderType, dict[str, str]]:
-        """Return (provider_type, provider_config) for a model name.
+    def resolve_model(self, model: str) -> tuple[ProviderType, ProviderInfo]:
+        """Return (provider_type, provider_info) for a model name.
 
         Raises KeyError if the model is not in the routing table.
         """

--- a/src/llm_rosetta/gateway/providers.py
+++ b/src/llm_rosetta/gateway/providers.py
@@ -1,0 +1,198 @@
+"""Gateway provider definitions — auth, URLs, defaults, and key rotation."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger("llm-rosetta-gateway")
+
+# Type alias for auth-header builder callables
+AuthHeaderFn = Callable[[str], dict[str, str]]
+
+
+# ---------------------------------------------------------------------------
+# API key rotation (round-robin)
+# ---------------------------------------------------------------------------
+
+
+class KeyRing:
+    """Round-robin API key selector.
+
+    Accepts a single key string **or** a comma-separated list of keys.
+    Each call to :meth:`next` returns the next key in rotation.
+    """
+
+    def __init__(self, keys_csv: str) -> None:
+        self._keys = [k.strip() for k in keys_csv.split(",") if k.strip()]
+        self._idx = 0
+
+    def next(self) -> str:
+        """Return the next API key."""
+        if not self._keys:
+            raise ValueError("No API keys configured")
+        key = self._keys[self._idx]
+        self._idx = (self._idx + 1) % len(self._keys)
+        return key
+
+    def __len__(self) -> int:
+        return len(self._keys)
+
+
+# ---------------------------------------------------------------------------
+# Provider descriptor
+# ---------------------------------------------------------------------------
+
+
+class ProviderInfo:
+    """Runtime representation of a single configured provider.
+
+    Encapsulates base_url, key rotation, auth-header construction,
+    and upstream URL building.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        api_key: str,
+        base_url: str,
+        auth_header_fn: AuthHeaderFn,
+        url_template: str,
+        stream_url_template: str | None = None,
+    ) -> None:
+        self.name = name
+        self.base_url = base_url.rstrip("/")
+        self.key_ring = KeyRing(api_key)
+        self._auth_header_fn = auth_header_fn
+        self._url_template = url_template
+        self._stream_url_template = stream_url_template
+
+    # -- public helpers used by the proxy -----------------------------------
+
+    def auth_headers(self) -> dict[str, str]:
+        """Return auth headers using the next rotated key."""
+        return self._auth_header_fn(self.key_ring.next())
+
+    def upstream_url(self, model: str, *, stream: bool = False) -> str:
+        tpl = (
+            self._stream_url_template
+            if (stream and self._stream_url_template)
+            else self._url_template
+        )
+        return tpl.format(base_url=self.base_url, model=model)
+
+
+# ---------------------------------------------------------------------------
+# Per-provider auth header builders
+# ---------------------------------------------------------------------------
+
+
+def _openai_auth(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _anthropic_auth(api_key: str) -> dict[str, str]:
+    return {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+    }
+
+
+def _google_auth(api_key: str) -> dict[str, str]:
+    return {"x-goog-api-key": api_key}
+
+
+# ---------------------------------------------------------------------------
+# Provider registry — known provider types and their characteristics
+# ---------------------------------------------------------------------------
+
+_PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
+    "openai_chat": {
+        "default_base_url": "https://api.openai.com/v1",
+        "default_api_key_env": "OPENAI_API_KEY",
+        "auth_header_fn": _openai_auth,
+        "url_template": "{base_url}/chat/completions",
+    },
+    "openai_responses": {
+        "default_base_url": "https://api.openai.com/v1",
+        "default_api_key_env": "OPENAI_API_KEY",
+        "auth_header_fn": _openai_auth,
+        "url_template": "{base_url}/responses",
+    },
+    "anthropic": {
+        "default_base_url": "https://api.anthropic.com",
+        "default_api_key_env": "ANTHROPIC_API_KEY",
+        "auth_header_fn": _anthropic_auth,
+        "url_template": "{base_url}/v1/messages",
+    },
+    "google": {
+        "default_base_url": "https://generativelanguage.googleapis.com",
+        "default_api_key_env": "GOOGLE_API_KEY",
+        "auth_header_fn": _google_auth,
+        "url_template": "{base_url}/v1beta/models/{model}:generateContent",
+        "stream_url_template": "{base_url}/v1beta/models/{model}:streamGenerateContent?alt=sse",
+    },
+}
+
+
+def get_default_base_url(provider_type: str) -> str:
+    """Return the default base URL for a known provider type, or ``""``."""
+    entry = _PROVIDER_REGISTRY.get(provider_type)
+    return entry["default_base_url"] if entry else ""
+
+
+def get_default_api_key_env(provider_type: str) -> str:
+    """Return the default env-var name for a provider's API key."""
+    entry = _PROVIDER_REGISTRY.get(provider_type)
+    return entry["default_api_key_env"] if entry else f"{provider_type.upper()}_API_KEY"
+
+
+def known_provider_types() -> list[str]:
+    """Return the list of built-in provider type names."""
+    return list(_PROVIDER_REGISTRY)
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def build_provider_info(
+    provider_type: str,
+    cfg: dict[str, str],
+) -> ProviderInfo:
+    """Create a :class:`ProviderInfo` from a provider config dict.
+
+    *cfg* is the dict from the JSONC config, e.g.
+    ``{"api_key": "sk-...", "base_url": "https://..."}``
+
+    For known provider types the auth and URL logic is looked up from the
+    registry.  Unknown types fall back to Bearer-token auth and a simple
+    ``{base_url}/`` URL template.
+    """
+    reg = _PROVIDER_REGISTRY.get(provider_type)
+
+    if reg:
+        auth_fn = reg["auth_header_fn"]
+        url_tpl = reg["url_template"]
+        stream_tpl = reg.get("stream_url_template")
+    else:
+        # Unknown / custom provider — best-effort defaults
+        auth_fn = _openai_auth
+        url_tpl = "{base_url}/"
+        stream_tpl = None
+        logger.warning(
+            "Unknown provider type '%s'; using Bearer auth and generic URL template",
+            provider_type,
+        )
+
+    return ProviderInfo(
+        name=provider_type,
+        api_key=cfg["api_key"],
+        base_url=cfg["base_url"],
+        auth_header_fn=auth_fn,
+        url_template=url_tpl,
+        stream_url_template=stream_tpl,
+    )


### PR DESCRIPTION
## Summary
- Add `providers.py` module centralizing provider definitions: auth-header builders, URL templates, default base URLs/API key env-var names, and round-robin `KeyRing` for API key rotation
- Refactor `config.py` to build `ProviderInfo` objects instead of passing raw dicts; `resolve_model()` now returns `ProviderInfo`
- Refactor `app.py` to use `ProviderInfo.auth_headers()` and `ProviderInfo.upstream_url()`, removing duplicated `_UPSTREAM_URL_TEMPLATES`, `_build_auth_headers`, and `_build_upstream_url`

## Test plan
- [x] All 1179 existing tests pass
- [x] ruff check and format clean
- [x] ty check clean on gateway module