### PR TITLE
refactor: normalize ImagePart, FilePart, AudioPart to canonical forms

### DIFF
--- a/src/llm_rosetta/converters/anthropic/content_ops.py
+++ b/src/llm_rosetta/converters/anthropic/content_ops.py
@@ -101,19 +101,6 @@ class AnthropicContentOps(BaseContentOps):
                 "source": {"type": "url", "url": image_url},
             }
 
-        # Top-level data + media_type (e.g. from Google GenAI converter)
-        raw_data = ir_image.get("data")
-        media_type = ir_image.get("media_type")
-        if raw_data and media_type:
-            return {
-                "type": "image",
-                "source": {
-                    "type": "base64",
-                    "media_type": media_type,
-                    "data": raw_data,
-                },
-            }
-
         raise ValueError("ImagePart must have either image_url or image_data")
 
     @staticmethod

--- a/src/llm_rosetta/converters/google_genai/content_ops.py
+++ b/src/llm_rosetta/converters/google_genai/content_ops.py
@@ -12,9 +12,11 @@ import warnings
 from typing import Any, cast
 
 from ...types.ir import (
+    AudioData,
     AudioPart,
     CitationPart,
     FilePart,
+    ImageData,
     ImagePart,
     ReasoningPart,
     RefusalPart,
@@ -83,16 +85,6 @@ class GoogleGenAIContentOps(BaseContentOps):
         Returns:
             Google inline_data Part dict, or None if unsupported format.
         """
-        # Direct data and media_type fields
-        if "data" in ir_image and "media_type" in ir_image:
-            return {
-                "inlineData": {
-                    "mimeType": ir_image["media_type"],
-                    "data": ir_image["data"],
-                }
-            }
-
-        # image_data nested structure
         if "image_data" in ir_image:
             image_data = ir_image["image_data"]
             return {
@@ -125,11 +117,15 @@ class GoogleGenAIContentOps(BaseContentOps):
         inline_data = provider_image.get("inline_data") or provider_image.get(
             "inlineData", {}
         )
-        return {
-            "type": "image",
-            "data": inline_data.get("data", ""),
-            "media_type": inline_data.get("mime_type", inline_data.get("mimeType", "")),
-        }
+        return ImagePart(
+            type="image",
+            image_data=ImageData(
+                data=inline_data.get("data", ""),
+                media_type=inline_data.get(
+                    "mime_type", inline_data.get("mimeType", "")
+                ),
+            ),
+        )
 
     # ==================== File ====================
 
@@ -143,16 +139,6 @@ class GoogleGenAIContentOps(BaseContentOps):
         Returns:
             Google inline_data Part dict, or None if unsupported format.
         """
-        # Direct data and media_type fields
-        if "data" in ir_file and "media_type" in ir_file:
-            return {
-                "inlineData": {
-                    "mimeType": ir_file["media_type"],
-                    "data": ir_file["data"],
-                }
-            }
-
-        # file_data nested structure
         if "file_data" in ir_file:
             file_data = ir_file["file_data"]
             return {
@@ -204,14 +190,6 @@ class GoogleGenAIContentOps(BaseContentOps):
         Returns:
             Google inline_data Part dict, or None if unsupported format.
         """
-        if "data" in ir_audio and "media_type" in ir_audio:
-            return {
-                "inlineData": {
-                    "mimeType": ir_audio["media_type"],
-                    "data": ir_audio["data"],
-                }
-            }
-
         if "audio_data" in ir_audio:
             audio_data = ir_audio["audio_data"]
             return {
@@ -240,15 +218,18 @@ class GoogleGenAIContentOps(BaseContentOps):
         if raw_inline:
             return AudioPart(
                 type="audio",
-                data=raw_inline.get("data", ""),
-                media_type=raw_inline.get("mime_type", raw_inline.get("mimeType", "")),
+                audio_data=AudioData(
+                    data=raw_inline.get("data", ""),
+                    media_type=raw_inline.get(
+                        "mime_type", raw_inline.get("mimeType", "")
+                    ),
+                ),
             )
         raw_file = provider_audio.get("file_data") or provider_audio.get("fileData")
         if raw_file:
             return AudioPart(
                 type="audio",
                 url=raw_file.get("file_uri", raw_file.get("fileUri", "")),
-                media_type=raw_file.get("mime_type", raw_file.get("mimeType", "")),
             )
         raise ValueError("Audio part must have inline_data or file_data")
 
@@ -421,7 +402,6 @@ class GoogleGenAIContentOps(BaseContentOps):
                     AudioPart(
                         type="audio",
                         url=file_data["file_uri"],
-                        media_type=mime_type,
                     )
                 )
             else:

--- a/src/llm_rosetta/converters/openai_chat/content_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/content_ops.py
@@ -92,16 +92,6 @@ class OpenAIChatContentOps(BaseContentOps):
                 "image_url": {"url": data_url, "detail": detail},
             }
 
-        # Top-level data + media_type (e.g. from Google GenAI converter)
-        raw_data = ir_image.get("data")
-        media_type = ir_image.get("media_type")
-        if raw_data and media_type:
-            data_url = f"data:{media_type};base64,{raw_data}"
-            return {
-                "type": "image_url",
-                "image_url": {"url": data_url, "detail": detail},
-            }
-
         raise ValueError("ImagePart must have either image_url or image_data")
 
     @staticmethod

--- a/src/llm_rosetta/converters/openai_responses/content_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/content_ops.py
@@ -105,10 +105,8 @@ class OpenAIResponsesContentOps(BaseContentOps):
         elif image_data:
             data_url = f"data:{image_data['media_type']};base64,{image_data['data']}"
             result["image_url"] = data_url
-        elif ir_image.get("data") and ir_image.get("media_type"):
-            # Top-level data + media_type (e.g. from Google GenAI converter)
-            data_url = f"data:{ir_image['media_type']};base64,{ir_image['data']}"
-            result["image_url"] = data_url
+        elif "provider_ref" in ir_image and "file_id" in ir_image["provider_ref"]:
+            result["file_id"] = ir_image["provider_ref"]["file_id"]
         else:
             raise ValueError("Image part must have either image_url/url or image_data")
 
@@ -144,10 +142,9 @@ class OpenAIResponsesContentOps(BaseContentOps):
             else:
                 return ImagePart(type="image", image_url=url, detail=detail)
         elif "file_id" in provider_image:
-            # File ID form, store as-is
             return ImagePart(
                 type="image",
-                file_id=provider_image["file_id"],
+                provider_ref={"file_id": provider_image["file_id"]},
                 detail=detail,
             )
 
@@ -179,6 +176,8 @@ class OpenAIResponsesContentOps(BaseContentOps):
             result["file_data"] = ir_file["file_data"]["data"]
         elif "file_url" in ir_file:
             result["file_url"] = ir_file["file_url"]
+        elif "provider_ref" in ir_file and "file_id" in ir_file["provider_ref"]:
+            result["file_id"] = ir_file["provider_ref"]["file_id"]
         else:
             raise ValueError("File part must have either file_data or file_url")
 
@@ -213,7 +212,7 @@ class OpenAIResponsesContentOps(BaseContentOps):
             return FilePart(
                 type="file",
                 file_name=file_name,
-                file_id=provider_file["file_id"],
+                provider_ref={"file_id": provider_file["file_id"]},
             )
 
         return FilePart(type="file", file_name=file_name)

--- a/src/llm_rosetta/types/__init__.py
+++ b/src/llm_rosetta/types/__init__.py
@@ -20,6 +20,7 @@ from .ir import (
     RefusalPart,
     CitationPart,
     AudioPart,
+    AudioData,
     # Role-specific content types
     SystemContentPart,
     UserContentPart,
@@ -103,6 +104,7 @@ __all__ = [
     "RefusalPart",
     "CitationPart",
     "AudioPart",
+    "AudioData",
     # Role-specific content types
     "SystemContentPart",
     "UserContentPart",

--- a/src/llm_rosetta/types/ir/__init__.py
+++ b/src/llm_rosetta/types/ir/__init__.py
@@ -81,6 +81,7 @@ from .messages import (
 # 内容部分类型 Content part types
 from .parts import (
     AssistantContentPart,
+    AudioData,
     AudioPart,
     CitationPart,
     ContentPart,
@@ -180,6 +181,7 @@ __all__ = [
     "RefusalPart",
     "CitationPart",
     "AudioPart",
+    "AudioData",
     # 角色特定内容类型 Role-specific content types
     "SystemContentPart",
     "UserContentPart",

--- a/src/llm_rosetta/types/ir/parts.py
+++ b/src/llm_rosetta/types/ir/parts.py
@@ -45,10 +45,10 @@ class ImagePart(TypedDict):
     type: Required[Literal["image"]]
     image_url: NotRequired[str]  # URL形式 URL form
     image_data: NotRequired[ImageData]  # base64形式 base64 form
-    data: NotRequired[str]  # 直接base64数据 Direct base64 data
-    media_type: NotRequired[str]  # 直接MIME类型 Direct MIME type
     detail: NotRequired[Literal["auto", "low", "high"]]  # OpenAI特性 OpenAI feature
-    file_id: NotRequired[str]  # OpenAI file ID
+    provider_ref: NotRequired[
+        dict[str, Any]
+    ]  # Provider-specific reference (e.g. file_id)
 
 
 class FileData(TypedDict):
@@ -76,9 +76,9 @@ class FilePart(TypedDict):
     file_data: NotRequired[FileData]  # base64形式 base64 form
     file_name: NotRequired[str]
     file_type: NotRequired[str]  # MIME type
-    file_id: NotRequired[str]  # OpenAI file ID
-    data: NotRequired[str]  # 直接base64数据 Direct base64 data
-    media_type: NotRequired[str]  # 直接MIME类型 Direct MIME type
+    provider_ref: NotRequired[
+        dict[str, Any]
+    ]  # Provider-specific reference (e.g. file_id)
 
 
 # ============================================================================
@@ -239,14 +239,14 @@ class AudioPart(TypedDict):
     """
 
     type: Required[Literal["audio"]]
-    audio_id: NotRequired[str]  # 音频ID Audio ID
     audio_data: NotRequired[AudioData]  # base64形式 base64 form
-    data: NotRequired[str]  # 直接base64数据 Direct base64 data
-    media_type: NotRequired[str]  # 直接MIME类型 Direct MIME type
     url: NotRequired[str]  # URL形式 URL form
     detail: NotRequired[
         Literal["auto", "low", "high"]
     ]  # 音频细节级别 Audio detail level
+    provider_ref: NotRequired[
+        dict[str, Any]
+    ]  # Provider-specific reference (e.g. audio_id)
 
 
 # ============================================================================

--- a/tests/converters/anthropic/test_content_ops.py
+++ b/tests/converters/anthropic/test_content_ops.py
@@ -183,7 +183,7 @@ class TestAnthropicContentOps:
     def test_ir_audio_to_p_raises(self):
         """Test ir_audio_to_p raises NotImplementedError."""
         with pytest.raises(NotImplementedError, match="does not support audio"):
-            AnthropicContentOps.ir_audio_to_p({"type": "audio", "audio_id": "a1"})
+            AnthropicContentOps.ir_audio_to_p({"type": "audio"})
 
     def test_p_audio_to_ir_raises(self):
         """Test p_audio_to_ir raises NotImplementedError."""

--- a/tests/converters/google_genai/test_content_ops.py
+++ b/tests/converters/google_genai/test_content_ops.py
@@ -50,11 +50,11 @@ class TestGoogleGenAIContentOps:
 
     # ==================== Image ====================
 
-    def test_ir_image_to_p_with_direct_data(self):
-        """Test IR ImagePart with direct data → Google inline_data Part."""
-        ir_image = cast(
-            ImagePart,
-            {"type": "image", "data": "base64data", "media_type": "image/jpeg"},
+    def test_ir_image_to_p_with_image_data_structured(self):
+        """Test IR ImagePart with image_data → Google inline_data Part."""
+        ir_image = ImagePart(
+            type="image",
+            image_data={"data": "base64data", "media_type": "image/jpeg"},
         )
         result = GoogleGenAIContentOps.ir_image_to_p(ir_image)
         assert result is not None
@@ -84,26 +84,28 @@ class TestGoogleGenAIContentOps:
         provider = {"inline_data": {"mime_type": "image/jpeg", "data": "base64data"}}
         result = GoogleGenAIContentOps.p_image_to_ir(provider)
         assert result["type"] == "image"
-        assert result["data"] == "base64data"
-        assert result["media_type"] == "image/jpeg"
+        assert result["image_data"]["data"] == "base64data"
+        assert result["image_data"]["media_type"] == "image/jpeg"
 
     def test_image_round_trip(self):
-        """Test image round-trip with direct data."""
-        original = cast(
-            ImagePart, {"type": "image", "data": "imgdata", "media_type": "image/gif"}
+        """Test image round-trip with image_data."""
+        original = ImagePart(
+            type="image",
+            image_data={"data": "imgdata", "media_type": "image/gif"},
         )
         provider = GoogleGenAIContentOps.ir_image_to_p(original)
         assert provider is not None
         restored = GoogleGenAIContentOps.p_image_to_ir(provider)
-        assert restored["data"] == "imgdata"
-        assert restored["media_type"] == "image/gif"
+        assert restored["image_data"]["data"] == "imgdata"
+        assert restored["image_data"]["media_type"] == "image/gif"
 
     # ==================== File ====================
 
-    def test_ir_file_to_p_with_direct_data(self):
-        """Test IR FilePart with direct data → Google inline_data Part."""
-        ir_file = cast(
-            FilePart, {"type": "file", "data": "filedata", "media_type": "text/csv"}
+    def test_ir_file_to_p_with_file_data_structured(self):
+        """Test IR FilePart with file_data → Google inline_data Part."""
+        ir_file = FilePart(
+            type="file",
+            file_data={"data": "filedata", "media_type": "text/csv"},
         )
         result = GoogleGenAIContentOps.ir_file_to_p(ir_file)
         assert result is not None
@@ -142,10 +144,11 @@ class TestGoogleGenAIContentOps:
 
     # ==================== Audio ====================
 
-    def test_ir_audio_to_p_with_direct_data(self):
-        """Test IR AudioPart with direct data → Google inline_data Part."""
-        ir_audio = cast(
-            AudioPart, {"type": "audio", "data": "audiodata", "media_type": "audio/wav"}
+    def test_ir_audio_to_p_with_audio_data_structured(self):
+        """Test IR AudioPart with audio_data → Google inline_data Part."""
+        ir_audio = AudioPart(
+            type="audio",
+            audio_data={"data": "audiodata", "media_type": "audio/wav"},
         )
         result = GoogleGenAIContentOps.ir_audio_to_p(ir_audio)
         assert result is not None
@@ -164,7 +167,8 @@ class TestGoogleGenAIContentOps:
         provider = {"inline_data": {"mime_type": "audio/wav", "data": "audiodata"}}
         result = GoogleGenAIContentOps.p_audio_to_ir(provider)
         assert result["type"] == "audio"
-        assert result["media_type"] == "audio/wav"
+        assert result["audio_data"]["data"] == "audiodata"
+        assert result["audio_data"]["media_type"] == "audio/wav"
 
     def test_p_audio_to_ir_file_data(self):
         """Test Google file_data audio Part → IR AudioPart."""
@@ -273,8 +277,8 @@ class TestGoogleGenAIContentOps:
         )
         assert len(parts) == 1
         assert parts[0]["type"] == "image"
-        assert parts[0]["data"] == "imgdata"
-        assert parts[0]["media_type"] == "image/png"
+        assert parts[0]["image_data"]["data"] == "imgdata"
+        assert parts[0]["image_data"]["media_type"] == "image/png"
 
     def test_p_part_to_ir_camelcase_file_data(self):
         """Test p_part_to_ir handles camelCase fileData."""
@@ -290,7 +294,8 @@ class TestGoogleGenAIContentOps:
         provider = {"inlineData": {"mimeType": "audio/wav", "data": "audiodata"}}
         result = GoogleGenAIContentOps.p_audio_to_ir(provider)
         assert result["type"] == "audio"
-        assert result["media_type"] == "audio/wav"
+        assert result["audio_data"]["data"] == "audiodata"
+        assert result["audio_data"]["media_type"] == "audio/wav"
 
     def test_p_part_to_ir_empty_text_ignored(self):
         """Test p_part_to_ir ignores empty text."""

--- a/tests/converters/google_genai/test_message_ops.py
+++ b/tests/converters/google_genai/test_message_ops.py
@@ -125,8 +125,10 @@ class TestGoogleGenAIMessageOps:
                     "content": [
                         {
                             "type": "image",
-                            "data": "base64data",
-                            "media_type": "image/jpeg",
+                            "image_data": {
+                                "data": "base64data",
+                                "media_type": "image/jpeg",
+                            },
                         }
                     ],
                 }
@@ -170,8 +172,10 @@ class TestGoogleGenAIMessageOps:
                         {"type": "text", "text": "What is this?"},
                         {
                             "type": "image",
-                            "data": "imgdata",
-                            "media_type": "image/png",
+                            "image_data": {
+                                "data": "imgdata",
+                                "media_type": "image/png",
+                            },
                         },
                         {"type": "text", "text": "Please describe it."},
                     ],

--- a/tests/converters/openai_chat/test_content_ops.py
+++ b/tests/converters/openai_chat/test_content_ops.py
@@ -133,7 +133,7 @@ class TestOpenAIChatContentOps:
     def test_ir_audio_to_p_raises(self):
         """Test ir_audio_to_p raises NotImplementedError."""
         with pytest.raises(NotImplementedError, match="does not support audio"):
-            OpenAIChatContentOps.ir_audio_to_p({"type": "audio", "audio_id": "a1"})
+            OpenAIChatContentOps.ir_audio_to_p({"type": "audio"})
 
     def test_p_audio_to_ir_raises(self):
         """Test p_audio_to_ir raises NotImplementedError."""

--- a/tests/converters/openai_responses/test_content_ops.py
+++ b/tests/converters/openai_responses/test_content_ops.py
@@ -137,7 +137,7 @@ class TestOpenAIResponsesContentOps:
         assert result["detail"] == "high"
 
     def test_p_image_to_ir_with_file_id(self):
-        """Test OpenAI Responses file_id image → IR dict with file_id."""
+        """Test OpenAI Responses file_id image → IR dict with provider_ref."""
         provider = {
             "type": "input_image",
             "file_id": "file-abc123",
@@ -145,7 +145,7 @@ class TestOpenAIResponsesContentOps:
         }
         result = OpenAIResponsesContentOps.p_image_to_ir(provider)
         assert result["type"] == "image"
-        assert result["file_id"] == "file-abc123"
+        assert result["provider_ref"]["file_id"] == "file-abc123"
 
     def test_image_url_round_trip(self):
         """Test image URL round-trip."""
@@ -228,7 +228,7 @@ class TestOpenAIResponsesContentOps:
         assert result["file_url"] == "https://example.com/test.txt"
 
     def test_p_file_to_ir_with_file_id(self):
-        """Test OpenAI Responses input_file with file_id → IR dict."""
+        """Test OpenAI Responses input_file with file_id → IR dict with provider_ref."""
         provider = {
             "type": "input_file",
             "filename": "test.txt",
@@ -236,14 +236,14 @@ class TestOpenAIResponsesContentOps:
         }
         result = OpenAIResponsesContentOps.p_file_to_ir(provider)
         assert result["type"] == "file"
-        assert result["file_id"] == "file-xyz"
+        assert result["provider_ref"]["file_id"] == "file-xyz"
 
     # ==================== Audio (not supported) ====================
 
     def test_ir_audio_to_p_raises(self):
         """Test ir_audio_to_p raises NotImplementedError."""
         with pytest.raises(NotImplementedError, match="does not support audio"):
-            OpenAIResponsesContentOps.ir_audio_to_p({"type": "audio", "audio_id": "a1"})
+            OpenAIResponsesContentOps.ir_audio_to_p({"type": "audio"})
 
     def test_p_audio_to_ir_raises(self):
         """Test p_audio_to_ir raises NotImplementedError."""

--- a/tests/test_converters_base.py
+++ b/tests/test_converters_base.py
@@ -102,11 +102,18 @@ class MockContentOps(BaseContentOps):
 
     @staticmethod
     def ir_audio_to_p(ir_audio: AudioPart, **kwargs: Any) -> dict[str, Any]:
-        return {"type": "audio", "id": ir_audio["audio_id"]}
+        audio_data = ir_audio.get("audio_data", {})
+        return {"type": "audio", "data": audio_data.get("data", "")}
 
     @staticmethod
     def p_audio_to_ir(provider_audio: Any, **kwargs: Any) -> AudioPart:
-        return {"type": "audio", "audio_id": provider_audio.get("id", "unknown")}
+        return {
+            "type": "audio",
+            "audio_data": {
+                "data": provider_audio.get("data", ""),
+                "media_type": "audio/wav",
+            },
+        }
 
     @staticmethod
     def ir_reasoning_to_p(ir_reasoning: ReasoningPart, **kwargs: Any) -> dict[str, Any]:

--- a/tests/test_ir_types.py
+++ b/tests/test_ir_types.py
@@ -206,10 +206,14 @@ class TestContentParts:
 
     def test_audio_part_creation(self):
         """测试音频部分创建"""
-        audio: AudioPart = {"type": "audio", "audio_id": "audio_123", "detail": "high"}
+        audio: AudioPart = {
+            "type": "audio",
+            "audio_data": {"data": "base64audio", "media_type": "audio/wav"},
+            "detail": "high",
+        }
 
         assert audio["type"] == "audio"
-        assert audio["audio_id"] == "audio_123"
+        assert audio["audio_data"]["data"] == "base64audio"
         assert is_part_type(audio, AudioPart)
 
 

--- a/tests/test_types/ir/test_ir_types.py
+++ b/tests/test_types/ir/test_ir_types.py
@@ -206,10 +206,14 @@ class TestContentParts:
 
     def test_audio_part_creation(self):
         """测试音频部分创建"""
-        audio: AudioPart = {"type": "audio", "audio_id": "audio_123", "detail": "high"}
+        audio: AudioPart = {
+            "type": "audio",
+            "audio_data": {"data": "base64audio", "media_type": "audio/wav"},
+            "detail": "high",
+        }
 
         assert audio["type"] == "audio"
-        assert audio["audio_id"] == "audio_123"
+        assert audio["audio_data"]["data"] == "base64audio"
         assert is_part_type(audio, AudioPart)
 
 


### PR DESCRIPTION
## Summary

Closes #68

- Normalize `ImagePart`, `FilePart`, and `AudioPart` to exactly 2 canonical data forms (URL + structured inline data) plus a unified `provider_ref: dict[str, Any]` for provider-specific references
- Fix Google GenAI converter (root cause) to emit `image_data: ImageData` / `audio_data: AudioData` instead of top-level `data` + `media_type`
- Remove band-aid fallbacks from Anthropic, OpenAI Chat, and OpenAI Responses converters that were working around the non-canonical format
- Replace provider-specific ID fields (`file_id`, `audio_id`) with `provider_ref` dict in OpenAI Responses converter

## Removed fields

| Type | Removed | Added |
|------|---------|-------|
| `ImagePart` | `data`, `media_type`, `file_id` | `provider_ref: NotRequired[dict[str, Any]]` |
| `FilePart` | `data`, `media_type`, `file_id` | `provider_ref: NotRequired[dict[str, Any]]` |
| `AudioPart` | `data`, `media_type`, `audio_id` | `provider_ref: NotRequired[dict[str, Any]]` |

## Test plan

- [x] `ruff check --fix && ruff format` — all clean
- [x] `ty check` — 0 errors
- [x] `pytest --ignore=tests/integration` — 1260 passed, 0 failed