### PR TITLE
refactor: expand ReasoningConfig for multi-provider effort semantics

### DIFF
--- a/src/llm_rosetta/converters/anthropic/config_ops.py
+++ b/src/llm_rosetta/converters/anthropic/config_ops.py
@@ -231,10 +231,11 @@ class AnthropicConfigOps(BaseConfigOps):
         """IR ReasoningConfig → Anthropic thinking parameter.
 
         Mapping:
-        - ``enabled: True`` → ``thinking.type = "enabled"``
+        - ``effort`` → ``thinking.type = "adaptive"`` + ``thinking.effort``
+          (``"minimal"`` downgraded to ``"low"`` with warning)
+        - ``enabled: True`` (no effort) → ``thinking.type = "enabled"``
         - ``enabled: False`` → ``thinking.type = "disabled"``
         - ``budget_tokens`` → ``thinking.budget_tokens``
-        - ``effort`` → not directly supported (warning)
 
         Args:
             ir_reasoning: IR reasoning config.
@@ -244,21 +245,30 @@ class AnthropicConfigOps(BaseConfigOps):
         """
         result: dict[str, Any] = {}
 
-        enabled = ir_reasoning.get("enabled")
-        if enabled is True:
-            thinking: dict[str, Any] = {"type": "enabled"}
+        effort = ir_reasoning.get("effort")
+        if effort is not None:
+            # Anthropic 4.6+: adaptive thinking with effort level
+            thinking: dict[str, Any] = {"type": "adaptive"}
+            if effort == "minimal":
+                warnings.warn(
+                    "Anthropic does not support 'minimal' effort, downgrading to 'low'",
+                    stacklevel=2,
+                )
+                thinking["effort"] = "low"
+            else:
+                thinking["effort"] = effort
             if "budget_tokens" in ir_reasoning:
                 thinking["budget_tokens"] = ir_reasoning["budget_tokens"]
             result["thinking"] = thinking
-        elif enabled is False:
-            result["thinking"] = {"type": "disabled"}
-
-        if "effort" in ir_reasoning:
-            warnings.warn(
-                "Anthropic does not support reasoning effort level, "
-                "use enabled and budget_tokens instead",
-                stacklevel=2,
-            )
+        else:
+            enabled = ir_reasoning.get("enabled")
+            if enabled is True:
+                thinking: dict[str, Any] = {"type": "enabled"}
+                if "budget_tokens" in ir_reasoning:
+                    thinking["budget_tokens"] = ir_reasoning["budget_tokens"]
+                result["thinking"] = thinking
+            elif enabled is False:
+                result["thinking"] = {"type": "disabled"}
 
         return result
 
@@ -284,10 +294,14 @@ class AnthropicConfigOps(BaseConfigOps):
             return cast(ReasoningConfig, result)
 
         thinking_type = thinking.get("type")
-        if thinking_type == "enabled":
+        if thinking_type in ("enabled", "adaptive"):
             result["enabled"] = True
         elif thinking_type == "disabled":
             result["enabled"] = False
+
+        effort = thinking.get("effort")
+        if effort is not None:
+            result["effort"] = effort
 
         budget_tokens = thinking.get("budget_tokens")
         if budget_tokens is not None:

--- a/src/llm_rosetta/converters/base/configs.py
+++ b/src/llm_rosetta/converters/base/configs.py
@@ -177,12 +177,12 @@ class BaseConfigOps(ABC):
 
         处理推理过程的控制：
         - 是否启用：enabled (bool) - Anthropic
-        - 推理努力：effort (low/medium/high) - OpenAI
+        - 推理努力：effort (minimal/low/medium/high/max)
         - 预算token：budget_tokens - Anthropic/Google
 
         Handles reasoning process control:
         - Enabled: enabled (bool) - Anthropic
-        - Reasoning effort: effort (low/medium/high) - OpenAI
+        - Reasoning effort: effort (minimal/low/medium/high/max)
         - Budget tokens: budget_tokens - Anthropic/Google
 
         Args:

--- a/src/llm_rosetta/converters/google_genai/config_ops.py
+++ b/src/llm_rosetta/converters/google_genai/config_ops.py
@@ -261,9 +261,10 @@ class GoogleGenAIConfigOps(BaseConfigOps):
     def ir_reasoning_config_to_p(ir_reasoning: ReasoningConfig, **kwargs: Any) -> dict:
         """IR ReasoningConfig → Google GenAI reasoning parameters.
 
-        Google reasoning is usually automatic or model-specific
-        (e.g. Gemini 2.0 Thinking). There's no direct config field
-        for reasoning effort in the standard API.
+        Mapping:
+        - ``effort`` → ``thinking_config.thinking_level``
+          (``"max"`` downgraded to ``"high"`` with warning)
+        - ``budget_tokens`` → ``thinking_config.thinking_budget``
 
         Args:
             ir_reasoning: IR reasoning config.
@@ -272,19 +273,23 @@ class GoogleGenAIConfigOps(BaseConfigOps):
             Dict of Google config fields to merge (may be empty).
         """
         result: dict[str, Any] = {}
+        thinking_config: dict[str, Any] = {}
 
-        # Google doesn't have a direct reasoning_effort equivalent
         if "effort" in ir_reasoning:
-            warnings.warn(
-                "Google GenAI does not support reasoning effort config, ignored",
-                stacklevel=2,
-            )
+            effort = ir_reasoning["effort"]
+            if effort == "max":
+                warnings.warn(
+                    "Google GenAI does not support 'max' effort, downgrading to 'high'",
+                    stacklevel=2,
+                )
+                effort = "high"
+            thinking_config["thinking_level"] = effort
 
         if "budget_tokens" in ir_reasoning:
-            # Some Google models may support thinking budget
-            result["thinking_config"] = {
-                "thinking_budget": ir_reasoning["budget_tokens"]
-            }
+            thinking_config["thinking_budget"] = ir_reasoning["budget_tokens"]
+
+        if thinking_config:
+            result["thinking_config"] = thinking_config
 
         return result
 
@@ -314,6 +319,12 @@ class GoogleGenAIConfigOps(BaseConfigOps):
             )
             if budget is not None:
                 result["budget_tokens"] = budget
+
+            level = thinking_config.get("thinking_level") or thinking_config.get(
+                "thinkingLevel"
+            )
+            if level is not None:
+                result["effort"] = level
 
         return cast(ReasoningConfig, result)
 

--- a/src/llm_rosetta/converters/openai_chat/config_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/config_ops.py
@@ -252,6 +252,7 @@ class OpenAIChatConfigOps(BaseConfigOps):
 
         Mapping:
         - ``effort`` → ``reasoning_effort``
+          (``"minimal"`` → ``"low"``, ``"max"`` → ``"high"`` with warning)
         - ``budget_tokens`` → not supported (warning)
 
         Args:
@@ -263,7 +264,21 @@ class OpenAIChatConfigOps(BaseConfigOps):
         result: dict[str, Any] = {}
 
         if "effort" in ir_reasoning:
-            result["reasoning_effort"] = ir_reasoning["effort"]
+            effort = ir_reasoning["effort"]
+            if effort == "minimal":
+                warnings.warn(
+                    "OpenAI Chat does not support 'minimal' effort, "
+                    "downgrading to 'low'",
+                    stacklevel=2,
+                )
+                effort = "low"
+            elif effort == "max":
+                warnings.warn(
+                    "OpenAI Chat does not support 'max' effort, downgrading to 'high'",
+                    stacklevel=2,
+                )
+                effort = "high"
+            result["reasoning_effort"] = effort
 
         if "budget_tokens" in ir_reasoning:
             warnings.warn(

--- a/src/llm_rosetta/converters/openai_responses/config_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/config_ops.py
@@ -242,6 +242,7 @@ class OpenAIResponsesConfigOps(BaseConfigOps):
         Mapping:
         - ``enabled`` → ``reasoning.type`` ("enabled"/"disabled")
         - ``effort`` → ``reasoning.effort``
+          (``"minimal"`` → ``"low"``, ``"max"`` → ``"high"`` with warning)
         - ``budget_tokens`` → not supported (warning)
 
         Args:
@@ -260,7 +261,22 @@ class OpenAIResponsesConfigOps(BaseConfigOps):
             reasoning_p["type"] = "disabled"
 
         if "effort" in ir_reasoning:
-            reasoning_p["effort"] = ir_reasoning["effort"]
+            effort = ir_reasoning["effort"]
+            if effort == "minimal":
+                warnings.warn(
+                    "OpenAI Responses API does not support 'minimal' effort, "
+                    "downgrading to 'low'",
+                    stacklevel=2,
+                )
+                effort = "low"
+            elif effort == "max":
+                warnings.warn(
+                    "OpenAI Responses API does not support 'max' effort, "
+                    "downgrading to 'high'",
+                    stacklevel=2,
+                )
+                effort = "high"
+            reasoning_p["effort"] = effort
 
         if reasoning_p:
             result["reasoning"] = reasoning_p

--- a/src/llm_rosetta/types/ir/configs.py
+++ b/src/llm_rosetta/types/ir/configs.py
@@ -105,15 +105,16 @@ class ReasoningConfig(TypedDict, total=False):
     Controls whether and how the model performs explicit reasoning.
 
     Provider mappings:
-    - OpenAI: reasoning_effort (low/medium/high)
-    - Anthropic: thinking.type (enabled/disabled) + thinking.budget_tokens
-    - Google: thinking_config.thinking_budget
+    - OpenAI: reasoning_effort (low/medium/high; minimal→low, max→high with warning)
+    - Anthropic: thinking.type (adaptive/enabled/disabled) + thinking.effort + budget_tokens
+    - Google: thinking_config.thinking_level (minimal/low/medium/high; max→high with warning)
+              + thinking_config.thinking_budget
     """
 
     enabled: bool  # Whether reasoning is enabled — Anthropic: thinking.type
     effort: Literal[
-        "low", "medium", "high"
-    ]  # Reasoning effort — OpenAI: reasoning_effort
+        "minimal", "low", "medium", "high", "max"
+    ]  # Reasoning effort level across providers
     budget_tokens: int  # Max tokens for reasoning — Anthropic/Google: budget_tokens
 
 

--- a/tests/converters/anthropic/test_config_ops.py
+++ b/tests/converters/anthropic/test_config_ops.py
@@ -150,10 +150,38 @@ class TestAnthropicConfigOps:
         result = AnthropicConfigOps.ir_reasoning_config_to_p(ir_reasoning)
         assert result["thinking"]["type"] == "disabled"
 
-    def test_ir_reasoning_config_effort_warning(self):
-        """Test effort field produces warning."""
-        with pytest.warns(UserWarning, match="does not support reasoning effort"):
-            AnthropicConfigOps.ir_reasoning_config_to_p({"effort": "high"})
+    def test_ir_reasoning_config_effort_adaptive(self):
+        """Test effort → adaptive thinking."""
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"effort": "high"})
+        )
+        assert result["thinking"]["type"] == "adaptive"
+        assert result["thinking"]["effort"] == "high"
+
+    def test_ir_reasoning_config_effort_max(self):
+        """Test 'max' effort maps directly to Anthropic."""
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"effort": "max"})
+        )
+        assert result["thinking"]["type"] == "adaptive"
+        assert result["thinking"]["effort"] == "max"
+
+    def test_ir_reasoning_config_effort_minimal_warning(self):
+        """Test 'minimal' effort downgraded to 'low' with warning."""
+        with pytest.warns(UserWarning, match="minimal"):
+            result = AnthropicConfigOps.ir_reasoning_config_to_p(
+                cast(ReasoningConfig, {"effort": "minimal"})
+            )
+        assert result["thinking"]["effort"] == "low"
+
+    def test_ir_reasoning_config_effort_with_budget(self):
+        """Test effort + budget_tokens combined."""
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"effort": "medium", "budget_tokens": 4096})
+        )
+        assert result["thinking"]["type"] == "adaptive"
+        assert result["thinking"]["effort"] == "medium"
+        assert result["thinking"]["budget_tokens"] == 4096
 
     def test_p_reasoning_config_to_ir(self):
         """Test Anthropic thinking → IR ReasoningConfig."""
@@ -161,6 +189,13 @@ class TestAnthropicConfigOps:
         result = AnthropicConfigOps.p_reasoning_config_to_ir(provider)
         assert result["enabled"] is True
         assert result["budget_tokens"] == 4096
+
+    def test_p_reasoning_config_to_ir_adaptive(self):
+        """Test adaptive thinking → IR with effort."""
+        provider = {"thinking": {"type": "adaptive", "effort": "high"}}
+        result = AnthropicConfigOps.p_reasoning_config_to_ir(provider)
+        assert result["enabled"] is True
+        assert result["effort"] == "high"
 
     def test_p_reasoning_config_to_ir_empty(self):
         """Test empty reasoning config → empty IR."""

--- a/tests/converters/google_genai/test_config_ops.py
+++ b/tests/converters/google_genai/test_config_ops.py
@@ -250,13 +250,35 @@ class TestGoogleGenAIConfigOps:
         )
         assert result["thinking_config"]["thinking_budget"] == 4096
 
-    def test_ir_reasoning_config_effort_warning(self):
-        """Test effort field produces warning."""
-        with pytest.warns(UserWarning, match="reasoning effort"):
+    def test_ir_reasoning_config_effort(self):
+        """Test effort → thinking_level."""
+        result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"effort": "high"})
+        )
+        assert result["thinking_config"]["thinking_level"] == "high"
+
+    def test_ir_reasoning_config_effort_minimal(self):
+        """Test 'minimal' effort maps directly to Google."""
+        result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"effort": "minimal"})
+        )
+        assert result["thinking_config"]["thinking_level"] == "minimal"
+
+    def test_ir_reasoning_config_effort_max_warning(self):
+        """Test 'max' effort downgraded to 'high' with warning."""
+        with pytest.warns(UserWarning, match="max"):
             result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
-                cast(ReasoningConfig, {"effort": "high"})
+                cast(ReasoningConfig, {"effort": "max"})
             )
-        assert result == {}
+        assert result["thinking_config"]["thinking_level"] == "high"
+
+    def test_ir_reasoning_config_effort_with_budget(self):
+        """Test effort + budget_tokens combined."""
+        result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"effort": "medium", "budget_tokens": 4096})
+        )
+        assert result["thinking_config"]["thinking_level"] == "medium"
+        assert result["thinking_config"]["thinking_budget"] == 4096
 
     def test_ir_reasoning_config_empty(self):
         """Test empty reasoning config → empty result."""
@@ -270,6 +292,12 @@ class TestGoogleGenAIConfigOps:
         provider = {"thinking_config": {"thinking_budget": 8192}}
         result = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
         assert result["budget_tokens"] == 8192
+
+    def test_p_reasoning_config_to_ir_with_level(self):
+        """Test thinking_level → IR effort."""
+        provider = {"thinking_config": {"thinking_level": "low"}}
+        result = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert result["effort"] == "low"
 
     def test_p_reasoning_config_to_ir_empty(self):
         """Test empty reasoning config → empty IR."""
@@ -287,6 +315,13 @@ class TestGoogleGenAIConfigOps:
         provider = GoogleGenAIConfigOps.ir_reasoning_config_to_p(original)
         restored = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
         assert restored["budget_tokens"] == 2048
+
+    def test_reasoning_config_effort_round_trip(self):
+        """Test effort round-trip."""
+        original = cast(ReasoningConfig, {"effort": "high"})
+        provider = GoogleGenAIConfigOps.ir_reasoning_config_to_p(original)
+        restored = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert restored["effort"] == "high"
 
     # ==================== Cache Config ====================
 

--- a/tests/converters/openai_chat/test_config_ops.py
+++ b/tests/converters/openai_chat/test_config_ops.py
@@ -158,6 +158,18 @@ class TestOpenAIChatConfigOps:
         result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"effort": "high"})
         assert result["reasoning_effort"] == "high"
 
+    def test_ir_reasoning_config_minimal_warning(self):
+        """Test 'minimal' effort downgraded to 'low' with warning."""
+        with pytest.warns(UserWarning, match="minimal"):
+            result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"effort": "minimal"})
+        assert result["reasoning_effort"] == "low"
+
+    def test_ir_reasoning_config_max_warning(self):
+        """Test 'max' effort downgraded to 'high' with warning."""
+        with pytest.warns(UserWarning, match="max"):
+            result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"effort": "max"})
+        assert result["reasoning_effort"] == "high"
+
     def test_ir_reasoning_config_budget_warning(self):
         """Test budget_tokens produces warning."""
         with pytest.warns(UserWarning, match="budget_tokens"):

--- a/tests/converters/openai_responses/test_config_ops.py
+++ b/tests/converters/openai_responses/test_config_ops.py
@@ -279,6 +279,22 @@ class TestOpenAIResponsesConfigOps:
         assert result["reasoning"]["type"] == "enabled"
         assert result["reasoning"]["effort"] == "medium"
 
+    def test_ir_reasoning_config_minimal_warning(self):
+        """Test 'minimal' effort downgraded to 'low' with warning."""
+        with pytest.warns(UserWarning, match="minimal"):
+            result = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(
+                cast(ReasoningConfig, {"effort": "minimal"})
+            )
+        assert result["reasoning"]["effort"] == "low"
+
+    def test_ir_reasoning_config_max_warning(self):
+        """Test 'max' effort downgraded to 'high' with warning."""
+        with pytest.warns(UserWarning, match="max"):
+            result = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(
+                cast(ReasoningConfig, {"effort": "max"})
+            )
+        assert result["reasoning"]["effort"] == "high"
+
     def test_ir_reasoning_config_budget_warning(self):
         """Test budget_tokens produces warning."""
         with pytest.warns(UserWarning, match="budget_tokens"):


### PR DESCRIPTION
## Summary

Closes #100

- Expand `effort` enum from `["low","medium","high"]` to `["minimal","low","medium","high","max"]`
- **Anthropic**: `effort` → `thinking.type="adaptive"` + `thinking.effort` (Anthropic 4.6+ adaptive thinking); `"minimal"` downgraded to `"low"` with warning
- **OpenAI Chat/Responses**: `"minimal"` → `"low"`, `"max"` → `"high"` with warning (OpenAI only supports low/medium/high)
- **Google GenAI**: `effort` → `thinking_config.thinking_level` (Gemini 3 thinkingLevel); `"max"` → `"high"` with warning; read `thinking_level` back to IR in p_to_ir

## Test plan

- [x] All 1237 unit tests pass
- [x] ruff check + format clean
- [x] ty check clean
- [x] New tests for each provider: adaptive thinking, minimal/max downgrade warnings, effort+budget combination, thinking_level round-trip