### PR TITLE
fix: Responses developer role mapping and Google additionalProperties stripping

### DIFF
--- a/scripts/rosetta-test-claude-code.sh
+++ b/scripts/rosetta-test-claude-code.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Launch Claude Code through Rosetta Gateway
+# Usage: ./scripts/rosetta-test-claude-code.sh [model]
+#   model defaults to gpt-4.1-nano
+#   Available models: gpt-4.1-nano, anthropic/claude-haiku-4.5, gemini-2.5-flash-lite
+#   Gateway maps model name → upstream provider automatically
+
+MODEL="${1:-gpt-4.1-nano}"
+
+ANTHROPIC_BASE_URL=http://localhost:8765 \
+	ANTHROPIC_API_KEY=dummy \
+	exec claude --model "$MODEL" --verbose

--- a/scripts/rosetta-test-codex.sh
+++ b/scripts/rosetta-test-codex.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Launch Codex CLI through Rosetta Gateway
+# Usage: ./scripts/rosetta-test-codex.sh [profile]
+#   profile: rosetta-openai (default), rosetta-anthropic, rosetta-google
+#   Profiles are defined in ~/.codex/config.toml
+
+PROFILE="${1:-rosetta-openai}"
+
+exec codex --profile "$PROFILE"

--- a/scripts/rosetta-test-kilo.sh
+++ b/scripts/rosetta-test-kilo.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Launch Kilo through Rosetta Gateway (via VS Code / IDE)
+# Kilo is an IDE extension — select "rosetta" provider in the IDE model picker.
+# Available models under rosetta provider:
+#   - gpt-4.1-nano              → OpenAI backend
+#   - anthropic/claude-haiku-4.5 → Anthropic backend
+#   - gemini-2.5-flash-lite     → Google backend
+#
+# Models are defined in ~/.config/kilo/kilo.jsonc under "rosetta" provider.
+echo "Kilo is an IDE extension. Select rosetta/<model> in the model picker."
+echo "Available rosetta models:"
+echo "  - rosetta/gpt-4.1-nano"
+echo "  - rosetta/anthropic/claude-haiku-4.5"
+echo "  - rosetta/gemini-2.5-flash-lite"

--- a/scripts/rosetta-test-opencode.sh
+++ b/scripts/rosetta-test-opencode.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Launch OpenCode through Rosetta Gateway
+# Usage: ./scripts/rosetta-test-opencode.sh [model]
+#   model defaults to gpt-4.1-nano
+#   Available models: gpt-4.1-nano, anthropic/claude-haiku-4.5, gemini-2.5-flash-lite
+#   Models are defined in ~/.config/opencode/opencode.json under "rosetta" provider
+
+MODEL="${1:-gpt-4.1-nano}"
+
+exec opencode -m "rosetta/$MODEL"

--- a/src/llm_rosetta/converters/base/tools.py
+++ b/src/llm_rosetta/converters/base/tools.py
@@ -140,6 +140,7 @@ def _resolve_ref(ref: str, defs: dict[str, dict[str, Any]]) -> dict[str, Any]:
 def sanitize_schema(
     schema: dict[str, Any],
     defs: dict[str, dict[str, Any]] | None = None,
+    extra_strip_keys: set[str] | None = None,
 ) -> dict[str, Any]:
     """Recursively remove unsupported JSON Schema keywords.
 
@@ -153,6 +154,8 @@ def sanitize_schema(
         defs: Collected ``$defs``/``definitions`` from the top-level schema.
             Populated automatically on the first call if the schema contains
             definition maps.
+        extra_strip_keys: Additional provider-specific keys to strip
+            (e.g. ``{"additionalProperties"}`` for Google GenAI).
 
     Returns:
         A new dict with unsupported keys removed at every level.
@@ -165,6 +168,8 @@ def sanitize_schema(
             if isinstance(d, dict):
                 defs.update(d)
 
+    strip_keys = UNSUPPORTED_SCHEMA_KEYS | (extra_strip_keys or set())
+
     # Resolve $ref: inline the referenced definition (merge siblings).
     ref = schema.get("$ref")
     if isinstance(ref, str) and defs:
@@ -174,20 +179,22 @@ def sanitize_schema(
             # replaced by the resolved definition's content.
             merged = {k: v for k, v in schema.items() if k != "$ref"}
             merged.update(resolved)
-            return sanitize_schema(merged, defs)
+            return sanitize_schema(merged, defs, extra_strip_keys)
 
     result: dict[str, Any] = {}
     for key, value in schema.items():
-        if key in UNSUPPORTED_SCHEMA_KEYS or key in _DEFS_KEYS:
+        if key in strip_keys or key in _DEFS_KEYS:
             continue
         if key == "$ref":
             # Unresolvable $ref — drop it to avoid upstream rejection.
             continue
         if isinstance(value, dict):
-            result[key] = sanitize_schema(value, defs)
+            result[key] = sanitize_schema(value, defs, extra_strip_keys)
         elif isinstance(value, list):
             result[key] = [
-                sanitize_schema(item, defs) if isinstance(item, dict) else item
+                sanitize_schema(item, defs, extra_strip_keys)
+                if isinstance(item, dict)
+                else item
                 for item in value
             ]
         else:

--- a/src/llm_rosetta/converters/google_genai/tool_ops.py
+++ b/src/llm_rosetta/converters/google_genai/tool_ops.py
@@ -58,7 +58,10 @@ class GoogleGenAIToolOps(BaseToolOps):
         parameters = ir_tool.get("parameters")
         if parameters:
             func_decl["parameters"] = (
-                sanitize_schema(parameters)
+                sanitize_schema(
+                    parameters,
+                    extra_strip_keys={"additionalProperties"},
+                )
                 if isinstance(parameters, dict)
                 else parameters
             )

--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -430,9 +430,12 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
                 if converted:
                     ir_content.extend(converted)
 
+        # Map Responses API "developer" role to IR "system"
+        ir_role = "system" if role == "developer" else role
+
         # Empty messages are also created because subsequent tool calls
         # may need to be appended
-        return {"role": role, "content": ir_content}
+        return {"role": ir_role, "content": ir_content}
 
     def _p_content_part_to_ir(self, provider_part: Any) -> list[ContentPart]:
         """Convert a single Responses API content part to IR content part(s).

--- a/tests/converters/google_genai/test_tool_ops.py
+++ b/tests/converters/google_genai/test_tool_ops.py
@@ -40,6 +40,30 @@ class TestGoogleGenAIToolOps:
         assert func_decl["description"] == "Get current weather"
         assert "parameters" in func_decl
 
+    def test_ir_tool_definition_to_p_strips_additional_properties(self):
+        """Test additionalProperties is stripped for Google GenAI."""
+        ir_tool: ToolDefinition = {
+            "type": "function",
+            "name": "create_item",
+            "description": "Create an item",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": "string", "additionalProperties": False},
+                    },
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        }
+        result = GoogleGenAIToolOps.ir_tool_definition_to_p(ir_tool)
+        params = result["function_declarations"][0]["parameters"]
+        assert "additionalProperties" not in params
+        assert "additionalProperties" not in params["properties"]["tags"]["items"]
+
     def test_p_tool_definition_to_ir(self):
         """Test Google FunctionDeclaration → IR ToolDefinition."""
         provider_tool = {

--- a/tests/converters/openai_responses/test_message_ops.py
+++ b/tests/converters/openai_responses/test_message_ops.py
@@ -340,6 +340,24 @@ class TestOpenAIResponsesMessageOps:
         assert result[0]["role"] == "system"
         assert result[0]["content"][0]["text"] == "Be helpful"
 
+    def test_p_message_to_ir_developer(self):
+        """Test OpenAI Responses developer message → IR SystemMessage."""
+        result = cast(
+            list[Any],
+            self.message_ops.p_messages_to_ir(
+                [
+                    {
+                        "type": "message",
+                        "role": "developer",
+                        "content": [{"type": "input_text", "text": "Be helpful"}],
+                    }
+                ]
+            ),
+        )
+        assert len(result) == 1
+        assert result[0]["role"] == "system"
+        assert result[0]["content"][0]["text"] == "Be helpful"
+
     def test_p_message_to_ir_assistant(self):
         """Test OpenAI Responses assistant message → IR AssistantMessage."""
         result = cast(


### PR DESCRIPTION
## Summary

- **Responses API `developer` role**: Map `developer` → `system` in Provider→IR direction. Codex/Claude Code send `role: "developer"` messages which failed IR validation (only `system/user/assistant/tool` accepted). Discovered during gateway integration testing.
- **Google GenAI `additionalProperties`**: Add `extra_strip_keys` parameter to `sanitize_schema()` for provider-specific unsupported JSON Schema keywords. Google rejects `additionalProperties` in `function_declarations` parameters. Now recursively stripped when converting tool schemas for Google.
- **Gateway test scripts**: Add launcher scripts for Codex, OpenCode, Kilo, and Claude Code CLI tools pointing at the Rosetta gateway.

## Test plan

- [x] New test: `test_p_message_to_ir_developer` — verifies developer→system mapping
- [x] New test: `test_ir_tool_definition_to_p_strips_additional_properties` — verifies recursive stripping
- [x] All 1383 unit tests pass
- [ ] CI green