### PR TITLE
fix: convert Google modality token list to IR dict

### DIFF
--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -60,6 +60,33 @@ from .message_ops import GoogleGenAIMessageOps
 from .tool_ops import GoogleGenAIToolOps
 
 
+def _modality_list_to_dict(modality_list: list[dict]) -> dict[str, int]:
+    """Convert Google's ``list[ModalityTokenCount]`` to IR ``dict[str, int]``.
+
+    Example: ``[{"modality": "TEXT", "token_count": 42}]``
+    → ``{"text_tokens": 42}``
+    """
+    result: dict[str, int] = {}
+    for item in modality_list:
+        modality = (item.get("modality") or "unknown").lower()
+        count = item.get("token_count") or item.get("tokenCount") or 0
+        result[f"{modality}_tokens"] = count
+    return result
+
+
+def _dict_to_modality_list(details: dict[str, int]) -> list[dict[str, Any]]:
+    """Convert IR ``dict[str, int]`` back to Google's ``list[ModalityTokenCount]``.
+
+    Example: ``{"text_tokens": 42}``
+    → ``[{"modality": "TEXT", "tokenCount": 42}]``
+    """
+    result: list[dict[str, Any]] = []
+    for key, count in details.items():
+        modality = key.removesuffix("_tokens").upper()
+        result.append({"modality": modality, "tokenCount": count})
+    return result
+
+
 class GoogleGenAIConverter(BaseConverter):
     """Google GenAI API converter.
 
@@ -484,17 +511,28 @@ class GoogleGenAIConverter(BaseConverter):
                 usage_info["cache_read_tokens"] = cached
 
             # Modality breakdowns (Google-specific)
+            # Google returns list[ModalityTokenCount] e.g.
+            # [{"modality": "TEXT", "token_count": 42}];
+            # IR expects dict[str, int] e.g. {"text_tokens": 42}.
             prompt_details = p_usage.get("prompt_tokens_details") or p_usage.get(
                 "promptTokensDetails"
             )
             if prompt_details:
-                usage_info["prompt_tokens_details"] = prompt_details
+                usage_info["prompt_tokens_details"] = (
+                    _modality_list_to_dict(prompt_details)
+                    if isinstance(prompt_details, list)
+                    else prompt_details
+                )
 
             candidates_details = p_usage.get(
                 "candidates_tokens_details"
             ) or p_usage.get("candidatesTokensDetails")
             if candidates_details:
-                usage_info["completion_tokens_details"] = candidates_details
+                usage_info["completion_tokens_details"] = (
+                    _modality_list_to_dict(candidates_details)
+                    if isinstance(candidates_details, list)
+                    else candidates_details
+                )
 
             ir_response["usage"] = usage_info
 
@@ -566,14 +604,20 @@ class GoogleGenAIConverter(BaseConverter):
                 ]
 
             if "prompt_tokens_details" in ir_usage:
-                usage_metadata["promptTokensDetails"] = ir_usage[
-                    "prompt_tokens_details"
-                ]
+                details = ir_usage["prompt_tokens_details"]
+                usage_metadata["promptTokensDetails"] = (
+                    _dict_to_modality_list(details)
+                    if isinstance(details, dict)
+                    else details
+                )
 
             if "completion_tokens_details" in ir_usage:
-                usage_metadata["candidatesTokensDetails"] = ir_usage[
-                    "completion_tokens_details"
-                ]
+                details = ir_usage["completion_tokens_details"]
+                usage_metadata["candidatesTokensDetails"] = (
+                    _dict_to_modality_list(details)
+                    if isinstance(details, dict)
+                    else details
+                )
 
             provider_response["usageMetadata"] = usage_metadata
 

--- a/tests/converters/google_genai/test_converter.py
+++ b/tests/converters/google_genai/test_converter.py
@@ -463,6 +463,64 @@ class TestGoogleGenAIConverter:
         result = self.converter.response_from_provider(provider_response)
         assert result["usage"]["reasoning_tokens"] == 100
 
+    def test_response_from_provider_modality_token_details(self):
+        """Test Google list[ModalityTokenCount] → IR dict[str, int]."""
+        provider_response = {
+            "response_id": "resp-modality",
+            "model_version": "gemini-2.0-flash",
+            "candidates": [
+                {
+                    "index": 0,
+                    "content": {"role": "model", "parts": [{"text": "Hi"}]},
+                    "finish_reason": "STOP",
+                }
+            ],
+            "usage_metadata": {
+                "prompt_token_count": 50,
+                "candidates_token_count": 20,
+                "total_token_count": 70,
+                "prompt_tokens_details": [
+                    {"modality": "TEXT", "token_count": 40},
+                    {"modality": "IMAGE", "token_count": 10},
+                ],
+                "candidates_tokens_details": [
+                    {"modality": "TEXT", "token_count": 20},
+                ],
+            },
+        }
+        result = self.converter.response_from_provider(provider_response)
+        assert result["usage"]["prompt_tokens_details"] == {
+            "text_tokens": 40,
+            "image_tokens": 10,
+        }
+        assert result["usage"]["completion_tokens_details"] == {
+            "text_tokens": 20,
+        }
+
+    def test_response_from_provider_modality_camelcase(self):
+        """Test camelCase modality token details (REST API format)."""
+        provider_response = {
+            "responseId": "resp-camel",
+            "modelVersion": "gemini-2.0-flash",
+            "candidates": [
+                {
+                    "index": 0,
+                    "content": {"role": "model", "parts": [{"text": "Hi"}]},
+                    "finishReason": "STOP",
+                }
+            ],
+            "usageMetadata": {
+                "promptTokenCount": 30,
+                "candidatesTokenCount": 10,
+                "totalTokenCount": 40,
+                "promptTokensDetails": [
+                    {"modality": "TEXT", "tokenCount": 30},
+                ],
+            },
+        }
+        result = self.converter.response_from_provider(provider_response)
+        assert result["usage"]["prompt_tokens_details"] == {"text_tokens": 30}
+
     def test_response_from_provider_finish_reasons(self):
         """Test various finish reason mappings."""
         reason_map = {
@@ -665,6 +723,54 @@ class TestGoogleGenAIConverter:
         )
         result = self.converter.response_to_provider(ir_response)
         assert result["usageMetadata"]["thoughtsTokenCount"] == 50
+
+    def test_response_to_provider_modality_token_details(self):
+        """Test IR dict[str, int] → Google list[ModalityTokenCount]."""
+        ir_response = cast(
+            IRResponse,
+            {
+                "id": "resp_mod",
+                "object": "response",
+                "created": 1700000000,
+                "model": "gemini-2.0-flash",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Hi"}],
+                        },
+                        "finish_reason": {"reason": "stop"},
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 50,
+                    "completion_tokens": 20,
+                    "total_tokens": 70,
+                    "prompt_tokens_details": {
+                        "text_tokens": 40,
+                        "image_tokens": 10,
+                    },
+                    "completion_tokens_details": {
+                        "text_tokens": 20,
+                    },
+                },
+            },
+        )
+        result = self.converter.response_to_provider(ir_response)
+        prompt_details = result["usageMetadata"]["promptTokensDetails"]
+        assert isinstance(prompt_details, list)
+        assert len(prompt_details) == 2
+        # Convert to dict for easier assertion (order may vary)
+        detail_map = {d["modality"]: d["tokenCount"] for d in prompt_details}
+        assert detail_map["TEXT"] == 40
+        assert detail_map["IMAGE"] == 10
+
+        comp_details = result["usageMetadata"]["candidatesTokensDetails"]
+        assert isinstance(comp_details, list)
+        assert len(comp_details) == 1
+        assert comp_details[0]["modality"] == "TEXT"
+        assert comp_details[0]["tokenCount"] == 20
 
     def test_response_to_provider_finish_reasons(self):
         """Test finish reason mapping to provider."""
@@ -932,6 +1038,37 @@ class TestGoogleGenAIConverterFullRoundTrip:
         assert restored["candidates"][0]["content"]["parts"][0]["text"] == "Hello!"
         assert restored["candidates"][0]["finishReason"] == "STOP"
         assert restored["usageMetadata"]["totalTokenCount"] == 15
+
+    def test_response_round_trip_with_modality_details(self):
+        """Test modality token details survive Google → IR → Google round-trip."""
+        provider_response = {
+            "response_id": "resp-mod-rt",
+            "model_version": "gemini-2.0-flash",
+            "candidates": [
+                {
+                    "index": 0,
+                    "content": {"role": "model", "parts": [{"text": "Hi"}]},
+                    "finish_reason": "STOP",
+                }
+            ],
+            "usage_metadata": {
+                "prompt_token_count": 50,
+                "candidates_token_count": 20,
+                "total_token_count": 70,
+                "prompt_tokens_details": [
+                    {"modality": "TEXT", "token_count": 40},
+                    {"modality": "IMAGE", "token_count": 10},
+                ],
+            },
+        }
+        ir_response = self.converter.response_from_provider(provider_response)
+        restored = self.converter.response_to_provider(ir_response)
+
+        details = restored["usageMetadata"]["promptTokensDetails"]
+        assert isinstance(details, list)
+        detail_map = {d["modality"]: d["tokenCount"] for d in details}
+        assert detail_map["TEXT"] == 40
+        assert detail_map["IMAGE"] == 10
 
     def test_message_round_trip(self):
         """Test message round-trip: IR -> Google -> IR."""


### PR DESCRIPTION
## Summary

- Google GenAI returns `prompt_tokens_details` and `candidates_tokens_details` as `list[ModalityTokenCount]` (e.g. `[{"modality": "TEXT", "token_count": 42}]`), but IR expects `dict[str, int]` (e.g. `{"text_tokens": 42}`). This mismatch caused IR validation failures on non-streaming responses from Google upstream.
- Added `_modality_list_to_dict()` and `_dict_to_modality_list()` conversion helpers
- Handles both SDK (`token_count`) and REST API (`tokenCount`) field names
- Applied in both `response_from_provider` (Google→IR) and `response_to_provider` (IR→Google) paths

Fixes the `prompt_tokens_details` validation error discovered during gateway integration testing.

## Test plan

- [x] Unit tests for Google→IR conversion with `list[ModalityTokenCount]`
- [x] Unit tests for IR→Google conversion back to `list[ModalityTokenCount]`
- [x] Round-trip test (Google→IR→Google preserves modality details)
- [x] camelCase REST API format test
- [x] Full test suite passes (1385 passed)