### PR TITLE
fix: add contextual error messages for tool conversion failures

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -221,9 +221,23 @@ class AnthropicConverter(BaseConverter):
         # 3. Tools
         tools = provider_request.get("tools")
         if tools:
-            ir_request["tools"] = [
-                self.tool_ops.p_tool_definition_to_ir(t) for t in tools
-            ]
+            ir_tools = []
+            for t in tools:
+                try:
+                    ir_tools.append(self.tool_ops.p_tool_definition_to_ir(t))
+                except Exception as e:
+                    tool_type = (
+                        t.get("type", "unknown")
+                        if isinstance(t, dict)
+                        else type(t).__name__
+                    )
+                    tool_name = (
+                        t.get("name", "unnamed") if isinstance(t, dict) else str(t)
+                    )
+                    raise ValueError(
+                        f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
+                    ) from e
+            ir_request["tools"] = ir_tools
 
         # 4. Tool choice
         tool_choice = provider_request.get("tool_choice")

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -332,7 +332,20 @@ class GoogleGenAIConverter(BaseConverter):
         if tools:
             ir_tools: list = []
             for t in tools:
-                result = self.tool_ops.p_tool_definition_to_ir(t)
+                try:
+                    result = self.tool_ops.p_tool_definition_to_ir(t)
+                except Exception as e:
+                    tool_type = (
+                        t.get("type", "unknown")
+                        if isinstance(t, dict)
+                        else type(t).__name__
+                    )
+                    tool_name = (
+                        t.get("name", "unnamed") if isinstance(t, dict) else str(t)
+                    )
+                    raise ValueError(
+                        f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
+                    ) from e
                 if result is None:
                     continue
                 if isinstance(result, list):

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -199,9 +199,25 @@ class OpenAIChatConverter(BaseConverter):
         # 2. Tools
         tools = provider_request.get("tools")
         if tools:
-            ir_request["tools"] = [
-                self.tool_ops.p_tool_definition_to_ir(t) for t in tools
-            ]
+            ir_tools = []
+            for t in tools:
+                try:
+                    ir_tools.append(self.tool_ops.p_tool_definition_to_ir(t))
+                except Exception as e:
+                    tool_type = (
+                        t.get("type", "unknown")
+                        if isinstance(t, dict)
+                        else type(t).__name__
+                    )
+                    tool_name = (
+                        (t.get("function", {}).get("name") or t.get("name", "unnamed"))
+                        if isinstance(t, dict)
+                        else str(t)
+                    )
+                    raise ValueError(
+                        f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
+                    ) from e
+            ir_request["tools"] = ir_tools
 
         # 3. Tool choice
         tool_choice = provider_request.get("tool_choice")

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -213,7 +213,20 @@ class OpenAIResponsesConverter(BaseConverter):
                 # Skip disabled tools (e.g. web_search with external_web_access=false)
                 if isinstance(t, dict) and t.get("external_web_access") is False:
                     continue
-                ir_tools.append(self.tool_ops.p_tool_definition_to_ir(t))
+                try:
+                    ir_tools.append(self.tool_ops.p_tool_definition_to_ir(t))
+                except Exception as e:
+                    tool_type = (
+                        t.get("type", "unknown")
+                        if isinstance(t, dict)
+                        else type(t).__name__
+                    )
+                    tool_name = (
+                        t.get("name", "unnamed") if isinstance(t, dict) else str(t)
+                    )
+                    raise ValueError(
+                        f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
+                    ) from e
             if ir_tools:
                 ir_request["tools"] = ir_tools
 

--- a/tests/converters/anthropic/test_converter.py
+++ b/tests/converters/anthropic/test_converter.py
@@ -6,6 +6,8 @@ Tests the top-level AnthropicConverter with full request/response conversion.
 
 from typing import Any, cast
 
+import pytest
+
 from llm_rosetta.converters.anthropic import AnthropicConverter
 from llm_rosetta.types.ir import (
     FinishEvent,
@@ -257,6 +259,17 @@ class TestAnthropicConverter:
             cast(dict[str, Any], MockPydanticModel())
         )
         assert ir_request["model"] == "claude-3-5-sonnet-20241022"
+
+    def test_request_from_provider_malformed_tool_raises_with_context(self):
+        """Test that malformed tools raise clear errors with tool type/name context."""
+        provider_request = {
+            "model": "claude-3-5-sonnet-20241022",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}],
+            "tools": [42],  # non-dict tool triggers conversion error
+        }
+        with pytest.raises(ValueError, match=r"Unsupported tool"):
+            self.converter.request_from_provider(provider_request)
 
     # ==================== response_from_provider ====================
 

--- a/tests/converters/google_genai/test_converter.py
+++ b/tests/converters/google_genai/test_converter.py
@@ -334,6 +334,18 @@ class TestGoogleGenAIConverter:
         )
         assert ir_request["model"] == "gemini-2.0-flash"
 
+    def test_request_from_provider_malformed_tool_raises_with_context(self):
+        """Test that malformed tools raise clear errors with tool type/name context."""
+        provider_request = {
+            "model": "gemini-2.0-flash",
+            "contents": [{"role": "user", "parts": [{"text": "Hi"}]}],
+            "config": {
+                "tools": [42],  # non-dict tool triggers conversion error
+            },
+        }
+        with pytest.raises(ValueError, match=r"Unsupported tool"):
+            self.converter.request_from_provider(provider_request)
+
     # ==================== response_from_provider ====================
 
     def test_response_from_provider_basic(self):

--- a/tests/converters/openai_chat/test_converter.py
+++ b/tests/converters/openai_chat/test_converter.py
@@ -180,6 +180,16 @@ class TestOpenAIChatConverter:
         assert result["tool_choice"]["mode"] == "any"
         assert result["tool_config"]["disable_parallel"] is True
 
+    def test_request_from_provider_malformed_tool_raises_with_context(self):
+        """Test that malformed tools raise clear errors with tool type/name context."""
+        provider_request = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "tools": [42],  # non-dict tool triggers conversion error
+        }
+        with pytest.raises(ValueError, match=r"Unsupported tool"):
+            self.converter.request_from_provider(provider_request)
+
     # ==================== response_from_provider ====================
 
     def test_response_from_provider(self):

--- a/tests/converters/openai_responses/test_converter.py
+++ b/tests/converters/openai_responses/test_converter.py
@@ -191,6 +191,16 @@ class TestOpenAIResponsesConverter:
         result = self.converter.request_from_provider(provider_request)
         assert result["response_format"]["type"] == "json_object"
 
+    def test_request_from_provider_malformed_tool_raises_with_context(self):
+        """Test that malformed tools raise clear errors with tool type/name context."""
+        provider_request = {
+            "model": "gpt-4o",
+            "input": [],
+            "tools": [42],  # non-dict tool triggers conversion error
+        }
+        with pytest.raises(ValueError, match=r"Unsupported tool"):
+            self.converter.request_from_provider(provider_request)
+
     # ==================== response_from_provider ====================
 
     def test_response_from_provider_basic(self):


### PR DESCRIPTION
## Summary

Closes #85.

- Wraps `p_tool_definition_to_ir()` calls in all 4 converters with try/except that adds tool type and name context to the error message
- When a malformed or unsupported tool definition fails during conversion, the error now includes `type=` and `name=` so users can identify which tool caused the issue
- Adds unit tests for all 4 converters verifying the contextual error is raised

## Changed files

| File | Change |
|---|---|
| `converters/openai_responses/converter.py` | Wrap tool conversion with contextual error |
| `converters/openai_chat/converter.py` | Same, with Chat's nested `function.name` extraction |
| `converters/anthropic/converter.py` | Same |
| `converters/google_genai/converter.py` | Same |
| `tests/converters/*/test_converter.py` | Add `test_request_from_provider_malformed_tool_raises_with_context` |

## Test plan

- [x] All 1309 existing tests pass
- [x] New tests verify `ValueError` with contextual message for malformed tool input
- [x] `ruff check --fix && ruff format` clean