### PR TITLE
feat: unify conversion context for stream and non-stream paths

### DIFF
--- a/examples/rest_based/cross_an_gg_stream.py
+++ b/examples/rest_based/cross_an_gg_stream.py
@@ -47,7 +47,7 @@ from common import (  # noqa: E402
 )
 
 from llm_rosetta import AnthropicConverter, GoogleGenAIConverter  # noqa: E402
-from llm_rosetta.converters.base.stream_context import StreamContext  # noqa: E402
+from llm_rosetta.converters.base.context import StreamContext  # noqa: E402
 
 # Initialize converters
 an_converter = AnthropicConverter()

--- a/examples/rest_based/cross_an_or_stream.py
+++ b/examples/rest_based/cross_an_or_stream.py
@@ -47,7 +47,7 @@ from common import (  # noqa: E402
 )
 
 from llm_rosetta import AnthropicConverter, OpenAIResponsesConverter  # noqa: E402
-from llm_rosetta.converters.base.stream_context import StreamContext  # noqa: E402
+from llm_rosetta.converters.base.context import StreamContext  # noqa: E402
 
 # Initialize converters
 an_converter = AnthropicConverter()

--- a/examples/rest_based/cross_gg_or_stream.py
+++ b/examples/rest_based/cross_gg_or_stream.py
@@ -48,7 +48,7 @@ from common import (  # noqa: E402
 )
 
 from llm_rosetta import GoogleGenAIConverter, OpenAIResponsesConverter  # noqa: E402
-from llm_rosetta.converters.base.stream_context import StreamContext  # noqa: E402
+from llm_rosetta.converters.base.context import StreamContext  # noqa: E402
 
 # Initialize converters
 gg_converter = GoogleGenAIConverter()

--- a/examples/rest_based/cross_oc_an_stream.py
+++ b/examples/rest_based/cross_oc_an_stream.py
@@ -45,7 +45,7 @@ from common import (  # noqa: E402
 )
 
 from llm_rosetta import AnthropicConverter, OpenAIChatConverter  # noqa: E402
-from llm_rosetta.converters.base.stream_context import StreamContext  # noqa: E402
+from llm_rosetta.converters.base.context import StreamContext  # noqa: E402
 
 # Initialize converters
 oc_converter = OpenAIChatConverter()

--- a/examples/rest_based/cross_oc_gg_stream.py
+++ b/examples/rest_based/cross_oc_gg_stream.py
@@ -46,7 +46,7 @@ from common import (  # noqa: E402
 )
 
 from llm_rosetta import GoogleGenAIConverter, OpenAIChatConverter  # noqa: E402
-from llm_rosetta.converters.base.stream_context import StreamContext  # noqa: E402
+from llm_rosetta.converters.base.context import StreamContext  # noqa: E402
 
 # Initialize converters
 oc_converter = OpenAIChatConverter()

--- a/examples/rest_based/cross_oc_or_stream.py
+++ b/examples/rest_based/cross_oc_or_stream.py
@@ -47,7 +47,7 @@ from common import (  # noqa: E402
 )
 
 from llm_rosetta import OpenAIChatConverter, OpenAIResponsesConverter  # noqa: E402
-from llm_rosetta.converters.base.stream_context import StreamContext  # noqa: E402
+from llm_rosetta.converters.base.context import StreamContext  # noqa: E402
 
 # Initialize converters
 oc_converter = OpenAIChatConverter()

--- a/examples/sdk_based/cross_an_gg_stream.py
+++ b/examples/sdk_based/cross_an_gg_stream.py
@@ -45,7 +45,7 @@ from common import (  # noqa: E402
 )
 
 from llm_rosetta import AnthropicConverter, GoogleGenAIConverter  # noqa: E402
-from llm_rosetta.converters.base.stream_context import StreamContext  # noqa: E402
+from llm_rosetta.converters.base.context import StreamContext  # noqa: E402
 
 # Initialize converters
 an_converter = AnthropicConverter()

--- a/examples/sdk_based/cross_an_or_stream.py
+++ b/examples/sdk_based/cross_an_or_stream.py
@@ -46,7 +46,7 @@ from common import (  # noqa: E402
 )
 
 from llm_rosetta import AnthropicConverter, OpenAIResponsesConverter  # noqa: E402
-from llm_rosetta.converters.base.stream_context import StreamContext  # noqa: E402
+from llm_rosetta.converters.base.context import StreamContext  # noqa: E402
 
 # Initialize converters
 an_converter = AnthropicConverter()

--- a/examples/sdk_based/cross_gg_or_stream.py
+++ b/examples/sdk_based/cross_gg_or_stream.py
@@ -46,7 +46,7 @@ from common import (  # noqa: E402
 )
 
 from llm_rosetta import GoogleGenAIConverter, OpenAIResponsesConverter  # noqa: E402
-from llm_rosetta.converters.base.stream_context import StreamContext  # noqa: E402
+from llm_rosetta.converters.base.context import StreamContext  # noqa: E402
 
 # Initialize converters
 gg_converter = GoogleGenAIConverter()

--- a/examples/sdk_based/cross_oc_an_stream.py
+++ b/examples/sdk_based/cross_oc_an_stream.py
@@ -43,7 +43,7 @@ from common import (  # noqa: E402
 )
 
 from llm_rosetta import AnthropicConverter, OpenAIChatConverter  # noqa: E402
-from llm_rosetta.converters.base.stream_context import StreamContext  # noqa: E402
+from llm_rosetta.converters.base.context import StreamContext  # noqa: E402
 
 # Initialize converters
 oc_converter = OpenAIChatConverter()

--- a/examples/sdk_based/cross_oc_gg_stream.py
+++ b/examples/sdk_based/cross_oc_gg_stream.py
@@ -44,7 +44,7 @@ from common import (  # noqa: E402
 )
 
 from llm_rosetta import GoogleGenAIConverter, OpenAIChatConverter  # noqa: E402
-from llm_rosetta.converters.base.stream_context import StreamContext  # noqa: E402
+from llm_rosetta.converters.base.context import StreamContext  # noqa: E402
 
 # Initialize converters
 oc_converter = OpenAIChatConverter()

--- a/examples/sdk_based/cross_oc_or_stream.py
+++ b/examples/sdk_based/cross_oc_or_stream.py
@@ -46,7 +46,7 @@ from common import (  # noqa: E402
 )
 
 from llm_rosetta import OpenAIChatConverter, OpenAIResponsesConverter  # noqa: E402
-from llm_rosetta.converters.base.stream_context import StreamContext  # noqa: E402
+from llm_rosetta.converters.base.context import StreamContext  # noqa: E402
 
 # Initialize converters
 oc_converter = OpenAIChatConverter()

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -41,7 +41,7 @@ from ...types.ir.stream import (
     UsageEvent,
 )
 from ..base import BaseConverter
-from ..base.stream_context import StreamContext
+from ..base.context import ConversionContext, StreamContext
 from ..base.tools import fix_orphaned_tool_calls_ir, strip_orphaned_tool_config
 from ._constants import (
     ANTHROPIC_REASON_FROM_PROVIDER,
@@ -79,6 +79,8 @@ class AnthropicConverter(BaseConverter):
     def request_to_provider(
         self,
         ir_request: IRRequest,
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[dict[str, Any], list[str]]:
         """Convert IRRequest to Anthropic Messages API request parameters.
@@ -178,11 +180,16 @@ class AnthropicConverter(BaseConverter):
         if extensions:
             result.update(extensions)
 
+        if context is not None:
+            context.warnings.extend(warnings)
+
         return result, warnings
 
     def request_from_provider(
         self,
         provider_request: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> IRRequest:
         """Convert Anthropic Messages API request to IRRequest.
@@ -272,6 +279,8 @@ class AnthropicConverter(BaseConverter):
     def response_from_provider(
         self,
         provider_response: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> IRResponse:
         """Convert Anthropic Messages API response to IRResponse.
@@ -338,6 +347,8 @@ class AnthropicConverter(BaseConverter):
     def response_to_provider(
         self,
         ir_response: IRResponse,
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Convert IRResponse to Anthropic Messages API response.
@@ -407,6 +418,8 @@ class AnthropicConverter(BaseConverter):
     def messages_to_provider(
         self,
         messages: Sequence[Message | ExtensionItem],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """Convert IR message list to Anthropic message format.
@@ -424,6 +437,8 @@ class AnthropicConverter(BaseConverter):
     def messages_from_provider(
         self,
         provider_messages: list[Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> list[Message | ExtensionItem]:
         """Convert Anthropic messages to IR message list.

--- a/src/llm_rosetta/converters/base/__init__.py
+++ b/src/llm_rosetta/converters/base/__init__.py
@@ -22,14 +22,15 @@ from .configs import BaseConfigOps
 from .content import BaseContentOps
 from .converter import BaseConverter
 from .messages import BaseMessageOps
-from .stream_context import StreamContext
+from .context import ConversionContext, StreamContext
 from .tool_content import convert_content_blocks_to_ir, convert_ir_content_blocks_to_p
 from .tools import BaseToolOps, sanitize_schema
 
 __all__ = [
     # 主转换器 Main converter
     "BaseConverter",
-    # 流式上下文 Stream context
+    # 转换上下文 Conversion context
+    "ConversionContext",
     "StreamContext",
     # 功能域操作类 Functional domain operation classes
     "BaseContentOps",

--- a/src/llm_rosetta/converters/base/context.py
+++ b/src/llm_rosetta/converters/base/context.py
@@ -1,21 +1,47 @@
 """
-LLM-Rosetta - Stream Context
+LLM-Rosetta - Conversion Context
 
-Maintains state across stream chunk conversions for stateful stream
-transformations in Man-in-the-Middle scenarios.
+Provides the context hierarchy for conversion pipelines:
+
+- ``ConversionContext``: Base context for non-streaming conversions.
+  Carries warnings, structured options, and opaque metadata through
+  the conversion pipeline.
+- ``StreamContext``: Extended context for streaming conversions.
+  Adds session-level metadata, tool call tracking, lifecycle flags,
+  and deferred event payloads on top of ConversionContext.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
-class StreamContext:
+class ConversionContext:
+    """Shared context for a conversion pipeline.
+
+    Created once per conversion operation (request or response cycle)
+    and threaded through converter methods to carry shared state.
+
+    Attributes:
+        warnings: Accumulated warnings from conversion steps.
+        options: Structured conversion options (e.g., ``output_format``).
+        metadata: Opaque store for debugging and provider-specific state.
+    """
+
+    warnings: list[str] = field(default_factory=list)
+    options: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class StreamContext(ConversionContext):
     """Maintains state across stream chunk conversions.
 
-    Tracks session-level metadata and per-block state to enable
-    stateful stream transformations in Man-in-the-Middle scenarios.
+    Extends :class:`ConversionContext` with session-level metadata and
+    per-block state to enable stateful stream transformations in
+    Man-in-the-Middle scenarios.
 
     Attributes:
         response_id: Provider response ID (e.g., chatcmpl-xxx, msg_xxx).

--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -15,7 +15,7 @@ from ...types.ir.request import IRRequest
 from ...types.ir.response import IRResponse
 from ...types.ir.stream import IRStreamEvent
 from ...types.ir.validation import validate_ir_request, validate_ir_response
-from .stream_context import StreamContext
+from .context import ConversionContext, StreamContext
 
 
 class BaseConverter(ABC):
@@ -51,6 +51,8 @@ class BaseConverter(ABC):
     def request_to_provider(
         self,
         ir_request: IRRequest,
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[dict[str, Any], list[str]]:
         """将IRRequest转换为provider请求参数
@@ -68,6 +70,8 @@ class BaseConverter(ABC):
 
         Args:
             ir_request: IR格式的完整请求
+            context: Optional conversion context for carrying warnings,
+                options, and metadata through the pipeline.
             **kwargs: 额外参数
 
         Returns:
@@ -79,6 +83,8 @@ class BaseConverter(ABC):
     def request_from_provider(
         self,
         provider_request: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> IRRequest:
         """将provider请求转换为IRRequest
@@ -86,6 +92,7 @@ class BaseConverter(ABC):
 
         Args:
             provider_request: Provider格式的请求
+            context: Optional conversion context.
             **kwargs: 额外参数
 
         Returns:
@@ -97,6 +104,8 @@ class BaseConverter(ABC):
     def response_from_provider(
         self,
         provider_response: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> IRResponse:
         """将provider响应转换为IRResponse
@@ -104,6 +113,7 @@ class BaseConverter(ABC):
 
         Args:
             provider_response: Provider格式的响应
+            context: Optional conversion context.
             **kwargs: 额外参数
 
         Returns:
@@ -115,6 +125,8 @@ class BaseConverter(ABC):
     def response_to_provider(
         self,
         ir_response: IRResponse,
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """将IRResponse转换为provider响应
@@ -122,6 +134,7 @@ class BaseConverter(ABC):
 
         Args:
             ir_response: IR格式的响应
+            context: Optional conversion context.
             **kwargs: 额外参数
 
         Returns:
@@ -133,6 +146,8 @@ class BaseConverter(ABC):
     def messages_to_provider(
         self,
         messages: Sequence[Message | ExtensionItem],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """将消息列表转换为provider消息格式
@@ -143,6 +158,7 @@ class BaseConverter(ABC):
 
         Args:
             messages: IR格式的消息列表（可包含扩展项）
+            context: Optional conversion context.
             **kwargs: 额外参数
 
         Returns:
@@ -154,6 +170,8 @@ class BaseConverter(ABC):
     def messages_from_provider(
         self,
         provider_messages: list[Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> list[Message | ExtensionItem]:
         """将provider消息转换为IR消息列表
@@ -161,6 +179,7 @@ class BaseConverter(ABC):
 
         Args:
             provider_messages: Provider格式的消息列表
+            context: Optional conversion context.
             **kwargs: 额外参数
 
         Returns:
@@ -248,6 +267,19 @@ class BaseConverter(ABC):
     # ==================== Factory methods ====================
 
     @classmethod
+    def create_conversion_context(cls, **options: Any) -> ConversionContext:
+        """Create a conversion context for non-streaming conversions.
+
+        Args:
+            **options: Initial options to populate in the context
+                (e.g., ``output_format="rest"``).
+
+        Returns:
+            A new ConversionContext instance.
+        """
+        return ConversionContext(options=dict(options) if options else {})
+
+    @classmethod
     def create_stream_context(cls) -> StreamContext:
         """Create a stream context appropriate for this converter.
 
@@ -298,6 +330,8 @@ class BaseConverter(ABC):
     def message_to_provider(
         self,
         message: Message | ExtensionItem,
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[Any, list[str]]:
         """将单个消息转换为provider格式（便利方法）
@@ -305,17 +339,22 @@ class BaseConverter(ABC):
 
         Args:
             message: IR格式的单个消息
+            context: Optional conversion context.
             **kwargs: 额外参数
 
         Returns:
             Tuple[转换后的消息, 警告信息列表]
         """
-        result, warnings = self.messages_to_provider([message], **kwargs)
+        result, warnings = self.messages_to_provider(
+            [message], context=context, **kwargs
+        )
         return result[0] if result else None, warnings
 
     def message_from_provider(
         self,
         provider_message: Any,
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> Message | ExtensionItem:
         """将provider消息转换为IR格式（便利方法）
@@ -323,10 +362,13 @@ class BaseConverter(ABC):
 
         Args:
             provider_message: Provider格式的消息
+            context: Optional conversion context.
             **kwargs: 额外参数
 
         Returns:
             IR格式的消息
         """
-        result = self.messages_from_provider([provider_message], **kwargs)
+        result = self.messages_from_provider(
+            [provider_message], context=context, **kwargs
+        )
         return result[0] if result else cast(Message, {})

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -47,7 +47,7 @@ from ...types.ir.stream import (
     UsageEvent,
 )
 from ..base import BaseConverter
-from ..base.stream_context import StreamContext
+from ..base.context import ConversionContext, StreamContext
 from ..base.tools import fix_orphaned_tool_calls_ir, strip_orphaned_tool_config
 from ._constants import (
     GOOGLE_REASON_FROM_PROVIDER,
@@ -168,6 +168,8 @@ class GoogleGenAIConverter(BaseConverter):
     def request_to_provider(
         self,
         ir_request: IRRequest,
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[dict[str, Any], list[str]]:
         """Convert IRRequest to Google GenAI request parameters.
@@ -186,7 +188,10 @@ class GoogleGenAIConverter(BaseConverter):
         Returns:
             Tuple of (provider request dict, warnings list).
         """
-        output_format: str = kwargs.pop("output_format", "sdk")
+        output_format: str = kwargs.pop(
+            "output_format",
+            context.options.get("output_format", "sdk") if context else "sdk",
+        )
         warnings_list: list[str] = []
         result: dict[str, Any] = {"model": ir_request["model"]}
 
@@ -275,6 +280,9 @@ class GoogleGenAIConverter(BaseConverter):
 
         result["config"] = config
 
+        if context is not None:
+            context.warnings.extend(warnings_list)
+
         if output_format == "rest":
             return self._to_rest_body(result), warnings_list
 
@@ -283,6 +291,8 @@ class GoogleGenAIConverter(BaseConverter):
     def request_from_provider(
         self,
         provider_request: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> IRRequest:
         """Convert Google GenAI request to IRRequest.
@@ -395,6 +405,8 @@ class GoogleGenAIConverter(BaseConverter):
     def response_from_provider(
         self,
         provider_response: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> IRResponse:
         """Convert Google GenAI response to IRResponse.
@@ -474,6 +486,8 @@ class GoogleGenAIConverter(BaseConverter):
     def response_to_provider(
         self,
         ir_response: IRResponse,
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Convert IRResponse to Google GenAI response.
@@ -536,6 +550,8 @@ class GoogleGenAIConverter(BaseConverter):
     def messages_to_provider(
         self,
         messages: Sequence[Message | ExtensionItem],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """Convert IR message list to Google GenAI Content format.
@@ -553,6 +569,8 @@ class GoogleGenAIConverter(BaseConverter):
     def messages_from_provider(
         self,
         provider_messages: list[Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> list[Message | ExtensionItem]:
         """Convert Google GenAI Content list to IR message list.

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -31,7 +31,7 @@ from ...types.ir.stream import (
     UsageEvent,
 )
 from ..base import BaseConverter
-from ..base.stream_context import StreamContext
+from ..base.context import ConversionContext, StreamContext
 from ..base.tools import fix_orphaned_tool_calls_ir, strip_orphaned_tool_config
 from ._constants import OPENAI_CHAT_REASON_FROM_PROVIDER, OPENAI_CHAT_REASON_TO_PROVIDER
 from .config_ops import OpenAIChatConfigOps
@@ -65,6 +65,8 @@ class OpenAIChatConverter(BaseConverter):
     def request_to_provider(
         self,
         ir_request: IRRequest,
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[dict[str, Any], list[str]]:
         """Convert IRRequest to OpenAI Chat Completions request parameters.
@@ -151,11 +153,16 @@ class OpenAIChatConverter(BaseConverter):
         if extensions:
             result.update(extensions)
 
+        if context is not None:
+            context.warnings.extend(warnings)
+
         return result, warnings
 
     def request_from_provider(
         self,
         provider_request: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> IRRequest:
         """Convert OpenAI Chat Completions request to IRRequest.
@@ -274,6 +281,8 @@ class OpenAIChatConverter(BaseConverter):
     def response_from_provider(
         self,
         provider_response: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> IRResponse:
         """Convert OpenAI Chat Completions response to IRResponse.
@@ -353,6 +362,8 @@ class OpenAIChatConverter(BaseConverter):
     def response_to_provider(
         self,
         ir_response: IRResponse,
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Convert IRResponse to OpenAI Chat Completions response.
@@ -454,6 +465,8 @@ class OpenAIChatConverter(BaseConverter):
     def messages_to_provider(
         self,
         messages: Sequence[Message | ExtensionItem],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """Convert IR message list to OpenAI Chat message format.
@@ -471,6 +484,8 @@ class OpenAIChatConverter(BaseConverter):
     def messages_from_provider(
         self,
         provider_messages: list[Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> list[Message | ExtensionItem]:
         """Convert OpenAI Chat messages to IR message list.

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -35,7 +35,7 @@ from ...types.ir.stream import (
     UsageEvent,
 )
 from ..base import BaseConverter
-from ..base.stream_context import StreamContext
+from ..base.context import ConversionContext, StreamContext
 from ..base.tools import fix_orphaned_tool_calls_ir, strip_orphaned_tool_config
 from .stream_context import OpenAIResponsesStreamContext
 from ._constants import (
@@ -84,6 +84,8 @@ class OpenAIResponsesConverter(BaseConverter):
     def request_to_provider(
         self,
         ir_request: IRRequest,
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[dict[str, Any], list[str]]:
         """Convert IRRequest to OpenAI Responses API request parameters.
@@ -164,11 +166,16 @@ class OpenAIResponsesConverter(BaseConverter):
         if extensions:
             result.update(extensions)
 
+        if context is not None:
+            context.warnings.extend(warnings)
+
         return result, warnings
 
     def request_from_provider(
         self,
         provider_request: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> IRRequest:
         """Convert OpenAI Responses API request to IRRequest.
@@ -291,6 +298,8 @@ class OpenAIResponsesConverter(BaseConverter):
     def response_from_provider(
         self,
         provider_response: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> IRResponse:
         """Convert OpenAI Responses API response to IRResponse.
@@ -384,6 +393,8 @@ class OpenAIResponsesConverter(BaseConverter):
     def response_to_provider(
         self,
         ir_response: IRResponse,
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Convert IRResponse to OpenAI Responses API response.
@@ -465,6 +476,8 @@ class OpenAIResponsesConverter(BaseConverter):
     def messages_to_provider(
         self,
         messages: Sequence[Message | ExtensionItem],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """Convert IR message list to OpenAI Responses input items.
@@ -482,6 +495,8 @@ class OpenAIResponsesConverter(BaseConverter):
     def messages_from_provider(
         self,
         provider_messages: list[Any],
+        *,
+        context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> list[Message | ExtensionItem]:
         """Convert OpenAI Responses items to IR message list.

--- a/src/llm_rosetta/converters/openai_responses/stream_context.py
+++ b/src/llm_rosetta/converters/openai_responses/stream_context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from ..base.stream_context import StreamContext
+from ..base.context import StreamContext
 
 
 @dataclass

--- a/src/llm_rosetta/converters/openai_responses/utils.py
+++ b/src/llm_rosetta/converters/openai_responses/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..base.stream_context import StreamContext
+from ..base.context import StreamContext
 from ._constants import ResponsesEventType, generate_message_id
 from .stream_context import OpenAIResponsesStreamContext
 

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -22,6 +22,7 @@ from starlette.responses import JSONResponse, Response, StreamingResponse
 
 from llm_rosetta import get_converter_for_provider
 from llm_rosetta.auto_detect import ProviderType
+from llm_rosetta.converters.base.context import ConversionContext
 
 
 from .logging import (
@@ -284,9 +285,14 @@ async def handle_non_streaming(
     source_converter = get_converter_for_provider(source_provider)
     target_converter = get_converter_for_provider(target_provider)
 
+    # Shared context for the conversion pipeline
+    ctx = ConversionContext()
+    if target_provider == "google":
+        ctx.options["output_format"] = "rest"
+
     # 1. Source -> IR
     try:
-        ir_request = source_converter.request_from_provider(body)
+        ir_request = source_converter.request_from_provider(body, context=ctx)
     except Exception as exc:
         return error_response_for_source(
             source_provider, 400, f"Failed to parse request: {exc}"
@@ -300,12 +306,8 @@ async def handle_non_streaming(
 
     # 2. IR -> Target
     try:
-        # Google REST API needs flattened body; other providers use SDK format
-        convert_kwargs: dict[str, str] = {}
-        if target_provider == "google":
-            convert_kwargs["output_format"] = "rest"
         target_body, warnings = target_converter.request_to_provider(
-            ir_request, **convert_kwargs
+            ir_request, context=ctx
         )
     except Exception as exc:
         return error_response_for_source(
@@ -347,7 +349,9 @@ async def handle_non_streaming(
     # 6. Target response -> IR
     try:
         upstream_json = upstream_resp.json()
-        ir_response = target_converter.response_from_provider(upstream_json)
+        ir_response = target_converter.response_from_provider(
+            upstream_json, context=ctx
+        )
     except Exception as exc:
         return error_response_for_source(
             source_provider, 502, f"Failed to parse upstream response: {exc}"
@@ -361,7 +365,9 @@ async def handle_non_streaming(
 
     # 7. IR -> Source response
     try:
-        source_response = source_converter.response_to_provider(ir_response)
+        source_response = source_converter.response_to_provider(
+            ir_response, context=ctx
+        )
     except Exception as exc:
         return error_response_for_source(
             source_provider, 500, f"Failed to convert response: {exc}"
@@ -381,9 +387,14 @@ async def handle_streaming(
     source_converter = get_converter_for_provider(source_provider)
     target_converter = get_converter_for_provider(target_provider)
 
+    # Shared context for the request conversion phase
+    ctx = ConversionContext()
+    if target_provider == "google":
+        ctx.options["output_format"] = "rest"
+
     # 1. Source -> IR
     try:
-        ir_request = source_converter.request_from_provider(body)
+        ir_request = source_converter.request_from_provider(body, context=ctx)
     except Exception as exc:
         return error_response_for_source(
             source_provider, 400, f"Failed to parse request: {exc}"
@@ -397,12 +408,8 @@ async def handle_streaming(
 
     # 2. IR -> Target
     try:
-        # Google REST API needs flattened body; other providers use SDK format
-        convert_kwargs: dict[str, str] = {}
-        if target_provider == "google":
-            convert_kwargs["output_format"] = "rest"
         target_body, warnings = target_converter.request_to_provider(
-            ir_request, **convert_kwargs
+            ir_request, context=ctx
         )
     except Exception as exc:
         return error_response_for_source(

--- a/tests/converters/anthropic/test_stream.py
+++ b/tests/converters/anthropic/test_stream.py
@@ -5,7 +5,7 @@ Anthropic Messages API stream converter unit tests.
 from typing import Any, cast
 
 from llm_rosetta.converters.anthropic import AnthropicConverter
-from llm_rosetta.converters.base.stream_context import StreamContext
+from llm_rosetta.converters.base.context import StreamContext
 from llm_rosetta.types.ir.stream import (
     ContentBlockEndEvent,
     ContentBlockStartEvent,

--- a/tests/converters/base/test_conversion_context.py
+++ b/tests/converters/base/test_conversion_context.py
@@ -1,0 +1,121 @@
+"""Tests for ConversionContext and StreamContext inheritance."""
+
+from llm_rosetta.converters.base import BaseConverter
+from llm_rosetta.converters.base.context import ConversionContext, StreamContext
+from llm_rosetta.converters.openai_responses.stream_context import (
+    OpenAIResponsesStreamContext,
+)
+
+
+class TestConversionContext:
+    """Test ConversionContext dataclass."""
+
+    def test_defaults(self):
+        ctx = ConversionContext()
+        assert ctx.warnings == []
+        assert ctx.options == {}
+        assert ctx.metadata == {}
+
+    def test_warnings_accumulation(self):
+        ctx = ConversionContext()
+        ctx.warnings.append("warn1")
+        ctx.warnings.extend(["warn2", "warn3"])
+        assert ctx.warnings == ["warn1", "warn2", "warn3"]
+
+    def test_options(self):
+        ctx = ConversionContext(options={"output_format": "rest"})
+        assert ctx.options["output_format"] == "rest"
+
+    def test_metadata(self):
+        ctx = ConversionContext()
+        ctx.metadata["debug_info"] = {"step": "request_to_provider"}
+        assert ctx.metadata["debug_info"]["step"] == "request_to_provider"
+
+    def test_instances_isolated(self):
+        ctx1 = ConversionContext()
+        ctx2 = ConversionContext()
+        ctx1.warnings.append("only-in-ctx1")
+        assert ctx2.warnings == []
+
+
+class TestStreamContextInheritance:
+    """Test that StreamContext IS-A ConversionContext."""
+
+    def test_isinstance(self):
+        sc = StreamContext()
+        assert isinstance(sc, ConversionContext)
+
+    def test_inherits_fields(self):
+        sc = StreamContext()
+        assert hasattr(sc, "warnings")
+        assert hasattr(sc, "options")
+        assert hasattr(sc, "metadata")
+        assert sc.warnings == []
+        assert sc.options == {}
+        assert sc.metadata == {}
+
+    def test_stream_fields_intact(self):
+        sc = StreamContext()
+        assert sc.response_id == ""
+        assert sc.model == ""
+        assert sc.created == 0
+        assert sc.current_block_index == -1
+        assert sc.tool_call_id_map == {}
+
+    def test_stream_methods_work(self):
+        sc = StreamContext()
+        sc.register_tool_call("tc_1", "get_weather")
+        assert sc.get_tool_name("tc_1") == "get_weather"
+        sc.append_tool_call_args("tc_1", '{"city":')
+        sc.append_tool_call_args("tc_1", '"NYC"}')
+        assert sc.get_tool_call_args("tc_1") == '{"city":"NYC"}'
+
+    def test_warnings_in_stream_context(self):
+        sc = StreamContext()
+        sc.warnings.append("stream warning")
+        assert sc.warnings == ["stream warning"]
+
+    def test_options_in_stream_context(self):
+        sc = StreamContext(options={"output_format": "rest"})
+        assert sc.options["output_format"] == "rest"
+        assert sc.response_id == ""  # stream fields still default
+
+
+class TestOpenAIResponsesStreamContextInheritance:
+    """Test the full inheritance chain: OpenAIResponsesStreamContext -> StreamContext -> ConversionContext."""
+
+    def test_isinstance_chain(self):
+        ctx = OpenAIResponsesStreamContext()
+        assert isinstance(ctx, StreamContext)
+        assert isinstance(ctx, ConversionContext)
+
+    def test_has_all_fields(self):
+        ctx = OpenAIResponsesStreamContext()
+        # ConversionContext fields
+        assert ctx.warnings == []
+        assert ctx.options == {}
+        # StreamContext fields
+        assert ctx.response_id == ""
+        assert ctx.tool_call_id_map == {}
+        # OpenAIResponsesStreamContext fields
+        assert ctx.item_id_to_call_id == {}
+        assert ctx.output_item_emitted is False
+
+
+class TestFactoryMethods:
+    """Test create_conversion_context and create_stream_context."""
+
+    def test_create_conversion_context(self):
+        ctx = BaseConverter.create_conversion_context()
+        assert isinstance(ctx, ConversionContext)
+        assert ctx.warnings == []
+        assert ctx.options == {}
+
+    def test_create_conversion_context_with_options(self):
+        ctx = BaseConverter.create_conversion_context(output_format="rest")
+        assert ctx.options["output_format"] == "rest"
+
+    def test_create_stream_context_is_conversion_context(self):
+        sc = BaseConverter.create_stream_context()
+        assert isinstance(sc, StreamContext)
+        assert isinstance(sc, ConversionContext)

--- a/tests/converters/google_genai/test_stream.py
+++ b/tests/converters/google_genai/test_stream.py
@@ -5,7 +5,7 @@ Google GenAI stream converter unit tests.
 import json
 from typing import Any, cast
 
-from llm_rosetta.converters.base.stream_context import StreamContext
+from llm_rosetta.converters.base.context import StreamContext
 from llm_rosetta.converters.google_genai import GoogleGenAIConverter
 from llm_rosetta.types.ir.stream import (
     ContentBlockEndEvent,

--- a/tests/converters/openai_chat/test_stream.py
+++ b/tests/converters/openai_chat/test_stream.py
@@ -4,7 +4,7 @@ OpenAI Chat Completions stream converter unit tests.
 
 from typing import Any, cast
 
-from llm_rosetta.converters.base.stream_context import StreamContext
+from llm_rosetta.converters.base.context import StreamContext
 from llm_rosetta.converters.openai_chat import OpenAIChatConverter
 from llm_rosetta.types.ir.stream import (
     ContentBlockEndEvent,

--- a/tests/converters/openai_responses/test_utils.py
+++ b/tests/converters/openai_responses/test_utils.py
@@ -1,6 +1,6 @@
 """Tests for openai_responses utility functions."""
 
-from llm_rosetta.converters.base.stream_context import StreamContext
+from llm_rosetta.converters.base.context import StreamContext
 from llm_rosetta.converters.openai_responses._constants import ResponsesEventType
 from llm_rosetta.converters.openai_responses.stream_context import (
     OpenAIResponsesStreamContext,

--- a/tests/test_converters_base.py
+++ b/tests/test_converters_base.py
@@ -382,7 +382,7 @@ class MockConverter(BaseConverter):
     config_ops_class = MockConfigOps
 
     def request_to_provider(
-        self, ir_request: IRRequest, **kwargs: Any
+        self, ir_request: IRRequest, *, context=None, **kwargs: Any
     ) -> tuple[dict[str, Any], list[str]]:
         provider_request: dict[str, Any] = {"model": ir_request["model"]}
         warnings = []
@@ -406,7 +406,7 @@ class MockConverter(BaseConverter):
         return provider_request, warnings
 
     def request_from_provider(
-        self, provider_request: dict[str, Any], **kwargs: Any
+        self, provider_request: dict[str, Any], *, context=None, **kwargs: Any
     ) -> IRRequest:
         ir_request: IRRequest = {"model": provider_request["model"], "messages": []}
 
@@ -421,7 +421,7 @@ class MockConverter(BaseConverter):
         return ir_request
 
     def response_from_provider(
-        self, provider_response: dict[str, Any], **kwargs: Any
+        self, provider_response: dict[str, Any], *, context=None, **kwargs: Any
     ) -> IRResponse:
         return {
             "id": provider_response.get("id", ""),
@@ -433,7 +433,7 @@ class MockConverter(BaseConverter):
         }
 
     def response_to_provider(
-        self, ir_response: IRResponse, **kwargs: Any
+        self, ir_response: IRResponse, *, context=None, **kwargs: Any
     ) -> dict[str, Any]:
         return {
             "id": ir_response["id"],
@@ -445,12 +445,16 @@ class MockConverter(BaseConverter):
         }
 
     def messages_to_provider(
-        self, messages: Sequence[Union[Message, ExtensionItem]], **kwargs: Any
+        self,
+        messages: Sequence[Union[Message, ExtensionItem]],
+        *,
+        context=None,
+        **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         return self.message_ops_class.ir_messages_to_p(messages, **kwargs)
 
     def messages_from_provider(
-        self, provider_messages: list[Any], **kwargs: Any
+        self, provider_messages: list[Any], *, context=None, **kwargs: Any
     ) -> list[Union[Message, ExtensionItem]]:
         return self.message_ops_class.p_messages_to_ir(provider_messages, **kwargs)
 


### PR DESCRIPTION
## Summary

Closes #106.

- Introduces `ConversionContext` as a base dataclass with `warnings`, `options`, and `metadata` fields
- `StreamContext` now inherits from `ConversionContext` (IS-A), so streaming contexts also carry shared conversion state
- Renames `stream_context.py` → `context.py` to reflect broader scope
- Adds `context: ConversionContext | None = None` as keyword-only parameter to all 6 abstract converter methods + 2 convenience methods in `BaseConverter`
- Adds `create_conversion_context()` factory method to `BaseConverter`
- Google converter reads `output_format` from `context.options` as fallback when not in kwargs
- All 4 converters sync accumulated warnings to `context.warnings` when context is provided
- Gateway proxy creates and passes `ConversionContext` through the full conversion pipeline (both streaming and non-streaming handlers)
- Updates all import paths across src, tests, and examples (28 files)

## Design

```
ConversionContext (warnings, options, metadata)
  └── StreamContext (+ response_id, tool_call tracking, lifecycle, ...)
        └── OpenAIResponsesStreamContext (+ item_id tracking, text accumulation, ...)
```

Context is optional and keyword-only — all existing call sites continue to work without changes. The provider metadata cache (`_provider_metadata_cache`) stays global as it has a different lifecycle (cross-request).

## Test plan

- [x] 1325 existing tests pass (excluding pre-existing integration setup issue)
- [x] New `test_conversion_context.py` tests: ConversionContext defaults, warnings accumulation, StreamContext inheritance (isinstance), factory methods
- [x] `ruff check --fix && ruff format` clean