### PR TITLE
refactor: merge duplicate IR concepts (n/candidate_count, system_instruction)

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -97,16 +97,7 @@ class AnthropicConverter(BaseConverter):
         # 1. System instruction → top-level system parameter
         system_instruction = ir_request.get("system_instruction")
         if system_instruction:
-            if isinstance(system_instruction, str):
-                result["system"] = system_instruction
-            elif isinstance(system_instruction, list):
-                text_parts = []
-                for part in system_instruction:
-                    if isinstance(part, dict) and part.get("type") == "text":
-                        text_parts.append(part["text"])
-                    elif isinstance(part, str):
-                        text_parts.append(part)
-                result["system"] = " ".join(text_parts)
+            result["system"] = system_instruction
 
         # 2. Messages — fix orphaned tool_calls/results at IR level before
         #    conversion.  Anthropic strictly requires bidirectional pairing.
@@ -218,8 +209,9 @@ class AnthropicConverter(BaseConverter):
                 text_parts = []
                 for part in system_content:
                     if isinstance(part, dict) and part.get("type") == "text":
-                        text_parts.append({"type": "text", "text": part["text"]})
-                ir_request["system_instruction"] = text_parts
+                        text_parts.append(part["text"])
+                if text_parts:
+                    ir_request["system_instruction"] = " ".join(text_parts)
 
         # 2. Messages
         messages = provider_request.get("messages", [])

--- a/src/llm_rosetta/converters/google_genai/config_ops.py
+++ b/src/llm_rosetta/converters/google_genai/config_ops.py
@@ -47,8 +47,7 @@ class GoogleGenAIConfigOps(BaseConfigOps):
         - ``frequency_penalty`` → ``frequency_penalty`` (direct)
         - ``presence_penalty`` → ``presence_penalty`` (direct)
         - ``seed`` → ``seed`` (direct)
-        - ``candidate_count`` → ``candidate_count`` (Google-specific)
-        - ``n`` → ``candidate_count`` (alias)
+        - ``n`` → ``candidate_count`` (Google uses candidate_count)
 
         Args:
             ir_config: IR generation config.
@@ -67,7 +66,6 @@ class GoogleGenAIConfigOps(BaseConfigOps):
             "frequency_penalty",
             "presence_penalty",
             "seed",
-            "candidate_count",
         ]
         for field in _DIRECT_FIELDS:
             if field in ir_config:
@@ -77,8 +75,8 @@ class GoogleGenAIConfigOps(BaseConfigOps):
         if "max_tokens" in ir_config:
             result["max_output_tokens"] = ir_config["max_tokens"]
 
-        # n → candidate_count (if candidate_count not already set)
-        if "n" in ir_config and "candidate_count" not in result:
+        # n → candidate_count (Google uses candidate_count)
+        if "n" in ir_config:
             result["candidate_count"] = ir_config["n"]
 
         # Unsupported fields
@@ -143,12 +141,12 @@ class GoogleGenAIConfigOps(BaseConfigOps):
         if max_tokens is not None:
             result["max_tokens"] = max_tokens
 
-        # candidate_count → n (if present)
+        # candidate_count → n
         candidate_count = provider_config.get(
             "candidate_count", provider_config.get("candidateCount")
         )
         if candidate_count is not None:
-            result["candidate_count"] = candidate_count
+            result["n"] = candidate_count
 
         return cast(GenerationConfig, result)
 

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -196,14 +196,7 @@ class GoogleGenAIConverter(BaseConverter):
         # From IRRequest.system_instruction field
         ir_system = ir_request.get("system_instruction")
         if ir_system:
-            if isinstance(ir_system, str):
-                system_instruction = {"role": "user", "parts": [{"text": ir_system}]}
-            elif isinstance(ir_system, list):
-                parts = []
-                for part in ir_system:
-                    if isinstance(part, dict) and part.get("type") == "text":
-                        parts.append({"text": part["text"]})
-                system_instruction = {"role": "user", "parts": parts}
+            system_instruction = {"role": "user", "parts": [{"text": ir_system}]}
 
         # 2. Handle messages — fix orphaned tool_calls/results and strip
         #    orphaned tool_choice/tool_config at IR level before conversion.
@@ -317,9 +310,9 @@ class GoogleGenAIConverter(BaseConverter):
                 text_parts = []
                 for part in parts:
                     if isinstance(part, dict) and "text" in part:
-                        text_parts.append({"type": "text", "text": part["text"]})
+                        text_parts.append(part["text"])
                 if text_parts:
-                    ir_request["system_instruction"] = text_parts
+                    ir_request["system_instruction"] = " ".join(text_parts)
 
         # 2. Messages
         contents = provider_request.get("contents", [])

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -84,16 +84,7 @@ class OpenAIChatConverter(BaseConverter):
         messages: list[dict[str, Any]] = []
         system_instruction = ir_request.get("system_instruction")
         if system_instruction:
-            if isinstance(system_instruction, str):
-                messages.append({"role": "system", "content": system_instruction})
-            elif isinstance(system_instruction, list):
-                text_parts = []
-                for part in system_instruction:
-                    if isinstance(part, dict) and part.get("type") == "text":
-                        text_parts.append(part["text"])
-                    elif isinstance(part, str):
-                        text_parts.append(part)
-                messages.append({"role": "system", "content": " ".join(text_parts)})
+            messages.append({"role": "system", "content": system_instruction})
 
         # 2. Messages — fix orphaned tool_calls at IR level before conversion.
         # OpenAI Chat API strictly requires every tool_call_id to have a
@@ -195,8 +186,9 @@ class OpenAIChatConverter(BaseConverter):
                     text_parts = []
                     for part in content:
                         if isinstance(part, dict) and part.get("type") == "text":
-                            text_parts.append({"type": "text", "text": part["text"]})
-                    ir_request["system_instruction"] = text_parts
+                            text_parts.append(part["text"])
+                    if text_parts:
+                        ir_request["system_instruction"] = " ".join(text_parts)
             else:
                 converted = self.message_ops._p_message_to_ir(msg)
                 if converted:

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -102,16 +102,7 @@ class OpenAIResponsesConverter(BaseConverter):
         # 1. System instruction → instructions field
         system_instruction = ir_request.get("system_instruction")
         if system_instruction:
-            if isinstance(system_instruction, str):
-                result["instructions"] = system_instruction
-            elif isinstance(system_instruction, list):
-                text_parts = []
-                for part in system_instruction:
-                    if isinstance(part, dict) and part.get("type") == "text":
-                        text_parts.append(part["text"])
-                    elif isinstance(part, str):
-                        text_parts.append(part)
-                result["instructions"] = " ".join(text_parts)
+            result["instructions"] = system_instruction
 
         # 2. Messages → input items — fix orphaned tool_calls at IR level
         # before conversion.  OpenAI Responses API strictly requires every

--- a/src/llm_rosetta/types/ir/configs.py
+++ b/src/llm_rosetta/types/ir/configs.py
@@ -88,11 +88,10 @@ class GenerationConfig(TypedDict, total=False):
     logprobs: bool
     top_logprobs: int
 
-    # 生成选择数量 Number of choices to generate (OpenAI)
+    # 生成选择数量 Number of response candidates to generate
+    # OpenAI Chat: n
+    # Google: candidate_count / candidateCount
     n: int
-
-    # 候选数量 Number of candidates (Google, 少见)
-    candidate_count: int
 
 
 # ============================================================================

--- a/src/llm_rosetta/types/ir/request.py
+++ b/src/llm_rosetta/types/ir/request.py
@@ -63,7 +63,7 @@ class IRRequest(TypedDict):
     # - OpenAI Responses: instructions
     # - Anthropic: system
     # - Google: config.system_instruction
-    system_instruction: NotRequired[str | list[dict[str, Any]]]
+    system_instruction: NotRequired[str]
 
     # ========== 工具相关 Tool Related ==========
     tools: NotRequired[list[ToolDefinition]]

--- a/tests/converters/google_genai/test_config_ops.py
+++ b/tests/converters/google_genai/test_config_ops.py
@@ -63,23 +63,11 @@ class TestGoogleGenAIConfigOps:
         result = GoogleGenAIConfigOps.ir_generation_config_to_p(ir_config)
         assert result["seed"] == 42
 
-    def test_ir_generation_config_candidate_count(self):
-        """Test candidate_count conversion."""
-        ir_config = cast(GenerationConfig, {"candidate_count": 3})
-        result = GoogleGenAIConfigOps.ir_generation_config_to_p(ir_config)
-        assert result["candidate_count"] == 3
-
     def test_ir_generation_config_n_to_candidate_count(self):
-        """Test n → candidate_count alias."""
+        """Test n → candidate_count mapping."""
         ir_config = cast(GenerationConfig, {"n": 2})
         result = GoogleGenAIConfigOps.ir_generation_config_to_p(ir_config)
         assert result["candidate_count"] == 2
-
-    def test_ir_generation_config_candidate_count_takes_priority(self):
-        """Test candidate_count takes priority over n."""
-        ir_config = cast(GenerationConfig, {"candidate_count": 3, "n": 2})
-        result = GoogleGenAIConfigOps.ir_generation_config_to_p(ir_config)
-        assert result["candidate_count"] == 3
 
     def test_ir_generation_config_empty(self):
         """Test empty generation config."""
@@ -125,10 +113,10 @@ class TestGoogleGenAIConfigOps:
         assert result["seed"] == 123
 
     def test_p_generation_config_to_ir_candidate_count(self):
-        """Test candidate_count preserved in IR."""
+        """Test provider candidate_count → IR n."""
         provider = {"candidate_count": 3}
         result = GoogleGenAIConfigOps.p_generation_config_to_ir(provider)
-        assert result["candidate_count"] == 3
+        assert result["n"] == 3
 
     def test_p_generation_config_to_ir_empty(self):
         """Test empty provider config → empty IR."""

--- a/tests/converters/google_genai/test_converter.py
+++ b/tests/converters/google_genai/test_converter.py
@@ -55,21 +55,6 @@ class TestGoogleGenAIConverter:
             "You are a helpful assistant."
         )
 
-    def test_request_with_system_instruction_parts(self):
-        """Test request with parts-based system instruction."""
-        ir_request: IRRequest = {
-            "model": "gemini-2.0-flash",
-            "messages": [
-                {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}
-            ],
-            "system_instruction": [
-                {"type": "text", "text": "Be helpful."},
-                {"type": "text", "text": "Be concise."},
-            ],
-        }
-        result, warnings = self.converter.request_to_provider(ir_request)
-        assert len(result["system_instruction"]["parts"]) == 2
-
     def test_request_with_system_message_in_messages(self):
         """Test system message in messages list is extracted."""
         ir_request: IRRequest = {
@@ -261,9 +246,7 @@ class TestGoogleGenAIConverter:
             "config": {},
         }
         ir_request = self.converter.request_from_provider(provider_request)
-        assert ir_request["system_instruction"] == [
-            {"type": "text", "text": "Be helpful."}
-        ]
+        assert ir_request["system_instruction"] == "Be helpful."
 
     def test_request_from_provider_with_tools(self):
         """Test request from provider with tools."""

--- a/tests/converters/openai_responses/test_converter.py
+++ b/tests/converters/openai_responses/test_converter.py
@@ -54,24 +54,6 @@ class TestOpenAIResponsesConverter:
         result, _ = self.converter.request_to_provider(ir_request)
         assert result["instructions"] == "You are helpful."
 
-    def test_request_to_provider_with_system_instruction_parts(self):
-        """Test IRRequest with parts-based system_instruction -> instructions."""
-        ir_request = cast(
-            IRRequest,
-            {
-                "model": "gpt-4o",
-                "messages": [
-                    {"role": "user", "content": [{"type": "text", "text": "Hi"}]}
-                ],
-                "system_instruction": [
-                    {"type": "text", "text": "Be helpful."},
-                    {"type": "text", "text": "Be concise."},
-                ],
-            },
-        )
-        result, _ = self.converter.request_to_provider(ir_request)
-        assert result["instructions"] == "Be helpful. Be concise."
-
     def test_request_to_provider_full(self):
         """Test full IRRequest with all config options."""
         ir_request = cast(


### PR DESCRIPTION
## Summary

Closes #69

- Remove `candidate_count` from `GenerationConfig`, keep only `n`; Google GenAI converter maps `n` ↔ `candidate_count`
- Unify `system_instruction` type from `str | list[dict[str, Any]]` to `str`; all converters simplified (−82 lines of `isinstance` branching)

## Test plan

- [x] All 1256 unit tests pass
- [x] ruff check + format clean
- [x] ty check clean