### PR TITLE
refactor: extract shared utility functions in openai_responses

### DIFF
--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -44,12 +44,12 @@ from ._constants import (
     RESPONSES_REASON_TO_STATUS,
     RESPONSES_STATUS_TO_REASON,
     ResponsesEventType,
-    generate_message_id,
 )
 from .config_ops import OpenAIResponsesConfigOps
 from .content_ops import OpenAIResponsesContentOps
 from .message_ops import OpenAIResponsesMessageOps
 from .tool_ops import OpenAIResponsesToolOps
+from .utils import build_message_preamble_events, resolve_call_id
 
 
 class OpenAIResponsesConverter(BaseConverter):
@@ -735,12 +735,7 @@ class OpenAIResponsesConverter(BaseConverter):
         events: list[IRStreamEvent],
     ) -> None:
         delta_text = chunk.get("delta", "")
-        # Upstream may send call_id or item_id — resolve to call_id
-        call_id = chunk.get("call_id", "")
-        if not call_id and isinstance(context, OpenAIResponsesStreamContext):
-            item_id = chunk.get("item_id", "")
-            if item_id:
-                call_id = context.item_id_to_call_id.get(item_id, "")
+        call_id = resolve_call_id(chunk, context)
         delta_event = ToolCallDeltaEvent(
             type="tool_call_delta",
             tool_call_id=call_id,
@@ -762,12 +757,7 @@ class OpenAIResponsesConverter(BaseConverter):
         context: StreamContext | None,
         events: list[IRStreamEvent],
     ) -> None:
-        # Resolve call_id from item_id if needed
-        call_id = chunk.get("call_id", "")
-        if not call_id and isinstance(context, OpenAIResponsesStreamContext):
-            item_id = chunk.get("item_id", "")
-            if item_id:
-                call_id = context.item_id_to_call_id.get(item_id, "")
+        call_id = resolve_call_id(chunk, context)
         arguments = chunk.get("arguments", "")
         # Store final arguments in context
         if context is not None and call_id:
@@ -950,30 +940,7 @@ class OpenAIResponsesConverter(BaseConverter):
             # and mark the item as emitted so the first TextDelta doesn't
             # re-emit them.
             if context is not None and not context.output_item_emitted:
-                context.output_item_emitted = True
-                item_id = generate_message_id(context.response_id)
-                context.item_id = item_id
-                return [
-                    {
-                        "type": ResponsesEventType.OUTPUT_ITEM_ADDED,
-                        "output_index": 0,
-                        "item": {
-                            "id": item_id,
-                            "type": "message",
-                            "role": "assistant",
-                            "content": [],
-                        },
-                    },
-                    {
-                        "type": ResponsesEventType.CONTENT_PART_ADDED,
-                        "output_index": 0,
-                        "content_index": 0,
-                        "part": {
-                            "type": "output_text",
-                            "text": "",
-                        },
-                    },
-                ]
+                return build_message_preamble_events(context, output_index=0)
             # Fallback: just emit content_part.added (e.g. no context, or
             # output item already emitted by a prior ContentBlockStartEvent)
             return {
@@ -1038,31 +1005,8 @@ class OpenAIResponsesConverter(BaseConverter):
         # Emit output_item.added + content_part.added before the first
         # text delta so clients (e.g. Codex CLI) can register the item.
         if context is not None and not context.output_item_emitted:
-            context.output_item_emitted = True
-            item_id = generate_message_id(context.response_id)
-            context.item_id = item_id
-            return [
-                {
-                    "type": ResponsesEventType.OUTPUT_ITEM_ADDED,
-                    "output_index": choice_index,
-                    "item": {
-                        "id": item_id,
-                        "type": "message",
-                        "role": "assistant",
-                        "content": [],
-                    },
-                },
-                {
-                    "type": ResponsesEventType.CONTENT_PART_ADDED,
-                    "output_index": choice_index,
-                    "content_index": 0,
-                    "part": {
-                        "type": "output_text",
-                        "text": "",
-                    },
-                },
-                delta_event,
-            ]
+            preamble = build_message_preamble_events(context, output_index=choice_index)
+            return preamble + [delta_event]
 
         return delta_event
 

--- a/src/llm_rosetta/converters/openai_responses/utils.py
+++ b/src/llm_rosetta/converters/openai_responses/utils.py
@@ -1,0 +1,76 @@
+"""OpenAI Responses converter utilities — shared helpers for stream conversion."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..base.stream_context import StreamContext
+from ._constants import ResponsesEventType, generate_message_id
+from .stream_context import OpenAIResponsesStreamContext
+
+
+def resolve_call_id(chunk: dict[str, Any], context: StreamContext | None) -> str:
+    """Resolve a tool call_id from a Responses API event chunk.
+
+    The Responses API may provide either ``call_id`` or ``item_id`` on
+    function-call-related events.  When only ``item_id`` is present and
+    the context carries an item-to-call-id mapping, the call_id is
+    resolved via that mapping.
+
+    Args:
+        chunk: Responses API event dict.
+        context: Stream context (must be ``OpenAIResponsesStreamContext``
+            for item_id resolution to work).
+
+    Returns:
+        The resolved call_id, or ``""`` if unresolvable.
+    """
+    call_id = chunk.get("call_id", "")
+    if not call_id and isinstance(context, OpenAIResponsesStreamContext):
+        item_id = chunk.get("item_id", "")
+        if item_id:
+            call_id = context.item_id_to_call_id.get(item_id, "")
+    return call_id
+
+
+def build_message_preamble_events(
+    context: OpenAIResponsesStreamContext,
+    output_index: int = 0,
+) -> list[dict[str, Any]]:
+    """Build output_item.added + content_part.added for a new message item.
+
+    Marks the context as having emitted the output item and generates
+    the item_id.  Must only be called when ``context.output_item_emitted``
+    is ``False``.
+
+    Args:
+        context: Responses stream context.
+        output_index: The output array index for the item.
+
+    Returns:
+        Two-element list of SSE event dicts.
+    """
+    context.output_item_emitted = True
+    item_id = generate_message_id(context.response_id)
+    context.item_id = item_id
+    return [
+        {
+            "type": ResponsesEventType.OUTPUT_ITEM_ADDED,
+            "output_index": output_index,
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+            },
+        },
+        {
+            "type": ResponsesEventType.CONTENT_PART_ADDED,
+            "output_index": output_index,
+            "content_index": 0,
+            "part": {
+                "type": "output_text",
+                "text": "",
+            },
+        },
+    ]

--- a/tests/converters/openai_responses/test_utils.py
+++ b/tests/converters/openai_responses/test_utils.py
@@ -1,0 +1,98 @@
+"""Tests for openai_responses utility functions."""
+
+from llm_rosetta.converters.base.stream_context import StreamContext
+from llm_rosetta.converters.openai_responses._constants import ResponsesEventType
+from llm_rosetta.converters.openai_responses.stream_context import (
+    OpenAIResponsesStreamContext,
+)
+from llm_rosetta.converters.openai_responses.utils import (
+    build_message_preamble_events,
+    resolve_call_id,
+)
+
+
+class TestResolveCallId:
+    """Tests for resolve_call_id."""
+
+    def test_returns_call_id_when_present(self):
+        chunk = {"call_id": "call_abc", "item_id": "item_xyz"}
+        assert resolve_call_id(chunk, None) == "call_abc"
+
+    def test_falls_back_to_item_id_mapping(self):
+        ctx = OpenAIResponsesStreamContext()
+        ctx.item_id_to_call_id["item_xyz"] = "call_abc"
+        chunk = {"item_id": "item_xyz"}
+        assert resolve_call_id(chunk, ctx) == "call_abc"
+
+    def test_returns_empty_when_no_call_id_and_no_item_id(self):
+        ctx = OpenAIResponsesStreamContext()
+        assert resolve_call_id({}, ctx) == ""
+
+    def test_returns_empty_when_context_is_none(self):
+        chunk = {"item_id": "item_xyz"}
+        assert resolve_call_id(chunk, None) == ""
+
+    def test_returns_empty_when_context_is_base_stream_context(self):
+        ctx = StreamContext()
+        chunk = {"item_id": "item_xyz"}
+        assert resolve_call_id(chunk, ctx) == ""
+
+    def test_returns_empty_when_item_id_not_in_mapping(self):
+        ctx = OpenAIResponsesStreamContext()
+        chunk = {"item_id": "unknown_item"}
+        assert resolve_call_id(chunk, ctx) == ""
+
+    def test_prefers_call_id_over_item_id(self):
+        ctx = OpenAIResponsesStreamContext()
+        ctx.item_id_to_call_id["item_xyz"] = "call_from_map"
+        chunk = {"call_id": "call_direct", "item_id": "item_xyz"}
+        assert resolve_call_id(chunk, ctx) == "call_direct"
+
+
+class TestBuildMessagePreambleEvents:
+    """Tests for build_message_preamble_events."""
+
+    def setup_method(self):
+        self.ctx = OpenAIResponsesStreamContext()
+        self.ctx.response_id = "resp_123"
+
+    def test_returns_two_events(self):
+        events = build_message_preamble_events(self.ctx)
+        assert len(events) == 2
+
+    def test_first_event_is_output_item_added(self):
+        events = build_message_preamble_events(self.ctx)
+        assert events[0]["type"] == ResponsesEventType.OUTPUT_ITEM_ADDED
+        item = events[0]["item"]
+        assert item["type"] == "message"
+        assert item["role"] == "assistant"
+        assert item["content"] == []
+        assert item["id"] == "msg_resp_123"
+
+    def test_second_event_is_content_part_added(self):
+        events = build_message_preamble_events(self.ctx)
+        assert events[1]["type"] == ResponsesEventType.CONTENT_PART_ADDED
+        assert events[1]["content_index"] == 0
+        part = events[1]["part"]
+        assert part["type"] == "output_text"
+        assert part["text"] == ""
+
+    def test_sets_output_item_emitted(self):
+        assert self.ctx.output_item_emitted is False
+        build_message_preamble_events(self.ctx)
+        assert self.ctx.output_item_emitted is True
+
+    def test_stores_item_id_on_context(self):
+        assert self.ctx.item_id == ""
+        build_message_preamble_events(self.ctx)
+        assert self.ctx.item_id == "msg_resp_123"
+
+    def test_respects_output_index(self):
+        events = build_message_preamble_events(self.ctx, output_index=2)
+        assert events[0]["output_index"] == 2
+        assert events[1]["output_index"] == 2
+
+    def test_default_output_index_is_zero(self):
+        events = build_message_preamble_events(self.ctx)
+        assert events[0]["output_index"] == 0
+        assert events[1]["output_index"] == 0


### PR DESCRIPTION
## Summary

Closes #66 (partial — openai_responses scope).

- Extract `resolve_call_id()` — deduplicates call_id-from-item_id resolution (was repeated 2x in converter.py)
- Extract `build_message_preamble_events()` — deduplicates output_item.added + content_part.added construction (was repeated 2x in converter.py)
- Both placed in new `openai_responses/utils.py` (provider-specific, not cross-provider)
- Remove unused `generate_message_id` import from converter.py

Usage extraction, camelCase normalization, and fix_orphaned_tool_calls unification are deferred to separate issues per analysis in the plan.

## Test plan

- [x] 14 new unit tests in `test_utils.py` for both functions
- [x] All 70 existing stream tests pass
- [x] Full suite: 1274 passed
- [x] ruff check + format clean
- [x] ty check clean