### PR TITLE
refactor: expand ReasoningConfig effort enum for multi-provider semantics

### DIFF
--- a/src/llm_rosetta/converters/anthropic/config_ops.py
+++ b/src/llm_rosetta/converters/anthropic/config_ops.py
@@ -231,10 +231,14 @@ class AnthropicConfigOps(BaseConfigOps):
         """IR ReasoningConfig → Anthropic thinking parameter.
 
         Mapping:
-        - ``enabled: True`` → ``thinking.type = "enabled"``
+        - ``enabled: True`` → ``thinking.type = "enabled"`` (requires budget_tokens)
         - ``enabled: False`` → ``thinking.type = "disabled"``
         - ``budget_tokens`` → ``thinking.budget_tokens``
-        - ``effort`` → not directly supported (warning)
+        - ``effort`` (without ``enabled``) → ``thinking.type = "adaptive"``
+          (``"minimal"`` degrades to ``"disabled"`` with warning)
+
+        When both ``enabled`` and ``effort`` are set, ``enabled`` takes
+        precedence for the thinking type.
 
         Args:
             ir_reasoning: IR reasoning config.
@@ -245,20 +249,32 @@ class AnthropicConfigOps(BaseConfigOps):
         result: dict[str, Any] = {}
 
         enabled = ir_reasoning.get("enabled")
+        effort = ir_reasoning.get("effort")
+
         if enabled is True:
             thinking: dict[str, Any] = {"type": "enabled"}
             if "budget_tokens" in ir_reasoning:
                 thinking["budget_tokens"] = ir_reasoning["budget_tokens"]
             result["thinking"] = thinking
+            if effort is not None:
+                warnings.warn(
+                    "Anthropic enabled mode requires explicit budget_tokens; "
+                    "effort is ignored when enabled=True",
+                    stacklevel=2,
+                )
         elif enabled is False:
             result["thinking"] = {"type": "disabled"}
-
-        if "effort" in ir_reasoning:
-            warnings.warn(
-                "Anthropic does not support reasoning effort level, "
-                "use enabled and budget_tokens instead",
-                stacklevel=2,
-            )
+        elif effort is not None:
+            # effort without explicit enabled → map to adaptive/disabled
+            if effort == "minimal":
+                result["thinking"] = {"type": "disabled"}
+                warnings.warn(
+                    "Anthropic does not support 'minimal' effort, "
+                    "degrading to thinking.type='disabled'",
+                    stacklevel=2,
+                )
+            else:
+                result["thinking"] = {"type": "adaptive"}
 
         return result
 
@@ -284,7 +300,7 @@ class AnthropicConfigOps(BaseConfigOps):
             return cast(ReasoningConfig, result)
 
         thinking_type = thinking.get("type")
-        if thinking_type == "enabled":
+        if thinking_type in ("enabled", "adaptive"):
             result["enabled"] = True
         elif thinking_type == "disabled":
             result["enabled"] = False

--- a/src/llm_rosetta/converters/google_genai/config_ops.py
+++ b/src/llm_rosetta/converters/google_genai/config_ops.py
@@ -257,13 +257,23 @@ class GoogleGenAIConfigOps(BaseConfigOps):
 
     # ==================== Reasoning Config ====================
 
+    # Effort → Google ThinkingLevel mapping
+    _EFFORT_TO_LEVEL: dict[str, str] = {
+        "minimal": "MINIMAL",
+        "low": "LOW",
+        "medium": "MEDIUM",
+        "high": "HIGH",
+    }
+    _LEVEL_TO_EFFORT: dict[str, str] = {v: k for k, v in _EFFORT_TO_LEVEL.items()}
+
     @staticmethod
     def ir_reasoning_config_to_p(ir_reasoning: ReasoningConfig, **kwargs: Any) -> dict:
         """IR ReasoningConfig → Google GenAI reasoning parameters.
 
-        Google reasoning is usually automatic or model-specific
-        (e.g. Gemini 2.0 Thinking). There's no direct config field
-        for reasoning effort in the standard API.
+        Mapping:
+        - ``effort`` → ``thinking_config.thinking_level``
+          (minimal/low/medium/high direct map; max→HIGH with warning)
+        - ``budget_tokens`` → ``thinking_config.thinking_budget``
 
         Args:
             ir_reasoning: IR reasoning config.
@@ -272,19 +282,26 @@ class GoogleGenAIConfigOps(BaseConfigOps):
             Dict of Google config fields to merge (may be empty).
         """
         result: dict[str, Any] = {}
+        thinking_config: dict[str, Any] = {}
 
-        # Google doesn't have a direct reasoning_effort equivalent
-        if "effort" in ir_reasoning:
-            warnings.warn(
-                "Google GenAI does not support reasoning effort config, ignored",
-                stacklevel=2,
-            )
+        effort = ir_reasoning.get("effort")
+        if effort is not None:
+            level = GoogleGenAIConfigOps._EFFORT_TO_LEVEL.get(effort)
+            if level is not None:
+                thinking_config["thinking_level"] = level
+            elif effort == "max":
+                thinking_config["thinking_level"] = "HIGH"
+                warnings.warn(
+                    "Google GenAI does not support 'max' effort, "
+                    "degrading to thinking_level='HIGH'",
+                    stacklevel=2,
+                )
 
         if "budget_tokens" in ir_reasoning:
-            # Some Google models may support thinking budget
-            result["thinking_config"] = {
-                "thinking_budget": ir_reasoning["budget_tokens"]
-            }
+            thinking_config["thinking_budget"] = ir_reasoning["budget_tokens"]
+
+        if thinking_config:
+            result["thinking_config"] = thinking_config
 
         return result
 
@@ -314,6 +331,14 @@ class GoogleGenAIConfigOps(BaseConfigOps):
             )
             if budget is not None:
                 result["budget_tokens"] = budget
+
+            level = thinking_config.get("thinking_level") or thinking_config.get(
+                "thinkingLevel"
+            )
+            if level is not None:
+                effort = GoogleGenAIConfigOps._LEVEL_TO_EFFORT.get(level)
+                if effort is not None:
+                    result["effort"] = effort
 
         return cast(ReasoningConfig, result)
 

--- a/src/llm_rosetta/converters/openai_chat/config_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/config_ops.py
@@ -262,8 +262,23 @@ class OpenAIChatConfigOps(BaseConfigOps):
         """
         result: dict[str, Any] = {}
 
-        if "effort" in ir_reasoning:
-            result["reasoning_effort"] = ir_reasoning["effort"]
+        effort = ir_reasoning.get("effort")
+        if effort is not None:
+            # OpenAI Chat only supports low/medium/high
+            if effort == "minimal":
+                result["reasoning_effort"] = "low"
+                warnings.warn(
+                    "OpenAI Chat does not support 'minimal' effort, degrading to 'low'",
+                    stacklevel=2,
+                )
+            elif effort == "max":
+                result["reasoning_effort"] = "high"
+                warnings.warn(
+                    "OpenAI Chat does not support 'max' effort, degrading to 'high'",
+                    stacklevel=2,
+                )
+            else:
+                result["reasoning_effort"] = effort
 
         if "budget_tokens" in ir_reasoning:
             warnings.warn(

--- a/src/llm_rosetta/converters/openai_responses/config_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/config_ops.py
@@ -259,8 +259,25 @@ class OpenAIResponsesConfigOps(BaseConfigOps):
         elif enabled is False:
             reasoning_p["type"] = "disabled"
 
-        if "effort" in ir_reasoning:
-            reasoning_p["effort"] = ir_reasoning["effort"]
+        effort = ir_reasoning.get("effort")
+        if effort is not None:
+            # OpenAI Responses only supports low/medium/high
+            if effort == "minimal":
+                reasoning_p["effort"] = "low"
+                warnings.warn(
+                    "OpenAI Responses does not support 'minimal' effort, "
+                    "degrading to 'low'",
+                    stacklevel=2,
+                )
+            elif effort == "max":
+                reasoning_p["effort"] = "high"
+                warnings.warn(
+                    "OpenAI Responses does not support 'max' effort, "
+                    "degrading to 'high'",
+                    stacklevel=2,
+                )
+            else:
+                reasoning_p["effort"] = effort
 
         if reasoning_p:
             result["reasoning"] = reasoning_p

--- a/src/llm_rosetta/types/ir/configs.py
+++ b/src/llm_rosetta/types/ir/configs.py
@@ -105,15 +105,14 @@ class ReasoningConfig(TypedDict, total=False):
     Controls whether and how the model performs explicit reasoning.
 
     Provider mappings:
-    - OpenAI: reasoning_effort (low/medium/high)
-    - Anthropic: thinking.type (enabled/disabled) + thinking.budget_tokens
-    - Google: thinking_config.thinking_budget
+    - OpenAI: reasoning_effort (low/medium/high; minimal→low, max→high with warning)
+    - Anthropic: thinking.type (enabled/disabled/adaptive) + thinking.budget_tokens
+    - Google: thinking_config.thinking_level (MINIMAL/LOW/MEDIUM/HIGH; max→HIGH with warning)
+              + thinking_config.thinking_budget
     """
 
     enabled: bool  # Whether reasoning is enabled — Anthropic: thinking.type
-    effort: Literal[
-        "low", "medium", "high"
-    ]  # Reasoning effort — OpenAI: reasoning_effort
+    effort: Literal["minimal", "low", "medium", "high", "max"]  # Reasoning effort level
     budget_tokens: int  # Max tokens for reasoning — Anthropic/Google: budget_tokens
 
 

--- a/tests/converters/anthropic/test_config_ops.py
+++ b/tests/converters/anthropic/test_config_ops.py
@@ -150,10 +150,35 @@ class TestAnthropicConfigOps:
         result = AnthropicConfigOps.ir_reasoning_config_to_p(ir_reasoning)
         assert result["thinking"]["type"] == "disabled"
 
-    def test_ir_reasoning_config_effort_warning(self):
-        """Test effort field produces warning."""
-        with pytest.warns(UserWarning, match="does not support reasoning effort"):
-            AnthropicConfigOps.ir_reasoning_config_to_p({"effort": "high"})
+    def test_ir_reasoning_config_effort_to_adaptive(self):
+        """Test effort without enabled → adaptive thinking."""
+        result = AnthropicConfigOps.ir_reasoning_config_to_p({"effort": "high"})
+        assert result["thinking"]["type"] == "adaptive"
+
+    def test_ir_reasoning_config_effort_low_to_adaptive(self):
+        """Test low effort → adaptive thinking."""
+        result = AnthropicConfigOps.ir_reasoning_config_to_p({"effort": "low"})
+        assert result["thinking"]["type"] == "adaptive"
+
+    def test_ir_reasoning_config_effort_max_to_adaptive(self):
+        """Test max effort → adaptive thinking."""
+        result = AnthropicConfigOps.ir_reasoning_config_to_p({"effort": "max"})
+        assert result["thinking"]["type"] == "adaptive"
+
+    def test_ir_reasoning_config_effort_minimal_to_disabled(self):
+        """Test minimal effort → disabled with warning."""
+        with pytest.warns(UserWarning, match="'minimal' effort"):
+            result = AnthropicConfigOps.ir_reasoning_config_to_p({"effort": "minimal"})
+        assert result["thinking"]["type"] == "disabled"
+
+    def test_ir_reasoning_config_enabled_with_effort_warning(self):
+        """Test enabled=True with effort emits warning, enabled takes precedence."""
+        with pytest.warns(UserWarning, match="effort is ignored when enabled=True"):
+            result = AnthropicConfigOps.ir_reasoning_config_to_p(
+                {"enabled": True, "effort": "high", "budget_tokens": 2048}
+            )
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 2048
 
     def test_p_reasoning_config_to_ir(self):
         """Test Anthropic thinking → IR ReasoningConfig."""
@@ -161,6 +186,12 @@ class TestAnthropicConfigOps:
         result = AnthropicConfigOps.p_reasoning_config_to_ir(provider)
         assert result["enabled"] is True
         assert result["budget_tokens"] == 4096
+
+    def test_p_reasoning_config_to_ir_adaptive(self):
+        """Test Anthropic adaptive thinking → IR enabled=True."""
+        provider = {"thinking": {"type": "adaptive"}}
+        result = AnthropicConfigOps.p_reasoning_config_to_ir(provider)
+        assert result["enabled"] is True
 
     def test_p_reasoning_config_to_ir_empty(self):
         """Test empty reasoning config → empty IR."""

--- a/tests/converters/google_genai/test_config_ops.py
+++ b/tests/converters/google_genai/test_config_ops.py
@@ -250,13 +250,34 @@ class TestGoogleGenAIConfigOps:
         )
         assert result["thinking_config"]["thinking_budget"] == 4096
 
-    def test_ir_reasoning_config_effort_warning(self):
-        """Test effort field produces warning."""
-        with pytest.warns(UserWarning, match="reasoning effort"):
+    def test_ir_reasoning_config_effort_to_thinking_level(self):
+        """Test effort → thinking_config.thinking_level mapping."""
+        for effort, level in [
+            ("minimal", "MINIMAL"),
+            ("low", "LOW"),
+            ("medium", "MEDIUM"),
+            ("high", "HIGH"),
+        ]:
             result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
-                cast(ReasoningConfig, {"effort": "high"})
+                cast(ReasoningConfig, {"effort": effort})
             )
-        assert result == {}
+            assert result["thinking_config"]["thinking_level"] == level
+
+    def test_ir_reasoning_config_effort_max_degrades(self):
+        """Test max effort → HIGH with warning."""
+        with pytest.warns(UserWarning, match="'max' effort"):
+            result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
+                cast(ReasoningConfig, {"effort": "max"})
+            )
+        assert result["thinking_config"]["thinking_level"] == "HIGH"
+
+    def test_ir_reasoning_config_effort_and_budget(self):
+        """Test effort and budget_tokens coexist in thinking_config."""
+        result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"effort": "high", "budget_tokens": 4096})
+        )
+        assert result["thinking_config"]["thinking_level"] == "HIGH"
+        assert result["thinking_config"]["thinking_budget"] == 4096
 
     def test_ir_reasoning_config_empty(self):
         """Test empty reasoning config → empty result."""
@@ -271,6 +292,18 @@ class TestGoogleGenAIConfigOps:
         result = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
         assert result["budget_tokens"] == 8192
 
+    def test_p_reasoning_config_to_ir_with_level(self):
+        """Test Google thinking_level → IR effort."""
+        provider = {"thinking_config": {"thinking_level": "MEDIUM"}}
+        result = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert result["effort"] == "medium"
+
+    def test_p_reasoning_config_to_ir_camelcase_level(self):
+        """Test camelCase thinkingLevel → IR effort."""
+        provider = {"thinkingConfig": {"thinkingLevel": "LOW"}}
+        result = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert result["effort"] == "low"
+
     def test_p_reasoning_config_to_ir_empty(self):
         """Test empty reasoning config → empty IR."""
         result = GoogleGenAIConfigOps.p_reasoning_config_to_ir({})
@@ -281,12 +314,19 @@ class TestGoogleGenAIConfigOps:
         result = GoogleGenAIConfigOps.p_reasoning_config_to_ir("invalid")
         assert result == {}
 
-    def test_reasoning_config_round_trip(self):
-        """Test reasoning config round-trip."""
+    def test_reasoning_config_budget_round_trip(self):
+        """Test reasoning config budget round-trip."""
         original = cast(ReasoningConfig, {"budget_tokens": 2048})
         provider = GoogleGenAIConfigOps.ir_reasoning_config_to_p(original)
         restored = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
         assert restored["budget_tokens"] == 2048
+
+    def test_reasoning_config_effort_round_trip(self):
+        """Test reasoning config effort round-trip."""
+        original = cast(ReasoningConfig, {"effort": "high"})
+        provider = GoogleGenAIConfigOps.ir_reasoning_config_to_p(original)
+        restored = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert restored["effort"] == "high"
 
     # ==================== Cache Config ====================
 

--- a/tests/converters/openai_chat/test_config_ops.py
+++ b/tests/converters/openai_chat/test_config_ops.py
@@ -158,6 +158,18 @@ class TestOpenAIChatConfigOps:
         result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"effort": "high"})
         assert result["reasoning_effort"] == "high"
 
+    def test_ir_reasoning_config_minimal_degrades(self):
+        """Test minimal effort → low with warning."""
+        with pytest.warns(UserWarning, match="'minimal' effort"):
+            result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"effort": "minimal"})
+        assert result["reasoning_effort"] == "low"
+
+    def test_ir_reasoning_config_max_degrades(self):
+        """Test max effort → high with warning."""
+        with pytest.warns(UserWarning, match="'max' effort"):
+            result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"effort": "max"})
+        assert result["reasoning_effort"] == "high"
+
     def test_ir_reasoning_config_budget_warning(self):
         """Test budget_tokens produces warning."""
         with pytest.warns(UserWarning, match="budget_tokens"):

--- a/tests/converters/openai_responses/test_config_ops.py
+++ b/tests/converters/openai_responses/test_config_ops.py
@@ -279,6 +279,22 @@ class TestOpenAIResponsesConfigOps:
         assert result["reasoning"]["type"] == "enabled"
         assert result["reasoning"]["effort"] == "medium"
 
+    def test_ir_reasoning_config_minimal_degrades(self):
+        """Test minimal effort → low with warning."""
+        with pytest.warns(UserWarning, match="'minimal' effort"):
+            result = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(
+                cast(ReasoningConfig, {"effort": "minimal"})
+            )
+        assert result["reasoning"]["effort"] == "low"
+
+    def test_ir_reasoning_config_max_degrades(self):
+        """Test max effort → high with warning."""
+        with pytest.warns(UserWarning, match="'max' effort"):
+            result = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(
+                cast(ReasoningConfig, {"effort": "max"})
+            )
+        assert result["reasoning"]["effort"] == "high"
+
     def test_ir_reasoning_config_budget_warning(self):
         """Test budget_tokens produces warning."""
         with pytest.warns(UserWarning, match="budget_tokens"):


### PR DESCRIPTION
## Summary

Closes #100

Expand `ReasoningConfig.effort` from `Literal["low", "medium", "high"]` to `Literal["minimal", "low", "medium", "high", "max"]` to cover diverging provider reasoning semantics.

### Per-converter changes

| Provider | Before | After |
|----------|--------|-------|
| **Anthropic** | effort → warning (ignored) | effort → `thinking.type="adaptive"`; `"minimal"` → `"disabled"` with warning |
| **Google GenAI** | effort → warning (ignored) | effort → `thinking_config.thinking_level` (MINIMAL/LOW/MEDIUM/HIGH); `"max"` → HIGH with warning |
| **OpenAI Chat** | pass-through | `"minimal"` → `"low"`, `"max"` → `"high"` with degradation warnings |
| **OpenAI Responses** | pass-through | Same clamping as Chat |

### Reverse mapping (p → IR)

- Anthropic: `thinking.type="adaptive"` → `enabled=True`
- Google: `thinking_level` → `effort` (MINIMAL→minimal, LOW→low, etc.)

## Test plan

- [x] `ruff check --fix && ruff format` — all clean
- [x] `ty check` — 0 errors
- [x] `pytest --ignore=tests/integration` — 1238 passed, 0 failed