### PR TITLE
refactor: replace Iterable with list/Sequence in IR types

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -15,8 +15,8 @@ Key Anthropic differences from OpenAI:
 """
 
 import time
+from collections.abc import Sequence
 from typing import Any, cast
-from collections.abc import Iterable
 
 from ...types.ir import (
     ExtensionItem,
@@ -400,7 +400,7 @@ class AnthropicConverter(BaseConverter):
 
     def messages_to_provider(
         self,
-        messages: Iterable[Message | ExtensionItem],
+        messages: Sequence[Message | ExtensionItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """Convert IR message list to Anthropic message format.

--- a/src/llm_rosetta/converters/anthropic/message_ops.py
+++ b/src/llm_rosetta/converters/anthropic/message_ops.py
@@ -12,8 +12,8 @@ Key Anthropic differences:
 - All content is block-based (no string shorthand in structured mode)
 """
 
+from collections.abc import Sequence
 from typing import Any, cast
-from collections.abc import Iterable
 
 from ...types.ir import (
     ContentPart,
@@ -56,7 +56,7 @@ class AnthropicMessageOps(BaseMessageOps):
 
     def ir_messages_to_p(
         self,
-        ir_messages: Iterable[Message | ExtensionItem],
+        ir_messages: Sequence[Message | ExtensionItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """IR Messages → Anthropic messages.
@@ -118,7 +118,7 @@ class AnthropicMessageOps(BaseMessageOps):
 
         return None, warnings
 
-    def _ir_system_to_p(self, content: Iterable) -> list[dict[str, Any]]:
+    def _ir_system_to_p(self, content: list) -> list[dict[str, Any]]:
         """Convert IR system message content to Anthropic system content blocks.
 
         Returns list of text blocks for the top-level ``system`` parameter.
@@ -130,7 +130,7 @@ class AnthropicMessageOps(BaseMessageOps):
         return blocks
 
     def _ir_user_to_p(
-        self, content: Iterable, warnings: list[str]
+        self, content: list, warnings: list[str]
     ) -> tuple[dict[str, Any], list[str]]:
         """Convert IR user message content to Anthropic user message.
 
@@ -163,7 +163,7 @@ class AnthropicMessageOps(BaseMessageOps):
         return {"role": "user", "content": anthropic_content}, warnings
 
     def _ir_assistant_to_p(
-        self, content: Iterable, warnings: list[str]
+        self, content: list, warnings: list[str]
     ) -> tuple[dict[str, Any], list[str]]:
         """Convert IR assistant message content to Anthropic assistant message.
 
@@ -197,7 +197,7 @@ class AnthropicMessageOps(BaseMessageOps):
         return {"role": "assistant", "content": anthropic_content}, warnings
 
     def _ir_tool_to_p(
-        self, content: Iterable, warnings: list[str]
+        self, content: list, warnings: list[str]
     ) -> tuple[Any, list[str]]:
         """Convert IR tool message content to Anthropic user message with tool_result.
 

--- a/src/llm_rosetta/converters/base/README_en.md
+++ b/src/llm_rosetta/converters/base/README_en.md
@@ -74,7 +74,7 @@ Handles message-level conversion. Serves as a bridge between content/tool layers
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `ir_messages_to_p` | `(ir_messages: Iterable[Message \| ExtensionItem]) → Tuple[List[Any], List[str]]` | Batch convert IR messages to provider format (abstract) |
+| `ir_messages_to_p` | `(ir_messages: Sequence[Message \| ExtensionItem]) → Tuple[List[Any], List[str]]` | Batch convert IR messages to provider format (abstract) |
 | `p_messages_to_ir` | `(provider_messages: List[Any]) → List[Message \| ExtensionItem]` | Batch convert provider messages to IR format (abstract) |
 | `ir_message_to_p` | `(ir_message) → Tuple[Any, List[str]]` | Single message convenience method (concrete) |
 | `p_message_to_ir` | `(provider_message) → Message \| ExtensionItem` | Single message convenience method (concrete) |
@@ -113,7 +113,7 @@ config_ops_class: Optional[Type] = None    # → BaseConfigOps subclass
 | `request_from_provider` | `(provider_request: Dict) → IRRequest` | Provider request → IR request |
 | `response_from_provider` | `(provider_response: Dict) → IRResponse` | Provider response → IR response |
 | `response_to_provider` | `(ir_response: IRResponse) → Dict` | IR response → provider response |
-| `messages_to_provider` | `(messages: Iterable[Message \| ExtensionItem]) → Tuple[List, List[str]]` | IR messages → provider messages |
+| `messages_to_provider` | `(messages: Sequence[Message \| ExtensionItem]) → Tuple[List, List[str]]` | IR messages → provider messages |
 | `messages_from_provider` | `(provider_messages: List) → List[Message \| ExtensionItem]` | Provider messages → IR messages |
 
 **Convenience methods** (concrete):

--- a/src/llm_rosetta/converters/base/README_zh.md
+++ b/src/llm_rosetta/converters/base/README_zh.md
@@ -74,7 +74,7 @@ L3  Converter       — request_to_provider / request_from_provider / response_*
 
 | 方法 | 签名 | 说明 |
 |------|------|------|
-| `ir_messages_to_p` | `(ir_messages: Iterable[Message \| ExtensionItem]) → Tuple[List[Any], List[str]]` | 批量转换 IR 消息到 provider 格式（抽象） |
+| `ir_messages_to_p` | `(ir_messages: Sequence[Message \| ExtensionItem]) → Tuple[List[Any], List[str]]` | 批量转换 IR 消息到 provider 格式（抽象） |
 | `p_messages_to_ir` | `(provider_messages: List[Any]) → List[Message \| ExtensionItem]` | 批量转换 provider 消息到 IR 格式（抽象） |
 | `ir_message_to_p` | `(ir_message) → Tuple[Any, List[str]]` | 单个消息便利方法（具体） |
 | `p_message_to_ir` | `(provider_message) → Message \| ExtensionItem` | 单个消息便利方法（具体） |
@@ -113,7 +113,7 @@ config_ops_class: Optional[Type] = None    # → BaseConfigOps 子类
 | `request_from_provider` | `(provider_request: Dict) → IRRequest` | Provider 请求 → IR 请求 |
 | `response_from_provider` | `(provider_response: Dict) → IRResponse` | Provider 响应 → IR 响应 |
 | `response_to_provider` | `(ir_response: IRResponse) → Dict` | IR 响应 → provider 响应 |
-| `messages_to_provider` | `(messages: Iterable[Message \| ExtensionItem]) → Tuple[List, List[str]]` | IR 消息 → provider 消息 |
+| `messages_to_provider` | `(messages: Sequence[Message \| ExtensionItem]) → Tuple[List, List[str]]` | IR 消息 → provider 消息 |
 | `messages_from_provider` | `(provider_messages: List) → List[Message \| ExtensionItem]` | Provider 消息 → IR 消息 |
 
 **便利方法**（具体）：

--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -6,8 +6,8 @@ Defines the basic interface for converters (abstract base class, functional doma
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from typing import Any, cast
-from collections.abc import Iterable
 
 from ...types.ir.extensions import ExtensionItem
 from ...types.ir.messages import Message
@@ -128,7 +128,7 @@ class BaseConverter(ABC):
     @abstractmethod
     def messages_to_provider(
         self,
-        messages: Iterable[Message | ExtensionItem],
+        messages: Sequence[Message | ExtensionItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """将消息列表转换为provider消息格式

--- a/src/llm_rosetta/converters/base/messages.py
+++ b/src/llm_rosetta/converters/base/messages.py
@@ -17,8 +17,8 @@ Note: This layer will call methods from content.py and tools.py to handle messag
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from typing import Any, cast
-from collections.abc import Iterable
 
 from ...types.ir.extensions import ExtensionItem
 from ...types.ir.messages import Message
@@ -37,7 +37,7 @@ class BaseMessageOps(ABC):
     @staticmethod
     @abstractmethod
     def ir_messages_to_p(
-        ir_messages: Iterable[Message | ExtensionItem], **kwargs: Any
+        ir_messages: Sequence[Message | ExtensionItem], **kwargs: Any
     ) -> tuple[list[Any], list[str]]:
         """IR Messages → Provider Messages
         将IR消息列表转换为Provider消息列表
@@ -141,7 +141,7 @@ class BaseMessageOps(ABC):
     # ==================== 辅助方法（子类可选实现） Helper methods (optional for subclasses) ====================
 
     def validate_messages(
-        self, messages: Iterable[Message | ExtensionItem]
+        self, messages: Sequence[Message | ExtensionItem]
     ) -> list[str]:
         """验证消息列表的有效性（可选实现）
         Validate message list validity (optional implementation)
@@ -157,8 +157,8 @@ class BaseMessageOps(ABC):
         """
         errors = []
 
-        if not isinstance(messages, Iterable) or isinstance(messages, (str, dict)):
-            errors.append("Messages must be an iterable (but not a string or dict)")
+        if not isinstance(messages, Sequence) or isinstance(messages, (str, bytes)):
+            errors.append("Messages must be a list or sequence")
             return errors
 
         for i, item in enumerate(messages):

--- a/src/llm_rosetta/converters/base/tools.py
+++ b/src/llm_rosetta/converters/base/tools.py
@@ -17,8 +17,8 @@ Handles all tool-related conversions:
 
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from typing import Any, cast
-from collections.abc import Iterable
 
 from ...types.ir import (
     Message,
@@ -204,7 +204,7 @@ def sanitize_schema(
 
 
 def fix_orphaned_tool_calls_ir(
-    messages: Iterable[Message],
+    messages: Sequence[Message],
     *,
     placeholder: str = "[No output available yet]",
 ) -> list[Message]:
@@ -354,7 +354,7 @@ def strip_orphaned_tool_config(ir_request: IRRequest) -> list[str]:
         List of warning strings for each stripped field.
     """
     tools = ir_request.get("tools")
-    has_tools = bool(tools and any(True for _ in tools))
+    has_tools = bool(tools)
 
     if has_tools:
         return []

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -16,8 +16,8 @@ Also maintains backward compatibility with the old to_provider/from_provider API
 
 import json
 import time
+from collections.abc import Sequence
 from typing import Any, cast
-from collections.abc import Iterable
 
 
 from ...types.ir import (
@@ -529,7 +529,7 @@ class GoogleGenAIConverter(BaseConverter):
 
     def messages_to_provider(
         self,
-        messages: Iterable[Message | ExtensionItem],
+        messages: Sequence[Message | ExtensionItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """Convert IR message list to Google GenAI Content format.
@@ -565,7 +565,7 @@ class GoogleGenAIConverter(BaseConverter):
 
     def build_config(
         self,
-        tools: Iterable[ToolDefinition] | None = None,
+        tools: Sequence[ToolDefinition] | None = None,
         tool_choice: ToolChoice | None = None,
     ) -> dict[str, Any] | None:
         """Build Google GenAI config parameters (backward compatibility).
@@ -592,7 +592,7 @@ class GoogleGenAIConverter(BaseConverter):
     def to_provider(
         self,
         ir_input: IRInput | IRRequest,
-        tools: Iterable[ToolDefinition] | None = None,
+        tools: Sequence[ToolDefinition] | None = None,
         tool_choice: ToolChoice | None = None,
         **kwargs: Any,
     ) -> tuple[dict[str, Any], list[str]]:

--- a/src/llm_rosetta/converters/google_genai/message_ops.py
+++ b/src/llm_rosetta/converters/google_genai/message_ops.py
@@ -14,8 +14,8 @@ Google-specific:
 """
 
 import warnings
+from collections.abc import Sequence
 from typing import Any, cast
-from collections.abc import Iterable
 
 from ...types.ir import (
     ContentPart,
@@ -73,7 +73,7 @@ class GoogleGenAIMessageOps(BaseMessageOps):
 
     def ir_messages_to_p(
         self,
-        ir_messages: Iterable[Message | ExtensionItem],
+        ir_messages: Sequence[Message | ExtensionItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """IR Messages → Google GenAI Content list + system_instruction.
@@ -227,7 +227,7 @@ class GoogleGenAIMessageOps(BaseMessageOps):
 
     @staticmethod
     def _reconcile_tool_call_ids(
-        ir_messages: list[Message | ExtensionItem],
+        ir_messages: Sequence[Message | ExtensionItem],
     ) -> None:
         """Match tool_result tool_call_ids to tool_call tool_call_ids by name.
 
@@ -380,7 +380,7 @@ class GoogleGenAIMessageOps(BaseMessageOps):
 
     @staticmethod
     def extract_system_instruction(
-        ir_messages: Iterable[Message | ExtensionItem],
+        ir_messages: Sequence[Message | ExtensionItem],
     ) -> tuple[Any, list[Message | ExtensionItem]]:
         """Extract system messages from IR message list.
 
@@ -399,7 +399,7 @@ class GoogleGenAIMessageOps(BaseMessageOps):
         for item in ir_messages:
             if is_message(item) and item.get("role") == "system":
                 parts: list[dict[str, str]] = []
-                for part in cast(Iterable[ContentPart], item.get("content", [])):
+                for part in cast(list[ContentPart], item.get("content", [])):
                     if is_text_part(part):
                         parts.append({"text": part["text"]})
                 if system_instruction is None:

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -6,8 +6,8 @@ Composes ContentOps, ToolOps, MessageOps, and ConfigOps for full bidirectional
 conversion between IR and OpenAI Chat Completions API format.
 """
 
+from collections.abc import Sequence
 from typing import Any, cast
-from collections.abc import Iterable
 
 from ...types.ir import (
     ExtensionItem,
@@ -445,7 +445,7 @@ class OpenAIChatConverter(BaseConverter):
 
     def messages_to_provider(
         self,
-        messages: Iterable[Message | ExtensionItem],
+        messages: Sequence[Message | ExtensionItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """Convert IR message list to OpenAI Chat message format.

--- a/src/llm_rosetta/converters/openai_chat/message_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/message_ops.py
@@ -7,8 +7,8 @@ Handles bidirectional conversion of system, user, assistant, and tool messages.
 This layer calls content_ops and tool_ops for part-level conversions.
 """
 
+from collections.abc import Sequence
 from typing import Any, cast
-from collections.abc import Iterable
 
 from ...types.ir import (
     ContentPart,
@@ -54,7 +54,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
 
     def ir_messages_to_p(
         self,
-        ir_messages: Iterable[Message | ExtensionItem],
+        ir_messages: Sequence[Message | ExtensionItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """IR Messages → OpenAI Chat messages.
@@ -184,7 +184,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
 
         return None, warnings
 
-    def _ir_system_to_p(self, content: Iterable) -> dict[str, Any]:
+    def _ir_system_to_p(self, content: list) -> dict[str, Any]:
         """Convert IR system message content to OpenAI system message.
 
         Concatenates all text parts into a single string.
@@ -196,7 +196,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
         return {"role": "system", "content": " ".join(text_parts)}
 
     def _ir_user_to_p(
-        self, content: Iterable, warnings: list[str]
+        self, content: list, warnings: list[str]
     ) -> tuple[Any, list[str]]:
         """Convert IR user message content to OpenAI user message(s).
 
@@ -249,7 +249,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
         return result_messages, warnings
 
     def _ir_assistant_to_p(
-        self, content: Iterable, warnings: list[str]
+        self, content: list, warnings: list[str]
     ) -> tuple[dict[str, Any], list[str]]:
         """Convert IR assistant message content to OpenAI assistant message.
 
@@ -301,7 +301,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
         return openai_message, warnings
 
     def _ir_tool_messages_to_p(
-        self, content: Iterable, warnings: list[str]
+        self, content: list, warnings: list[str]
     ) -> tuple[Any, list[str]]:
         """Convert IR tool message content to OpenAI tool role message(s).
 

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -9,8 +9,8 @@ Note: Responses API uses a flat list of items (input/output) instead of
 nested messages. The converter handles this structural difference.
 """
 
+from collections.abc import Sequence
 from typing import Any, cast
-from collections.abc import Iterable
 
 from ...types.ir import (
     ExtensionItem,
@@ -454,7 +454,7 @@ class OpenAIResponsesConverter(BaseConverter):
 
     def messages_to_provider(
         self,
-        messages: Iterable[Message | ExtensionItem],
+        messages: Sequence[Message | ExtensionItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """Convert IR message list to OpenAI Responses input items.

--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -12,8 +12,8 @@ Output items include messages, function_call, reasoning, etc.
 This layer calls content_ops and tool_ops for part-level conversions.
 """
 
+from collections.abc import Sequence
 from typing import Any, cast
-from collections.abc import Iterable
 
 from ...types.ir import (
     ContentPart,
@@ -53,7 +53,7 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
 
     def ir_messages_to_p(
         self,
-        ir_messages: Iterable[Message | ExtensionItem],
+        ir_messages: Sequence[Message | ExtensionItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """IR Messages → OpenAI Responses input items.
@@ -110,7 +110,7 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
         return [], warnings
 
     def _ir_input_message_to_p(
-        self, role: str, content: Iterable, warnings: list[str]
+        self, role: str, content: list, warnings: list[str]
     ) -> tuple[list[dict[str, Any]], list[str]]:
         """Convert IR system/user/developer message to Responses API items.
 
@@ -161,7 +161,7 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
         return result_items, warnings
 
     def _ir_assistant_to_p(
-        self, content: Iterable, warnings: list[str]
+        self, content: list, warnings: list[str]
     ) -> tuple[list[dict[str, Any]], list[str]]:
         """Convert IR assistant message to Responses API items.
 
@@ -213,7 +213,7 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
         return result_items, warnings
 
     def _ir_tool_messages_to_p(
-        self, content: Iterable, warnings: list[str]
+        self, content: list, warnings: list[str]
     ) -> tuple[list[dict[str, Any]], list[str]]:
         """Convert IR tool message content to Responses API function_call_output items.
 

--- a/src/llm_rosetta/types/ir/__init__.py
+++ b/src/llm_rosetta/types/ir/__init__.py
@@ -31,8 +31,6 @@ This module reorganizes IR type definitions:
 # ============================================================================
 # 向后兼容类型定义 Backward compatibility type definitions
 # ============================================================================
-from collections.abc import Iterable
-
 from .configs import (
     CacheConfig,
     GenerationConfig,
@@ -158,8 +156,10 @@ from .type_guards import (
 
 # 为了向后兼容，定义旧的类型别名
 # For backward compatibility, define old type aliases
-IRInput = Iterable[Message | ExtensionItem]
-IRInputSimple = Iterable[Message]
+from collections.abc import Sequence
+
+IRInput = Sequence[Message | ExtensionItem]
+IRInputSimple = Sequence[Message]
 
 
 # ============================================================================

--- a/src/llm_rosetta/types/ir/configs.py
+++ b/src/llm_rosetta/types/ir/configs.py
@@ -20,7 +20,6 @@ Contains various configuration parameters for controlling model generation behav
 """
 
 from typing import Any, Literal, TypedDict
-from collections.abc import Iterable
 
 # ============================================================================
 # 生成控制配置 Generation control configuration
@@ -68,7 +67,7 @@ class GenerationConfig(TypedDict, total=False):
     # OpenAI: stop (str | List[str])
     # Anthropic: stop_sequences (List[str])
     # Google: config.stop_sequences (List[str])
-    stop_sequences: Iterable[str]
+    stop_sequences: list[str]
 
     # 截断策略 Truncation strategy (OpenAI Responses, 少见)
     truncation: Literal["auto", "disabled"]

--- a/src/llm_rosetta/types/ir/extensions.py
+++ b/src/llm_rosetta/types/ir/extensions.py
@@ -7,7 +7,6 @@ IR extension type definitions for special scenario extensions
 
 import sys
 from typing import Any, Literal, TypedDict, TypeGuard, Union
-from collections.abc import Iterable
 
 if sys.version_info >= (3, 11):
     from typing import NotRequired, Required
@@ -107,9 +106,7 @@ class ToolChainNode(TypedDict):
     type: Required[Literal["tool_chain_node"]]
     node_id: Required[str]
     tool_call: Required[dict[str, Any]]  # ToolCallPart
-    depends_on: NotRequired[
-        Iterable[str]
-    ]  # 依赖的节点ID列表 List of dependent node IDs
+    depends_on: NotRequired[list[str]]  # 依赖的节点ID列表 List of dependent node IDs
     auto_execute: NotRequired[bool]  # 是否自动执行 Whether to auto execute
 
 

--- a/src/llm_rosetta/types/ir/messages.py
+++ b/src/llm_rosetta/types/ir/messages.py
@@ -7,7 +7,6 @@ IR message type definitions with independent role TypedDicts
 
 import sys
 from typing import Any, Literal, TypedDict, Union
-from collections.abc import Iterable
 
 if sys.version_info >= (3, 11):
     from typing import NotRequired, Required
@@ -59,7 +58,7 @@ class BaseMessage(TypedDict):
     Base message type, common foundation for all role messages.
     """
 
-    content: Required[Iterable[ContentPart]]
+    content: Required[list[ContentPart]]
     metadata: NotRequired[MessageMetadata]
 
 
@@ -81,7 +80,7 @@ class SystemMessage(TypedDict):
     """
 
     role: Required[Literal["system"]]
-    content: Required[Iterable[SystemContentPart]]
+    content: Required[list[SystemContentPart]]
     metadata: NotRequired[MessageMetadata]
 
 
@@ -98,7 +97,7 @@ class UserMessage(TypedDict):
     """
 
     role: Required[Literal["user"]]
-    content: Required[Iterable[UserContentPart]]
+    content: Required[list[UserContentPart]]
     metadata: NotRequired[MessageMetadata]
 
 
@@ -115,7 +114,7 @@ class AssistantMessage(TypedDict):
     """
 
     role: Required[Literal["assistant"]]
-    content: Required[Iterable[AssistantContentPart]]
+    content: Required[list[AssistantContentPart]]
     metadata: NotRequired[MessageMetadata]
 
 
@@ -135,7 +134,7 @@ class ToolMessage(TypedDict):
     """
 
     role: Required[Literal["tool"]]
-    content: Required[Iterable[ToolContentPart]]
+    content: Required[list[ToolContentPart]]
     metadata: NotRequired[MessageMetadata]
 
 
@@ -161,7 +160,7 @@ class LegacyMessage(TypedDict):
     """
 
     role: Required[Literal["system", "user", "assistant", "tool"]]
-    content: Required[Iterable[ContentPart]]
+    content: Required[list[ContentPart]]
     metadata: NotRequired[MessageMetadata]
 
 

--- a/src/llm_rosetta/types/ir/request.py
+++ b/src/llm_rosetta/types/ir/request.py
@@ -12,7 +12,6 @@ Unified request parameter types based on sdk_body_structures.md
 
 import sys
 from typing import Any, TypedDict
-from collections.abc import Iterable
 
 if sys.version_info >= (3, 11):
     from typing import NotRequired, Required
@@ -56,7 +55,7 @@ class IRRequest(TypedDict):
 
     # ========== 必需字段 Required Fields ==========
     model: Required[str]
-    messages: Required[Iterable[Message]]
+    messages: Required[list[Message]]
 
     # ========== 系统指令 System Instruction ==========
     # 映射关系:
@@ -64,10 +63,10 @@ class IRRequest(TypedDict):
     # - OpenAI Responses: instructions
     # - Anthropic: system
     # - Google: config.system_instruction
-    system_instruction: NotRequired[str | Iterable[dict[str, Any]]]
+    system_instruction: NotRequired[str | list[dict[str, Any]]]
 
     # ========== 工具相关 Tool Related ==========
-    tools: NotRequired[Iterable[ToolDefinition]]
+    tools: NotRequired[list[ToolDefinition]]
     tool_choice: NotRequired[ToolChoice]
     tool_config: NotRequired[ToolCallConfig]
 

--- a/src/llm_rosetta/types/ir/tools.py
+++ b/src/llm_rosetta/types/ir/tools.py
@@ -7,7 +7,6 @@ IR tool-related type definitions
 
 import sys
 from typing import Any, Literal, TypedDict
-from collections.abc import Iterable
 
 if sys.version_info >= (3, 11):
     from typing import NotRequired
@@ -41,7 +40,7 @@ class ToolDefinition(TypedDict):
     name: str
     description: str
     parameters: dict[str, Any]  # JSON Schema
-    required_parameters: NotRequired[Iterable[str]]
+    required_parameters: NotRequired[list[str]]
     metadata: NotRequired[dict[str, Any]]
 
 

--- a/tests/test_converters_base.py
+++ b/tests/test_converters_base.py
@@ -10,8 +10,8 @@ Tests for LLM-Rosetta Converters Base Module
 """
 
 from abc import ABC
+from collections.abc import Sequence
 from typing import Any, Union, cast
-from collections.abc import Iterable
 
 import pytest
 
@@ -138,7 +138,7 @@ class MockMessageOps(BaseMessageOps):
 
     @staticmethod
     def ir_messages_to_p(
-        ir_messages: Iterable[Union[Message, ExtensionItem]], **kwargs: Any
+        ir_messages: Sequence[Union[Message, ExtensionItem]], **kwargs: Any
     ) -> tuple[list[Any], list[str]]:
         provider_messages = []
         warnings = []
@@ -438,7 +438,7 @@ class MockConverter(BaseConverter):
         }
 
     def messages_to_provider(
-        self, messages: Iterable[Union[Message, ExtensionItem]], **kwargs: Any
+        self, messages: Sequence[Union[Message, ExtensionItem]], **kwargs: Any
     ) -> tuple[list[Any], list[str]]:
         return self.message_ops_class.ir_messages_to_p(messages, **kwargs)
 
@@ -802,14 +802,14 @@ class TestBaseMessageOps:
 
         # 无效消息 - 不是列表
         errors = self.message_ops.validate_messages(
-            cast(Iterable[Union[Message, ExtensionItem]], "not a list")
+            cast(Sequence[Union[Message, ExtensionItem]], "not a list")
         )
         assert len(errors) > 0
-        assert "must be an iterable" in errors[0]
+        assert "must be a list or sequence" in errors[0]
 
         # 无效消息 - 缺少role或type
         errors = self.message_ops.validate_messages(
-            cast(Iterable[Union[Message, ExtensionItem]], [{"some_field": "value"}])
+            cast(Sequence[Union[Message, ExtensionItem]], [{"some_field": "value"}])
         )
         assert len(errors) > 0
         assert "must have either 'role'" in errors[0]


### PR DESCRIPTION
## Summary

Closes #67.

- **TypedDict fields** (`IRRequest.messages`, `Message.content`, etc.): `Iterable[X]` → `list[X]` for concrete, indexable, serialization-friendly semantics
- **Function parameters** (`ir_messages_to_p`, `messages_to_provider`, etc.): `Iterable[X]` → `Sequence[X]` (covariant, read-only) to accept list/tuple without type variance issues
- **Type aliases** (`IRInput`, `IRInputSimple`): `Iterable[X]` → `Sequence[X]`
- **Bug fix**: `strip_orphaned_tool_config` had `any(True for _ in tools)` which would exhaust a generator — simplified to `bool(tools)`

## Test plan

- [x] `ruff check` — 0 errors
- [x] `ty check` — 0 errors (was 70 with all-`list` approach due to invariance)
- [x] `pytest` — 1260 passed
- [x] Verified argo-proxy and toolregistry don't pass non-list types