### PR TITLE
fix: handle None usage tokens and validate provider base_url

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -323,8 +323,8 @@ class AnthropicConverter(BaseConverter):
         # Usage
         p_usage = provider_response.get("usage")
         if p_usage:
-            input_tokens = p_usage.get("input_tokens", 0)
-            output_tokens = p_usage.get("output_tokens", 0)
+            input_tokens = p_usage.get("input_tokens") or 0
+            output_tokens = p_usage.get("output_tokens") or 0
             usage_info: dict[str, Any] = {
                 "prompt_tokens": input_tokens,
                 "completion_tokens": output_tokens,
@@ -401,8 +401,8 @@ class AnthropicConverter(BaseConverter):
         ir_usage = ir_response.get("usage")
         if ir_usage:
             usage: dict[str, Any] = {
-                "input_tokens": ir_usage.get("prompt_tokens", 0),
-                "output_tokens": ir_usage.get("completion_tokens", 0),
+                "input_tokens": ir_usage.get("prompt_tokens") or 0,
+                "output_tokens": ir_usage.get("completion_tokens") or 0,
             }
 
             if "cache_read_tokens" in ir_usage:
@@ -500,9 +500,9 @@ class AnthropicConverter(BaseConverter):
                     UsageEvent(
                         type="usage",
                         usage={
-                            "prompt_tokens": usage.get("input_tokens", 0),
+                            "prompt_tokens": usage.get("input_tokens") or 0,
                             "completion_tokens": 0,
-                            "total_tokens": usage.get("input_tokens", 0),
+                            "total_tokens": usage.get("input_tokens") or 0,
                         },
                     )
                 )
@@ -614,16 +614,15 @@ class AnthropicConverter(BaseConverter):
             # Final usage
             usage = chunk.get("usage")
             if usage:
+                input_tokens = usage.get("input_tokens") or 0
+                output_tokens = usage.get("output_tokens") or 0
                 events.append(
                     UsageEvent(
                         type="usage",
                         usage={
-                            "prompt_tokens": usage.get("input_tokens", 0),
-                            "completion_tokens": usage.get("output_tokens", 0),
-                            "total_tokens": (
-                                usage.get("input_tokens", 0)
-                                + usage.get("output_tokens", 0)
-                            ),
+                            "prompt_tokens": input_tokens,
+                            "completion_tokens": output_tokens,
+                            "total_tokens": input_tokens + output_tokens,
                         },
                     )
                 )
@@ -785,8 +784,8 @@ class AnthropicConverter(BaseConverter):
             return {
                 "type": "message_delta",
                 "usage": {
-                    "input_tokens": usage.get("prompt_tokens", 0),
-                    "output_tokens": usage.get("completion_tokens", 0),
+                    "input_tokens": usage.get("prompt_tokens") or 0,
+                    "output_tokens": usage.get("completion_tokens") or 0,
                 },
             }
 

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -444,9 +444,9 @@ class GoogleGenAIConverter(BaseConverter):
         ir_usage = ir_response.get("usage")
         if ir_usage:
             usage_metadata: dict[str, Any] = {
-                "prompt_token_count": ir_usage.get("prompt_tokens", 0),
-                "candidates_token_count": ir_usage.get("completion_tokens", 0),
-                "total_token_count": ir_usage.get("total_tokens", 0),
+                "prompt_token_count": ir_usage.get("prompt_tokens") or 0,
+                "candidates_token_count": ir_usage.get("completion_tokens") or 0,
+                "total_token_count": ir_usage.get("total_tokens") or 0,
             }
 
             if "reasoning_tokens" in ir_usage:
@@ -895,9 +895,9 @@ class GoogleGenAIConverter(BaseConverter):
         elif is_usage_event(event):
             usage = event["usage"]
             usage_metadata: dict[str, Any] = {
-                "prompt_token_count": usage.get("prompt_tokens", 0),
-                "candidates_token_count": usage.get("completion_tokens", 0),
-                "total_token_count": usage.get("total_tokens", 0),
+                "prompt_token_count": usage.get("prompt_tokens") or 0,
+                "candidates_token_count": usage.get("completion_tokens") or 0,
+                "total_token_count": usage.get("total_tokens") or 0,
             }
 
             if "reasoning_tokens" in usage:

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -319,9 +319,9 @@ class OpenAIChatConverter(BaseConverter):
         p_usage = provider_response.get("usage")
         if p_usage:
             usage_info: dict[str, Any] = {
-                "prompt_tokens": p_usage.get("prompt_tokens", 0),
-                "completion_tokens": p_usage.get("completion_tokens", 0),
-                "total_tokens": p_usage.get("total_tokens", 0),
+                "prompt_tokens": p_usage.get("prompt_tokens") or 0,
+                "completion_tokens": p_usage.get("completion_tokens") or 0,
+                "total_tokens": p_usage.get("total_tokens") or 0,
             }
 
             p_prompt_details = p_usage.get("prompt_tokens_details")
@@ -411,9 +411,9 @@ class OpenAIChatConverter(BaseConverter):
         ir_usage = ir_response.get("usage")
         if ir_usage:
             usage: dict[str, Any] = {
-                "prompt_tokens": ir_usage.get("prompt_tokens", 0),
-                "completion_tokens": ir_usage.get("completion_tokens", 0),
-                "total_tokens": ir_usage.get("total_tokens", 0),
+                "prompt_tokens": ir_usage.get("prompt_tokens") or 0,
+                "completion_tokens": ir_usage.get("completion_tokens") or 0,
+                "total_tokens": ir_usage.get("total_tokens") or 0,
             }
 
             if "prompt_tokens_details" in ir_usage:
@@ -617,9 +617,9 @@ class OpenAIChatConverter(BaseConverter):
                 UsageEvent(
                     type="usage",
                     usage={
-                        "prompt_tokens": usage.get("prompt_tokens", 0),
-                        "completion_tokens": usage.get("completion_tokens", 0),
-                        "total_tokens": usage.get("total_tokens", 0),
+                        "prompt_tokens": usage.get("prompt_tokens") or 0,
+                        "completion_tokens": usage.get("completion_tokens") or 0,
+                        "total_tokens": usage.get("total_tokens") or 0,
                     },
                 )
             )
@@ -770,9 +770,9 @@ class OpenAIChatConverter(BaseConverter):
             usage = event["usage"]
             result = {
                 "usage": {
-                    "prompt_tokens": usage.get("prompt_tokens", 0),
-                    "completion_tokens": usage.get("completion_tokens", 0),
-                    "total_tokens": usage.get("total_tokens", 0),
+                    "prompt_tokens": usage.get("prompt_tokens") or 0,
+                    "completion_tokens": usage.get("completion_tokens") or 0,
+                    "total_tokens": usage.get("total_tokens") or 0,
                 }
             }
 

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -336,9 +336,9 @@ class OpenAIResponsesConverter(BaseConverter):
         p_usage = provider_response.get("usage")
         if p_usage:
             usage_info: dict[str, Any] = {
-                "prompt_tokens": p_usage.get("input_tokens", 0),
-                "completion_tokens": p_usage.get("output_tokens", 0),
-                "total_tokens": p_usage.get("total_tokens", 0),
+                "prompt_tokens": p_usage.get("input_tokens") or 0,
+                "completion_tokens": p_usage.get("output_tokens") or 0,
+                "total_tokens": p_usage.get("total_tokens") or 0,
             }
 
             # Handle detailed statistics
@@ -422,9 +422,9 @@ class OpenAIResponsesConverter(BaseConverter):
         ir_usage = ir_response.get("usage")
         if ir_usage:
             usage: dict[str, Any] = {
-                "input_tokens": ir_usage.get("prompt_tokens", 0),
-                "output_tokens": ir_usage.get("completion_tokens", 0),
-                "total_tokens": ir_usage.get("total_tokens", 0),
+                "input_tokens": ir_usage.get("prompt_tokens") or 0,
+                "output_tokens": ir_usage.get("completion_tokens") or 0,
+                "total_tokens": ir_usage.get("total_tokens") or 0,
             }
 
             if "cache_read_tokens" in ir_usage:
@@ -733,9 +733,9 @@ class OpenAIResponsesConverter(BaseConverter):
                     UsageEvent(
                         type="usage",
                         usage={
-                            "prompt_tokens": usage.get("input_tokens", 0),
-                            "completion_tokens": usage.get("output_tokens", 0),
-                            "total_tokens": usage.get("total_tokens", 0),
+                            "prompt_tokens": usage.get("input_tokens") or 0,
+                            "completion_tokens": usage.get("output_tokens") or 0,
+                            "total_tokens": usage.get("total_tokens") or 0,
                         },
                     )
                 )
@@ -879,9 +879,10 @@ class OpenAIResponsesConverter(BaseConverter):
             # Merge pending usage from context if available
             if context is not None and context.pending_usage is not None:
                 response["usage"] = {
-                    "input_tokens": context.pending_usage.get("prompt_tokens", 0),
-                    "output_tokens": context.pending_usage.get("completion_tokens", 0),
-                    "total_tokens": context.pending_usage.get("total_tokens", 0),
+                    "input_tokens": context.pending_usage.get("prompt_tokens") or 0,
+                    "output_tokens": context.pending_usage.get("completion_tokens")
+                    or 0,
+                    "total_tokens": context.pending_usage.get("total_tokens") or 0,
                 }
 
             return {
@@ -904,9 +905,9 @@ class OpenAIResponsesConverter(BaseConverter):
                 "response": {
                     "status": "completed",
                     "usage": {
-                        "input_tokens": usage.get("prompt_tokens", 0),
-                        "output_tokens": usage.get("completion_tokens", 0),
-                        "total_tokens": usage.get("total_tokens", 0),
+                        "input_tokens": usage.get("prompt_tokens") or 0,
+                        "output_tokens": usage.get("completion_tokens") or 0,
+                        "total_tokens": usage.get("total_tokens") or 0,
                     },
                 },
             }

--- a/src/llm_rosetta/gateway/providers.py
+++ b/src/llm_rosetta/gateway/providers.py
@@ -63,6 +63,11 @@ class ProviderInfo:
         stream_url_template: str | None = None,
         proxy_url: str | None = None,
     ) -> None:
+        if not base_url.startswith(("http://", "https://")):
+            raise ValueError(
+                f"Provider '{name}': base_url must start with http:// or https://, "
+                f"got '{base_url}'"
+            )
         self.name = name
         self.base_url = base_url.rstrip("/")
         self.key_ring = KeyRing(api_key)


### PR DESCRIPTION
## Summary
- Fix `TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'` in Anthropic streaming when usage tokens are `null` — replace `.get("*_tokens", 0)` with `.get("*_tokens") or 0` across all four converters
- Add `base_url` protocol validation in `ProviderInfo` to fail fast on config typos like `https:example.com` (missing `//`)

## Test plan
- [x] All 1179 tests pass
- [x] ruff clean
- [x] Verified streaming with Anthropic provider no longer crashes on null usage tokens