### PR TITLE
refactor: replace ReasoningConfig.enabled with mode field

### DIFF
--- a/src/llm_rosetta/converters/anthropic/config_ops.py
+++ b/src/llm_rosetta/converters/anthropic/config_ops.py
@@ -228,55 +228,70 @@ class AnthropicConfigOps(BaseConfigOps):
 
     @staticmethod
     def ir_reasoning_config_to_p(ir_reasoning: ReasoningConfig, **kwargs: Any) -> dict:
-        """IR ReasoningConfig → Anthropic thinking parameter.
+        """IR ReasoningConfig → Anthropic thinking + output_config parameters.
 
         Mapping:
-        - ``effort`` → ``thinking.type = "adaptive"`` + ``thinking.effort``
+        - ``mode: "auto"`` (or ``effort`` without ``mode``)
+          → ``thinking.type = "adaptive"``
+        - ``mode: "enabled"`` + ``budget_tokens``
+          → ``thinking.type = "enabled"`` + ``thinking.budget_tokens``
+        - ``mode: "enabled"`` without ``budget_tokens``
+          → falls back to ``"adaptive"`` with warning
+        - ``mode: "disabled"`` → ``thinking.type = "disabled"``
+        - ``budget_tokens`` alone → ``thinking.type = "enabled"``
+        - ``effort`` → ``output_config.effort`` (top-level, NOT ``thinking.effort``)
           (``"minimal"`` downgraded to ``"low"`` with warning)
-        - ``enabled: True`` + ``budget_tokens`` (no effort)
-          → ``thinking.type = "enabled"``
-        - ``enabled: True`` (no effort, no budget) → ``thinking.type = "adaptive"``
-        - ``enabled: False`` → ``thinking.type = "disabled"``
-        - ``budget_tokens`` → ``thinking.budget_tokens``
 
         Args:
             ir_reasoning: IR reasoning config.
 
         Returns:
-            Dict of Anthropic request fields to merge.
+            Dict of Anthropic request fields to merge (``thinking`` and/or
+            ``output_config``).
         """
         result: dict[str, Any] = {}
-
+        mode = ir_reasoning.get("mode")
         effort = ir_reasoning.get("effort")
-        if effort is not None:
-            # Anthropic 4.6+: adaptive thinking with effort level
+        budget_tokens = ir_reasoning.get("budget_tokens")
+
+        # Determine thinking type from mode
+        if mode == "disabled":
+            result["thinking"] = {"type": "disabled"}
+            return result  # effort/budget irrelevant when disabled
+
+        if mode == "enabled":
+            if budget_tokens is not None:
+                result["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": budget_tokens,
+                }
+            else:
+                # "enabled" requires budget_tokens; fall back to adaptive
+                warnings.warn(
+                    "Anthropic 'enabled' thinking requires budget_tokens, "
+                    "falling back to 'adaptive'",
+                    stacklevel=2,
+                )
+                result["thinking"] = {"type": "adaptive"}
+        elif mode == "auto" or effort is not None:
+            # auto mode, or effort without explicit mode → adaptive
             thinking: dict[str, Any] = {"type": "adaptive"}
+            if budget_tokens is not None:
+                thinking["budget_tokens"] = budget_tokens
+            result["thinking"] = thinking
+        elif budget_tokens is not None:
+            # budget_tokens without mode or effort → "enabled"
+            result["thinking"] = {"type": "enabled", "budget_tokens": budget_tokens}
+
+        # effort → output_config.effort (separate top-level field)
+        if effort is not None:
             if effort == "minimal":
                 warnings.warn(
                     "Anthropic does not support 'minimal' effort, downgrading to 'low'",
                     stacklevel=2,
                 )
-                thinking["effort"] = "low"
-            else:
-                thinking["effort"] = effort
-            if "budget_tokens" in ir_reasoning:
-                thinking["budget_tokens"] = ir_reasoning["budget_tokens"]
-            result["thinking"] = thinking
-        else:
-            enabled = ir_reasoning.get("enabled")
-            if enabled is True:
-                if "budget_tokens" in ir_reasoning:
-                    # Explicit budget → "enabled" (full control over thinking budget)
-                    thinking: dict[str, Any] = {"type": "enabled"}
-                    thinking["budget_tokens"] = ir_reasoning["budget_tokens"]
-                else:
-                    # No budget, no effort → "adaptive" (let the model decide);
-                    # "enabled" requires budget_tokens, so fall back to "adaptive"
-                    # to ensure a valid round-trip.
-                    thinking: dict[str, Any] = {"type": "adaptive"}
-                result["thinking"] = thinking
-            elif enabled is False:
-                result["thinking"] = {"type": "disabled"}
+                effort = "low"
+            result["output_config"] = {"effort": effort}
 
         return result
 
@@ -284,10 +299,14 @@ class AnthropicConfigOps(BaseConfigOps):
     def p_reasoning_config_to_ir(
         provider_reasoning: Any, **kwargs: Any
     ) -> ReasoningConfig:
-        """Anthropic thinking parameter → IR ReasoningConfig.
+        """Anthropic thinking + output_config → IR ReasoningConfig.
+
+        Extracts ``thinking.type`` → ``mode``, ``thinking.budget_tokens`` →
+        ``budget_tokens``, and ``output_config.effort`` → ``effort``.
 
         Args:
-            provider_reasoning: Dict with ``thinking`` field.
+            provider_reasoning: Dict with ``thinking`` and/or ``output_config``
+                fields (typically the full provider request).
 
         Returns:
             IR ReasoningConfig.
@@ -298,22 +317,25 @@ class AnthropicConfigOps(BaseConfigOps):
             return cast(ReasoningConfig, result)
 
         thinking = provider_reasoning.get("thinking")
-        if not isinstance(thinking, dict):
-            return cast(ReasoningConfig, result)
+        if isinstance(thinking, dict):
+            thinking_type = thinking.get("type")
+            if thinking_type == "adaptive":
+                result["mode"] = "auto"
+            elif thinking_type == "enabled":
+                result["mode"] = "enabled"
+            elif thinking_type == "disabled":
+                result["mode"] = "disabled"
 
-        thinking_type = thinking.get("type")
-        if thinking_type in ("enabled", "adaptive"):
-            result["enabled"] = True
-        elif thinking_type == "disabled":
-            result["enabled"] = False
+            budget_tokens = thinking.get("budget_tokens")
+            if budget_tokens is not None:
+                result["budget_tokens"] = budget_tokens
 
-        effort = thinking.get("effort")
-        if effort is not None:
-            result["effort"] = effort
-
-        budget_tokens = thinking.get("budget_tokens")
-        if budget_tokens is not None:
-            result["budget_tokens"] = budget_tokens
+        # effort lives in output_config, not thinking
+        output_config = provider_reasoning.get("output_config")
+        if isinstance(output_config, dict):
+            effort = output_config.get("effort")
+            if effort is not None:
+                result["effort"] = effort
 
         return cast(ReasoningConfig, result)
 

--- a/src/llm_rosetta/converters/anthropic/config_ops.py
+++ b/src/llm_rosetta/converters/anthropic/config_ops.py
@@ -233,7 +233,9 @@ class AnthropicConfigOps(BaseConfigOps):
         Mapping:
         - ``effort`` → ``thinking.type = "adaptive"`` + ``thinking.effort``
           (``"minimal"`` downgraded to ``"low"`` with warning)
-        - ``enabled: True`` (no effort) → ``thinking.type = "enabled"``
+        - ``enabled: True`` + ``budget_tokens`` (no effort)
+          → ``thinking.type = "enabled"``
+        - ``enabled: True`` (no effort, no budget) → ``thinking.type = "adaptive"``
         - ``enabled: False`` → ``thinking.type = "disabled"``
         - ``budget_tokens`` → ``thinking.budget_tokens``
 
@@ -263,9 +265,15 @@ class AnthropicConfigOps(BaseConfigOps):
         else:
             enabled = ir_reasoning.get("enabled")
             if enabled is True:
-                thinking: dict[str, Any] = {"type": "enabled"}
                 if "budget_tokens" in ir_reasoning:
+                    # Explicit budget → "enabled" (full control over thinking budget)
+                    thinking: dict[str, Any] = {"type": "enabled"}
                     thinking["budget_tokens"] = ir_reasoning["budget_tokens"]
+                else:
+                    # No budget, no effort → "adaptive" (let the model decide);
+                    # "enabled" requires budget_tokens, so fall back to "adaptive"
+                    # to ensure a valid round-trip.
+                    thinking: dict[str, Any] = {"type": "adaptive"}
                 result["thinking"] = thinking
             elif enabled is False:
                 result["thinking"] = {"type": "disabled"}

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -261,10 +261,9 @@ class AnthropicConverter(BaseConverter):
             ir_request["generation"] = gen_config
 
         # 6. Reasoning config
-        if "thinking" in provider_request:
-            ir_request["reasoning"] = self.config_ops.p_reasoning_config_to_ir(
-                {"thinking": provider_request["thinking"]}
-            )
+        reasoning = self.config_ops.p_reasoning_config_to_ir(provider_request)
+        if reasoning:
+            ir_request["reasoning"] = reasoning
 
         # 7. Stream config
         stream = provider_request.get("stream")

--- a/src/llm_rosetta/converters/base/configs.py
+++ b/src/llm_rosetta/converters/base/configs.py
@@ -176,12 +176,12 @@ class BaseConfigOps(ABC):
         将IR推理配置转换为Provider推理配置
 
         处理推理过程的控制：
-        - 是否启用：enabled (bool) - Anthropic
+        - 推理模式：mode (auto/enabled/disabled) - Anthropic, OpenAI Responses, Google
         - 推理努力：effort (minimal/low/medium/high/max)
         - 预算token：budget_tokens - Anthropic/Google
 
         Handles reasoning process control:
-        - Enabled: enabled (bool) - Anthropic
+        - Reasoning mode: mode (auto/enabled/disabled) - Anthropic, OpenAI Responses, Google
         - Reasoning effort: effort (minimal/low/medium/high/max)
         - Budget tokens: budget_tokens - Anthropic/Google
 
@@ -203,7 +203,7 @@ class BaseConfigOps(ABC):
         将Provider推理配置转换为IR推理配置
 
         Args:
-            provider_reasoning: Provider格式的推理配置
+            provider_reasoning: Provider请求字典（完整的provider_request）
             **kwargs: 额外参数
 
         Returns:

--- a/src/llm_rosetta/converters/google_genai/config_ops.py
+++ b/src/llm_rosetta/converters/google_genai/config_ops.py
@@ -262,6 +262,9 @@ class GoogleGenAIConfigOps(BaseConfigOps):
         """IR ReasoningConfig → Google GenAI reasoning parameters.
 
         Mapping:
+        - ``mode: "disabled"`` → ``thinking_config.thinking_budget = 0``
+        - ``mode: "auto"`` (no budget) → ``thinking_config.thinking_budget = -1``
+        - ``mode: "enabled"`` → uses provided ``budget_tokens``
         - ``effort`` → ``thinking_config.thinking_level``
           (``"max"`` downgraded to ``"high"`` with warning)
         - ``budget_tokens`` → ``thinking_config.thinking_budget``
@@ -274,6 +277,12 @@ class GoogleGenAIConfigOps(BaseConfigOps):
         """
         result: dict[str, Any] = {}
         thinking_config: dict[str, Any] = {}
+
+        mode = ir_reasoning.get("mode")
+        if mode == "disabled":
+            thinking_config["thinking_budget"] = 0
+        elif mode == "auto" and "budget_tokens" not in ir_reasoning:
+            thinking_config["thinking_budget"] = -1
 
         if "effort" in ir_reasoning:
             effort = ir_reasoning["effort"]
@@ -299,8 +308,15 @@ class GoogleGenAIConfigOps(BaseConfigOps):
     ) -> ReasoningConfig:
         """Google GenAI reasoning parameters → IR ReasoningConfig.
 
+        Mapping:
+        - ``thinking_budget == 0`` → ``mode: "disabled"``
+        - ``thinking_budget == -1`` → ``mode: "auto"``
+        - ``thinking_budget > 0`` → ``mode: "enabled"`` + ``budget_tokens``
+        - ``thinking_level`` only → ``mode: "auto"``
+
         Args:
-            provider_reasoning: Dict with Google reasoning fields.
+            provider_reasoning: Provider request dict (or generation_config
+                subset with Google reasoning fields).
 
         Returns:
             IR ReasoningConfig.
@@ -314,17 +330,26 @@ class GoogleGenAIConfigOps(BaseConfigOps):
             "thinking_config"
         ) or provider_reasoning.get("thinkingConfig")
         if thinking_config:
-            budget = thinking_config.get("thinking_budget") or thinking_config.get(
-                "thinkingBudget"
-            )
+            budget = thinking_config.get("thinking_budget")
+            if budget is None:
+                budget = thinking_config.get("thinkingBudget")
             if budget is not None:
-                result["budget_tokens"] = budget
+                if budget == 0:
+                    result["mode"] = "disabled"
+                elif budget == -1:
+                    result["mode"] = "auto"
+                else:
+                    result["mode"] = "enabled"
+                    result["budget_tokens"] = budget
 
             level = thinking_config.get("thinking_level") or thinking_config.get(
                 "thinkingLevel"
             )
             if level is not None:
                 result["effort"] = level
+                # effort implies active reasoning
+                if "mode" not in result:
+                    result["mode"] = "auto"
 
         return cast(ReasoningConfig, result)
 

--- a/src/llm_rosetta/converters/openai_chat/config_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/config_ops.py
@@ -253,6 +253,7 @@ class OpenAIChatConfigOps(BaseConfigOps):
         Mapping:
         - ``effort`` → ``reasoning_effort``
           (``"minimal"`` → ``"low"``, ``"max"`` → ``"high"`` with warning)
+        - ``mode: "disabled"`` → skip ``reasoning_effort`` entirely
         - ``budget_tokens`` → not supported (warning)
 
         Args:
@@ -262,6 +263,10 @@ class OpenAIChatConfigOps(BaseConfigOps):
             Dict of OpenAI request fields to merge.
         """
         result: dict[str, Any] = {}
+
+        # mode: "disabled" → skip reasoning_effort
+        if ir_reasoning.get("mode") == "disabled":
+            return result
 
         if "effort" in ir_reasoning:
             effort = ir_reasoning["effort"]
@@ -294,8 +299,11 @@ class OpenAIChatConfigOps(BaseConfigOps):
     ) -> ReasoningConfig:
         """OpenAI Chat reasoning parameters → IR ReasoningConfig.
 
+        Extracts ``reasoning_effort`` from the provider request.
+
         Args:
-            provider_reasoning: Dict with ``reasoning_effort`` field.
+            provider_reasoning: Provider request dict (or subset with
+                ``reasoning_effort``).
 
         Returns:
             IR ReasoningConfig.

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -252,11 +252,9 @@ class OpenAIChatConverter(BaseConverter):
             )
 
         # 7. Reasoning config
-        reasoning_effort = provider_request.get("reasoning_effort")
-        if reasoning_effort:
-            ir_request["reasoning"] = self.config_ops.p_reasoning_config_to_ir(
-                {"reasoning_effort": reasoning_effort}
-            )
+        reasoning = self.config_ops.p_reasoning_config_to_ir(provider_request)
+        if reasoning:
+            ir_request["reasoning"] = reasoning
 
         # 8. Stream config
         stream = provider_request.get("stream")

--- a/src/llm_rosetta/converters/openai_responses/config_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/config_ops.py
@@ -240,7 +240,8 @@ class OpenAIResponsesConfigOps(BaseConfigOps):
         Responses API uses a ``reasoning`` object with ``type`` and ``effort``.
 
         Mapping:
-        - ``enabled`` → ``reasoning.type`` ("enabled"/"disabled")
+        - ``mode`` → ``reasoning.type`` ("enabled"/"disabled";
+          "auto" maps to "enabled" as OpenAI has no auto concept)
         - ``effort`` → ``reasoning.effort``
           (``"minimal"`` → ``"low"``, ``"max"`` → ``"high"`` with warning)
         - ``budget_tokens`` → not supported (warning)
@@ -254,10 +255,10 @@ class OpenAIResponsesConfigOps(BaseConfigOps):
         result: dict[str, Any] = {}
         reasoning_p: dict[str, Any] = {}
 
-        enabled = ir_reasoning.get("enabled")
-        if enabled is True:
+        mode = ir_reasoning.get("mode")
+        if mode in ("enabled", "auto"):
             reasoning_p["type"] = "enabled"
-        elif enabled is False:
+        elif mode == "disabled":
             reasoning_p["type"] = "disabled"
 
         if "effort" in ir_reasoning:
@@ -296,7 +297,8 @@ class OpenAIResponsesConfigOps(BaseConfigOps):
         """OpenAI Responses reasoning parameters → IR ReasoningConfig.
 
         Args:
-            provider_reasoning: Dict with ``reasoning`` field or reasoning object.
+            provider_reasoning: Provider request dict (or subset with
+                ``reasoning`` field).
 
         Returns:
             IR ReasoningConfig.
@@ -313,9 +315,9 @@ class OpenAIResponsesConfigOps(BaseConfigOps):
 
         reasoning_type = reasoning.get("type")
         if reasoning_type == "enabled":
-            result["enabled"] = True
+            result["mode"] = "enabled"
         elif reasoning_type == "disabled":
-            result["enabled"] = False
+            result["mode"] = "disabled"
 
         if "effort" in reasoning:
             result["effort"] = reasoning["effort"]

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -269,11 +269,9 @@ class OpenAIResponsesConverter(BaseConverter):
             )
 
         # 8. Reasoning config
-        reasoning = provider_request.get("reasoning")
+        reasoning = self.config_ops.p_reasoning_config_to_ir(provider_request)
         if reasoning:
-            ir_request["reasoning"] = self.config_ops.p_reasoning_config_to_ir(
-                {"reasoning": reasoning}
-            )
+            ir_request["reasoning"] = reasoning
 
         # 9. Stream config
         stream = provider_request.get("stream")

--- a/src/llm_rosetta/types/ir/configs.py
+++ b/src/llm_rosetta/types/ir/configs.py
@@ -104,14 +104,30 @@ class ReasoningConfig(TypedDict, total=False):
 
     Controls whether and how the model performs explicit reasoning.
 
-    Provider mappings:
-    - OpenAI: reasoning_effort (low/medium/high; minimal→low, max→high with warning)
-    - Anthropic: thinking.type (adaptive/enabled/disabled) + thinking.effort + budget_tokens
-    - Google: thinking_config.thinking_level (minimal/low/medium/high; max→high with warning)
-              + thinking_config.thinking_budget
+    Provider mappings for ``mode``:
+    - ``"auto"``: Model decides when/how much to think.
+      Anthropic: ``thinking.type="adaptive"``,
+      Google: ``thinking_budget=-1``
+    - ``"enabled"``: Explicit thinking with budget control.
+      Anthropic: ``thinking.type="enabled"`` + ``budget_tokens``,
+      OpenAI Responses: ``reasoning.type="enabled"``
+    - ``"disabled"``: No thinking.
+      Anthropic: ``thinking.type="disabled"``,
+      Google: ``thinking_budget=0``,
+      OpenAI Responses: ``reasoning.type="disabled"``
+
+    Provider mappings for ``effort``:
+    - Anthropic: ``output_config.effort``
+    - OpenAI Chat: ``reasoning_effort``
+    - OpenAI Responses: ``reasoning.effort``
+    - Google: ``thinking_config.thinking_level``
+
+    Provider mappings for ``budget_tokens``:
+    - Anthropic: ``thinking.budget_tokens``
+    - Google: ``thinking_config.thinking_budget``
     """
 
-    enabled: bool  # Whether reasoning is enabled — Anthropic: thinking.type
+    mode: Literal["auto", "enabled", "disabled"]
     effort: Literal[
         "minimal", "low", "medium", "high", "max"
     ]  # Reasoning effort level across providers

--- a/tests/converters/anthropic/test_config_ops.py
+++ b/tests/converters/anthropic/test_config_ops.py
@@ -137,12 +137,23 @@ class TestAnthropicConfigOps:
 
     # ==================== Reasoning Config ====================
 
-    def test_ir_reasoning_config_enabled(self):
-        """Test reasoning enabled → Anthropic thinking param."""
+    def test_ir_reasoning_config_enabled_with_budget(self):
+        """Test reasoning enabled + budget_tokens → 'enabled' type."""
         ir_reasoning = cast(ReasoningConfig, {"enabled": True, "budget_tokens": 2048})
         result = AnthropicConfigOps.ir_reasoning_config_to_p(ir_reasoning)
         assert result["thinking"]["type"] == "enabled"
         assert result["thinking"]["budget_tokens"] == 2048
+
+    def test_ir_reasoning_config_enabled_without_budget(self):
+        """Test reasoning enabled without budget_tokens → 'adaptive' type.
+
+        'enabled' requires budget_tokens; when absent, fall back to
+        'adaptive' to produce a valid Anthropic request.
+        """
+        ir_reasoning = cast(ReasoningConfig, {"enabled": True})
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(ir_reasoning)
+        assert result["thinking"]["type"] == "adaptive"
+        assert "budget_tokens" not in result["thinking"]
 
     def test_ir_reasoning_config_disabled(self):
         """Test reasoning disabled → Anthropic thinking param."""
@@ -197,10 +208,49 @@ class TestAnthropicConfigOps:
         assert result["enabled"] is True
         assert result["effort"] == "high"
 
+    def test_p_reasoning_config_to_ir_adaptive_no_effort(self):
+        """Test adaptive thinking without effort → IR enabled only."""
+        provider = {"thinking": {"type": "adaptive"}}
+        result = AnthropicConfigOps.p_reasoning_config_to_ir(provider)
+        assert result["enabled"] is True
+        assert "effort" not in result
+        assert "budget_tokens" not in result
+
     def test_p_reasoning_config_to_ir_empty(self):
         """Test empty reasoning config → empty IR."""
         result = AnthropicConfigOps.p_reasoning_config_to_ir({})
         assert result == {}
+
+    def test_reasoning_config_roundtrip_adaptive_no_effort(self):
+        """Test round-trip: adaptive (no effort) → IR → adaptive.
+
+        Regression test for argo-proxy#502: force_conversion caused
+        {"type": "adaptive"} to become {"type": "enabled"} (without
+        budget_tokens), which Anthropic API rejects.
+        """
+        # Anthropic → IR
+        provider_input = {"thinking": {"type": "adaptive"}}
+        ir = AnthropicConfigOps.p_reasoning_config_to_ir(provider_input)
+        # IR → Anthropic
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(ir)
+        assert result["thinking"]["type"] == "adaptive"
+        assert "budget_tokens" not in result["thinking"]
+
+    def test_reasoning_config_roundtrip_adaptive_with_effort(self):
+        """Test round-trip: adaptive + effort → IR → adaptive + effort."""
+        provider_input = {"thinking": {"type": "adaptive", "effort": "high"}}
+        ir = AnthropicConfigOps.p_reasoning_config_to_ir(provider_input)
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(ir)
+        assert result["thinking"]["type"] == "adaptive"
+        assert result["thinking"]["effort"] == "high"
+
+    def test_reasoning_config_roundtrip_enabled_with_budget(self):
+        """Test round-trip: enabled + budget → IR → enabled + budget."""
+        provider_input = {"thinking": {"type": "enabled", "budget_tokens": 4096}}
+        ir = AnthropicConfigOps.p_reasoning_config_to_ir(provider_input)
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(ir)
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 4096
 
     # ==================== Cache Config ====================
 

--- a/tests/converters/anthropic/test_config_ops.py
+++ b/tests/converters/anthropic/test_config_ops.py
@@ -138,44 +138,59 @@ class TestAnthropicConfigOps:
     # ==================== Reasoning Config ====================
 
     def test_ir_reasoning_config_enabled_with_budget(self):
-        """Test reasoning enabled + budget_tokens → 'enabled' type."""
-        ir_reasoning = cast(ReasoningConfig, {"enabled": True, "budget_tokens": 2048})
+        """Test mode: enabled + budget_tokens → 'enabled' type."""
+        ir_reasoning = cast(ReasoningConfig, {"mode": "enabled", "budget_tokens": 2048})
         result = AnthropicConfigOps.ir_reasoning_config_to_p(ir_reasoning)
         assert result["thinking"]["type"] == "enabled"
         assert result["thinking"]["budget_tokens"] == 2048
 
     def test_ir_reasoning_config_enabled_without_budget(self):
-        """Test reasoning enabled without budget_tokens → 'adaptive' type.
+        """Test mode: enabled without budget_tokens → 'adaptive' fallback.
 
         'enabled' requires budget_tokens; when absent, fall back to
         'adaptive' to produce a valid Anthropic request.
         """
-        ir_reasoning = cast(ReasoningConfig, {"enabled": True})
-        result = AnthropicConfigOps.ir_reasoning_config_to_p(ir_reasoning)
+        ir_reasoning = cast(ReasoningConfig, {"mode": "enabled"})
+        with pytest.warns(UserWarning, match="budget_tokens"):
+            result = AnthropicConfigOps.ir_reasoning_config_to_p(ir_reasoning)
         assert result["thinking"]["type"] == "adaptive"
         assert "budget_tokens" not in result["thinking"]
 
     def test_ir_reasoning_config_disabled(self):
-        """Test reasoning disabled → Anthropic thinking param."""
-        ir_reasoning = cast(ReasoningConfig, {"enabled": False})
+        """Test mode: disabled → Anthropic thinking param."""
+        ir_reasoning = cast(ReasoningConfig, {"mode": "disabled"})
         result = AnthropicConfigOps.ir_reasoning_config_to_p(ir_reasoning)
         assert result["thinking"]["type"] == "disabled"
 
+    def test_ir_reasoning_config_auto(self):
+        """Test mode: auto → adaptive thinking."""
+        ir_reasoning = cast(ReasoningConfig, {"mode": "auto"})
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(ir_reasoning)
+        assert result["thinking"]["type"] == "adaptive"
+
+    def test_ir_reasoning_config_auto_with_effort(self):
+        """Test mode: auto + effort → adaptive + output_config.effort."""
+        ir_reasoning = cast(ReasoningConfig, {"mode": "auto", "effort": "high"})
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(ir_reasoning)
+        assert result["thinking"]["type"] == "adaptive"
+        assert result["output_config"]["effort"] == "high"
+        assert "effort" not in result["thinking"]
+
     def test_ir_reasoning_config_effort_adaptive(self):
-        """Test effort → adaptive thinking."""
+        """Test effort without mode → adaptive thinking + output_config."""
         result = AnthropicConfigOps.ir_reasoning_config_to_p(
             cast(ReasoningConfig, {"effort": "high"})
         )
         assert result["thinking"]["type"] == "adaptive"
-        assert result["thinking"]["effort"] == "high"
+        assert result["output_config"]["effort"] == "high"
 
     def test_ir_reasoning_config_effort_max(self):
-        """Test 'max' effort maps directly to Anthropic."""
+        """Test 'max' effort maps directly to output_config."""
         result = AnthropicConfigOps.ir_reasoning_config_to_p(
             cast(ReasoningConfig, {"effort": "max"})
         )
         assert result["thinking"]["type"] == "adaptive"
-        assert result["thinking"]["effort"] == "max"
+        assert result["output_config"]["effort"] == "max"
 
     def test_ir_reasoning_config_effort_minimal_warning(self):
         """Test 'minimal' effort downgraded to 'low' with warning."""
@@ -183,7 +198,7 @@ class TestAnthropicConfigOps:
             result = AnthropicConfigOps.ir_reasoning_config_to_p(
                 cast(ReasoningConfig, {"effort": "minimal"})
             )
-        assert result["thinking"]["effort"] == "low"
+        assert result["output_config"]["effort"] == "low"
 
     def test_ir_reasoning_config_effort_with_budget(self):
         """Test effort + budget_tokens combined."""
@@ -191,28 +206,40 @@ class TestAnthropicConfigOps:
             cast(ReasoningConfig, {"effort": "medium", "budget_tokens": 4096})
         )
         assert result["thinking"]["type"] == "adaptive"
-        assert result["thinking"]["effort"] == "medium"
         assert result["thinking"]["budget_tokens"] == 4096
+        assert result["output_config"]["effort"] == "medium"
+
+    def test_ir_reasoning_config_budget_only(self):
+        """Test budget_tokens without mode or effort → 'enabled' type."""
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"budget_tokens": 4096})
+        )
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 4096
+        assert "output_config" not in result
 
     def test_p_reasoning_config_to_ir(self):
         """Test Anthropic thinking → IR ReasoningConfig."""
         provider = {"thinking": {"type": "enabled", "budget_tokens": 4096}}
         result = AnthropicConfigOps.p_reasoning_config_to_ir(provider)
-        assert result["enabled"] is True
+        assert result["mode"] == "enabled"
         assert result["budget_tokens"] == 4096
 
     def test_p_reasoning_config_to_ir_adaptive(self):
-        """Test adaptive thinking → IR with effort."""
-        provider = {"thinking": {"type": "adaptive", "effort": "high"}}
+        """Test adaptive thinking + output_config.effort → IR."""
+        provider = {
+            "thinking": {"type": "adaptive"},
+            "output_config": {"effort": "high"},
+        }
         result = AnthropicConfigOps.p_reasoning_config_to_ir(provider)
-        assert result["enabled"] is True
+        assert result["mode"] == "auto"
         assert result["effort"] == "high"
 
     def test_p_reasoning_config_to_ir_adaptive_no_effort(self):
-        """Test adaptive thinking without effort → IR enabled only."""
+        """Test adaptive thinking without effort → IR mode: auto only."""
         provider = {"thinking": {"type": "adaptive"}}
         result = AnthropicConfigOps.p_reasoning_config_to_ir(provider)
-        assert result["enabled"] is True
+        assert result["mode"] == "auto"
         assert "effort" not in result
         assert "budget_tokens" not in result
 
@@ -231,6 +258,7 @@ class TestAnthropicConfigOps:
         # Anthropic → IR
         provider_input = {"thinking": {"type": "adaptive"}}
         ir = AnthropicConfigOps.p_reasoning_config_to_ir(provider_input)
+        assert ir["mode"] == "auto"
         # IR → Anthropic
         result = AnthropicConfigOps.ir_reasoning_config_to_p(ir)
         assert result["thinking"]["type"] == "adaptive"
@@ -238,11 +266,14 @@ class TestAnthropicConfigOps:
 
     def test_reasoning_config_roundtrip_adaptive_with_effort(self):
         """Test round-trip: adaptive + effort → IR → adaptive + effort."""
-        provider_input = {"thinking": {"type": "adaptive", "effort": "high"}}
+        provider_input = {
+            "thinking": {"type": "adaptive"},
+            "output_config": {"effort": "high"},
+        }
         ir = AnthropicConfigOps.p_reasoning_config_to_ir(provider_input)
         result = AnthropicConfigOps.ir_reasoning_config_to_p(ir)
         assert result["thinking"]["type"] == "adaptive"
-        assert result["thinking"]["effort"] == "high"
+        assert result["output_config"]["effort"] == "high"
 
     def test_reasoning_config_roundtrip_enabled_with_budget(self):
         """Test round-trip: enabled + budget → IR → enabled + budget."""

--- a/tests/converters/anthropic/test_converter.py
+++ b/tests/converters/anthropic/test_converter.py
@@ -168,7 +168,7 @@ class TestAnthropicConverter:
             "messages": [
                 {"role": "user", "content": [{"type": "text", "text": "Think!"}]}
             ],
-            "reasoning": {"enabled": True, "budget_tokens": 2048},
+            "reasoning": {"mode": "enabled", "budget_tokens": 2048},
         }
         result, warnings = self.converter.request_to_provider(ir_request)
         assert result["thinking"]["type"] == "enabled"
@@ -236,7 +236,7 @@ class TestAnthropicConverter:
             ],
         }
         ir_request = self.converter.request_from_provider(provider_request)
-        assert ir_request["reasoning"]["enabled"] is True
+        assert ir_request["reasoning"]["mode"] == "enabled"
         assert ir_request["reasoning"]["budget_tokens"] == 4096
 
     def test_request_from_provider_pydantic(self):

--- a/tests/converters/google_genai/test_config_ops.py
+++ b/tests/converters/google_genai/test_config_ops.py
@@ -287,17 +287,60 @@ class TestGoogleGenAIConfigOps:
         )
         assert result == {}
 
+    def test_ir_reasoning_config_mode_disabled(self):
+        """Test mode: disabled → thinking_budget: 0."""
+        result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"mode": "disabled"})
+        )
+        assert result["thinking_config"]["thinking_budget"] == 0
+
+    def test_ir_reasoning_config_mode_auto(self):
+        """Test mode: auto → thinking_budget: -1."""
+        result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"mode": "auto"})
+        )
+        assert result["thinking_config"]["thinking_budget"] == -1
+
+    def test_ir_reasoning_config_mode_auto_with_effort(self):
+        """Test mode: auto + effort → thinking_budget: -1 + thinking_level."""
+        result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"mode": "auto", "effort": "high"})
+        )
+        assert result["thinking_config"]["thinking_budget"] == -1
+        assert result["thinking_config"]["thinking_level"] == "high"
+
+    def test_ir_reasoning_config_mode_enabled_with_budget(self):
+        """Test mode: enabled + budget → uses budget_tokens."""
+        result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"mode": "enabled", "budget_tokens": 4096})
+        )
+        assert result["thinking_config"]["thinking_budget"] == 4096
+
     def test_p_reasoning_config_to_ir(self):
         """Test Google thinking_config → IR ReasoningConfig."""
         provider = {"thinking_config": {"thinking_budget": 8192}}
         result = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert result["mode"] == "enabled"
         assert result["budget_tokens"] == 8192
 
+    def test_p_reasoning_config_to_ir_budget_zero(self):
+        """Test thinking_budget: 0 → mode: disabled."""
+        provider = {"thinking_config": {"thinking_budget": 0}}
+        result = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert result["mode"] == "disabled"
+
+    def test_p_reasoning_config_to_ir_budget_negative(self):
+        """Test thinking_budget: -1 → mode: auto."""
+        provider = {"thinking_config": {"thinking_budget": -1}}
+        result = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert result["mode"] == "auto"
+
     def test_p_reasoning_config_to_ir_with_level(self):
-        """Test thinking_level → IR effort."""
+        """Test thinking_level → IR effort + mode: auto."""
         provider = {"thinking_config": {"thinking_level": "low"}}
         result = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
         assert result["effort"] == "low"
+        assert result["mode"] == "auto"
 
     def test_p_reasoning_config_to_ir_empty(self):
         """Test empty reasoning config → empty IR."""
@@ -310,10 +353,11 @@ class TestGoogleGenAIConfigOps:
         assert result == {}
 
     def test_reasoning_config_round_trip(self):
-        """Test reasoning config round-trip."""
-        original = cast(ReasoningConfig, {"budget_tokens": 2048})
+        """Test reasoning config round-trip: enabled + budget."""
+        original = cast(ReasoningConfig, {"mode": "enabled", "budget_tokens": 2048})
         provider = GoogleGenAIConfigOps.ir_reasoning_config_to_p(original)
         restored = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert restored["mode"] == "enabled"
         assert restored["budget_tokens"] == 2048
 
     def test_reasoning_config_effort_round_trip(self):
@@ -322,6 +366,22 @@ class TestGoogleGenAIConfigOps:
         provider = GoogleGenAIConfigOps.ir_reasoning_config_to_p(original)
         restored = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
         assert restored["effort"] == "high"
+
+    def test_reasoning_config_roundtrip_auto(self):
+        """Test round-trip: auto → thinking_budget: -1 → auto."""
+        original = cast(ReasoningConfig, {"mode": "auto"})
+        provider = GoogleGenAIConfigOps.ir_reasoning_config_to_p(original)
+        assert provider["thinking_config"]["thinking_budget"] == -1
+        restored = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert restored["mode"] == "auto"
+
+    def test_reasoning_config_roundtrip_disabled(self):
+        """Test round-trip: disabled → thinking_budget: 0 → disabled."""
+        original = cast(ReasoningConfig, {"mode": "disabled"})
+        provider = GoogleGenAIConfigOps.ir_reasoning_config_to_p(original)
+        assert provider["thinking_config"]["thinking_budget"] == 0
+        restored = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert restored["mode"] == "disabled"
 
     # ==================== Cache Config ====================
 

--- a/tests/converters/openai_chat/test_config_ops.py
+++ b/tests/converters/openai_chat/test_config_ops.py
@@ -175,6 +175,20 @@ class TestOpenAIChatConfigOps:
         with pytest.warns(UserWarning, match="budget_tokens"):
             OpenAIChatConfigOps.ir_reasoning_config_to_p({"budget_tokens": 1000})
 
+    def test_ir_reasoning_config_mode_disabled(self):
+        """Test mode: disabled skips reasoning_effort entirely."""
+        result = OpenAIChatConfigOps.ir_reasoning_config_to_p(
+            {"mode": "disabled", "effort": "high"}
+        )
+        assert result == {}
+
+    def test_ir_reasoning_config_mode_auto_with_effort(self):
+        """Test mode: auto still outputs reasoning_effort."""
+        result = OpenAIChatConfigOps.ir_reasoning_config_to_p(
+            {"mode": "auto", "effort": "medium"}
+        )
+        assert result["reasoning_effort"] == "medium"
+
     def test_p_reasoning_config_to_ir(self):
         """Test OpenAI reasoning_effort → IR ReasoningConfig."""
         result = OpenAIChatConfigOps.p_reasoning_config_to_ir(

--- a/tests/converters/openai_responses/test_config_ops.py
+++ b/tests/converters/openai_responses/test_config_ops.py
@@ -271,13 +271,28 @@ class TestOpenAIResponsesConfigOps:
         )
         assert result["reasoning"] == {"effort": "high"}
 
-    def test_ir_reasoning_config_with_enabled(self):
-        """Test reasoning config with enabled field."""
+    def test_ir_reasoning_config_with_mode(self):
+        """Test reasoning config with mode field."""
         result = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(
-            cast(ReasoningConfig, {"enabled": True, "effort": "medium"})
+            cast(ReasoningConfig, {"mode": "enabled", "effort": "medium"})
         )
         assert result["reasoning"]["type"] == "enabled"
         assert result["reasoning"]["effort"] == "medium"
+
+    def test_ir_reasoning_config_auto_mode(self):
+        """Test mode: auto maps to reasoning.type: enabled."""
+        result = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"mode": "auto", "effort": "high"})
+        )
+        assert result["reasoning"]["type"] == "enabled"
+        assert result["reasoning"]["effort"] == "high"
+
+    def test_ir_reasoning_config_disabled_mode(self):
+        """Test mode: disabled maps to reasoning.type: disabled."""
+        result = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"mode": "disabled"})
+        )
+        assert result["reasoning"]["type"] == "disabled"
 
     def test_ir_reasoning_config_minimal_warning(self):
         """Test 'minimal' effort downgraded to 'low' with warning."""
@@ -315,7 +330,7 @@ class TestOpenAIResponsesConfigOps:
             {"reasoning": {"effort": "medium", "type": "enabled"}}
         )
         assert result["effort"] == "medium"
-        assert result["enabled"] is True
+        assert result["mode"] == "enabled"
 
     def test_p_reasoning_config_to_ir_direct(self):
         """Test direct reasoning object (without nesting)."""

--- a/tests/test_types/ir/test_ir_types.py
+++ b/tests/test_types/ir/test_ir_types.py
@@ -698,12 +698,12 @@ class TestConfigTypes:
         """测试推理配置创建"""
         config: ReasoningConfig = {
             "effort": "medium",
-            "enabled": True,
+            "mode": "enabled",
             "budget_tokens": 1000,
         }
 
         assert config["effort"] == "medium"
-        assert config["enabled"] is True
+        assert config["mode"] == "enabled"
         assert config["budget_tokens"] == 1000
 
     def test_cache_config_creation(self):


### PR DESCRIPTION
## Summary

Replace `enabled: bool` with `mode: Literal["auto", "enabled", "disabled"]` in IR `ReasoningConfig` to properly represent three-state reasoning across all providers.

- **IR type**: `enabled: bool` → `mode: Literal["auto", "enabled", "disabled"]`
- **Anthropic**: `effort` maps to `output_config.effort` (not `thinking.effort`); `mode: "auto"` ↔ `thinking.type: "adaptive"`
- **Google GenAI**: `mode` ↔ `thinking_budget` sentinel values (0 = disabled, -1 = auto, positive = enabled)
- **OpenAI Responses**: `mode` ↔ `reasoning.type`
- **OpenAI Chat**: `mode: "disabled"` skips `reasoning_effort` output
- All converters unified to pass full `provider_request` to `p_reasoning_config_to_ir` (prepares for future provider shim mechanism)
- Fix Google GenAI falsy-zero bug in `thinking_budget` extraction

Closes #141

## Test plan

- [x] All 1381 unit tests pass (`pytest tests/ --ignore=tests/integration`)
- [x] `ruff check` and `ruff format` clean
- [ ] CI passes