### PR TITLE
fix: map content_filter to incomplete status in Responses to_provider

### DIFF
--- a/src/llm_rosetta/converters/openai_responses/_constants.py
+++ b/src/llm_rosetta/converters/openai_responses/_constants.py
@@ -38,15 +38,20 @@ RESPONSES_INCOMPLETE_REASON_TO_IR: dict[str, str] = {
 }
 
 # to_provider: IR finish reason -> response status
-# NOTE: content_filter -> "completed" is a known gap, tracked in #90
 RESPONSES_REASON_TO_STATUS: dict[str, str] = {
     "stop": "completed",
     "length": "incomplete",
     "error": "failed",
     "tool_calls": "completed",
-    "content_filter": "completed",  # TODO: should be "incomplete", see #90
+    "content_filter": "incomplete",
     "cancelled": "cancelled",
     "refusal": "completed",
+}
+
+# to_provider: IR finish reason -> incomplete_details.reason
+RESPONSES_REASON_TO_INCOMPLETE_REASON: dict[str, str] = {
+    "length": "max_output_tokens",
+    "content_filter": "content_filter",
 }
 
 

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -39,6 +39,7 @@ from ..base.stream_context import StreamContext
 from ..base.tools import fix_orphaned_tool_calls_ir, strip_orphaned_tool_config
 from ._constants import (
     RESPONSES_INCOMPLETE_REASON_TO_IR,
+    RESPONSES_REASON_TO_INCOMPLETE_REASON,
     RESPONSES_REASON_TO_STATUS,
     RESPONSES_STATUS_TO_REASON,
     ResponsesEventType,
@@ -421,10 +422,9 @@ class OpenAIResponsesConverter(BaseConverter):
             finish_reason = choice.get("finish_reason", {}).get("reason", "stop")
             status = RESPONSES_REASON_TO_STATUS.get(finish_reason, "completed")
             provider_response["status"] = status
-            if status == "incomplete":
-                provider_response["incomplete_details"] = {
-                    "reason": "max_output_tokens"
-                }
+            incomplete_reason = RESPONSES_REASON_TO_INCOMPLETE_REASON.get(finish_reason)
+            if incomplete_reason:
+                provider_response["incomplete_details"] = {"reason": incomplete_reason}
 
         # Usage
         ir_usage = ir_response.get("usage")
@@ -1146,7 +1146,7 @@ class OpenAIResponsesConverter(BaseConverter):
         reason = event["finish_reason"]["reason"]
         status = RESPONSES_REASON_TO_STATUS.get(reason, "completed")
 
-        response = self._build_finish_response(status, context)
+        response = self._build_finish_response(status, context, reason)
 
         # Emit done events before response.completed
         results: list[dict[str, Any]] = []
@@ -1176,6 +1176,7 @@ class OpenAIResponsesConverter(BaseConverter):
         self,
         status: str,
         context: StreamContext | None,
+        finish_reason: str = "length",
     ) -> dict[str, Any]:
         """Build the response dict for a FinishEvent."""
         output: list[dict[str, Any]] = []
@@ -1218,7 +1219,10 @@ class OpenAIResponsesConverter(BaseConverter):
             response["model"] = context.model
 
         if status == "incomplete":
-            response["incomplete_details"] = {"reason": "max_output_tokens"}
+            incomplete_reason = RESPONSES_REASON_TO_INCOMPLETE_REASON.get(
+                finish_reason, "max_output_tokens"
+            )
+            response["incomplete_details"] = {"reason": incomplete_reason}
 
         # Merge pending usage from context if available
         if context is not None and context.pending_usage is not None:

--- a/tests/converters/openai_responses/test_constants.py
+++ b/tests/converters/openai_responses/test_constants.py
@@ -4,6 +4,7 @@ import pytest
 
 from llm_rosetta.converters.openai_responses._constants import (
     RESPONSES_INCOMPLETE_REASON_TO_IR,
+    RESPONSES_REASON_TO_INCOMPLETE_REASON,
     RESPONSES_REASON_TO_STATUS,
     RESPONSES_STATUS_TO_REASON,
     ResponsesEventType,
@@ -49,6 +50,19 @@ class TestResponsesStatusMaps:
             assert back == status, (
                 f"status '{status}' -> IR '{ir_reason}' -> status '{back}' "
                 f"(expected '{status}')"
+            )
+
+    def test_round_trip_incomplete_reason(self):
+        """Incomplete reasons round-trip: incomplete_details.reason -> IR -> status + incomplete_details.reason."""
+        for inc_reason, ir_reason in RESPONSES_INCOMPLETE_REASON_TO_IR.items():
+            status = RESPONSES_REASON_TO_STATUS.get(ir_reason)
+            assert status == "incomplete", (
+                f"IR reason '{ir_reason}' should map to 'incomplete' status, got '{status}'"
+            )
+            back = RESPONSES_REASON_TO_INCOMPLETE_REASON.get(ir_reason)
+            assert back == inc_reason, (
+                f"IR reason '{ir_reason}' -> incomplete_reason '{back}' "
+                f"(expected '{inc_reason}')"
             )
 
 

--- a/tests/converters/openai_responses/test_converter.py
+++ b/tests/converters/openai_responses/test_converter.py
@@ -525,6 +525,31 @@ class TestOpenAIResponsesConverter:
         assert result["status"] == "incomplete"
         assert result["incomplete_details"]["reason"] == "max_output_tokens"
 
+    def test_response_to_provider_content_filter_finish_reason(self):
+        """Test IRResponse with content_filter finish reason -> incomplete status."""
+        ir_response = cast(
+            IRResponse,
+            {
+                "id": "resp-cf",
+                "object": "response",
+                "created": 1000,
+                "model": "gpt-4o",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Filtered"}],
+                        },
+                        "finish_reason": {"reason": "content_filter"},
+                    }
+                ],
+            },
+        )
+        result = self.converter.response_to_provider(ir_response)
+        assert result["status"] == "incomplete"
+        assert result["incomplete_details"]["reason"] == "content_filter"
+
     def test_response_to_provider_error_finish_reason(self):
         """Test IRResponse with error finish reason -> failed status."""
         ir_response = cast(

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -472,12 +472,7 @@ class TestStreamResponseToProvider:
         assert completed["response"]["status"] == "failed"
 
     def test_finish_event_content_filter(self):
-        """FinishEvent with 'content_filter' → response.completed with status 'completed'.
-
-        Note: content_filter is not specially handled in to_provider direction,
-        so it defaults to 'completed' status. The from_provider direction correctly
-        maps incomplete/content_filter to 'content_filter' IR reason.
-        """
+        """FinishEvent with 'content_filter' → response.completed with status 'incomplete'."""
         event = cast(
             FinishEvent,
             {"type": "finish", "finish_reason": {"reason": "content_filter"}},
@@ -486,7 +481,10 @@ class TestStreamResponseToProvider:
             list[dict[str, Any]], self.converter.stream_response_to_provider(event)
         )
         completed = next(r for r in results if r["type"] == "response.completed")
-        assert completed["response"]["status"] == "completed"
+        assert completed["response"]["status"] == "incomplete"
+        assert completed["response"]["incomplete_details"] == {
+            "reason": "content_filter"
+        }
 
     def test_finish_event_tool_calls(self):
         """FinishEvent with 'tool_calls' → response.completed with status 'completed'."""


### PR DESCRIPTION
## Summary

Closes #90.

- `content_filter` IR finish reason was incorrectly mapped to `status: "completed"` in `response_to_provider` and `stream_response_to_provider`. Now correctly maps to `status: "incomplete"` with `incomplete_details.reason: "content_filter"`.
- Introduces `RESPONSES_REASON_TO_INCOMPLETE_REASON` mapping to replace hardcoded `"max_output_tokens"`, supporting both `length` and `content_filter` incomplete reasons via a single lookup.

## Test plan

- [x] Updated `test_finish_event_content_filter` to assert `incomplete` status and `content_filter` reason
- [x] Added `test_response_to_provider_content_filter_finish_reason` for non-stream path
- [x] Added `test_round_trip_incomplete_reason` to validate constants consistency
- [x] 280 tests passed, ruff + ty clean