### PR TITLE
feat(gateway): add proxy support for upstream requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,19 @@ lint-fix:
 # Run tests
 test:
 	@echo "Running tests..."
-	pytest tests/ -v --tb=short
+	pytest tests/ --ignore=tests/integration -v --tb=short
 	@echo "Tests completed."
+
+# Run integration tests (requires API keys; uses proxychains if available)
+test-integration:
+	@echo "Running integration tests..."
+	@if command -v proxychains >/dev/null 2>&1; then \
+		echo "(using proxychains)"; \
+		proxychains -q pytest tests/integration/ -v --tb=short; \
+	else \
+		pytest tests/integration/ -v --tb=short; \
+	fi
+	@echo "Integration tests completed."
 
 # ──────────────────────────────────────────────
 # Package targets
@@ -74,7 +85,8 @@ help:
 	@echo "Development:"
 	@echo "  lint           - Run ruff linter and format check"
 	@echo "  lint-fix       - Auto-fix lint and formatting issues"
-	@echo "  test           - Run tests with pytest"
+	@echo "  test               - Run unit tests with pytest"
+	@echo "  test-integration   - Run integration tests via proxychains"
 	@echo ""
 	@echo "Package targets:"
 	@echo "  build-package  - Build the Python package"
@@ -91,4 +103,4 @@ help:
 	@echo ""
 	@echo "Detected version: $(VERSION)"
 
-.PHONY: all lint lint-fix test build-package push-package clean-package build push clean help
+.PHONY: all lint lint-fix test test-integration build-package push-package clean-package build push clean help

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -254,15 +254,17 @@ def _extract_model(source_provider: ProviderType, body: dict[str, Any]) -> str |
 # Core proxy logic
 # ---------------------------------------------------------------------------
 
-# Shared httpx client (created once, reused across requests)
-_http_client: httpx.AsyncClient | None = None
+# Shared httpx clients keyed by proxy URL (None = direct connection)
+_http_clients: dict[str | None, httpx.AsyncClient] = {}
 
 
-def _get_client() -> httpx.AsyncClient:
-    global _http_client
-    if _http_client is None:
-        _http_client = httpx.AsyncClient(timeout=300.0)
-    return _http_client
+def _get_client(proxy_url: str | None = None) -> httpx.AsyncClient:
+    if proxy_url not in _http_clients:
+        _http_clients[proxy_url] = httpx.AsyncClient(
+            timeout=300.0,
+            proxy=proxy_url,
+        )
+    return _http_clients[proxy_url]
 
 
 async def _handle_non_streaming(
@@ -300,7 +302,7 @@ async def _handle_non_streaming(
     )
 
     # 4. Forward to upstream
-    client = _get_client()
+    client = _get_client(provider_info.proxy_url)
     try:
         upstream_resp = await client.post(url, json=upstream_body, headers=headers)
     except httpx.HTTPError as exc:
@@ -377,7 +379,7 @@ async def _handle_streaming(
         from_ctx = StreamContext()  # upstream -> IR
         to_ctx = StreamContext()  # IR -> source
 
-        client = _get_client()
+        client = _get_client(provider_info.proxy_url)
         async with client.stream(
             "POST", url, json=upstream_body, headers=headers
         ) as upstream_resp:
@@ -574,10 +576,9 @@ def create_app(config: GatewayConfig) -> Starlette:
     ]
 
     async def on_shutdown() -> None:
-        global _http_client
-        if _http_client is not None:
-            await _http_client.aclose()
-            _http_client = None
+        for client in _http_clients.values():
+            await client.aclose()
+        _http_clients.clear()
 
     return Starlette(routes=routes, on_shutdown=[on_shutdown])
 
@@ -746,6 +747,11 @@ def main() -> None:
     parser.add_argument("--host", default=None, help="Override server host")
     parser.add_argument("--port", type=int, default=None, help="Override server port")
     parser.add_argument(
+        "--proxy",
+        default=None,
+        help="HTTP/SOCKS proxy URL for upstream requests (overrides config)",
+    )
+    parser.add_argument(
         "--log-level",
         default="info",
         choices=["debug", "info", "warning", "error"],
@@ -806,6 +812,11 @@ def main() -> None:
         sys.exit(1)
 
     raw_config = load_config(config_path)
+
+    # CLI --proxy overrides config-level server.proxy
+    if args.proxy:
+        raw_config.setdefault("server", {})["proxy"] = args.proxy
+
     config = GatewayConfig(raw_config)
 
     host = args.host or config.host

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -107,11 +107,12 @@ class GatewayConfig:
         self.models: dict[str, ProviderType] = raw.get("models", {})
         self.host: str = raw.get("server", {}).get("host", "0.0.0.0")
         self.port: int = raw.get("server", {}).get("port", 8765)
+        self.proxy: str | None = raw.get("server", {}).get("proxy")
         self._validate()
 
         # Build ProviderInfo objects (with key rotation support)
         self.providers: dict[str, ProviderInfo] = {
-            name: build_provider_info(name, cfg)
+            name: build_provider_info(name, cfg, global_proxy=self.proxy)
             for name, cfg in self._raw_providers.items()
         }
 

--- a/src/llm_rosetta/gateway/providers.py
+++ b/src/llm_rosetta/gateway/providers.py
@@ -61,6 +61,7 @@ class ProviderInfo:
         auth_header_fn: AuthHeaderFn,
         url_template: str,
         stream_url_template: str | None = None,
+        proxy_url: str | None = None,
     ) -> None:
         self.name = name
         self.base_url = base_url.rstrip("/")
@@ -68,6 +69,7 @@ class ProviderInfo:
         self._auth_header_fn = auth_header_fn
         self._url_template = url_template
         self._stream_url_template = stream_url_template
+        self.proxy_url = proxy_url
 
     # -- public helpers used by the proxy -----------------------------------
 
@@ -162,11 +164,16 @@ def known_provider_types() -> list[str]:
 def build_provider_info(
     provider_type: str,
     cfg: dict[str, str],
+    *,
+    global_proxy: str | None = None,
 ) -> ProviderInfo:
     """Create a :class:`ProviderInfo` from a provider config dict.
 
     *cfg* is the dict from the JSONC config, e.g.
     ``{"api_key": "sk-...", "base_url": "https://..."}``
+
+    *global_proxy* is the server-level proxy URL (from ``server.proxy``).
+    A per-provider ``"proxy"`` key in *cfg* takes precedence.
 
     For known provider types the auth and URL logic is looked up from the
     registry.  Unknown types fall back to Bearer-token auth and a simple
@@ -188,6 +195,9 @@ def build_provider_info(
             provider_type,
         )
 
+    # Per-provider proxy overrides global proxy
+    proxy_url = cfg.get("proxy") or global_proxy or None
+
     return ProviderInfo(
         name=provider_type,
         api_key=cfg["api_key"],
@@ -195,4 +205,5 @@ def build_provider_info(
         auth_header_fn=auth_fn,
         url_template=url_tpl,
         stream_url_template=stream_tpl,
+        proxy_url=proxy_url,
     )


### PR DESCRIPTION
## Summary
- Add global (`server.proxy`) and per-provider (`proxy` key) HTTP/SOCKS proxy configuration
- `ProviderInfo` gains optional `proxy_url`; per-provider overrides global
- CLI `--proxy` flag overrides config-level proxy
- httpx clients keyed by proxy URL for efficient reuse
- Makefile: add `test-integration` target using proxychains (if available), exclude integration tests from `test`

## Test plan
- [x] All 1179 unit tests pass
- [x] ruff check/format clean
- [x] ty check clean