### PR TITLE
refactor: formalize StreamContext state management

### DIFF
--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -241,6 +241,20 @@ class BaseConverter(ABC):
             return dict(data.__dict__)
         raise TypeError(f"Cannot normalize {type(data).__name__} to dict")
 
+    # ==================== Factory methods ====================
+
+    @classmethod
+    def create_stream_context(cls) -> StreamContext:
+        """Create a stream context appropriate for this converter.
+
+        Subclasses may override to return a provider-specific context
+        subclass with additional state fields.
+
+        Returns:
+            A new StreamContext instance.
+        """
+        return StreamContext()
+
     # ==================== 便利方法 Convenience methods ====================
 
     def message_to_provider(

--- a/src/llm_rosetta/converters/base/stream_context.py
+++ b/src/llm_rosetta/converters/base/stream_context.py
@@ -5,7 +5,12 @@ Maintains state across stream chunk conversions for stateful stream
 transformations in Man-in-the-Middle scenarios.
 """
 
+from __future__ import annotations
 
+from dataclasses import dataclass, field
+
+
+@dataclass
 class StreamContext:
     """Maintains state across stream chunk conversions.
 
@@ -18,34 +23,36 @@ class StreamContext:
         created: Unix timestamp of the response creation.
         current_block_index: Current 0-based content block index.
         tool_call_id_map: Mapping from tool_call_id to tool_name.
+        tool_call_item_id_map: Mapping from tool_call_id to item_id.
         pending_usage: Usage info stored by UsageEvent for later merging
             into a FinishEvent (prevents duplicate terminal events).
+        pending_finish: Deferred finish event payload.
         pending_response: Deferred response.completed payload stored by
             FinishEvent, emitted by StreamEndEvent after usage is merged.
     """
 
-    def __init__(self) -> None:
-        self.response_id: str = ""
-        self.model: str = ""
-        self.created: int = 0
-        self.current_block_index: int = -1
-        self.tool_call_id_map: dict[str, str] = {}  # tool_call_id -> tool_name
-        self.tool_call_item_id_map: dict[str, str] = {}  # tool_call_id -> item_id
-        self.pending_usage: dict | None = None
-        self.pending_finish: dict | None = None
-        self.pending_response: dict | None = None
-        self._started: bool = False
-        self._ended: bool = False
-        # Tool call accumulation for streaming
-        self._tool_call_args: dict[str, str] = {}  # call_id -> accumulated args
-        self._tool_call_order: list[str] = []  # call_ids in order received
-        # item_id -> call_id mapping (OpenAI uses item_id in delta events)
-        self._item_id_to_call_id: dict[str, str] = {}
-        # Responses API streaming state
-        self._output_item_emitted: bool = False
-        self._item_id: str = ""
-        self._accumulated_text: str = ""
-        self._content_part_done_emitted: bool = False
+    # Session-level metadata
+    response_id: str = ""
+    model: str = ""
+    created: int = 0
+    current_block_index: int = -1
+
+    # Tool call tracking
+    tool_call_id_map: dict[str, str] = field(default_factory=dict)
+    tool_call_item_id_map: dict[str, str] = field(default_factory=dict)
+
+    # Deferred event payloads
+    pending_usage: dict | None = None
+    pending_finish: dict | None = None
+    pending_response: dict | None = None
+
+    # Lifecycle flags
+    _started: bool = field(default=False, repr=False)
+    _ended: bool = field(default=False, repr=False)
+
+    # Tool call accumulation for streaming
+    _tool_call_args: dict[str, str] = field(default_factory=dict, repr=False)
+    _tool_call_order: list[str] = field(default_factory=list, repr=False)
 
     def next_block_index(self) -> int:
         """Increment and return the next block index.
@@ -77,7 +84,6 @@ class StreamContext:
         """
         if tool_call_id and item_id:
             self.tool_call_item_id_map[tool_call_id] = item_id
-            self._item_id_to_call_id[item_id] = tool_call_id
 
     def get_tool_call_item_id(self, tool_call_id: str) -> str:
         """Get the Responses output item ID for a tool call.

--- a/src/llm_rosetta/converters/openai_responses/__init__.py
+++ b/src/llm_rosetta/converters/openai_responses/__init__.py
@@ -8,10 +8,12 @@ from .config_ops import OpenAIResponsesConfigOps
 from .content_ops import OpenAIResponsesContentOps
 from .converter import OpenAIResponsesConverter
 from .message_ops import OpenAIResponsesMessageOps
+from .stream_context import OpenAIResponsesStreamContext
 from .tool_ops import OpenAIResponsesToolOps
 
 __all__ = [
     "OpenAIResponsesConverter",
+    "OpenAIResponsesStreamContext",
     "OpenAIResponsesContentOps",
     "OpenAIResponsesToolOps",
     "OpenAIResponsesMessageOps",

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -37,6 +37,7 @@ from ...types.ir.stream import (
 from ..base import BaseConverter
 from ..base.stream_context import StreamContext
 from ..base.tools import fix_orphaned_tool_calls_ir, strip_orphaned_tool_config
+from .stream_context import OpenAIResponsesStreamContext
 from ._constants import (
     RESPONSES_INCOMPLETE_REASON_TO_IR,
     RESPONSES_REASON_TO_INCOMPLETE_REASON,
@@ -72,6 +73,11 @@ class OpenAIResponsesConverter(BaseConverter):
         self.tool_ops = self.tool_ops_class()
         self.message_ops = self.message_ops_class(self.content_ops, self.tool_ops)
         self.config_ops = self.config_ops_class()
+
+    @classmethod
+    def create_stream_context(cls) -> OpenAIResponsesStreamContext:
+        """Create a stream context with Responses API specific state."""
+        return OpenAIResponsesStreamContext()
 
     # ==================== Top-level Interfaces ====================
 
@@ -731,10 +737,10 @@ class OpenAIResponsesConverter(BaseConverter):
         delta_text = chunk.get("delta", "")
         # Upstream may send call_id or item_id — resolve to call_id
         call_id = chunk.get("call_id", "")
-        if not call_id and context is not None:
+        if not call_id and isinstance(context, OpenAIResponsesStreamContext):
             item_id = chunk.get("item_id", "")
             if item_id:
-                call_id = context._item_id_to_call_id.get(item_id, "")
+                call_id = context.item_id_to_call_id.get(item_id, "")
         delta_event = ToolCallDeltaEvent(
             type="tool_call_delta",
             tool_call_id=call_id,
@@ -758,10 +764,10 @@ class OpenAIResponsesConverter(BaseConverter):
     ) -> None:
         # Resolve call_id from item_id if needed
         call_id = chunk.get("call_id", "")
-        if not call_id and context is not None:
+        if not call_id and isinstance(context, OpenAIResponsesStreamContext):
             item_id = chunk.get("item_id", "")
             if item_id:
-                call_id = context._item_id_to_call_id.get(item_id, "")
+                call_id = context.item_id_to_call_id.get(item_id, "")
         arguments = chunk.get("arguments", "")
         # Store final arguments in context
         if context is not None and call_id:
@@ -936,19 +942,17 @@ class OpenAIResponsesConverter(BaseConverter):
     def _handle_content_block_start_to_p(
         self,
         event: ContentBlockStartEvent,
-        context: StreamContext | None,
+        context: OpenAIResponsesStreamContext | None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         block_type = event["block_type"]
         if block_type == "text":
             # With context: emit output_item.added + content_part.added
             # and mark the item as emitted so the first TextDelta doesn't
             # re-emit them.
-            if context is not None and not getattr(
-                context, "_output_item_emitted", False
-            ):
-                context._output_item_emitted = True
+            if context is not None and not context.output_item_emitted:
+                context.output_item_emitted = True
                 item_id = generate_message_id(context.response_id)
-                context._item_id = item_id
+                context.item_id = item_id
                 return [
                     {
                         "type": ResponsesEventType.OUTPUT_ITEM_ADDED,
@@ -985,11 +989,11 @@ class OpenAIResponsesConverter(BaseConverter):
     def _handle_content_block_end_to_p(
         self,
         event: ContentBlockEndEvent,
-        context: StreamContext | None,
+        context: OpenAIResponsesStreamContext | None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         if context is not None:
-            context._content_part_done_emitted = True
-            accumulated = getattr(context, "_accumulated_text", "")
+            context.content_part_done_emitted = True
+            accumulated = context.accumulated_text
             # Emit output_text.done before content_part.done (matches
             # OpenAI's event ordering)
             return [
@@ -1016,7 +1020,7 @@ class OpenAIResponsesConverter(BaseConverter):
     def _handle_text_delta_to_p(
         self,
         event: TextDeltaEvent,
-        context: StreamContext | None,
+        context: OpenAIResponsesStreamContext | None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         choice_index = event.get("choice_index", 0)
         text = event["text"]
@@ -1029,16 +1033,14 @@ class OpenAIResponsesConverter(BaseConverter):
 
         # Accumulate text in context for response.completed output
         if context is not None:
-            if not hasattr(context, "_accumulated_text"):
-                context._accumulated_text = ""
-            context._accumulated_text += text
+            context.accumulated_text += text
 
         # Emit output_item.added + content_part.added before the first
         # text delta so clients (e.g. Codex CLI) can register the item.
-        if context is not None and not getattr(context, "_output_item_emitted", False):
-            context._output_item_emitted = True
+        if context is not None and not context.output_item_emitted:
+            context.output_item_emitted = True
             item_id = generate_message_id(context.response_id)
-            context._item_id = item_id
+            context.item_id = item_id
             return [
                 {
                     "type": ResponsesEventType.OUTPUT_ITEM_ADDED,
@@ -1141,7 +1143,7 @@ class OpenAIResponsesConverter(BaseConverter):
     def _handle_finish_to_p(
         self,
         event: FinishEvent,
-        context: StreamContext | None,
+        context: OpenAIResponsesStreamContext | None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         reason = event["finish_reason"]["reason"]
         status = RESPONSES_REASON_TO_STATUS.get(reason, "completed")
@@ -1175,14 +1177,14 @@ class OpenAIResponsesConverter(BaseConverter):
     def _build_finish_response(
         self,
         status: str,
-        context: StreamContext | None,
+        context: OpenAIResponsesStreamContext | None,
         finish_reason: str = "length",
     ) -> dict[str, Any]:
         """Build the response dict for a FinishEvent."""
         output: list[dict[str, Any]] = []
         if context is not None:
-            accumulated = getattr(context, "_accumulated_text", "")
-            item_id = getattr(context, "_item_id", "")
+            accumulated = context.accumulated_text
+            item_id = context.item_id
             if accumulated:
                 output.append(
                     {
@@ -1236,19 +1238,19 @@ class OpenAIResponsesConverter(BaseConverter):
 
     def _emit_text_done_events(
         self,
-        context: StreamContext,
+        context: OpenAIResponsesStreamContext,
         results: list[dict[str, Any]],
     ) -> None:
         """Emit text done events if we had text output."""
-        if not getattr(context, "_output_item_emitted", False):
+        if not context.output_item_emitted:
             return
 
-        accumulated = getattr(context, "_accumulated_text", "")
-        item_id = getattr(context, "_item_id", "")
+        accumulated = context.accumulated_text
+        item_id = context.item_id
 
         # Only emit output_text.done + content_part.done if not
         # already emitted by a prior ContentBlockEndEvent
-        if not getattr(context, "_content_part_done_emitted", False):
+        if not context.content_part_done_emitted:
             results.append(
                 {
                     "type": ResponsesEventType.OUTPUT_TEXT_DONE,
@@ -1280,7 +1282,7 @@ class OpenAIResponsesConverter(BaseConverter):
 
     def _emit_tool_call_done_events(
         self,
-        context: StreamContext,
+        context: OpenAIResponsesStreamContext,
         results: list[dict[str, Any]],
     ) -> None:
         """Emit done events for each tool call."""
@@ -1288,9 +1290,7 @@ class OpenAIResponsesConverter(BaseConverter):
             tool_name = context.get_tool_name(call_id)
             arguments = context._tool_call_args.get(call_id, "")
             item_id = context.get_tool_call_item_id(call_id) or call_id
-            output_index = tc_idx + (
-                1 if getattr(context, "_output_item_emitted", False) else 0
-            )
+            output_index = tc_idx + (1 if context.output_item_emitted else 0)
 
             # response.function_call_arguments.done
             results.append(

--- a/src/llm_rosetta/converters/openai_responses/stream_context.py
+++ b/src/llm_rosetta/converters/openai_responses/stream_context.py
@@ -1,0 +1,48 @@
+"""OpenAI Responses API stream context with provider-specific state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..base.stream_context import StreamContext
+
+
+@dataclass
+class OpenAIResponsesStreamContext(StreamContext):
+    """Stream context with OpenAI Responses API specific state.
+
+    Extends the base StreamContext with fields needed for Responses API
+    stream conversion, including output item tracking, text accumulation,
+    and item-to-call-id resolution.
+
+    Attributes:
+        item_id_to_call_id: Reverse mapping from Responses item_id to
+            tool call_id for function call argument delta resolution.
+        output_item_emitted: Whether the initial output_item.added and
+            content_part.added events have been emitted.
+        item_id: Current output item ID for the response message.
+        accumulated_text: Accumulated text deltas for the final
+            response.completed payload.
+        content_part_done_emitted: Whether content_part.done has been
+            emitted (prevents duplicate emission).
+    """
+
+    item_id_to_call_id: dict[str, str] = field(default_factory=dict)
+    output_item_emitted: bool = False
+    item_id: str = ""
+    accumulated_text: str = ""
+    content_part_done_emitted: bool = False
+
+    def register_tool_call_item(self, tool_call_id: str, item_id: str) -> None:
+        """Register tool call item with reverse item_id mapping.
+
+        Extends the base implementation to also populate
+        ``item_id_to_call_id`` for Responses API delta resolution.
+
+        Args:
+            tool_call_id: The stable tool correlation identifier.
+            item_id: The Responses output item identifier for the function call.
+        """
+        super().register_tool_call_item(tool_call_id, item_id)
+        if tool_call_id and item_id:
+            self.item_id_to_call_id[item_id] = tool_call_id

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -22,7 +22,7 @@ from starlette.responses import JSONResponse, Response, StreamingResponse
 
 from llm_rosetta import get_converter_for_provider
 from llm_rosetta.auto_detect import ProviderType
-from llm_rosetta.converters.base.stream_context import StreamContext
+
 
 from .logging import (
     get_logger,
@@ -423,8 +423,8 @@ async def handle_streaming(
 
     async def event_generator() -> AsyncIterator[str]:
         """Stream SSE events from upstream, converting each chunk."""
-        from_ctx = StreamContext()  # upstream -> IR
-        to_ctx = StreamContext()  # IR -> source
+        from_ctx = target_converter.create_stream_context()  # upstream -> IR
+        to_ctx = source_converter.create_stream_context()  # IR -> source
         chunk_count = 0
         t0 = time.monotonic()
 

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -4,8 +4,10 @@ OpenAI Responses API stream converter unit tests.
 
 from typing import Any, cast
 
-from llm_rosetta.converters.base.stream_context import StreamContext
 from llm_rosetta.converters.openai_responses import OpenAIResponsesConverter
+from llm_rosetta.converters.openai_responses.stream_context import (
+    OpenAIResponsesStreamContext,
+)
 from llm_rosetta.types.ir.stream import (
     ContentBlockEndEvent,
     ContentBlockStartEvent,
@@ -408,7 +410,7 @@ class TestStreamResponseToProvider:
 
     def test_tool_call_delta_empty_id_resolved_by_index(self):
         """ToolCallDeltaEvent with empty tool_call_id resolved via context index."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         # Simulate a prior tool_call_start that registered the call
         ctx.register_tool_call("call_abc", "get_weather")
         ctx.register_tool_call_item("call_abc", "call_abc")
@@ -600,7 +602,7 @@ class TestStreamResponseFromProviderWithContext:
 
     def test_response_created_emits_stream_start(self):
         """response.created with context emits StreamStartEvent."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         event = {
             "type": "response.created",
             "response": {
@@ -638,7 +640,7 @@ class TestStreamResponseFromProviderWithContext:
 
     def test_response_completed_emits_stream_end(self):
         """response.completed with context emits StreamEndEvent after other events."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         ctx.mark_started()
         event = {
             "type": "response.completed",
@@ -666,7 +668,7 @@ class TestStreamResponseFromProviderWithContext:
 
     def test_response_failed_emits_stream_end(self):
         """response.failed with context emits StreamEndEvent after FinishEvent."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         ctx.mark_started()
         event = {
             "type": "response.failed",
@@ -686,7 +688,7 @@ class TestStreamResponseFromProviderWithContext:
 
     def test_output_item_added_function_call_registers_tool(self):
         """response.output_item.added (function_call) registers tool in context."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         event = {
             "type": "response.output_item.added",
             "output_index": 1,
@@ -710,7 +712,7 @@ class TestStreamResponseFromProviderWithContext:
 
         The actual content block is signaled by response.content_part.added.
         """
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         event = {
             "type": "response.output_item.added",
             "output_index": 0,
@@ -742,7 +744,7 @@ class TestStreamResponseFromProviderWithContext:
 
     def test_content_part_added_emits_content_block_start(self):
         """response.content_part.added with context emits ContentBlockStartEvent."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         event = {
             "type": "response.content_part.added",
             "part": {"type": "output_text", "text": ""},
@@ -758,7 +760,7 @@ class TestStreamResponseFromProviderWithContext:
 
     def test_content_part_added_summary_text(self):
         """response.content_part.added with summary_text maps to thinking block type."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         event = {
             "type": "response.content_part.added",
             "part": {"type": "summary_text", "text": ""},
@@ -781,7 +783,7 @@ class TestStreamResponseFromProviderWithContext:
 
     def test_content_part_done_emits_content_block_end(self):
         """response.content_part.done with context emits ContentBlockEndEvent."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         ctx.next_block_index()  # set to 0
         event = {
             "type": "response.content_part.done",
@@ -809,7 +811,7 @@ class TestStreamResponseFromProviderWithContext:
 
         The actual content block end is signaled by response.content_part.done.
         """
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         ctx.next_block_index()  # set to 0
         event = {
             "type": "response.output_item.done",
@@ -827,7 +829,7 @@ class TestStreamResponseFromProviderWithContext:
 
     def test_text_delta_unchanged_with_context(self):
         """Text delta behavior is unchanged when context is provided."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         event = {
             "type": "response.output_text.delta",
             "delta": "Hello",
@@ -863,7 +865,7 @@ class TestStreamResponseToProviderWithContext:
 
     def test_stream_start_event(self):
         """StreamStartEvent → response.created."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         event = cast(
             StreamStartEvent,
             {
@@ -901,7 +903,7 @@ class TestStreamResponseToProviderWithContext:
 
     def test_stream_end_event(self):
         """StreamEndEvent → empty dict."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         ctx.mark_started()
         event = cast(StreamEndEvent, {"type": "stream_end"})
         result = cast(
@@ -960,7 +962,7 @@ class TestStreamResponseToProviderWithContext:
 
     def test_usage_with_context_no_duplicate_completed(self):
         """UsageEvent with context stores usage, returns empty dict (no duplicate)."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         ctx.mark_started()
         event = cast(
             UsageEvent,
@@ -1001,7 +1003,7 @@ class TestStreamResponseToProviderWithContext:
 
     def test_finish_with_context_defers_response_completed(self):
         """FinishEvent with context defers response.completed to StreamEndEvent."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         ctx.mark_started()
         ctx.pending_usage = {
             "prompt_tokens": 10,
@@ -1038,7 +1040,7 @@ class TestStreamResponseToProviderWithContext:
 
     def test_finish_with_context_no_pending_usage(self):
         """FinishEvent with context but no pending usage omits usage field."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         ctx.mark_started()
         event = cast(
             FinishEvent,
@@ -1079,7 +1081,7 @@ class TestStreamResponseToProviderWithContext:
 
     def test_no_duplicate_response_completed_with_context(self):
         """With context, UsageEvent + FinishEvent + StreamEndEvent produce one response.completed."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         ctx.mark_started()
 
         # First: UsageEvent → stored in context, returns empty
@@ -1127,7 +1129,7 @@ class TestStreamResponseToProviderWithContext:
 
     def test_full_stream_sequence_with_context(self):
         """Full stream sequence produces correct events with no duplicates."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
 
         # 1. StreamStartEvent
         start_result = cast(
@@ -1265,7 +1267,7 @@ class TestStreamResponseToProviderWithContext:
 
     def test_cross_chunk_usage_after_finish(self):
         """UsageEvent arriving after FinishEvent (OpenAI Chat pattern) is merged."""
-        ctx = StreamContext()
+        ctx = OpenAIResponsesStreamContext()
         ctx.mark_started()
 
         # 1. FinishEvent arrives first (no pending_usage yet)


### PR DESCRIPTION
## Summary

Closes #65.

- Convert `StreamContext` from manual `__init__` to `@dataclass`, keeping only shared fields in the base class
- Extract 5 OpenAI Responses-specific fields (`output_item_emitted`, `item_id`, `accumulated_text`, `content_part_done_emitted`, `item_id_to_call_id`) into `OpenAIResponsesStreamContext` subclass
- Eliminate all 10 defensive `getattr()`/`hasattr()` patterns in the Responses converter — direct attribute access throughout
- Add `BaseConverter.create_stream_context()` factory method; gateway proxy uses it instead of hardcoded `StreamContext()`

## Test plan

- [x] 1260 tests passed (all non-integration)
- [x] ruff check + format clean
- [x] ty type check clean
- [x] Other converters (openai_chat, anthropic, google_genai) unaffected — they use base `StreamContext` only