### PR TITLE
fix: map tool call ID prefixes for cross-format Responses API conversion

### DIFF
--- a/src/llm_rosetta/converters/openai_responses/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/tool_ops.py
@@ -376,7 +376,16 @@ class OpenAIResponsesToolOps(BaseToolOps):
             # Recover Responses API item ID from provider_metadata if available;
             # the API requires 'id' to start with 'fc_' prefix.
             metadata = ir_tool_call.get("provider_metadata") or {}
-            item_id = metadata.get("responses_item_id", tool_call_id)
+            item_id = metadata.get("responses_item_id")
+            if not item_id:
+                # Cross-format: ensure fc_ prefix required by Responses API
+                if tool_call_id and tool_call_id.startswith("fc_"):
+                    item_id = tool_call_id
+                elif tool_call_id and tool_call_id.startswith("call_"):
+                    item_id = "fc_" + tool_call_id[5:]
+                else:
+                    # Other prefixes (e.g. toolu_ from Anthropic)
+                    item_id = "fc_" + tool_call_id
             return {
                 "type": "function_call",
                 "id": item_id,
@@ -453,10 +462,14 @@ class OpenAIResponsesToolOps(BaseToolOps):
             # 'call_id' (correlation ID, call_ prefix). Store call_id as
             # tool_call_id for correlation, preserve 'id' in provider_metadata
             # for lossless round-trip.
-            call_id = provider_tool_call.get(
-                "call_id", provider_tool_call.get("id", "")
-            )
+            call_id = provider_tool_call.get("call_id")
             item_id = provider_tool_call.get("id", "")
+            if not call_id:
+                # Fallback: derive call_ prefix from fc_ prefix
+                if item_id.startswith("fc_"):
+                    call_id = "call_" + item_id[3:]
+                else:
+                    call_id = item_id
             part = ToolCallPart(
                 type="tool_call",
                 tool_call_id=call_id,

--- a/tests/converters/openai_responses/test_tool_ops.py
+++ b/tests/converters/openai_responses/test_tool_ops.py
@@ -218,7 +218,7 @@ class TestOpenAIResponsesToolOps:
         )
         result = OpenAIResponsesToolOps.ir_tool_call_to_p(ir_tc)
         assert result["type"] == "function_call"
-        assert result["id"] == "call_123"
+        assert result["id"] == "fc_123"  # call_ prefix → fc_ prefix for Responses API
         assert result["call_id"] == "call_123"
         assert result["name"] == "get_weather"
         assert json.loads(result["arguments"]) == {"city": "Beijing"}


### PR DESCRIPTION
## Summary

- OpenAI Responses API requires `fc_` prefix on the `id` field of `function_call` items, but cross-format conversion from Chat (`call_`) or Anthropic (`toolu_`) passed through the original prefix unchanged, causing 400 errors from the upstream API
- **IR→Provider**: when `responses_item_id` is absent in provider_metadata (cross-format case), derive a properly `fc_`-prefixed item ID from the IR tool_call_id
- **Provider→IR**: when `call_id` is absent in provider response, derive `call_` prefix from `fc_` item ID instead of storing the raw `fc_` prefix in IR (prevents double-prefixing on round-trip)

Discovered during gateway integration testing with Codex CLI (Responses wire format) pointing at Anthropic/Google upstream providers.

## Test plan

- [x] Updated existing `test_tool_ops.py` assertion for `call_` → `fc_` prefix mapping
- [x] All 1381 unit tests pass
- [x] CI green