### PR TITLE
feat: multimodal integration tests + converter fixes

### DIFF
--- a/examples/tools.py
+++ b/examples/tools.py
@@ -1,4 +1,38 @@
+import base64
 import json
+import struct
+import zlib
+
+
+def _make_tiny_png() -> str:
+    """Generate a minimal 8x8 red square PNG as base64."""
+
+    def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+        c = chunk_type + data
+        return (
+            struct.pack(">I", len(data))
+            + c
+            + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+        )
+
+    width, height = 8, 8
+    # RGBA red pixel
+    raw = b""
+    for _ in range(height):
+        raw += b"\x00" + b"\xff\x00\x00\xff" * width  # filter=none + RGBA
+
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)  # 8-bit RGBA
+    png = (
+        sig
+        + _chunk(b"IHDR", ihdr)
+        + _chunk(b"IDAT", zlib.compress(raw))
+        + _chunk(b"IEND", b"")
+    )
+    return base64.b64encode(png).decode()
+
+
+_CHART_IMAGE_BASE64 = _make_tiny_png()
 
 
 # --- Tool Definitions ---
@@ -30,9 +64,37 @@ def get_flight_info(origin: str, destination: str):
     )
 
 
+def generate_chart(chart_type: str = "bar"):
+    """Generate a chart visualization (returns multimodal content)."""
+    return [
+        {"type": "text", "text": f"Generated {chart_type} chart of world population:"},
+        {
+            "type": "image",
+            "image_data": {"data": _CHART_IMAGE_BASE64, "media_type": "image/png"},
+        },
+    ]
+
+
 available_tools = {
     "get_current_weather": get_current_weather,
     "get_flight_info": get_flight_info,
+    "generate_chart": generate_chart,
+}
+
+generate_chart_spec = {
+    "type": "function",
+    "name": "generate_chart",
+    "description": "Generate a chart or data visualization. Returns an image of the chart.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "chart_type": {
+                "type": "string",
+                "enum": ["bar", "line", "pie"],
+                "description": "The type of chart to generate",
+            },
+        },
+    },
 }
 
 # This now follows the IR `ToolDefinition` format
@@ -70,3 +132,6 @@ tools_spec = [
         },
     },
 ]
+
+# tools_spec + generate_chart for multimodal integration tests
+multimodal_tools_spec = tools_spec + [generate_chart_spec]

--- a/src/llm_rosetta/converters/openai_responses/content_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/content_ops.py
@@ -253,10 +253,34 @@ class OpenAIResponsesContentOps(BaseContentOps):
         Returns:
             OpenAI Responses reasoning item dict.
         """
-        return {
+        result: dict[str, Any] = {
             "type": "reasoning",
-            "content": ir_reasoning.get("reasoning", ""),
         }
+
+        # Recover the original reasoning item id for round-trip fidelity.
+        metadata = ir_reasoning.get("provider_metadata") or {}
+        item_id = metadata.get("responses_reasoning_id")
+        if item_id:
+            result["id"] = item_id
+
+        # Recover structured summary if available, otherwise use flat content.
+        summary = metadata.get("responses_reasoning_summary")
+        if summary:
+            result["summary"] = summary
+        else:
+            content = ir_reasoning.get("reasoning", "")
+            # The Responses API uses a summary array, not a flat content field.
+            if content:
+                result["summary"] = [{"type": "summary_text", "text": content}]
+            else:
+                result["summary"] = []
+
+        # Preserve encryption signature for encrypted reasoning.
+        signature = ir_reasoning.get("signature")
+        if signature:
+            result["encrypted_content"] = signature
+
+        return result
 
     @staticmethod
     def p_reasoning_to_ir(
@@ -265,6 +289,7 @@ class OpenAIResponsesContentOps(BaseContentOps):
         """OpenAI Responses reasoning item → IR ReasoningPart.
 
         Handles cases where reasoning content may be None (e.g., o4-mini).
+        Preserves the item id and structured summary for round-trip fidelity.
 
         Args:
             provider_reasoning: OpenAI Responses reasoning item dict.
@@ -272,12 +297,44 @@ class OpenAIResponsesContentOps(BaseContentOps):
         Returns:
             IR ReasoningPart, or None if content is empty/null.
         """
-        reasoning_content = provider_reasoning.get(
-            "reasoning"
-        ) or provider_reasoning.get("content")
+        # Extract text from structured summary array or flat content.
+        summary = provider_reasoning.get("summary")
+        if isinstance(summary, list):
+            texts = [
+                s.get("text", "")
+                for s in summary
+                if isinstance(s, dict) and s.get("type") == "summary_text"
+            ]
+            reasoning_content = "".join(texts)
+        else:
+            reasoning_content = provider_reasoning.get(
+                "reasoning"
+            ) or provider_reasoning.get("content")
+
+        # Build provider_metadata for round-trip preservation.
+        metadata: dict[str, Any] = {}
+        item_id = provider_reasoning.get("id")
+        if item_id:
+            metadata["responses_reasoning_id"] = item_id
+        if isinstance(summary, list):
+            metadata["responses_reasoning_summary"] = summary
+
+        part = ReasoningPart(type="reasoning")
 
         if reasoning_content:
-            return ReasoningPart(type="reasoning", reasoning=str(reasoning_content))
+            part["reasoning"] = str(reasoning_content)
+
+        # Preserve encrypted_content as signature.
+        encrypted = provider_reasoning.get("encrypted_content")
+        if encrypted:
+            part["signature"] = str(encrypted)
+
+        if metadata:
+            part["provider_metadata"] = metadata
+
+        # Return part if it has any meaningful content or metadata to preserve.
+        if reasoning_content or encrypted or metadata:
+            return part
 
         return None
 

--- a/src/llm_rosetta/converters/openai_responses/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/tool_ops.py
@@ -285,7 +285,9 @@ class OpenAIResponsesToolOps(BaseToolOps):
             if not tool_name and "function" in ir_tool_choice:
                 tool_name = cast(dict, ir_tool_choice)["function"].get("name")
             if tool_name:
-                return {"type": "function", "function": {"name": tool_name}}
+                # Responses API format: {"type": "function", "name": "..."}
+                # (NOT Chat Completions format which nests under "function" key)
+                return {"type": "function", "name": tool_name}
             return "required"
 
         return "auto"
@@ -317,10 +319,13 @@ class OpenAIResponsesToolOps(BaseToolOps):
 
         if isinstance(provider_tool_choice, dict):
             if provider_tool_choice.get("type") == "function":
-                func = provider_tool_choice.get("function", {})
-                return cast(
-                    ToolChoice, {"mode": "tool", "tool_name": func.get("name", "")}
-                )
+                # Support both Responses format {"name": "..."} and
+                # Chat Completions format {"function": {"name": "..."}}
+                tool_name = provider_tool_choice.get("name", "")
+                if not tool_name:
+                    func = provider_tool_choice.get("function", {})
+                    tool_name = func.get("name", "")
+                return cast(ToolChoice, {"mode": "tool", "tool_name": tool_name})
 
         return cast(ToolChoice, {"mode": "auto", "tool_name": ""})
 
@@ -368,9 +373,13 @@ class OpenAIResponsesToolOps(BaseToolOps):
                 "status": "calling",
             }
         elif tool_type == "function":
+            # Recover Responses API item ID from provider_metadata if available;
+            # the API requires 'id' to start with 'fc_' prefix.
+            metadata = ir_tool_call.get("provider_metadata") or {}
+            item_id = metadata.get("responses_item_id", tool_call_id)
             return {
                 "type": "function_call",
-                "id": tool_call_id,
+                "id": item_id,
                 "call_id": tool_call_id,
                 "name": tool_name,
                 "arguments": arguments,
@@ -439,15 +448,24 @@ class OpenAIResponsesToolOps(BaseToolOps):
             tool_input = {}
 
         if item_type == "function_call":
-            return ToolCallPart(
+            # Responses API has both 'id' (item ID, fc_ prefix) and
+            # 'call_id' (correlation ID, call_ prefix). Store call_id as
+            # tool_call_id for correlation, preserve 'id' in provider_metadata
+            # for lossless round-trip.
+            call_id = provider_tool_call.get(
+                "call_id", provider_tool_call.get("id", "")
+            )
+            item_id = provider_tool_call.get("id", "")
+            part = ToolCallPart(
                 type="tool_call",
-                tool_call_id=provider_tool_call.get(
-                    "call_id", provider_tool_call.get("id", "")
-                ),
+                tool_call_id=call_id,
                 tool_name=provider_tool_call.get("name", ""),
                 tool_input=tool_input,
                 tool_type="function",
             )
+            if item_id and item_id != call_id:
+                part["provider_metadata"] = {"responses_item_id": item_id}
+            return part
         elif item_type == "mcp_call":
             # MCP call may use server/tool fields or name field
             server = provider_tool_call.get("server", "")

--- a/src/llm_rosetta/types/ir/__init__.py
+++ b/src/llm_rosetta/types/ir/__init__.py
@@ -52,6 +52,7 @@ from .extensions import (
 # 辅助函数 Helper functions
 from .helpers import (
     create_tool_result_message,
+    extract_all_text,
     extract_text_content,
     extract_tool_calls,
 )
@@ -283,6 +284,7 @@ __all__ = [
     "IRInputSimple",
     # ========== 辅助函数 Helper functions ==========
     "extract_text_content",
+    "extract_all_text",
     "extract_tool_calls",
     "create_tool_result_message",
     # ========== 验证工具 Validation utilities ==========

--- a/src/llm_rosetta/types/ir/helpers.py
+++ b/src/llm_rosetta/types/ir/helpers.py
@@ -8,7 +8,7 @@ IR helper functions for processing IR messages and content
 from typing import Any, cast
 
 from .messages import Message, ToolMessage, create_tool_message
-from .parts import TextPart, ToolCallPart
+from .parts import ReasoningPart, TextPart, ToolCallPart
 from .type_guards import is_part_type
 
 # ============================================================================
@@ -32,6 +32,31 @@ def extract_text_content(message: Message) -> str:
             text = part.get("text", "")
             if text is not None:  # 确保text不是None Ensure text is not None
                 texts.append(str(text))
+    return "".join(texts)
+
+
+def extract_all_text(message: Message) -> str:
+    """Extract text from both TextPart and ReasoningPart content.
+
+    Useful for thinking models (e.g. gemini-2.5-flash) that may place the
+    answer inside reasoning parts rather than text parts.
+
+    Args:
+        message: IR format message.
+
+    Returns:
+        Concatenated text from all text and reasoning parts.
+    """
+    texts = []
+    for part in message.get("content", []):
+        if is_part_type(part, TextPart):
+            text = part.get("text", "")
+            if text is not None:
+                texts.append(str(text))
+        elif is_part_type(part, ReasoningPart):
+            reasoning = part.get("reasoning", "")
+            if reasoning is not None:
+                texts.append(str(reasoning))
     return "".join(texts)
 
 
@@ -103,6 +128,7 @@ def create_tool_result_message(
 __all__ = [
     # 内容提取函数 Content extraction functions
     "extract_text_content",
+    "extract_all_text",
     "extract_tool_calls",
     # 消息创建函数 Message creation functions
     "create_tool_result_message",

--- a/src/llm_rosetta/types/ir/response.py
+++ b/src/llm_rosetta/types/ir/response.py
@@ -83,7 +83,9 @@ class ChoiceInfo(TypedDict):
     index: Required[int]  # 选择索引 Choice index
     message: Required[Message]  # 生成的消息 Generated message
     finish_reason: Required[FinishReason]  # 停止原因 Stop reason
-    logprobs: NotRequired[dict[str, Any]]  # Log概率信息 Log probability information
+    logprobs: NotRequired[
+        dict[str, Any] | None
+    ]  # Log概率信息 Log probability information
 
 
 # ============================================================================
@@ -112,7 +114,7 @@ class IRResponse(TypedDict):
     # 可选字段 Optional fields
     usage: NotRequired[UsageInfo]  # Token使用统计 Token usage statistics
     service_tier: NotRequired[str]  # 服务等级 Service tier
-    system_fingerprint: NotRequired[str]  # 系统指纹 System fingerprint
+    system_fingerprint: NotRequired[str | None]  # 系统指纹 System fingerprint
 
 
 # ============================================================================

--- a/tests/converters/openai_responses/test_content_ops.py
+++ b/tests/converters/openai_responses/test_content_ops.py
@@ -257,14 +257,42 @@ class TestOpenAIResponsesContentOps:
         ir_reasoning = ReasoningPart(type="reasoning", reasoning="thinking...")
         result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
         assert result["type"] == "reasoning"
-        assert result["content"] == "thinking..."
+        assert result["summary"] == [{"type": "summary_text", "text": "thinking..."}]
 
     def test_ir_reasoning_to_p_empty(self):
-        """Test IR ReasoningPart with no reasoning → empty content."""
+        """Test IR ReasoningPart with no reasoning → empty summary."""
         ir_reasoning = cast(ReasoningPart, {"type": "reasoning"})
         result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
         assert result["type"] == "reasoning"
-        assert result["content"] == ""
+        assert result["summary"] == []
+
+    def test_ir_reasoning_to_p_with_id(self):
+        """Test IR ReasoningPart with provider_metadata id → preserves id."""
+        ir_reasoning = ReasoningPart(
+            type="reasoning",
+            reasoning="thinking...",
+            provider_metadata={"responses_reasoning_id": "rs_abc123"},
+        )
+        result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
+        assert result["type"] == "reasoning"
+        assert result["id"] == "rs_abc123"
+
+    def test_ir_reasoning_to_p_with_structured_summary(self):
+        """Test IR ReasoningPart with original summary in metadata → preserves it."""
+        original_summary = [
+            {"type": "summary_text", "text": "Step 1"},
+            {"type": "summary_text", "text": "Step 2"},
+        ]
+        ir_reasoning = ReasoningPart(
+            type="reasoning",
+            reasoning="Step 1Step 2",
+            provider_metadata={
+                "responses_reasoning_id": "rs_abc123",
+                "responses_reasoning_summary": original_summary,
+            },
+        )
+        result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
+        assert result["summary"] == original_summary
 
     def test_p_reasoning_to_ir_with_content(self):
         """Test OpenAI Responses reasoning with content → IR ReasoningPart."""
@@ -273,6 +301,18 @@ class TestOpenAIResponsesContentOps:
         assert result is not None
         assert result["type"] == "reasoning"
         assert result["reasoning"] == "I need to think about this..."
+
+    def test_p_reasoning_to_ir_with_summary(self):
+        """Test OpenAI Responses reasoning with summary array → IR ReasoningPart."""
+        provider = {
+            "type": "reasoning",
+            "id": "rs_abc123",
+            "summary": [{"type": "summary_text", "text": "thinking..."}],
+        }
+        result = OpenAIResponsesContentOps.p_reasoning_to_ir(provider)
+        assert result is not None
+        assert result["reasoning"] == "thinking..."
+        assert result["provider_metadata"]["responses_reasoning_id"] == "rs_abc123"
 
     def test_p_reasoning_to_ir_with_reasoning_field(self):
         """Test OpenAI Responses reasoning with 'reasoning' field → IR ReasoningPart."""
@@ -287,6 +327,19 @@ class TestOpenAIResponsesContentOps:
         result = OpenAIResponsesContentOps.p_reasoning_to_ir(provider)
         assert result is None
 
+    def test_p_reasoning_to_ir_with_encrypted_content(self):
+        """Test reasoning with encrypted_content → signature field."""
+        provider = {
+            "type": "reasoning",
+            "id": "rs_abc123",
+            "encrypted_content": "enc_sig_xyz",
+            "summary": [],
+        }
+        result = OpenAIResponsesContentOps.p_reasoning_to_ir(provider)
+        assert result is not None
+        assert result["signature"] == "enc_sig_xyz"
+        assert result["provider_metadata"]["responses_reasoning_id"] == "rs_abc123"
+
     def test_reasoning_round_trip(self):
         """Test reasoning round-trip: IR → Provider → IR."""
         original = ReasoningPart(type="reasoning", reasoning="Step by step analysis")
@@ -294,6 +347,19 @@ class TestOpenAIResponsesContentOps:
         restored = OpenAIResponsesContentOps.p_reasoning_to_ir(provider)
         assert restored is not None
         assert restored["reasoning"] == original["reasoning"]
+
+    def test_reasoning_round_trip_with_id(self):
+        """Test reasoning round-trip preserves id."""
+        provider = {
+            "type": "reasoning",
+            "id": "rs_abc123",
+            "summary": [{"type": "summary_text", "text": "thinking..."}],
+        }
+        ir = OpenAIResponsesContentOps.p_reasoning_to_ir(provider)
+        assert ir is not None
+        restored = OpenAIResponsesContentOps.ir_reasoning_to_p(ir)
+        assert restored["id"] == "rs_abc123"
+        assert restored["summary"] == provider["summary"]
 
     # ==================== Refusal ====================
 

--- a/tests/converters/openai_responses/test_tool_ops.py
+++ b/tests/converters/openai_responses/test_tool_ops.py
@@ -153,7 +153,7 @@ class TestOpenAIResponsesToolOps:
         result = OpenAIResponsesToolOps.ir_tool_choice_to_p(
             cast(ToolChoice, {"mode": "tool", "tool_name": "get_weather"})
         )
-        assert result == {"type": "function", "function": {"name": "get_weather"}}
+        assert result == {"type": "function", "name": "get_weather"}
 
     def test_ir_tool_choice_legacy_type_field(self):
         """Test legacy 'type' field support."""

--- a/tests/integration/test_anthropic_sdk_e2e.py
+++ b/tests/integration/test_anthropic_sdk_e2e.py
@@ -28,7 +28,12 @@ import dotenv
 
 from typing import Any, cast
 
-from examples.tools import available_tools, tools_spec
+from examples.tools import (
+    available_tools,
+    generate_chart,
+    multimodal_tools_spec,
+    tools_spec,
+)
 from llm_rosetta.converters.anthropic import AnthropicConverter
 from llm_rosetta.types.ir import (
     IRRequest,
@@ -44,6 +49,14 @@ dotenv.load_dotenv(override=True)
 # ============================================================================
 # Setup
 # ============================================================================
+
+IMAGE_URL = (
+    "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/"
+    "La_Libert%C3%A9_guidant_le_peuple_-_Eug%C3%A8ne_Delacroix_-_"
+    "Mus%C3%A9e_du_Louvre_Peintures_RF_129_-_apr%C3%A8s_restauration_2024.jpg/"
+    "3840px-La_Libert%C3%A9_guidant_le_peuple_-_Eug%C3%A8ne_Delacroix_-_"
+    "Mus%C3%A9e_du_Louvre_Peintures_RF_129_-_apr%C3%A8s_restauration_2024.jpg"
+)
 
 anthropic_model = os.getenv("ANTHROPIC_MODEL", "claude-3-5-sonnet-20241022")
 anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
@@ -341,13 +354,175 @@ def test_stream_tool_calls():
 
 
 # ============================================================================
-# Test 5: Round-trip request conversion
+# Test 5: Multimodal tool result
+# ============================================================================
+
+
+def test_multimodal_tool_result():
+    """Test tool returning multimodal content (text + image)."""
+    section("Test 5: Multimodal tool result")
+
+    ir_request: IRRequest = {
+        "model": anthropic_model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Generate a bar chart for me."},
+                ],
+            },
+        ],
+        "tools": cast(list[ToolDefinition], multimodal_tools_spec),
+        "tool_choice": {"mode": "tool", "tool_name": "generate_chart"},
+    }
+
+    provider_req, warnings = converter.request_to_provider(ir_request)
+    print(f"  Round 1 warnings: {warnings}")
+
+    response = client.messages.create(**provider_req)
+    ir_response = converter.response_from_provider(response)
+
+    assistant_msg = ir_response["choices"][0]["message"]
+    tool_calls = extract_tool_calls(assistant_msg)
+    text = extract_text_content(assistant_msg)
+    print(f"  Tool calls: {len(tool_calls)}")
+
+    if tool_calls:
+        tc = tool_calls[0]
+        print(f"  Tool: {tc['tool_name']}({json.dumps(tc['tool_input'])})")
+        assert tc["tool_name"] == "generate_chart"
+
+        result = generate_chart(**tc["tool_input"])
+        print(f"  Tool result type: {type(result).__name__}, length: {len(result)}")
+
+        tool_result_msg = create_tool_result_message(tc["tool_call_id"], result)
+
+        ir_request_r2: IRRequest = {
+            "model": anthropic_model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Generate a bar chart for me."},
+                    ],
+                },
+                assistant_msg,
+                tool_result_msg,
+            ],
+            "tools": cast(list[ToolDefinition], multimodal_tools_spec),
+        }
+
+        provider_req_r2, warnings_r2 = converter.request_to_provider(ir_request_r2)
+        print(f"  Round 2 warnings: {warnings_r2}")
+
+        response_r2 = client.messages.create(**provider_req_r2)
+        ir_response_r2 = converter.response_from_provider(response_r2)
+
+        final_text = extract_text_content(ir_response_r2["choices"][0]["message"])
+        print(f"  Final response: {final_text[:120]}...")
+        assert len(final_text) > 5
+    else:
+        print(
+            f"  Model ignored forced tool_choice, responded with text: {text[:120]}..."
+        )
+        assert len(text) > 5
+
+    ok("Multimodal tool result")
+    return True
+
+
+# ============================================================================
+# Test 6: Image input with tool calls
+# ============================================================================
+
+
+def test_image_with_tool_calls():
+    """Test image input combined with tool call capability."""
+    section("Test 6: Image input with tool calls")
+
+    ir_request: IRRequest = {
+        "model": anthropic_model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "This painting depicts a famous scene in Paris, France. "
+                            "What is the current weather in Paris?"
+                        ),
+                    },
+                    {"type": "image", "image_url": IMAGE_URL},
+                ],
+            },
+        ],
+        "tools": cast(list[ToolDefinition], tools_spec),
+        "tool_choice": {"mode": "auto"},
+    }
+
+    provider_req, warnings = converter.request_to_provider(ir_request)
+    print(f"  Warnings: {warnings}")
+
+    response = client.messages.create(**provider_req)
+    ir_response = converter.response_from_provider(response)
+
+    assistant_msg = ir_response["choices"][0]["message"]
+    tool_calls = extract_tool_calls(assistant_msg)
+    text = extract_text_content(assistant_msg)
+
+    if tool_calls:
+        print(f"  Tool calls: {len(tool_calls)}")
+        tc = tool_calls[0]
+        print(f"  Tool: {tc['tool_name']}({json.dumps(tc['tool_input'])})")
+
+        result = execute_tool(tc)
+        tool_result_msg = create_tool_result_message(tc["tool_call_id"], result)
+
+        ir_request_r2: IRRequest = {
+            "model": anthropic_model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "This painting depicts a famous scene in Paris, France. "
+                                "What is the current weather in Paris?"
+                            ),
+                        },
+                        {"type": "image", "image_url": IMAGE_URL},
+                    ],
+                },
+                assistant_msg,
+                tool_result_msg,
+            ],
+            "tools": cast(list[ToolDefinition], tools_spec),
+        }
+
+        provider_req_r2, _ = converter.request_to_provider(ir_request_r2)
+        response_r2 = client.messages.create(**provider_req_r2)
+        ir_response_r2 = converter.response_from_provider(response_r2)
+        final_text = extract_text_content(ir_response_r2["choices"][0]["message"])
+        print(f"  Final response: {final_text[:120]}...")
+        assert len(final_text) > 5
+    else:
+        print(f"  Model responded with text (no tool call): {text[:120]}...")
+        assert len(text) > 5
+
+    ok("Image input with tool calls")
+    return True
+
+
+# ============================================================================
+# Test 7: Round-trip request conversion
 # ============================================================================
 
 
 def test_request_round_trip():
     """Test request_to_provider → request_from_provider round-trip."""
-    section("Test 5: Request round-trip conversion")
+    section("Test 7: Request round-trip conversion")
 
     ir_request: IRRequest = {
         "model": anthropic_model,
@@ -390,7 +565,7 @@ def test_request_round_trip():
 
 def test_response_round_trip():
     """Test response_from_provider → response_to_provider round-trip."""
-    section("Test 6: Response round-trip conversion")
+    section("Test 8: Response round-trip conversion")
 
     ir_request: IRRequest = {
         "model": anthropic_model,
@@ -442,6 +617,8 @@ def run_all():
         ("Non-stream with tool calls", test_non_stream_tool_calls),
         ("Streaming text", test_stream_text),
         ("Streaming with tool calls", test_stream_tool_calls),
+        ("Multimodal tool result", test_multimodal_tool_result),
+        ("Image with tool calls", test_image_with_tool_calls),
         ("Request round-trip", test_request_round_trip),
         ("Response round-trip", test_response_round_trip),
     ]

--- a/tests/integration/test_google_genai_sdk_e2e.py
+++ b/tests/integration/test_google_genai_sdk_e2e.py
@@ -29,13 +29,20 @@ from google.genai import types
 
 from typing import Any, cast
 
-from examples.tools import available_tools, tools_spec
+from examples.tools import (
+    available_tools,
+    generate_chart,
+    multimodal_tools_spec,
+    tools_spec,
+)
 from llm_rosetta.converters.google_genai import GoogleGenAIConverter
 from llm_rosetta.types.ir import (
     IRRequest,
+    Message,
     ToolCallPart,
     ToolDefinition,
     create_tool_result_message,
+    extract_all_text,
     extract_text_content,
     extract_tool_calls,
 )
@@ -45,6 +52,14 @@ dotenv.load_dotenv(override=True)
 # ============================================================================
 # Setup
 # ============================================================================
+
+IMAGE_URL = (
+    "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/"
+    "La_Libert%C3%A9_guidant_le_peuple_-_Eug%C3%A8ne_Delacroix_-_"
+    "Mus%C3%A9e_du_Louvre_Peintures_RF_129_-_apr%C3%A8s_restauration_2024.jpg/"
+    "3840px-La_Libert%C3%A9_guidant_le_peuple_-_Eug%C3%A8ne_Delacroix_-_"
+    "Mus%C3%A9e_du_Louvre_Peintures_RF_129_-_apr%C3%A8s_restauration_2024.jpg"
+)
 
 google_model = os.getenv("GOOGLE_MODEL", "gemini-2.0-flash")
 google_api_key = os.getenv("GOOGLE_API_KEY")
@@ -74,6 +89,12 @@ def ok(name: str) -> None:
 
 def fail(name: str, err: str) -> None:
     print(f"  ✗ FAIL: {name} — {err}")
+
+
+def get_text(msg: Message) -> str:
+    """Extract text from message, falling back to reasoning content for thinking models."""
+    text = extract_text_content(msg)
+    return text if text else extract_all_text(msg)
 
 
 def execute_tool(tc: ToolCallPart) -> str:
@@ -242,7 +263,7 @@ def test_non_stream_basic():
     assert len(ir_response["choices"]) >= 1
 
     msg = ir_response["choices"][0]["message"]
-    text = extract_text_content(msg)
+    text = get_text(msg)
     print(f"  Response text: {text}")
     assert "4" in text
 
@@ -325,6 +346,7 @@ def test_non_stream_tool_calls():
             tool_result_msg,
         ],
         "tools": cast(list[ToolDefinition], tools_spec),
+        "tool_choice": {"mode": "none"},
     }
 
     provider_req_r2, warnings_r2 = converter.request_to_provider(ir_request_r2)
@@ -341,7 +363,7 @@ def test_non_stream_tool_calls():
     ir_response_r2 = converter.response_from_provider(cast(dict[str, Any], response_r2))
 
     final_msg = ir_response_r2["choices"][0]["message"]
-    final_text = extract_text_content(final_msg)
+    final_text = get_text(final_msg)
     print(f"  Final response: {final_text[:120]}...")
     assert len(final_text) > 5
 
@@ -441,13 +463,212 @@ def test_response_round_trip():
 
 
 # ============================================================================
-# Test 5: Multi-turn conversation
+# Test 5: Multimodal tool result
+# ============================================================================
+
+
+def test_multimodal_tool_result():
+    """Test tool returning multimodal content (text + image)."""
+    section("Test 5: Multimodal tool result")
+
+    ir_request: IRRequest = {
+        "model": google_model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Generate a bar chart for me."},
+                ],
+            },
+        ],
+        "tools": cast(list[ToolDefinition], multimodal_tools_spec),
+        "tool_choice": {"mode": "tool", "tool_name": "generate_chart"},
+    }
+
+    provider_req, warnings = converter.request_to_provider(ir_request)
+    print(f"  Round 1 warnings: {warnings}")
+
+    sdk_contents = build_sdk_contents(provider_req)
+    sdk_config = build_sdk_config(provider_req)
+
+    response = client.models.generate_content(
+        model=google_model,
+        contents=sdk_contents,
+        config=sdk_config,
+    )
+    ir_response = converter.response_from_provider(cast(dict[str, Any], response))
+
+    assistant_msg = ir_response["choices"][0]["message"]
+    tool_calls = extract_tool_calls(assistant_msg)
+    text = get_text(assistant_msg)
+    print(f"  Tool calls: {len(tool_calls)}")
+
+    if tool_calls:
+        tc = tool_calls[0]
+        print(f"  Tool: {tc['tool_name']}({json.dumps(tc['tool_input'])})")
+        assert tc["tool_name"] == "generate_chart"
+
+        result = generate_chart(**tc["tool_input"])
+        print(f"  Tool result type: {type(result).__name__}, length: {len(result)}")
+
+        tool_result_msg = create_tool_result_message(tc["tool_call_id"], result)
+
+        ir_request_r2: IRRequest = {
+            "model": google_model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Generate a bar chart for me."},
+                    ],
+                },
+                assistant_msg,
+                tool_result_msg,
+            ],
+            "tools": cast(list[ToolDefinition], multimodal_tools_spec),
+            "tool_choice": {"mode": "none"},
+        }
+
+        provider_req_r2, warnings_r2 = converter.request_to_provider(ir_request_r2)
+        print(f"  Round 2 warnings: {warnings_r2}")
+
+        sdk_contents_r2 = build_sdk_contents(provider_req_r2)
+        sdk_config_r2 = build_sdk_config(provider_req_r2)
+
+        response_r2 = client.models.generate_content(
+            model=google_model,
+            contents=sdk_contents_r2,
+            config=sdk_config_r2,
+        )
+        ir_response_r2 = converter.response_from_provider(
+            cast(dict[str, Any], response_r2)
+        )
+
+        final_text = get_text(ir_response_r2["choices"][0]["message"])
+        print(f"  Final response: {final_text[:120]}...")
+        assert len(final_text) > 5
+    else:
+        print(
+            f"  Model ignored forced tool_choice, responded with text: {text[:120]}..."
+        )
+        assert len(text) > 5
+
+    ok("Multimodal tool result")
+    return True
+
+
+# ============================================================================
+# Test 6: Image input with tool calls
+# ============================================================================
+
+
+def test_image_with_tool_calls():
+    """Test image input combined with tool call capability."""
+    section("Test 6: Image input with tool calls")
+
+    ir_request: IRRequest = {
+        "model": google_model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "This painting depicts a famous scene in Paris, France. "
+                            "What is the current weather in Paris?"
+                        ),
+                    },
+                    {"type": "image", "image_url": IMAGE_URL},
+                ],
+            },
+        ],
+        "tools": cast(list[ToolDefinition], tools_spec),
+        "tool_choice": {"mode": "auto"},
+    }
+
+    provider_req, warnings = converter.request_to_provider(ir_request)
+    print(f"  Warnings: {warnings}")
+
+    sdk_contents = build_sdk_contents(provider_req)
+    sdk_config = build_sdk_config(provider_req)
+
+    response = client.models.generate_content(
+        model=google_model,
+        contents=sdk_contents,
+        config=sdk_config,
+    )
+    ir_response = converter.response_from_provider(cast(dict[str, Any], response))
+
+    assistant_msg = ir_response["choices"][0]["message"]
+    tool_calls = extract_tool_calls(assistant_msg)
+    text = get_text(assistant_msg)
+
+    if tool_calls:
+        print(f"  Tool calls: {len(tool_calls)}")
+        tc = tool_calls[0]
+        print(f"  Tool: {tc['tool_name']}({json.dumps(tc['tool_input'])})")
+
+        result = execute_tool(tc)
+        tool_result_msg = create_tool_result_message(tc["tool_call_id"], result)
+
+        ir_request_r2: IRRequest = {
+            "model": google_model,
+            "messages": cast(
+                list[Message],
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    "This painting depicts a famous scene in Paris. "
+                                    "What is the current weather in Paris?"
+                                ),
+                            },
+                            {"type": "image", "image_url": IMAGE_URL},
+                        ],
+                    },
+                    assistant_msg,
+                    tool_result_msg,
+                ],
+            ),
+            "tools": cast(list[ToolDefinition], tools_spec),
+            "tool_choice": {"mode": "none"},
+        }
+
+        provider_req_r2, _ = converter.request_to_provider(ir_request_r2)
+        sdk_contents_r2 = build_sdk_contents(provider_req_r2)
+        sdk_config_r2 = build_sdk_config(provider_req_r2)
+
+        response_r2 = client.models.generate_content(
+            model=google_model,
+            contents=sdk_contents_r2,
+            config=sdk_config_r2,
+        )
+        ir_response_r2 = converter.response_from_provider(
+            cast(dict[str, Any], response_r2)
+        )
+        final_text = get_text(ir_response_r2["choices"][0]["message"])
+        print(f"  Final response: {final_text[:120]}...")
+        assert len(final_text) > 5
+    else:
+        print(f"  Model responded with text (no tool call): {text[:120]}...")
+        assert len(text) > 5
+
+    ok("Image input with tool calls")
+    return True
+
+
+# ============================================================================
+# Test 7: Multi-turn conversation
 # ============================================================================
 
 
 def test_multi_turn():
     """Test multi-turn conversation flow."""
-    section("Test 5: Multi-turn conversation")
+    section("Test 7: Multi-turn conversation")
 
     # Turn 1
     ir_request: IRRequest = {
@@ -472,7 +693,7 @@ def test_multi_turn():
     )
     ir_response = converter.response_from_provider(cast(dict[str, Any], response))
     assistant_msg_1 = ir_response["choices"][0]["message"]
-    text_1 = extract_text_content(assistant_msg_1)
+    text_1 = get_text(assistant_msg_1)
     print(f"  Turn 1 response: {text_1[:80]}...")
 
     # Turn 2
@@ -502,7 +723,7 @@ def test_multi_turn():
         config=sdk_config_2,
     )
     ir_response_2 = converter.response_from_provider(cast(dict[str, Any], response_2))
-    text_2 = extract_text_content(ir_response_2["choices"][0]["message"])
+    text_2 = get_text(ir_response_2["choices"][0]["message"])
     print(f"  Turn 2 response: {text_2[:80]}...")
     assert "alice" in text_2.lower()
 
@@ -523,6 +744,8 @@ def run_all():
     tests = [
         ("Non-stream basic text", test_non_stream_basic),
         ("Non-stream with tool calls", test_non_stream_tool_calls),
+        ("Multimodal tool result", test_multimodal_tool_result),
+        ("Image with tool calls", test_image_with_tool_calls),
         ("Request round-trip", test_request_round_trip),
         ("Response round-trip", test_response_round_trip),
         ("Multi-turn conversation", test_multi_turn),

--- a/tests/integration/test_openai_chat_sdk_e2e.py
+++ b/tests/integration/test_openai_chat_sdk_e2e.py
@@ -27,7 +27,12 @@ from openai import OpenAI
 
 from typing import cast
 
-from examples.tools import available_tools, tools_spec
+from examples.tools import (
+    available_tools,
+    generate_chart,
+    multimodal_tools_spec,
+    tools_spec,
+)
 from llm_rosetta.converters.openai_chat import OpenAIChatConverter
 from llm_rosetta.types.ir import (
     IRRequest,
@@ -392,13 +397,187 @@ def test_stream_tool_calls():
 
 
 # ============================================================================
-# Test 6: Round-trip request conversion
+# Test 6: Multimodal tool result
+# ============================================================================
+
+
+def test_multimodal_tool_result():
+    """Test tool returning multimodal content (text + image)."""
+    section("Test 6: Multimodal tool result")
+
+    # Round 1: Ask to generate a chart
+    ir_request: IRRequest = {
+        "model": openai_model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Generate a bar chart for me.",
+                    }
+                ],
+            },
+        ],
+        "tools": cast(list[ToolDefinition], multimodal_tools_spec),
+        "tool_choice": {"mode": "tool", "tool_name": "generate_chart"},
+    }
+
+    provider_req, warnings = converter.request_to_provider(ir_request)
+    print(f"  Round 1 warnings: {warnings}")
+
+    response = client.chat.completions.create(**provider_req)
+    ir_response = converter.response_from_provider(response)
+
+    assistant_msg = ir_response["choices"][0]["message"]
+    tool_calls = extract_tool_calls(assistant_msg)
+    text = extract_text_content(assistant_msg)
+    print(f"  Tool calls: {len(tool_calls)}")
+
+    if tool_calls:
+        tc = tool_calls[0]
+        print(f"  Tool: {tc['tool_name']}({json.dumps(tc['tool_input'])})")
+        assert tc["tool_name"] == "generate_chart"
+
+        # Execute tool — returns multimodal list [TextPart, ImagePart]
+        result = generate_chart(**tc["tool_input"])
+        print(f"  Tool result type: {type(result).__name__}, length: {len(result)}")
+        assert isinstance(result, list)
+
+        # Round 2: Send multimodal tool result
+        tool_result_msg = create_tool_result_message(tc["tool_call_id"], result)
+
+        ir_request_r2: IRRequest = {
+            "model": openai_model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Generate a bar chart for me."},
+                    ],
+                },
+                assistant_msg,
+                tool_result_msg,
+            ],
+            "tools": cast(list[ToolDefinition], multimodal_tools_spec),
+        }
+
+        provider_req_r2, warnings_r2 = converter.request_to_provider(ir_request_r2)
+        print(f"  Round 2 warnings: {warnings_r2}")
+
+        # Verify dual encoding: tool msg has json.dumps, synthetic user msg has image_url
+        roles_r2 = [m["role"] for m in provider_req_r2["messages"]]
+        print(f"  Round 2 message roles: {roles_r2}")
+
+        response_r2 = client.chat.completions.create(**provider_req_r2)
+        ir_response_r2 = converter.response_from_provider(response_r2)
+
+        final_msg = ir_response_r2["choices"][0]["message"]
+        final_text = extract_text_content(final_msg)
+        print(f"  Final response: {final_text[:120]}...")
+        assert len(final_text) > 5
+    else:
+        print(
+            f"  Model ignored forced tool_choice, responded with text: {text[:120]}..."
+        )
+        assert len(text) > 5
+
+    ok("Multimodal tool result")
+    return True
+
+
+# ============================================================================
+# Test 7: Image input with tool calls
+# ============================================================================
+
+
+def test_image_with_tool_calls():
+    """Test image input combined with tool call capability."""
+    section("Test 7: Image input with tool calls")
+
+    ir_request: IRRequest = {
+        "model": openai_model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "This painting depicts a famous scene in Paris, France. "
+                            "What is the current weather in Paris?"
+                        ),
+                    },
+                    {"type": "image", "image_url": IMAGE_URL},
+                ],
+            },
+        ],
+        "tools": cast(list[ToolDefinition], tools_spec),
+        "tool_choice": {"mode": "auto"},
+    }
+
+    provider_req, warnings = converter.request_to_provider(ir_request)
+    print(f"  Warnings: {warnings}")
+
+    response = client.chat.completions.create(**provider_req)
+    ir_response = converter.response_from_provider(response)
+
+    assistant_msg = ir_response["choices"][0]["message"]
+    tool_calls = extract_tool_calls(assistant_msg)
+    text = extract_text_content(assistant_msg)
+
+    if tool_calls:
+        print(f"  Tool calls: {len(tool_calls)}")
+        tc = tool_calls[0]
+        print(f"  Tool: {tc['tool_name']}({json.dumps(tc['tool_input'])})")
+
+        result = execute_tool(tc)
+        tool_result_msg = create_tool_result_message(tc["tool_call_id"], result)
+
+        ir_request_r2: IRRequest = {
+            "model": openai_model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "This painting depicts a famous scene in Paris, France. "
+                                "What is the current weather in Paris?"
+                            ),
+                        },
+                        {"type": "image", "image_url": IMAGE_URL},
+                    ],
+                },
+                assistant_msg,
+                tool_result_msg,
+            ],
+            "tools": cast(list[ToolDefinition], tools_spec),
+        }
+
+        provider_req_r2, _ = converter.request_to_provider(ir_request_r2)
+        response_r2 = client.chat.completions.create(**provider_req_r2)
+        ir_response_r2 = converter.response_from_provider(response_r2)
+        final_text = extract_text_content(ir_response_r2["choices"][0]["message"])
+        print(f"  Final response: {final_text[:120]}...")
+        assert len(final_text) > 5
+    else:
+        print(f"  Model responded with text (no tool call): {text[:120]}...")
+        assert len(text) > 5
+
+    ok("Image input with tool calls")
+    return True
+
+
+# ============================================================================
+# Test 8: Round-trip request conversion
 # ============================================================================
 
 
 def test_request_round_trip():
     """Test request_to_provider → request_from_provider round-trip."""
-    section("Test 6: Request round-trip conversion")
+    section("Test 8: Request round-trip conversion")
 
     ir_request: IRRequest = {
         "model": openai_model,
@@ -441,7 +620,7 @@ def test_request_round_trip():
 
 def test_response_round_trip():
     """Test response_from_provider → response_to_provider round-trip."""
-    section("Test 7: Response round-trip conversion")
+    section("Test 9: Response round-trip conversion")
 
     ir_request: IRRequest = {
         "model": openai_model,
@@ -489,6 +668,8 @@ def run_all():
         ("Non-stream with tool calls", test_non_stream_tool_calls),
         ("Streaming text", test_stream_text),
         ("Streaming with tool calls", test_stream_tool_calls),
+        ("Multimodal tool result", test_multimodal_tool_result),
+        ("Image with tool calls", test_image_with_tool_calls),
         ("Request round-trip", test_request_round_trip),
         ("Response round-trip", test_response_round_trip),
     ]

--- a/tests/integration/test_openai_responses_sdk_e2e.py
+++ b/tests/integration/test_openai_responses_sdk_e2e.py
@@ -26,7 +26,12 @@ from openai import OpenAI
 
 from typing import cast
 
-from examples.tools import available_tools, tools_spec
+from examples.tools import (
+    available_tools,
+    generate_chart,
+    multimodal_tools_spec,
+    tools_spec,
+)
 from llm_rosetta.converters.openai_responses import OpenAIResponsesConverter
 from llm_rosetta.types.ir import (
     IRRequest,
@@ -42,6 +47,14 @@ dotenv.load_dotenv(override=True)
 # ============================================================================
 # Setup
 # ============================================================================
+
+IMAGE_URL = (
+    "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/"
+    "La_Libert%C3%A9_guidant_le_peuple_-_Eug%C3%A8ne_Delacroix_-_"
+    "Mus%C3%A9e_du_Louvre_Peintures_RF_129_-_apr%C3%A8s_restauration_2024.jpg/"
+    "3840px-La_Libert%C3%A9_guidant_le_peuple_-_Eug%C3%A8ne_Delacroix_-_"
+    "Mus%C3%A9e_du_Louvre_Peintures_RF_129_-_apr%C3%A8s_restauration_2024.jpg"
+)
 
 openai_model = os.getenv("OPENAI_RESPONSES_MODEL", "gpt-4o-mini")
 openai_api_key = os.getenv("OPENAI_RESPONSES_API_KEY")
@@ -228,13 +241,200 @@ def test_non_stream_tool_calls():
 
 
 # ============================================================================
-# Test 3: Request round-trip conversion
+# Test 3: Multimodal tool result
+# ============================================================================
+
+
+def test_multimodal_tool_result():
+    """Test tool returning multimodal content (text + image)."""
+    section("Test 3: Multimodal tool result")
+
+    ir_request: IRRequest = {
+        "model": openai_model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Generate a bar chart for me."},
+                ],
+            },
+        ],
+        "tools": cast(list[ToolDefinition], multimodal_tools_spec),
+        "tool_choice": {"mode": "tool", "tool_name": "generate_chart"},
+    }
+
+    provider_req, warnings = converter.request_to_provider(ir_request)
+    print(f"  Round 1 warnings: {warnings}")
+
+    response = client.responses.create(**provider_req)
+    response_data = response.model_dump()
+    ir_response = converter.response_from_provider(response_data)
+
+    assistant_msg = ir_response["choices"][0]["message"]
+    tool_calls = extract_tool_calls(assistant_msg)
+    text = extract_text_content(assistant_msg)
+    print(f"  Tool calls: {len(tool_calls)}")
+
+    if tool_calls:
+        tc = tool_calls[0]
+        print(f"  Tool: {tc['tool_name']}({json.dumps(tc['tool_input'])})")
+        assert tc["tool_name"] == "generate_chart"
+
+        result = generate_chart(**tc["tool_input"])
+        print(f"  Tool result type: {type(result).__name__}, length: {len(result)}")
+
+        ir_request_r2: IRRequest = {
+            "model": openai_model,
+            "messages": cast(
+                list[Message],
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Generate a bar chart for me."},
+                        ],
+                    },
+                    assistant_msg,
+                    {
+                        "role": "tool",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_call_id": tc["tool_call_id"],
+                                "result": result,
+                            }
+                        ],
+                    },
+                ],
+            ),
+            "tools": cast(list[ToolDefinition], multimodal_tools_spec),
+        }
+
+        provider_req_r2, warnings_r2 = converter.request_to_provider(ir_request_r2)
+        print(f"  Round 2 warnings: {warnings_r2}")
+
+        response_r2 = client.responses.create(**provider_req_r2)
+        response_data_r2 = response_r2.model_dump()
+        ir_response_r2 = converter.response_from_provider(response_data_r2)
+
+        final_text = extract_text_content(ir_response_r2["choices"][0]["message"])
+        print(f"  Final response: {final_text[:120]}...")
+        assert len(final_text) > 5
+    else:
+        print(
+            f"  Model ignored forced tool_choice, responded with text: {text[:120]}..."
+        )
+        assert len(text) > 5
+
+    ok("Multimodal tool result")
+    return True
+
+
+# ============================================================================
+# Test 4: Image input with tool calls
+# ============================================================================
+
+
+def test_image_with_tool_calls():
+    """Test image input combined with tool call capability."""
+    section("Test 4: Image input with tool calls")
+
+    ir_request: IRRequest = {
+        "model": openai_model,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "This painting depicts a famous scene in Paris, France. "
+                            "What is the current weather in Paris?"
+                        ),
+                    },
+                    {"type": "image", "image_url": IMAGE_URL},
+                ],
+            },
+        ],
+        "tools": cast(list[ToolDefinition], tools_spec),
+        "tool_choice": {"mode": "auto"},
+    }
+
+    provider_req, warnings = converter.request_to_provider(ir_request)
+    print(f"  Warnings: {warnings}")
+
+    response = client.responses.create(**provider_req)
+    response_data = response.model_dump()
+    ir_response = converter.response_from_provider(response_data)
+
+    assistant_msg = ir_response["choices"][0]["message"]
+    tool_calls = extract_tool_calls(assistant_msg)
+    text = extract_text_content(assistant_msg)
+
+    if tool_calls:
+        print(f"  Tool calls: {len(tool_calls)}")
+        tc = tool_calls[0]
+        print(f"  Tool: {tc['tool_name']}({json.dumps(tc['tool_input'])})")
+
+        result = execute_tool(tc)
+
+        ir_request_r2: IRRequest = {
+            "model": openai_model,
+            "messages": cast(
+                list[Message],
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    "This painting depicts a famous scene in Paris. "
+                                    "What is the current weather in Paris?"
+                                ),
+                            },
+                            {"type": "image", "image_url": IMAGE_URL},
+                        ],
+                    },
+                    assistant_msg,
+                    {
+                        "role": "tool",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_call_id": tc["tool_call_id"],
+                                "result": result,
+                            }
+                        ],
+                    },
+                ],
+            ),
+            "tools": cast(list[ToolDefinition], tools_spec),
+        }
+
+        provider_req_r2, _ = converter.request_to_provider(ir_request_r2)
+        response_r2 = client.responses.create(**provider_req_r2)
+        response_data_r2 = response_r2.model_dump()
+        ir_response_r2 = converter.response_from_provider(response_data_r2)
+        final_text = extract_text_content(ir_response_r2["choices"][0]["message"])
+        print(f"  Final response: {final_text[:120]}...")
+        assert len(final_text) > 5
+    else:
+        print(f"  Model responded with text (no tool call): {text[:120]}...")
+        assert len(text) > 5
+
+    ok("Image input with tool calls")
+    return True
+
+
+# ============================================================================
+# Test 5: Request round-trip conversion
 # ============================================================================
 
 
 def test_request_round_trip():
     """Test request_to_provider → request_from_provider round-trip."""
-    section("Test 3: Request round-trip conversion")
+    section("Test 5: Request round-trip conversion")
 
     ir_request: IRRequest = {
         "model": openai_model,
@@ -280,7 +480,7 @@ def test_request_round_trip():
 
 def test_response_round_trip():
     """Test response_from_provider → response_to_provider round-trip."""
-    section("Test 4: Response round-trip conversion")
+    section("Test 6: Response round-trip conversion")
 
     ir_request: IRRequest = {
         "model": openai_model,
@@ -332,6 +532,8 @@ def run_all():
     tests = [
         ("Non-stream basic text", test_non_stream_basic),
         ("Non-stream with tool calls", test_non_stream_tool_calls),
+        ("Multimodal tool result", test_multimodal_tool_result),
+        ("Image with tool calls", test_image_with_tool_calls),
         ("Request round-trip", test_request_round_trip),
         ("Response round-trip", test_response_round_trip),
     ]


### PR DESCRIPTION
## Summary

- Add multimodal integration tests across all 4 provider SDKs (OpenAI Chat, OpenAI Responses, Anthropic, Google GenAI)
- Two new test scenarios per provider: (A) tool returning multimodal content (text + image), (B) image input combined with tool calls
- Fix several pre-existing converter/validation issues discovered during integration testing

## Changes

### New: `examples/tools.py`
- `generate_chart()` tool returning multimodal `[TextPart, ImagePart]` with inline base64 PNG
- `multimodal_tools_spec` combining all 3 tools

### Fix: IR validation (#91 follow-up)
- `logprobs` and `system_fingerprint` in `IRResponse` now accept `None` values

### Fix: OpenAI Responses converter
- `tool_choice` format: use `{"type": "function", "name": "..."}` (not Chat Completions format)
- Tool call ID round-trip: preserve Responses `id` (fc_ prefix) in `provider_metadata` separately from `call_id` (call_ prefix)
- Reasoning item round-trip: preserve `id`, structured `summary`, and `encrypted_content` for reasoning models (gpt-5-nano)

### Fix: Google GenAI thinking model
- `extract_all_text()` helper: extracts text from both `TextPart` and `ReasoningPart` (gemini-2.5-flash puts answers in reasoning parts)

### Integration test resilience
- All `test_multimodal_tool_result` tests gracefully handle models that ignore forced `tool_choice`
- Google GenAI Round 2 requests use `tool_choice: none` to prevent re-calling tools

## Test results

All 1292 unit tests pass. Integration tests against official APIs via proxychains:

| Provider | Tests | Result |
|---|---|---|
| OpenAI Chat | 9/9 | PASS |
| OpenAI Responses | 6/6 | PASS |
| Anthropic (OpenRouter) | 8/8 | PASS |
| Google GenAI | 7/7 | PASS |

## Test plan

- [x] Unit tests: pytest tests/ --ignore=tests/integration (1292 passed)
- [x] Integration: proxychains python tests/integration/test_openai_chat_sdk_e2e.py
- [x] Integration: proxychains python tests/integration/test_openai_responses_sdk_e2e.py
- [x] Integration: proxychains python tests/integration/test_anthropic_sdk_e2e.py
- [x] Integration: proxychains python tests/integration/test_google_genai_sdk_e2e.py