### PR TITLE
feat: add gateway admin panel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 "llm_rosetta" = ["py.typed"]
+"llm_rosetta.gateway.admin" = ["admin.html"]
 
 [tool.setuptools.dynamic]
 version = { attr = "llm_rosetta.__version__" }

--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from typing import TYPE_CHECKING
 
 from .metrics import MetricsCollector
+from .persistence import PersistenceManager
 from .request_log import RequestLog
 
 if TYPE_CHECKING:
@@ -12,7 +15,9 @@ if TYPE_CHECKING:
 
     from ..config import GatewayConfig
 
-__all__ = ["setup_admin", "MetricsCollector", "RequestLog"]
+__all__ = ["setup_admin", "MetricsCollector", "RequestLog", "PersistenceManager"]
+
+logger = logging.getLogger("llm-rosetta-gateway")
 
 
 def setup_admin(
@@ -25,7 +30,32 @@ def setup_admin(
     Routes are added separately in ``create_app`` *before* the Starlette
     instance is constructed so that its Router compiles them properly.
     """
-    app.state.metrics = MetricsCollector()
-    app.state.request_log = RequestLog()
+    metrics = MetricsCollector()
+    request_log = RequestLog()
+
+    # Set up file persistence alongside the config file
+    persistence: PersistenceManager | None = None
+    if config_path:
+        data_dir = os.path.join(os.path.dirname(config_path), "data")
+        persistence = PersistenceManager(data_dir)
+
+        # Restore persisted request log
+        saved_entries = persistence.load_log_entries(request_log._max_entries)
+        if saved_entries:
+            request_log.load_entries(saved_entries)
+            logger.info("Loaded %d request log entries from disk", len(saved_entries))
+
+        # Restore persisted metrics counters
+        saved_metrics = persistence.load_metrics()
+        if saved_metrics:
+            metrics.load_counters(saved_metrics)
+            logger.info(
+                "Loaded metrics from disk (total_requests=%d)",
+                metrics.total_requests,
+            )
+
+    app.state.metrics = metrics
+    app.state.request_log = request_log
+    app.state.persistence = persistence
     app.state.gateway_config = config
     app.state.config_path = config_path

--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -1,0 +1,31 @@
+"""Admin panel for the llm-rosetta gateway."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .metrics import MetricsCollector
+from .request_log import RequestLog
+
+if TYPE_CHECKING:
+    from starlette.applications import Starlette
+
+    from ..config import GatewayConfig
+
+__all__ = ["setup_admin", "MetricsCollector", "RequestLog"]
+
+
+def setup_admin(
+    app: Starlette,
+    config: GatewayConfig,
+    config_path: str | None,
+) -> None:
+    """Initialize admin panel state on the app.
+
+    Routes are added separately in ``create_app`` *before* the Starlette
+    instance is constructed so that its Router compiles them properly.
+    """
+    app.state.metrics = MetricsCollector()
+    app.state.request_log = RequestLog()
+    app.state.gateway_config = config
+    app.state.config_path = config_path

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -1,0 +1,918 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>llm-rosetta Gateway — Admin</title>
+<style>
+:root {
+  --bg: #0f1117;
+  --bg-card: #1a1d27;
+  --bg-hover: #242838;
+  --border: #2d3148;
+  --text: #e4e7ef;
+  --text-dim: #8b90a5;
+  --accent: #6366f1;
+  --accent-hover: #818cf8;
+  --green: #22c55e;
+  --red: #ef4444;
+  --orange: #f59e0b;
+  --blue: #3b82f6;
+  --radius: 8px;
+  --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --mono: 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: var(--font); background: var(--bg); color: var(--text); min-height: 100vh; }
+a { color: var(--accent); text-decoration: none; }
+
+/* Header */
+.header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 16px 24px; border-bottom: 1px solid var(--border);
+}
+.header h1 { font-size: 18px; font-weight: 600; }
+.header h1 span { color: var(--text-dim); font-weight: 400; }
+.header .config-path { font-size: 12px; color: var(--text-dim); font-family: var(--mono); }
+
+/* Tabs */
+.tabs {
+  display: flex; gap: 0; border-bottom: 1px solid var(--border);
+  padding: 0 24px;
+}
+.tab {
+  padding: 12px 20px; cursor: pointer; font-size: 14px; color: var(--text-dim);
+  border-bottom: 2px solid transparent; transition: all 0.15s;
+}
+.tab:hover { color: var(--text); }
+.tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* Content */
+.content { padding: 24px; max-width: 1200px; margin: 0 auto; }
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+
+/* Cards */
+.stats-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px; margin-bottom: 24px;
+}
+.stat-card {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 16px;
+}
+.stat-card .label { font-size: 12px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.5px; }
+.stat-card .value { font-size: 28px; font-weight: 700; margin-top: 4px; }
+.stat-card .value.green { color: var(--green); }
+.stat-card .value.red { color: var(--red); }
+.stat-card .value.blue { color: var(--blue); }
+
+/* Section */
+.section { margin-bottom: 32px; }
+.section-header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 16px;
+}
+.section-header h2 { font-size: 16px; font-weight: 600; }
+
+/* Buttons */
+.btn {
+  padding: 8px 16px; border-radius: var(--radius); border: 1px solid var(--border);
+  background: var(--bg-card); color: var(--text); cursor: pointer; font-size: 13px;
+  transition: all 0.15s;
+}
+.btn:hover { background: var(--bg-hover); }
+.btn-primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-danger { color: var(--red); }
+.btn-danger:hover { background: rgba(239,68,68,0.1); }
+.btn-sm { padding: 4px 10px; font-size: 12px; }
+
+/* Tables */
+table { width: 100%; border-collapse: collapse; }
+th, td {
+  text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+th { color: var(--text-dim); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; }
+tr:hover td { background: var(--bg-hover); }
+
+/* Provider cards */
+.provider-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+}
+.provider-card {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 16px;
+}
+.provider-card .name { font-size: 15px; font-weight: 600; margin-bottom: 8px; }
+.provider-card .field { font-size: 12px; color: var(--text-dim); margin-bottom: 4px; }
+.provider-card .field code {
+  font-family: var(--mono); color: var(--text); background: var(--bg);
+  padding: 2px 6px; border-radius: 4px; font-size: 11px;
+}
+.provider-card .actions { margin-top: 12px; display: flex; gap: 8px; }
+
+/* Modal */
+.modal-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.6);
+  display: none; align-items: center; justify-content: center; z-index: 100;
+}
+.modal-overlay.open { display: flex; }
+.modal {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: 12px; padding: 24px; width: 440px; max-width: 90vw;
+}
+.modal h3 { margin-bottom: 16px; font-size: 16px; }
+.form-group { margin-bottom: 14px; }
+.form-group label { display: block; font-size: 12px; color: var(--text-dim); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+.form-group input, .form-group select {
+  width: 100%; padding: 8px 12px; background: var(--bg); border: 1px solid var(--border);
+  border-radius: var(--radius); color: var(--text); font-size: 14px; font-family: var(--mono);
+}
+.form-group input:focus, .form-group select:focus { outline: none; border-color: var(--accent); }
+.modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 20px; }
+
+/* Toast */
+.toast {
+  position: fixed; bottom: 24px; right: 24px;
+  padding: 12px 20px; border-radius: var(--radius); font-size: 13px;
+  z-index: 200; opacity: 0; transition: opacity 0.3s;
+}
+.toast.show { opacity: 1; }
+.toast.success { background: var(--green); color: #fff; }
+.toast.error { background: var(--red); color: #fff; }
+
+/* Charts */
+.chart-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 24px; }
+.chart-box {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 16px;
+}
+.chart-box h3 { font-size: 13px; color: var(--text-dim); margin-bottom: 12px; }
+canvas { width: 100%; height: 160px; }
+
+/* Filters */
+.filters { display: flex; gap: 12px; margin-bottom: 16px; flex-wrap: wrap; }
+.filters select, .filters input {
+  padding: 6px 10px; background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--radius); color: var(--text); font-size: 13px;
+}
+
+/* Pagination */
+.pagination { display: flex; align-items: center; gap: 12px; margin-top: 16px; justify-content: center; }
+.pagination .info { font-size: 13px; color: var(--text-dim); }
+
+/* Status badge */
+.badge {
+  display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600;
+}
+.badge-ok { background: rgba(34,197,94,0.15); color: var(--green); }
+.badge-error { background: rgba(239,68,68,0.15); color: var(--red); }
+.badge-stream { background: rgba(99,102,241,0.15); color: var(--accent); }
+
+/* Test button dropdown */
+.test-group { position: relative; display: inline-flex; }
+.test-group .btn-test {
+  border-radius: var(--radius) 0 0 var(--radius); border-right: none;
+  color: var(--orange); font-weight: 600;
+}
+.test-group .btn-test:hover { background: rgba(245,158,11,0.1); }
+.test-group .btn-caret {
+  border-radius: 0 var(--radius) var(--radius) 0; padding: 4px 6px;
+  color: var(--orange);
+}
+.test-group .btn-caret:hover { background: rgba(245,158,11,0.1); }
+.test-menu {
+  display: none; position: absolute; top: 100%; right: 0; margin-top: 4px;
+  background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius);
+  min-width: 180px; z-index: 50; box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+}
+.test-menu.open { display: block; }
+.test-menu-item {
+  padding: 8px 14px; font-size: 13px; cursor: pointer; white-space: nowrap;
+}
+.test-menu-item:hover { background: var(--bg-hover); }
+.test-menu-item:first-child { border-radius: var(--radius) var(--radius) 0 0; }
+.test-menu-item:last-child { border-radius: 0 0 var(--radius) var(--radius); }
+
+/* Test result modal (wider) */
+.modal-wide { width: 620px; max-width: 95vw; }
+.test-meta { display: flex; gap: 16px; margin-bottom: 12px; flex-wrap: wrap; }
+.test-meta .meta-item { font-size: 12px; color: var(--text-dim); }
+.test-meta .meta-item strong { color: var(--text); }
+.test-output {
+  background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius);
+  padding: 14px; font-family: var(--mono); font-size: 13px; line-height: 1.6;
+  max-height: 360px; overflow-y: auto; white-space: pre-wrap; word-break: break-word;
+}
+.test-output.streaming { border-color: var(--accent); }
+.test-spinner {
+  display: inline-block; width: 14px; height: 14px; border: 2px solid var(--border);
+  border-top-color: var(--accent); border-radius: 50%;
+  animation: spin 0.6s linear infinite; vertical-align: middle; margin-right: 6px;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Responsive */
+@media (max-width: 768px) {
+  .chart-row { grid-template-columns: 1fr; }
+  .provider-grid { grid-template-columns: 1fr; }
+  .stats-grid { grid-template-columns: repeat(2, 1fr); }
+}
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div>
+    <h1>llm-rosetta <span>gateway admin</span></h1>
+  </div>
+  <div class="config-path" id="configPath"></div>
+</div>
+
+<div class="tabs">
+  <div class="tab active" data-tab="config">Configuration</div>
+  <div class="tab" data-tab="dashboard">Dashboard</div>
+  <div class="tab" data-tab="logs">Request Log</div>
+</div>
+
+<div class="content">
+  <!-- Configuration Tab -->
+  <div class="tab-panel active" id="tab-config">
+    <div class="section">
+      <div class="section-header">
+        <h2>Server Settings</h2>
+      </div>
+      <div class="provider-card" style="max-width:480px">
+        <div class="form-group" style="margin-bottom:0">
+          <label>Global Proxy URL</label>
+          <div style="display:flex;gap:8px">
+            <input id="globalProxy" placeholder="e.g. http://127.0.0.1:7890" style="flex:1;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);color:var(--text);font-size:14px;font-family:var(--mono)">
+            <button class="btn btn-primary btn-sm" onclick="saveServerSettings()">Save</button>
+          </div>
+          <div style="font-size:11px;color:var(--text-dim);margin-top:6px">Applies to all providers unless overridden per-provider.</div>
+        </div>
+      </div>
+    </div>
+    <div class="section">
+      <div class="section-header">
+        <h2>Providers</h2>
+        <button class="btn btn-primary btn-sm" onclick="openProviderModal()">+ Add Provider</button>
+      </div>
+      <div class="provider-grid" id="providerGrid"></div>
+    </div>
+    <div class="section">
+      <div class="section-header">
+        <h2>Model Routing</h2>
+        <button class="btn btn-primary btn-sm" onclick="openModelModal()">+ Add Model</button>
+      </div>
+      <table>
+        <thead><tr><th>Model</th><th>Provider</th><th></th></tr></thead>
+        <tbody id="modelTable"></tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- Dashboard Tab -->
+  <div class="tab-panel" id="tab-dashboard">
+    <div class="stats-grid" id="statsGrid"></div>
+    <div class="chart-row">
+      <div class="chart-box">
+        <h3>Throughput (req/s)</h3>
+        <canvas id="chartThroughput"></canvas>
+      </div>
+      <div class="chart-box">
+        <h3>Latency (ms)</h3>
+        <canvas id="chartLatency"></canvas>
+      </div>
+    </div>
+    <div class="section">
+      <h2 style="margin-bottom:12px">Per-Provider Breakdown</h2>
+      <table>
+        <thead><tr><th>Provider</th><th>Requests</th></tr></thead>
+        <tbody id="providerBreakdown"></tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- Request Log Tab -->
+  <div class="tab-panel" id="tab-logs">
+    <div class="filters">
+      <select id="filterModel"><option value="">All Models</option></select>
+      <select id="filterProvider"><option value="">All Providers</option></select>
+      <select id="filterStatus">
+        <option value="">All Status</option>
+        <option value="ok">OK (2xx/3xx)</option>
+        <option value="error">Error (4xx/5xx)</option>
+      </select>
+      <button class="btn btn-danger btn-sm" onclick="clearLogs()">Clear Log</button>
+    </div>
+    <table>
+      <thead><tr><th>Time</th><th>Model</th><th>Source &rarr; Target</th><th>Mode</th><th>Status</th><th>Duration</th></tr></thead>
+      <tbody id="logTable"></tbody>
+    </table>
+    <div class="pagination">
+      <button class="btn btn-sm" id="prevPage" onclick="changePage(-1)">Prev</button>
+      <span class="info" id="pageInfo"></span>
+      <button class="btn btn-sm" id="nextPage" onclick="changePage(1)">Next</button>
+    </div>
+  </div>
+</div>
+
+<!-- Provider Modal -->
+<div class="modal-overlay" id="providerModal">
+  <div class="modal">
+    <h3 id="providerModalTitle">Add Provider</h3>
+    <div class="form-group">
+      <label>Provider Name / Type</label>
+      <input id="provName" placeholder="e.g. openai_chat, anthropic, my_custom">
+    </div>
+    <div class="form-group">
+      <label>Base URL</label>
+      <input id="provBaseUrl" placeholder="https://api.openai.com/v1">
+    </div>
+    <div class="form-group">
+      <label>API Key (or ${ENV_VAR} placeholder)</label>
+      <input id="provApiKey" placeholder="${OPENAI_API_KEY}">
+    </div>
+    <div class="form-group">
+      <label>Proxy URL (optional, overrides global)</label>
+      <input id="provProxy" placeholder="e.g. http://127.0.0.1:7890">
+    </div>
+    <div class="modal-actions">
+      <button class="btn" onclick="closeModal('providerModal')">Cancel</button>
+      <button class="btn btn-primary" onclick="saveProvider()">Save</button>
+    </div>
+  </div>
+</div>
+
+<!-- Model Modal -->
+<div class="modal-overlay" id="modelModal">
+  <div class="modal">
+    <h3 id="modelModalTitle">Add Model</h3>
+    <div class="form-group">
+      <label>Model Name</label>
+      <input id="modelName" placeholder="e.g. gpt-4o, claude-sonnet-4-20250514">
+    </div>
+    <div class="form-group">
+      <label>Provider</label>
+      <select id="modelProvider"></select>
+    </div>
+    <div class="modal-actions">
+      <button class="btn" onclick="closeModal('modelModal')">Cancel</button>
+      <button class="btn btn-primary" onclick="saveModel()">Save</button>
+    </div>
+  </div>
+</div>
+
+<!-- Test Result Modal -->
+<div class="modal-overlay" id="testModal">
+  <div class="modal modal-wide">
+    <h3 id="testModalTitle">Test Result</h3>
+    <div class="test-meta" id="testMeta"></div>
+    <div class="test-output" id="testOutput"></div>
+    <div class="modal-actions">
+      <button class="btn" onclick="closeModal('testModal')">Close</button>
+    </div>
+  </div>
+</div>
+
+<!-- Toast -->
+<div class="toast" id="toast"></div>
+
+<script>
+// ===================== State =====================
+let currentTab = 'config';
+let configData = null;
+let logOffset = 0;
+const LOG_LIMIT = 30;
+let dashboardTimer = null;
+let logTimer = null;
+
+// ===================== API =====================
+const api = {
+  async get(url) {
+    const r = await fetch(url);
+    return r.json();
+  },
+  async put(url, body) {
+    const r = await fetch(url, {method:'PUT', headers:{'Content-Type':'application/json'}, body:JSON.stringify(body)});
+    return r.json();
+  },
+  async del(url) {
+    const r = await fetch(url, {method:'DELETE'});
+    return r.json();
+  },
+  async post(url) {
+    const r = await fetch(url, {method:'POST'});
+    return r.json();
+  }
+};
+
+// ===================== Toast =====================
+function showToast(msg, type='success') {
+  const t = document.getElementById('toast');
+  t.textContent = msg;
+  t.className = 'toast show ' + type;
+  setTimeout(() => t.className = 'toast', 3000);
+}
+
+// ===================== Modal =====================
+function closeModal(id) { document.getElementById(id).classList.remove('open'); }
+
+function openProviderModal(name, baseUrl, apiKey, proxy) {
+  document.getElementById('providerModalTitle').textContent = name ? 'Edit Provider' : 'Add Provider';
+  document.getElementById('provName').value = name || '';
+  document.getElementById('provName').readOnly = !!name;
+  document.getElementById('provBaseUrl').value = baseUrl || '';
+  document.getElementById('provApiKey').value = apiKey || '';
+  document.getElementById('provProxy').value = proxy || '';
+  document.getElementById('providerModal').classList.add('open');
+}
+
+function openModelModal(model, provider) {
+  document.getElementById('modelModalTitle').textContent = model ? 'Edit Model' : 'Add Model';
+  document.getElementById('modelName').value = model || '';
+  document.getElementById('modelName').readOnly = !!model;
+  // Populate provider dropdown from config
+  const sel = document.getElementById('modelProvider');
+  sel.innerHTML = '';
+  if (configData) {
+    for (const p of Object.keys(configData.providers)) {
+      const opt = document.createElement('option');
+      opt.value = p; opt.textContent = p;
+      if (p === provider) opt.selected = true;
+      sel.appendChild(opt);
+    }
+  }
+  document.getElementById('modelModal').classList.add('open');
+}
+
+// ===================== Config Tab =====================
+async function loadConfig() {
+  configData = await api.get('/admin/api/config');
+  document.getElementById('configPath').textContent = configData.config_path || '';
+  document.getElementById('globalProxy').value = (configData.server && configData.server.proxy) || '';
+  renderProviders();
+  renderModels();
+}
+
+async function saveServerSettings() {
+  const proxy = document.getElementById('globalProxy').value.trim();
+  const res = await api.put('/admin/api/config/server', {proxy});
+  if (res.ok) { showToast('Server settings saved'); loadConfig(); }
+  else { showToast(res.error || 'Failed', 'error'); }
+}
+
+function renderProviders() {
+  const grid = document.getElementById('providerGrid');
+  const providers = configData.providers || {};
+  if (Object.keys(providers).length === 0) {
+    grid.innerHTML = '<p style="color:var(--text-dim)">No providers configured.</p>';
+    return;
+  }
+  grid.innerHTML = Object.entries(providers).map(([name, cfg]) => `
+    <div class="provider-card">
+      <div class="name">${esc(name)}</div>
+      <div class="field">Base URL: <code>${esc(cfg.base_url || '')}</code></div>
+      <div class="field">API Key: <code>${esc(cfg.api_key || '')}</code></div>
+      ${cfg.proxy ? `<div class="field">Proxy: <code>${esc(cfg.proxy)}</code></div>` : ''}
+      <div class="actions">
+        <button class="btn btn-sm" onclick="editProvider('${esc(name)}')">Edit</button>
+        <button class="btn btn-sm btn-danger" onclick="deleteProvider('${esc(name)}')">Delete</button>
+      </div>
+    </div>
+  `).join('');
+}
+
+function renderModels() {
+  const tbody = document.getElementById('modelTable');
+  const models = configData.models || {};
+  if (Object.keys(models).length === 0) {
+    tbody.innerHTML = '<tr><td colspan="3" style="color:var(--text-dim)">No models configured.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = Object.entries(models).map(([name, prov]) => `
+    <tr>
+      <td><code>${esc(name)}</code></td>
+      <td>${esc(prov)}</td>
+      <td style="text-align:right; white-space:nowrap">
+        <div class="test-group">
+          <button class="btn btn-sm btn-test" onclick="runTest('${esc(name)}','text')">Test</button>
+          <button class="btn btn-sm btn-caret" onclick="toggleTestMenu(this)">&#9662;</button>
+          <div class="test-menu">
+            <div class="test-menu-item" onclick="runTest('${esc(name)}','text')">Simple Text</div>
+            <div class="test-menu-item" onclick="runTest('${esc(name)}','stream')">Stream</div>
+            <div class="test-menu-item" onclick="runTest('${esc(name)}','tools')">Function Call</div>
+            <div class="test-menu-item" onclick="runTest('${esc(name)}','vision')">Image Understanding</div>
+          </div>
+        </div>
+        <button class="btn btn-sm" onclick="editModel('${esc(name)}','${esc(prov)}')">Edit</button>
+        <button class="btn btn-sm btn-danger" onclick="deleteModel('${esc(name)}')">Delete</button>
+      </td>
+    </tr>
+  `).join('');
+
+  // Update filter dropdowns
+  updateFilterOptions();
+}
+
+async function saveProvider() {
+  const name = document.getElementById('provName').value.trim();
+  const baseUrl = document.getElementById('provBaseUrl').value.trim();
+  const apiKey = document.getElementById('provApiKey').value.trim();
+  const proxy = document.getElementById('provProxy').value.trim();
+  if (!name || !baseUrl || !apiKey) { showToast('Name, Base URL, and API Key are required', 'error'); return; }
+  const body = {api_key: apiKey, base_url: baseUrl, proxy};
+  const res = await api.put(`/admin/api/config/providers/${encodeURIComponent(name)}`, body);
+  if (res.ok) { showToast(`Provider '${name}' saved`); closeModal('providerModal'); loadConfig(); }
+  else { showToast(res.error || 'Failed', 'error'); }
+}
+
+async function deleteProvider(name) {
+  if (!confirm(`Delete provider '${name}'?`)) return;
+  const res = await api.del(`/admin/api/config/providers/${encodeURIComponent(name)}`);
+  if (res.ok) { showToast(`Provider '${name}' deleted`); loadConfig(); }
+  else { showToast(res.error || 'Failed', 'error'); }
+}
+
+function editProvider(name) {
+  const cfg = configData.providers[name] || {};
+  openProviderModal(name, cfg.base_url, cfg.api_key, cfg.proxy);
+}
+
+async function saveModel() {
+  const name = document.getElementById('modelName').value.trim();
+  const provider = document.getElementById('modelProvider').value;
+  if (!name || !provider) { showToast('All fields are required', 'error'); return; }
+  const res = await api.put(`/admin/api/config/models/${encodeURIComponent(name)}`, {provider});
+  if (res.ok) { showToast(`Model '${name}' saved`); closeModal('modelModal'); loadConfig(); }
+  else { showToast(res.error || 'Failed', 'error'); }
+}
+
+async function deleteModel(name) {
+  if (!confirm(`Delete model '${name}'?`)) return;
+  const res = await api.del(`/admin/api/config/models/${encodeURIComponent(name)}`);
+  if (res.ok) { showToast(`Model '${name}' deleted`); loadConfig(); }
+  else { showToast(res.error || 'Failed', 'error'); }
+}
+
+function editModel(name, provider) {
+  openModelModal(name, provider);
+}
+
+// ===================== Dashboard Tab =====================
+async function loadMetrics() {
+  const data = await api.get('/admin/api/metrics?seconds=60');
+  renderStats(data);
+  drawChart('chartThroughput', data.series, 'count', 'req/s');
+  drawChart('chartLatency', data.series, 'avg_ms', 'ms');
+  renderProviderBreakdown(data);
+}
+
+function renderStats(d) {
+  const uptime = formatDuration(d.uptime_seconds);
+  const errRate = (d.error_rate * 100).toFixed(1) + '%';
+  document.getElementById('statsGrid').innerHTML = `
+    <div class="stat-card"><div class="label">Total Requests</div><div class="value">${d.total_requests}</div></div>
+    <div class="stat-card"><div class="label">Error Rate</div><div class="value ${d.error_rate > 0.05 ? 'red' : 'green'}">${errRate}</div></div>
+    <div class="stat-card"><div class="label">Active Streams</div><div class="value blue">${d.active_streams}</div></div>
+    <div class="stat-card"><div class="label">Uptime</div><div class="value">${uptime}</div></div>
+  `;
+}
+
+function renderProviderBreakdown(d) {
+  const tbody = document.getElementById('providerBreakdown');
+  const entries = Object.entries(d.by_target_provider || {}).sort((a,b) => b[1]-a[1]);
+  if (entries.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="2" style="color:var(--text-dim)">No data yet</td></tr>';
+    return;
+  }
+  tbody.innerHTML = entries.map(([p,c]) => `<tr><td>${esc(p)}</td><td>${c}</td></tr>`).join('');
+}
+
+// ===================== Canvas Charts =====================
+function drawChart(canvasId, series, key, unit) {
+  const canvas = document.getElementById(canvasId);
+  const ctx = canvas.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  const rect = canvas.getBoundingClientRect();
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  ctx.scale(dpr, dpr);
+  const w = rect.width, h = rect.height;
+
+  ctx.clearRect(0, 0, w, h);
+
+  const values = series.map(s => s[key]);
+  const maxVal = Math.max(...values, 1);
+
+  const padL = 40, padR = 8, padT = 8, padB = 24;
+  const chartW = w - padL - padR;
+  const chartH = h - padT - padB;
+
+  // Grid lines
+  ctx.strokeStyle = '#2d3148';
+  ctx.lineWidth = 0.5;
+  for (let i = 0; i <= 4; i++) {
+    const y = padT + (chartH / 4) * i;
+    ctx.beginPath(); ctx.moveTo(padL, y); ctx.lineTo(w - padR, y); ctx.stroke();
+  }
+
+  // Y-axis labels
+  ctx.fillStyle = '#8b90a5';
+  ctx.font = '10px sans-serif';
+  ctx.textAlign = 'right';
+  for (let i = 0; i <= 4; i++) {
+    const y = padT + (chartH / 4) * i;
+    const val = maxVal * (1 - i/4);
+    ctx.fillText(val.toFixed(val >= 10 ? 0 : 1), padL - 6, y + 3);
+  }
+
+  // X-axis labels
+  ctx.textAlign = 'center';
+  ctx.fillText('-60s', padL, h - 4);
+  ctx.fillText('-30s', padL + chartW/2, h - 4);
+  ctx.fillText('now', padL + chartW, h - 4);
+
+  if (values.length === 0) return;
+
+  // Line
+  ctx.strokeStyle = '#6366f1';
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  for (let i = 0; i < values.length; i++) {
+    const x = padL + (i / (values.length - 1)) * chartW;
+    const y = padT + chartH - (values[i] / maxVal) * chartH;
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+
+  // Fill
+  ctx.lineTo(padL + chartW, padT + chartH);
+  ctx.lineTo(padL, padT + chartH);
+  ctx.closePath();
+  ctx.fillStyle = 'rgba(99,102,241,0.08)';
+  ctx.fill();
+}
+
+// ===================== Request Log Tab =====================
+async function loadLogs() {
+  const model = document.getElementById('filterModel').value;
+  const provider = document.getElementById('filterProvider').value;
+  const status = document.getElementById('filterStatus').value;
+  let url = `/admin/api/requests?limit=${LOG_LIMIT}&offset=${logOffset}`;
+  if (model) url += `&model=${encodeURIComponent(model)}`;
+  if (provider) url += `&provider=${encodeURIComponent(provider)}`;
+  if (status) url += `&status=${encodeURIComponent(status)}`;
+
+  const data = await api.get(url);
+  renderLogs(data.entries, data.total);
+}
+
+function renderLogs(entries, total) {
+  const tbody = document.getElementById('logTable');
+  if (entries.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="6" style="color:var(--text-dim)">No requests logged yet</td></tr>';
+  } else {
+    tbody.innerHTML = entries.map(e => {
+      const time = new Date(e.timestamp).toLocaleTimeString();
+      const statusCls = e.status_code < 400 ? 'badge-ok' : 'badge-error';
+      const modeBadge = e.is_stream ? '<span class="badge badge-stream">stream</span>' : '';
+      return `<tr>
+        <td>${time}</td>
+        <td><code>${esc(e.model)}</code></td>
+        <td>${esc(e.source_provider)} &rarr; ${esc(e.target_provider)}</td>
+        <td>${modeBadge}</td>
+        <td><span class="badge ${statusCls}">${e.status_code}</span></td>
+        <td>${e.duration_ms.toFixed(0)} ms</td>
+      </tr>`;
+    }).join('');
+  }
+
+  // Pagination
+  const totalPages = Math.ceil(total / LOG_LIMIT) || 1;
+  const currentPage = Math.floor(logOffset / LOG_LIMIT) + 1;
+  document.getElementById('pageInfo').textContent = `Page ${currentPage} / ${totalPages} (${total} total)`;
+  document.getElementById('prevPage').disabled = logOffset === 0;
+  document.getElementById('nextPage').disabled = logOffset + LOG_LIMIT >= total;
+}
+
+function changePage(dir) {
+  logOffset = Math.max(0, logOffset + dir * LOG_LIMIT);
+  loadLogs();
+}
+
+async function clearLogs() {
+  if (!confirm('Clear all request logs?')) return;
+  await api.del('/admin/api/requests');
+  logOffset = 0;
+  loadLogs();
+  showToast('Logs cleared');
+}
+
+function updateFilterOptions() {
+  if (!configData) return;
+  const models = Object.keys(configData.models || {});
+  const providers = Object.keys(configData.providers || {});
+  const mSel = document.getElementById('filterModel');
+  const pSel = document.getElementById('filterProvider');
+  // preserve selection
+  const mVal = mSel.value, pVal = pSel.value;
+  mSel.innerHTML = '<option value="">All Models</option>' + models.map(m => `<option value="${esc(m)}">${esc(m)}</option>`).join('');
+  pSel.innerHTML = '<option value="">All Providers</option>' + providers.map(p => `<option value="${esc(p)}">${esc(p)}</option>`).join('');
+  mSel.value = mVal; pSel.value = pVal;
+}
+
+// ===================== Tabs =====================
+document.querySelectorAll('.tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+    tab.classList.add('active');
+    const id = tab.dataset.tab;
+    document.getElementById('tab-' + id).classList.add('active');
+    currentTab = id;
+    stopTimers();
+    if (id === 'dashboard') { loadMetrics(); dashboardTimer = setInterval(loadMetrics, 3000); }
+    if (id === 'logs') { logOffset = 0; loadLogs(); logTimer = setInterval(loadLogs, 5000); }
+    if (id === 'config') { loadConfig(); }
+  });
+});
+
+function stopTimers() {
+  if (dashboardTimer) { clearInterval(dashboardTimer); dashboardTimer = null; }
+  if (logTimer) { clearInterval(logTimer); logTimer = null; }
+}
+
+// Filter change handlers
+document.getElementById('filterModel').addEventListener('change', () => { logOffset = 0; loadLogs(); });
+document.getElementById('filterProvider').addEventListener('change', () => { logOffset = 0; loadLogs(); });
+document.getElementById('filterStatus').addEventListener('change', () => { logOffset = 0; loadLogs(); });
+
+// Close modal on overlay click
+document.querySelectorAll('.modal-overlay').forEach(m => {
+  m.addEventListener('click', e => { if (e.target === m) m.classList.remove('open'); });
+});
+
+// ===================== Helpers =====================
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+function formatDuration(seconds) {
+  if (seconds < 60) return Math.floor(seconds) + 's';
+  if (seconds < 3600) return Math.floor(seconds/60) + 'm ' + Math.floor(seconds%60) + 's';
+  const h = Math.floor(seconds/3600);
+  const m = Math.floor((seconds%3600)/60);
+  return h + 'h ' + m + 'm';
+}
+
+// ===================== Test Model =====================
+// A tiny 8x8 PNG with colored quadrants (red/green/blue/yellow), base64 encoded
+const TEST_IMAGE_B64 = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAANklEQVQI12P4z8BAAGBiIEoBEwMM/GdgYPj/H8r+D2YzMEDYcDYjIyMDAwMDGAxhw0XgbABhLxAP0k3xLgAAAABJRU5ErkJggg==';
+
+const TEST_LABELS = {text:'Simple Text', stream:'Stream', tools:'Function Call', vision:'Image Understanding'};
+
+function buildTestPayload(model, type) {
+  const base = {model, max_tokens: 256};
+  switch(type) {
+    case 'text':
+      return {...base, messages:[{role:'user', content:'Say "Hello! The gateway test is working." and nothing else.'}]};
+    case 'stream':
+      return {...base, stream:true, messages:[{role:'user', content:'Count from 1 to 5, one number per line.'}]};
+    case 'tools':
+      return {...base,
+        messages:[{role:'user', content:"What's the weather in San Francisco?"}],
+        tools:[{type:'function', function:{
+          name:'get_weather',
+          description:'Get current weather for a location',
+          parameters:{type:'object', properties:{location:{type:'string',description:'City name'}}, required:['location']}
+        }}]
+      };
+    case 'vision':
+      return {...base,
+        messages:[{role:'user', content:[
+          {type:'text', text:'Describe what you see in this image in one sentence.'},
+          {type:'image_url', image_url:{url:'data:image/png;base64,' + TEST_IMAGE_B64}}
+        ]}]
+      };
+  }
+}
+
+function toggleTestMenu(btn) {
+  // Close any other open menus first
+  document.querySelectorAll('.test-menu.open').forEach(m => m.classList.remove('open'));
+  const menu = btn.parentElement.querySelector('.test-menu');
+  menu.classList.toggle('open');
+  // Close on outside click
+  const close = (e) => { if (!menu.contains(e.target) && e.target !== btn) { menu.classList.remove('open'); document.removeEventListener('click', close); }};
+  setTimeout(() => document.addEventListener('click', close), 0);
+}
+
+async function runTest(model, type) {
+  // Close any open dropdown
+  document.querySelectorAll('.test-menu.open').forEach(m => m.classList.remove('open'));
+
+  const output = document.getElementById('testOutput');
+  const meta = document.getElementById('testMeta');
+  document.getElementById('testModalTitle').textContent = `Test: ${TEST_LABELS[type]}`;
+  meta.innerHTML = `<div class="meta-item"><strong>Model:</strong> ${esc(model)}</div>`;
+  output.textContent = '';
+  output.className = 'test-output';
+  document.getElementById('testModal').classList.add('open');
+
+  const payload = buildTestPayload(model, type);
+  const t0 = performance.now();
+
+  if (type === 'stream') {
+    output.classList.add('streaming');
+    output.innerHTML = '<span class="test-spinner"></span>Connecting...';
+    try {
+      const res = await fetch('/v1/chat/completions', {
+        method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)
+      });
+      if (!res.ok) {
+        const errText = await res.text();
+        output.className = 'test-output';
+        output.textContent = `Error ${res.status}: ${errText}`;
+        meta.innerHTML += `<div class="meta-item"><strong>Status:</strong> <span style="color:var(--red)">${res.status}</span></div>`;
+        return;
+      }
+      output.textContent = '';
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let fullText = '';
+      let buffer = '';
+      while(true) {
+        const {done, value} = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, {stream:true});
+        const lines = buffer.split('\n');
+        buffer = lines.pop(); // keep incomplete line
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6);
+          if (data === '[DONE]') continue;
+          try {
+            const chunk = JSON.parse(data);
+            const delta = chunk.choices?.[0]?.delta?.content || '';
+            fullText += delta;
+            output.textContent = fullText;
+            output.scrollTop = output.scrollHeight;
+          } catch(e) {}
+        }
+      }
+      output.className = 'test-output';
+      if (!fullText) output.textContent = '(empty response)';
+      const elapsed = ((performance.now() - t0)/1000).toFixed(2);
+      meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${elapsed}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--green)">OK (stream)</span></div>`;
+    } catch(e) {
+      output.className = 'test-output';
+      output.textContent = `Network error: ${e.message}`;
+    }
+  } else {
+    // Non-streaming
+    output.innerHTML = '<span class="test-spinner"></span>Sending request...';
+    try {
+      const res = await fetch('/v1/chat/completions', {
+        method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)
+      });
+      const elapsed = ((performance.now() - t0)/1000).toFixed(2);
+      const body = await res.json();
+
+      if (!res.ok) {
+        output.textContent = JSON.stringify(body, null, 2);
+        meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${elapsed}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--red)">${res.status}</span></div>`;
+        return;
+      }
+
+      meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${elapsed}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--green)">200 OK</span></div>`;
+
+      // Extract usage if present
+      if (body.usage) {
+        meta.innerHTML += `<div class="meta-item"><strong>Tokens:</strong> ${body.usage.prompt_tokens || '?'} in / ${body.usage.completion_tokens || '?'} out</div>`;
+      }
+
+      // Display result based on type
+      const choice = body.choices?.[0];
+      if (type === 'tools' && choice?.message?.tool_calls) {
+        const tc = choice.message.tool_calls[0];
+        output.textContent = `Tool call: ${tc.function?.name || tc.name || '?'}(${tc.function?.arguments || JSON.stringify(tc.arguments) || '{}'})`;
+        if (choice.message.content) {
+          output.textContent += '\n\nContent: ' + choice.message.content;
+        }
+      } else {
+        output.textContent = choice?.message?.content || JSON.stringify(body, null, 2);
+      }
+    } catch(e) {
+      output.textContent = `Network error: ${e.message}`;
+    }
+  }
+}
+
+// ===================== Init =====================
+loadConfig();
+</script>
+</body>
+</html>

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -117,10 +117,11 @@ tr:hover td { background: var(--bg-hover); }
   font-family: var(--mono); color: var(--text); background: var(--bg);
   padding: 2px 6px; border-radius: 4px; font-size: 11px;
 }
+.provider-card .field code { overflow: hidden; text-overflow: ellipsis; max-width: 220px; display: inline-block; vertical-align: bottom; }
 .provider-card .actions { margin-top: 12px; display: flex; gap: 8px; }
-.key-field { display: flex; align-items: center; gap: 4px; }
+.key-actions { display: inline-flex; gap: 2px; margin-left: 4px; vertical-align: middle; }
 .key-btn {
-  background: none; border: none; cursor: pointer; padding: 1px 3px;
+  background: none; border: none; cursor: pointer; padding: 2px 4px;
   color: var(--text-dim); font-size: 13px; line-height: 1; border-radius: 3px;
 }
 .key-btn:hover { color: var(--accent); background: var(--bg-hover); }
@@ -379,7 +380,11 @@ canvas { width: 100%; height: 160px; }
     </div>
     <div class="form-group">
       <label data-i18n="label.apiKey">API Key (or ${ENV_VAR} placeholder)</label>
-      <input id="provApiKey" placeholder="${OPENAI_API_KEY}">
+      <div style="display:flex;gap:4px;align-items:center">
+        <input id="provApiKey" placeholder="${OPENAI_API_KEY}" type="password" style="flex:1">
+        <button type="button" class="key-btn" title="Toggle visibility" onclick="toggleModalKeyVisibility()"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
+        <button type="button" class="key-btn" title="Copy" onclick="copyModalKey()"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
+      </div>
     </div>
     <div class="form-group">
       <label data-i18n="label.proxyUrl">Proxy URL (optional, overrides global)</label>
@@ -678,9 +683,17 @@ function openProviderModal(name, baseUrl, apiKey, proxy, provType) {
     typeSel.appendChild(opt);
   }
   document.getElementById('provBaseUrl').value = baseUrl || '';
-  document.getElementById('provApiKey').value = apiKey || '';
+  const keyInput = document.getElementById('provApiKey');
+  keyInput.value = apiKey || '';
+  keyInput.type = 'password';
   document.getElementById('provProxy').value = proxy || '';
   document.getElementById('providerModal').classList.add('open');
+  // When editing, fetch the real (unmasked) key
+  if (name) {
+    api.get(`/admin/api/config/providers/${encodeURIComponent(name)}/key`).then(res => {
+      if (res.api_key) keyInput.value = res.api_key;
+    }).catch(() => {});
+  }
 }
 
 function openModelModal(model, provider, capabilities) {
@@ -737,10 +750,7 @@ function renderProviders() {
       <div class="name">${esc(name)}</div>
       <div class="field">Type: <code>${esc(cfg.type || name)}</code></div>
       <div class="field">Base URL: <code>${esc(cfg.base_url || '')}</code></div>
-      <div class="field key-field">API Key: <code id="key-${esc(name)}" data-masked="${esc(cfg.api_key || '')}">${esc(cfg.api_key || '')}</code>
-        <button class="key-btn" title="Toggle visibility" onclick="toggleKeyVisibility('${esc(name)}')">&#128065;</button>
-        <button class="key-btn" title="Copy" onclick="copyKey('${esc(name)}')">&#128203;</button>
-      </div>
+      <div class="field">API Key: <code>${esc(cfg.api_key || '')}</code></div>
       ${cfg.proxy ? `<div class="field">Proxy: <code>${esc(cfg.proxy)}</code></div>` : ''}
       <div class="actions">
         <button class="btn btn-sm" onclick="editProvider('${esc(name)}')">${t('btn.edit')}</button>
@@ -819,51 +829,15 @@ function editProvider(name) {
   openProviderModal(name, cfg.base_url, cfg.api_key, cfg.proxy, cfg.type);
 }
 
-// Cache revealed keys so we don't re-fetch on every toggle
-const _revealedKeys = {};
-
-async function toggleKeyVisibility(name) {
-  const el = document.getElementById('key-' + name);
-  if (!el) return;
-  if (el.dataset.revealed === 'true') {
-    // Hide — restore masked value
-    el.textContent = el.dataset.masked;
-    el.dataset.revealed = 'false';
-    return;
-  }
-  // Reveal — fetch real key
-  if (_revealedKeys[name]) {
-    el.textContent = _revealedKeys[name];
-    el.dataset.revealed = 'true';
-    return;
-  }
-  try {
-    const res = await api.get(`/admin/api/config/providers/${encodeURIComponent(name)}/key`);
-    if (res.api_key) {
-      _revealedKeys[name] = res.api_key;
-      el.textContent = res.api_key;
-      el.dataset.revealed = 'true';
-    }
-  } catch(e) {
-    showToast('Failed to reveal key', 'error');
-  }
+function toggleModalKeyVisibility() {
+  const input = document.getElementById('provApiKey');
+  input.type = input.type === 'password' ? 'text' : 'password';
 }
 
-async function copyKey(name) {
-  let key = _revealedKeys[name];
-  if (!key) {
-    try {
-      const res = await api.get(`/admin/api/config/providers/${encodeURIComponent(name)}/key`);
-      key = res.api_key;
-      if (key) _revealedKeys[name] = key;
-    } catch(e) {
-      showToast('Failed to fetch key', 'error');
-      return;
-    }
-  }
-  if (!key) return;
+async function copyModalKey() {
+  const input = document.getElementById('provApiKey');
   try {
-    await navigator.clipboard.writeText(key);
+    await navigator.clipboard.writeText(input.value);
     showToast('API key copied');
   } catch(e) {
     showToast('Copy failed', 'error');

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -172,6 +172,16 @@ canvas { width: 100%; height: 160px; }
 .badge-error { background: rgba(239,68,68,0.15); color: var(--red); }
 .badge-stream { background: rgba(99,102,241,0.15); color: var(--accent); }
 
+/* Capability badges */
+.badge-cap { background: rgba(139,144,165,0.15); color: var(--text-dim); font-size: 10px; padding: 1px 6px; margin-right: 3px; }
+.badge-cap-vision { background: rgba(245,158,11,0.12); color: var(--orange); }
+.badge-cap-tools { background: rgba(59,130,246,0.12); color: var(--blue); }
+
+/* Checkbox group */
+.checkbox-group { display: flex; gap: 14px; flex-wrap: wrap; }
+.checkbox-group label { font-size: 13px; color: var(--text); display: flex; align-items: center; gap: 5px; cursor: pointer; text-transform: none; letter-spacing: 0; }
+.checkbox-group input[type="checkbox"] { accent-color: var(--accent); }
+
 /* Test button dropdown */
 .test-group { position: relative; display: inline-flex; }
 .test-group .btn-test {
@@ -196,6 +206,8 @@ canvas { width: 100%; height: 160px; }
 .test-menu-item:hover { background: var(--bg-hover); }
 .test-menu-item:first-child { border-radius: var(--radius) var(--radius) 0 0; }
 .test-menu-item:last-child { border-radius: 0 0 var(--radius) var(--radius); }
+.test-menu-item.disabled { color: var(--text-dim); opacity: 0.4; cursor: not-allowed; }
+.test-menu-item.disabled:hover { background: none; }
 
 /* Test result modal (wider) */
 .modal-wide { width: 620px; max-width: 95vw; }
@@ -360,6 +372,14 @@ canvas { width: 100%; height: 160px; }
       <label>Provider</label>
       <select id="modelProvider"></select>
     </div>
+    <div class="form-group">
+      <label>Capabilities</label>
+      <div class="checkbox-group">
+        <label><input type="checkbox" id="capText" checked disabled> text</label>
+        <label><input type="checkbox" id="capVision"> vision</label>
+        <label><input type="checkbox" id="capTools"> tools</label>
+      </div>
+    </div>
     <div class="modal-actions">
       <button class="btn" onclick="closeModal('modelModal')">Cancel</button>
       <button class="btn btn-primary" onclick="saveModel()">Save</button>
@@ -432,7 +452,7 @@ function openProviderModal(name, baseUrl, apiKey, proxy) {
   document.getElementById('providerModal').classList.add('open');
 }
 
-function openModelModal(model, provider) {
+function openModelModal(model, provider, capabilities) {
   document.getElementById('modelModalTitle').textContent = model ? 'Edit Model' : 'Add Model';
   document.getElementById('modelName').value = model || '';
   document.getElementById('modelName').readOnly = !!model;
@@ -447,6 +467,10 @@ function openModelModal(model, provider) {
       sel.appendChild(opt);
     }
   }
+  // Set capability checkboxes
+  const caps = capabilities || ['text'];
+  document.getElementById('capVision').checked = caps.includes('vision');
+  document.getElementById('capTools').checked = caps.includes('tools');
   document.getElementById('modelModal').classList.add('open');
 }
 
@@ -494,9 +518,17 @@ function renderModels() {
     tbody.innerHTML = '<tr><td colspan="3" style="color:var(--text-dim)">No models configured.</td></tr>';
     return;
   }
-  tbody.innerHTML = Object.entries(models).map(([name, prov]) => `
-    <tr>
-      <td><code>${esc(name)}</code></td>
+  tbody.innerHTML = Object.entries(models).map(([name, info]) => {
+    const prov = typeof info === 'string' ? info : info.provider;
+    const caps = typeof info === 'string' ? ['text'] : (info.capabilities || ['text']);
+    const capBadges = caps.map(c => {
+      const cls = c === 'vision' ? 'badge-cap-vision' : c === 'tools' ? 'badge-cap-tools' : 'badge-cap';
+      return `<span class="badge ${cls}">${esc(c)}</span>`;
+    }).join('');
+    const hasVision = caps.includes('vision');
+    const hasTools = caps.includes('tools');
+    return `<tr>
+      <td><code>${esc(name)}</code> ${capBadges}</td>
       <td>${esc(prov)}</td>
       <td style="text-align:right; white-space:nowrap">
         <div class="test-group">
@@ -505,15 +537,15 @@ function renderModels() {
           <div class="test-menu">
             <div class="test-menu-item" onclick="runTest('${esc(name)}','text')">Simple Text</div>
             <div class="test-menu-item" onclick="runTest('${esc(name)}','stream')">Stream</div>
-            <div class="test-menu-item" onclick="runTest('${esc(name)}','tools')">Function Call</div>
-            <div class="test-menu-item" onclick="runTest('${esc(name)}','vision')">Image Understanding</div>
+            <div class="test-menu-item${hasTools ? '' : ' disabled'}" onclick="${hasTools ? `runTest('${esc(name)}','tools')` : ''}">Function Call</div>
+            <div class="test-menu-item${hasVision ? '' : ' disabled'}" onclick="${hasVision ? `runTest('${esc(name)}','vision')` : ''}">Image Understanding</div>
           </div>
         </div>
         <button class="btn btn-sm" onclick="editModel('${esc(name)}','${esc(prov)}')">Edit</button>
         <button class="btn btn-sm btn-danger" onclick="deleteModel('${esc(name)}')">Delete</button>
       </td>
-    </tr>
-  `).join('');
+    </tr>`;
+  }).join('');
 
   // Update filter dropdowns
   updateFilterOptions();
@@ -547,7 +579,10 @@ async function saveModel() {
   const name = document.getElementById('modelName').value.trim();
   const provider = document.getElementById('modelProvider').value;
   if (!name || !provider) { showToast('All fields are required', 'error'); return; }
-  const res = await api.put(`/admin/api/config/models/${encodeURIComponent(name)}`, {provider});
+  const capabilities = ['text'];
+  if (document.getElementById('capVision').checked) capabilities.push('vision');
+  if (document.getElementById('capTools').checked) capabilities.push('tools');
+  const res = await api.put(`/admin/api/config/models/${encodeURIComponent(name)}`, {provider, capabilities});
   if (res.ok) { showToast(`Model '${name}' saved`); closeModal('modelModal'); loadConfig(); }
   else { showToast(res.error || 'Failed', 'error'); }
 }
@@ -560,7 +595,9 @@ async function deleteModel(name) {
 }
 
 function editModel(name, provider) {
-  openModelModal(name, provider);
+  const info = configData.models[name];
+  const caps = (typeof info === 'object' && info.capabilities) ? info.capabilities : ['text'];
+  openModelModal(name, provider, caps);
 }
 
 // ===================== Dashboard Tab =====================
@@ -769,8 +806,8 @@ function formatDuration(seconds) {
 }
 
 // ===================== Test Model =====================
-// A tiny 8x8 PNG with colored quadrants (red/green/blue/yellow), base64 encoded
-const TEST_IMAGE_B64 = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAANklEQVQI12P4z8BAAGBiIEoBEwMM/GdgYPj/H8r+D2YzMEDYcDYjIyMDAwMDGAxhw0XgbABhLxAP0k3xLgAAAABJRU5ErkJggg==';
+// Public domain test image (Wikimedia Commons — PNG transparency demo)
+const TEST_IMAGE_URL = 'https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png';
 
 const TEST_LABELS = {text:'Simple Text', stream:'Stream', tools:'Function Call', vision:'Image Understanding'};
 
@@ -794,7 +831,7 @@ function buildTestPayload(model, type) {
       return {...base,
         messages:[{role:'user', content:[
           {type:'text', text:'Describe what you see in this image in one sentence.'},
-          {type:'image_url', image_url:{url:'data:image/png;base64,' + TEST_IMAGE_B64}}
+          {type:'image_url', image_url:{url: TEST_IMAGE_URL}}
         ]}]
       };
   }

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -254,14 +254,18 @@ canvas { width: 100%; height: 160px; }
       <option value="light">Light</option>
       <option value="solarized">Solarized</option>
     </select>
+    <select id="langSwitcher" class="header-select" onchange="setLang(this.value)">
+      <option value="en">EN</option>
+      <option value="zh">中文</option>
+    </select>
     <div class="config-path" id="configPath"></div>
   </div>
 </div>
 
 <div class="tabs">
-  <div class="tab active" data-tab="config">Configuration</div>
-  <div class="tab" data-tab="dashboard">Dashboard</div>
-  <div class="tab" data-tab="logs">Request Log</div>
+  <div class="tab active" data-tab="config" data-i18n="tab.config">Configuration</div>
+  <div class="tab" data-tab="dashboard" data-i18n="tab.dashboard">Dashboard</div>
+  <div class="tab" data-tab="logs" data-i18n="tab.logs">Request Log</div>
 </div>
 
 <div class="content">
@@ -269,33 +273,33 @@ canvas { width: 100%; height: 160px; }
   <div class="tab-panel active" id="tab-config">
     <div class="section">
       <div class="section-header">
-        <h2>Server Settings</h2>
+        <h2 data-i18n="section.server">Server Settings</h2>
       </div>
       <div class="provider-card" style="max-width:480px">
         <div class="form-group" style="margin-bottom:0">
-          <label>Global Proxy URL</label>
+          <label data-i18n="label.globalProxy">Global Proxy URL</label>
           <div style="display:flex;gap:8px">
             <input id="globalProxy" placeholder="e.g. http://127.0.0.1:7890" style="flex:1;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);color:var(--text);font-size:14px;font-family:var(--mono)">
-            <button class="btn btn-primary btn-sm" onclick="saveServerSettings()">Save</button>
+            <button class="btn btn-primary btn-sm" onclick="saveServerSettings()" data-i18n="btn.save">Save</button>
           </div>
-          <div style="font-size:11px;color:var(--text-dim);margin-top:6px">Applies to all providers unless overridden per-provider.</div>
+          <div style="font-size:11px;color:var(--text-dim);margin-top:6px" data-i18n="label.globalProxy.hint">Applies to all providers unless overridden per-provider.</div>
         </div>
       </div>
     </div>
     <div class="section">
       <div class="section-header">
-        <h2>Providers</h2>
-        <button class="btn btn-primary btn-sm" onclick="openProviderModal()">+ Add Provider</button>
+        <h2 data-i18n="section.providers">Providers</h2>
+        <button class="btn btn-primary btn-sm" onclick="openProviderModal()" data-i18n="btn.addProvider">+ Add Provider</button>
       </div>
       <div class="provider-grid" id="providerGrid"></div>
     </div>
     <div class="section">
       <div class="section-header">
-        <h2>Model Routing</h2>
-        <button class="btn btn-primary btn-sm" onclick="openModelModal()">+ Add Model</button>
+        <h2 data-i18n="section.models">Model Routing</h2>
+        <button class="btn btn-primary btn-sm" onclick="openModelModal()" data-i18n="btn.addModel">+ Add Model</button>
       </div>
       <table>
-        <thead><tr><th>Model</th><th>Provider</th><th></th></tr></thead>
+        <thead><tr><th data-i18n="col.model">Model</th><th data-i18n="col.provider">Provider</th><th></th></tr></thead>
         <tbody id="modelTable"></tbody>
       </table>
     </div>
@@ -306,18 +310,18 @@ canvas { width: 100%; height: 160px; }
     <div class="stats-grid" id="statsGrid"></div>
     <div class="chart-row">
       <div class="chart-box">
-        <h3>Throughput (req/s)</h3>
+        <h3 data-i18n="chart.throughput">Throughput (req/s)</h3>
         <canvas id="chartThroughput"></canvas>
       </div>
       <div class="chart-box">
-        <h3>Latency (ms)</h3>
+        <h3 data-i18n="chart.latency">Latency (ms)</h3>
         <canvas id="chartLatency"></canvas>
       </div>
     </div>
     <div class="section">
-      <h2 style="margin-bottom:12px">Per-Provider Breakdown</h2>
+      <h2 style="margin-bottom:12px" data-i18n="section.breakdown">Per-Provider Breakdown</h2>
       <table>
-        <thead><tr><th>Provider</th><th>Requests</th></tr></thead>
+        <thead><tr><th data-i18n="col.provider">Provider</th><th data-i18n="col.requests">Requests</th></tr></thead>
         <tbody id="providerBreakdown"></tbody>
       </table>
     </div>
@@ -326,23 +330,23 @@ canvas { width: 100%; height: 160px; }
   <!-- Request Log Tab -->
   <div class="tab-panel" id="tab-logs">
     <div class="filters">
-      <select id="filterModel"><option value="">All Models</option></select>
-      <select id="filterProvider"><option value="">All Providers</option></select>
+      <select id="filterModel"><option value="" data-i18n="filter.allModels">All Models</option></select>
+      <select id="filterProvider"><option value="" data-i18n="filter.allProviders">All Providers</option></select>
       <select id="filterStatus">
-        <option value="">All Status</option>
-        <option value="ok">OK (2xx/3xx)</option>
-        <option value="error">Error (4xx/5xx)</option>
+        <option value="" data-i18n="filter.allStatus">All Status</option>
+        <option value="ok" data-i18n="filter.ok">OK (2xx/3xx)</option>
+        <option value="error" data-i18n="filter.error">Error (4xx/5xx)</option>
       </select>
-      <button class="btn btn-danger btn-sm" onclick="clearLogs()">Clear Log</button>
+      <button class="btn btn-danger btn-sm" onclick="clearLogs()" data-i18n="btn.clearLog">Clear Log</button>
     </div>
     <table>
-      <thead><tr><th>Time</th><th>Model</th><th>Source &rarr; Target</th><th>Mode</th><th>Status</th><th>Duration</th></tr></thead>
+      <thead><tr><th data-i18n="col.time">Time</th><th data-i18n="col.model">Model</th><th data-i18n="col.sourceTarget">Source &rarr; Target</th><th data-i18n="col.mode">Mode</th><th data-i18n="col.status">Status</th><th data-i18n="col.duration">Duration</th></tr></thead>
       <tbody id="logTable"></tbody>
     </table>
     <div class="pagination">
-      <button class="btn btn-sm" id="prevPage" onclick="changePage(-1)">Prev</button>
+      <button class="btn btn-sm" id="prevPage" onclick="changePage(-1)" data-i18n="btn.prev">Prev</button>
       <span class="info" id="pageInfo"></span>
-      <button class="btn btn-sm" id="nextPage" onclick="changePage(1)">Next</button>
+      <button class="btn btn-sm" id="nextPage" onclick="changePage(1)" data-i18n="btn.next">Next</button>
     </div>
   </div>
 </div>
@@ -350,26 +354,26 @@ canvas { width: 100%; height: 160px; }
 <!-- Provider Modal -->
 <div class="modal-overlay" id="providerModal">
   <div class="modal">
-    <h3 id="providerModalTitle">Add Provider</h3>
+    <h3 id="providerModalTitle" data-i18n="modal.addProvider">Add Provider</h3>
     <div class="form-group">
-      <label>Provider Name / Type</label>
+      <label data-i18n="label.providerName">Provider Name / Type</label>
       <input id="provName" placeholder="e.g. openai_chat, anthropic, my_custom">
     </div>
     <div class="form-group">
-      <label>Base URL</label>
+      <label data-i18n="label.baseUrl">Base URL</label>
       <input id="provBaseUrl" placeholder="https://api.openai.com/v1">
     </div>
     <div class="form-group">
-      <label>API Key (or ${ENV_VAR} placeholder)</label>
+      <label data-i18n="label.apiKey">API Key (or ${ENV_VAR} placeholder)</label>
       <input id="provApiKey" placeholder="${OPENAI_API_KEY}">
     </div>
     <div class="form-group">
-      <label>Proxy URL (optional, overrides global)</label>
+      <label data-i18n="label.proxyUrl">Proxy URL (optional, overrides global)</label>
       <input id="provProxy" placeholder="e.g. http://127.0.0.1:7890">
     </div>
     <div class="modal-actions">
-      <button class="btn" onclick="closeModal('providerModal')">Cancel</button>
-      <button class="btn btn-primary" onclick="saveProvider()">Save</button>
+      <button class="btn" onclick="closeModal('providerModal')" data-i18n="btn.cancel">Cancel</button>
+      <button class="btn btn-primary" onclick="saveProvider()" data-i18n="btn.save">Save</button>
     </div>
   </div>
 </div>
@@ -377,17 +381,17 @@ canvas { width: 100%; height: 160px; }
 <!-- Model Modal -->
 <div class="modal-overlay" id="modelModal">
   <div class="modal">
-    <h3 id="modelModalTitle">Add Model</h3>
+    <h3 id="modelModalTitle" data-i18n="modal.addModel">Add Model</h3>
     <div class="form-group">
-      <label>Model Name</label>
+      <label data-i18n="label.modelName">Model Name</label>
       <input id="modelName" placeholder="e.g. gpt-4o, claude-sonnet-4-20250514">
     </div>
     <div class="form-group">
-      <label>Provider</label>
+      <label data-i18n="label.provider">Provider</label>
       <select id="modelProvider"></select>
     </div>
     <div class="form-group">
-      <label>Capabilities</label>
+      <label data-i18n="label.capabilities">Capabilities</label>
       <div class="checkbox-group">
         <label><input type="checkbox" id="capText" checked disabled> text</label>
         <label><input type="checkbox" id="capVision" checked> vision</label>
@@ -395,8 +399,8 @@ canvas { width: 100%; height: 160px; }
       </div>
     </div>
     <div class="modal-actions">
-      <button class="btn" onclick="closeModal('modelModal')">Cancel</button>
-      <button class="btn btn-primary" onclick="saveModel()">Save</button>
+      <button class="btn" onclick="closeModal('modelModal')" data-i18n="btn.cancel">Cancel</button>
+      <button class="btn btn-primary" onclick="saveModel()" data-i18n="btn.save">Save</button>
     </div>
   </div>
 </div>
@@ -408,7 +412,7 @@ canvas { width: 100%; height: 160px; }
     <div class="test-meta" id="testMeta"></div>
     <div class="test-output" id="testOutput"></div>
     <div class="modal-actions">
-      <button class="btn" onclick="closeModal('testModal')">Close</button>
+      <button class="btn" onclick="closeModal('testModal')" data-i18n="btn.close">Close</button>
     </div>
   </div>
 </div>
@@ -463,6 +467,127 @@ function setTheme(name) {
 // Apply saved theme on load
 setTheme(currentTheme);
 
+// ===================== i18n =====================
+const I18N = {
+  en: {
+    'tab.config':'Configuration', 'tab.dashboard':'Dashboard', 'tab.logs':'Request Log',
+    'section.server':'Server Settings', 'section.providers':'Providers', 'section.models':'Model Routing',
+    'label.globalProxy':'Global Proxy URL',
+    'label.globalProxy.hint':'Applies to all providers unless overridden per-provider.',
+    'btn.save':'Save', 'btn.cancel':'Cancel', 'btn.close':'Close',
+    'btn.addProvider':'+ Add Provider', 'btn.addModel':'+ Add Model',
+    'btn.edit':'Edit', 'btn.delete':'Delete', 'btn.clearLog':'Clear Log',
+    'btn.prev':'Prev', 'btn.next':'Next', 'btn.test':'Test',
+    'label.providerName':'Provider Name / Type', 'label.baseUrl':'Base URL',
+    'label.apiKey':'API Key (or ${ENV_VAR} placeholder)',
+    'label.proxyUrl':'Proxy URL (optional, overrides global)',
+    'label.modelName':'Model Name', 'label.provider':'Provider', 'label.capabilities':'Capabilities',
+    'modal.addProvider':'Add Provider', 'modal.editProvider':'Edit Provider',
+    'modal.addModel':'Add Model', 'modal.editModel':'Edit Model',
+    'col.model':'Model', 'col.provider':'Provider', 'col.time':'Time',
+    'col.sourceTarget':'Source \u2192 Target', 'col.mode':'Mode',
+    'col.status':'Status', 'col.duration':'Duration', 'col.requests':'Requests',
+    'stat.totalRequests':'Total Requests', 'stat.errorRate':'Error Rate',
+    'stat.activeStreams':'Active Streams', 'stat.uptime':'Uptime',
+    'chart.throughput':'Throughput (req/s)', 'chart.latency':'Latency (ms)',
+    'section.breakdown':'Per-Provider Breakdown',
+    'filter.allModels':'All Models', 'filter.allProviders':'All Providers',
+    'filter.allStatus':'All Status', 'filter.ok':'OK (2xx/3xx)', 'filter.error':'Error (4xx/5xx)',
+    'test.text':'Simple Text', 'test.stream':'Stream',
+    'test.tools':'Function Call', 'test.vision':'Image Understanding',
+    'empty.providers':'No providers configured.', 'empty.models':'No models configured.',
+    'empty.logs':'No requests logged yet', 'empty.data':'No data yet',
+    'toast.serverSaved':'Server settings saved',
+    'toast.providerSaved':"Provider '{name}' saved",
+    'toast.providerDeleted':"Provider '{name}' deleted",
+    'toast.modelSaved':"Model '{name}' saved",
+    'toast.modelDeleted':"Model '{name}' deleted",
+    'toast.logCleared':'Logs cleared',
+    'confirm.deleteProvider':"Delete provider '{name}'?",
+    'confirm.deleteModel':"Delete model '{name}'?",
+    'confirm.clearLogs':'Clear all request logs?',
+    'error.fieldsRequired':'Name, Base URL, and API Key are required',
+    'error.modelRequired':'All fields are required',
+    'page.info':'Page {current} / {total} ({count} total)',
+    'test.connecting':'Connecting...', 'test.sending':'Sending request...',
+    'test.emptyResponse':'(empty response)',
+  },
+  zh: {
+    'tab.config':'\u914d\u7f6e\u7ba1\u7406', 'tab.dashboard':'\u76d1\u63a7\u9762\u677f', 'tab.logs':'\u8bf7\u6c42\u65e5\u5fd7',
+    'section.server':'\u670d\u52a1\u5668\u8bbe\u7f6e', 'section.providers':'\u670d\u52a1\u5546', 'section.models':'\u6a21\u578b\u8def\u7531',
+    'label.globalProxy':'\u5168\u5c40\u4ee3\u7406 URL',
+    'label.globalProxy.hint':'\u9002\u7528\u4e8e\u6240\u6709\u670d\u52a1\u5546\uff0c\u9664\u975e\u5355\u72ec\u8bbe\u7f6e\u4e86\u4ee3\u7406\u3002',
+    'btn.save':'\u4fdd\u5b58', 'btn.cancel':'\u53d6\u6d88', 'btn.close':'\u5173\u95ed',
+    'btn.addProvider':'+ \u6dfb\u52a0\u670d\u52a1\u5546', 'btn.addModel':'+ \u6dfb\u52a0\u6a21\u578b',
+    'btn.edit':'\u7f16\u8f91', 'btn.delete':'\u5220\u9664', 'btn.clearLog':'\u6e05\u9664\u65e5\u5fd7',
+    'btn.prev':'\u4e0a\u4e00\u9875', 'btn.next':'\u4e0b\u4e00\u9875', 'btn.test':'\u6d4b\u8bd5',
+    'label.providerName':'\u670d\u52a1\u5546\u540d\u79f0 / \u7c7b\u578b', 'label.baseUrl':'Base URL',
+    'label.apiKey':'API Key\uff08\u6216 ${ENV_VAR} \u5360\u4f4d\u7b26\uff09',
+    'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09',
+    'label.modelName':'\u6a21\u578b\u540d\u79f0', 'label.provider':'\u670d\u52a1\u5546', 'label.capabilities':'\u80fd\u529b',
+    'modal.addProvider':'\u6dfb\u52a0\u670d\u52a1\u5546', 'modal.editProvider':'\u7f16\u8f91\u670d\u52a1\u5546',
+    'modal.addModel':'\u6dfb\u52a0\u6a21\u578b', 'modal.editModel':'\u7f16\u8f91\u6a21\u578b',
+    'col.model':'\u6a21\u578b', 'col.provider':'\u670d\u52a1\u5546', 'col.time':'\u65f6\u95f4',
+    'col.sourceTarget':'\u6765\u6e90 \u2192 \u76ee\u6807', 'col.mode':'\u6a21\u5f0f',
+    'col.status':'\u72b6\u6001', 'col.duration':'\u8017\u65f6', 'col.requests':'\u8bf7\u6c42\u6570',
+    'stat.totalRequests':'\u603b\u8bf7\u6c42\u6570', 'stat.errorRate':'\u9519\u8bef\u7387',
+    'stat.activeStreams':'\u6d3b\u8dc3\u6d41', 'stat.uptime':'\u8fd0\u884c\u65f6\u95f4',
+    'chart.throughput':'\u541e\u5410\u91cf (req/s)', 'chart.latency':'\u5ef6\u8fdf (ms)',
+    'section.breakdown':'\u670d\u52a1\u5546\u7edf\u8ba1',
+    'filter.allModels':'\u5168\u90e8\u6a21\u578b', 'filter.allProviders':'\u5168\u90e8\u670d\u52a1\u5546',
+    'filter.allStatus':'\u5168\u90e8\u72b6\u6001', 'filter.ok':'\u6b63\u5e38 (2xx/3xx)', 'filter.error':'\u9519\u8bef (4xx/5xx)',
+    'test.text':'\u7b80\u5355\u6587\u672c', 'test.stream':'\u6d41\u5f0f',
+    'test.tools':'\u51fd\u6570\u8c03\u7528', 'test.vision':'\u56fe\u50cf\u7406\u89e3',
+    'empty.providers':'\u6682\u65e0\u670d\u52a1\u5546\u914d\u7f6e\u3002', 'empty.models':'\u6682\u65e0\u6a21\u578b\u914d\u7f6e\u3002',
+    'empty.logs':'\u6682\u65e0\u8bf7\u6c42\u8bb0\u5f55', 'empty.data':'\u6682\u65e0\u6570\u636e',
+    'toast.serverSaved':'\u670d\u52a1\u5668\u8bbe\u7f6e\u5df2\u4fdd\u5b58',
+    'toast.providerSaved':"\u670d\u52a1\u5546 '{name}' \u5df2\u4fdd\u5b58",
+    'toast.providerDeleted':"\u670d\u52a1\u5546 '{name}' \u5df2\u5220\u9664",
+    'toast.modelSaved':"\u6a21\u578b '{name}' \u5df2\u4fdd\u5b58",
+    'toast.modelDeleted':"\u6a21\u578b '{name}' \u5df2\u5220\u9664",
+    'toast.logCleared':'\u65e5\u5fd7\u5df2\u6e05\u9664',
+    'confirm.deleteProvider':"\u786e\u5b9a\u5220\u9664\u670d\u52a1\u5546 '{name}'\uff1f",
+    'confirm.deleteModel':"\u786e\u5b9a\u5220\u9664\u6a21\u578b '{name}'\uff1f",
+    'confirm.clearLogs':'\u786e\u5b9a\u6e05\u9664\u6240\u6709\u8bf7\u6c42\u65e5\u5fd7\uff1f',
+    'error.fieldsRequired':'\u540d\u79f0\u3001Base URL \u548c API Key \u4e3a\u5fc5\u586b\u9879',
+    'error.modelRequired':'\u6240\u6709\u5b57\u6bb5\u4e3a\u5fc5\u586b\u9879',
+    'page.info':'\u7b2c {current} / {total} \u9875\uff08\u5171 {count} \u6761\uff09',
+    'test.connecting':'\u8fde\u63a5\u4e2d...', 'test.sending':'\u53d1\u9001\u8bf7\u6c42\u4e2d...',
+    'test.emptyResponse':'\uff08\u7a7a\u54cd\u5e94\uff09',
+  },
+};
+
+let currentLang = localStorage.getItem('llm-rosetta-lang') || 'en';
+
+function t(key, params) {
+  let s = (I18N[currentLang] && I18N[currentLang][key]) || I18N.en[key] || key;
+  if (params) {
+    for (const [k, v] of Object.entries(params)) s = s.replace(`{${k}}`, v);
+  }
+  return s;
+}
+
+function setLang(lang) {
+  currentLang = lang;
+  localStorage.setItem('llm-rosetta-lang', lang);
+  document.getElementById('langSwitcher').value = lang;
+  applyI18n();
+}
+
+function applyI18n() {
+  // Update static elements with data-i18n attribute
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    el.textContent = t(el.dataset.i18n);
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+    el.placeholder = t(el.dataset.i18nPlaceholder);
+  });
+  // Re-render dynamic content
+  if (configData) { renderProviders(); renderModels(); }
+  if (currentTab === 'dashboard') loadMetrics();
+  if (currentTab === 'logs') loadLogs();
+}
+
 // ===================== State =====================
 let currentTab = 'config';
 let configData = null;
@@ -503,7 +628,7 @@ function showToast(msg, type='success') {
 function closeModal(id) { document.getElementById(id).classList.remove('open'); }
 
 function openProviderModal(name, baseUrl, apiKey, proxy) {
-  document.getElementById('providerModalTitle').textContent = name ? 'Edit Provider' : 'Add Provider';
+  document.getElementById('providerModalTitle').textContent = name ? t('modal.editProvider') : t('modal.addProvider');
   document.getElementById('provName').value = name || '';
   document.getElementById('provName').readOnly = !!name;
   document.getElementById('provBaseUrl').value = baseUrl || '';
@@ -513,7 +638,7 @@ function openProviderModal(name, baseUrl, apiKey, proxy) {
 }
 
 function openModelModal(model, provider, capabilities) {
-  document.getElementById('modelModalTitle').textContent = model ? 'Edit Model' : 'Add Model';
+  document.getElementById('modelModalTitle').textContent = model ? t('modal.editModel') : t('modal.addModel');
   document.getElementById('modelName').value = model || '';
   document.getElementById('modelName').readOnly = !!model;
   // Populate provider dropdown from config
@@ -546,7 +671,7 @@ async function loadConfig() {
 async function saveServerSettings() {
   const proxy = document.getElementById('globalProxy').value.trim();
   const res = await api.put('/admin/api/config/server', {proxy});
-  if (res.ok) { showToast('Server settings saved'); loadConfig(); }
+  if (res.ok) { showToast(t('toast.serverSaved')); loadConfig(); }
   else { showToast(res.error || 'Failed', 'error'); }
 }
 
@@ -554,7 +679,7 @@ function renderProviders() {
   const grid = document.getElementById('providerGrid');
   const providers = configData.providers || {};
   if (Object.keys(providers).length === 0) {
-    grid.innerHTML = '<p style="color:var(--text-dim)">No providers configured.</p>';
+    grid.innerHTML = `<p style="color:var(--text-dim)">${t('empty.providers')}</p>`;
     return;
   }
   grid.innerHTML = Object.entries(providers).map(([name, cfg]) => `
@@ -564,8 +689,8 @@ function renderProviders() {
       <div class="field">API Key: <code>${esc(cfg.api_key || '')}</code></div>
       ${cfg.proxy ? `<div class="field">Proxy: <code>${esc(cfg.proxy)}</code></div>` : ''}
       <div class="actions">
-        <button class="btn btn-sm" onclick="editProvider('${esc(name)}')">Edit</button>
-        <button class="btn btn-sm btn-danger" onclick="deleteProvider('${esc(name)}')">Delete</button>
+        <button class="btn btn-sm" onclick="editProvider('${esc(name)}')">${t('btn.edit')}</button>
+        <button class="btn btn-sm btn-danger" onclick="deleteProvider('${esc(name)}')">${t('btn.delete')}</button>
       </div>
     </div>
   `).join('');
@@ -575,7 +700,7 @@ function renderModels() {
   const tbody = document.getElementById('modelTable');
   const models = configData.models || {};
   if (Object.keys(models).length === 0) {
-    tbody.innerHTML = '<tr><td colspan="3" style="color:var(--text-dim)">No models configured.</td></tr>';
+    tbody.innerHTML = `<tr><td colspan="3" style="color:var(--text-dim)">${t('empty.models')}</td></tr>`;
     return;
   }
   tbody.innerHTML = Object.entries(models).map(([name, info]) => {
@@ -592,17 +717,17 @@ function renderModels() {
       <td>${esc(prov)}</td>
       <td style="text-align:right; white-space:nowrap">
         <div class="test-group">
-          <button class="btn btn-sm btn-test" onclick="runTest('${esc(name)}','text')">Test</button>
+          <button class="btn btn-sm btn-test" onclick="runTest('${esc(name)}','text')">${t('btn.test')}</button>
           <button class="btn btn-sm btn-caret" onclick="toggleTestMenu(this)">&#9662;</button>
           <div class="test-menu">
-            <div class="test-menu-item" onclick="runTest('${esc(name)}','text')">Simple Text</div>
-            <div class="test-menu-item" onclick="runTest('${esc(name)}','stream')">Stream</div>
-            <div class="test-menu-item${hasTools ? '' : ' disabled'}" onclick="${hasTools ? `runTest('${esc(name)}','tools')` : ''}">Function Call</div>
-            <div class="test-menu-item${hasVision ? '' : ' disabled'}" onclick="${hasVision ? `runTest('${esc(name)}','vision')` : ''}">Image Understanding</div>
+            <div class="test-menu-item" onclick="runTest('${esc(name)}','text')">${t('test.text')}</div>
+            <div class="test-menu-item" onclick="runTest('${esc(name)}','stream')">${t('test.stream')}</div>
+            <div class="test-menu-item${hasTools ? '' : ' disabled'}" onclick="${hasTools ? `runTest('${esc(name)}','tools')` : ''}">${t('test.tools')}</div>
+            <div class="test-menu-item${hasVision ? '' : ' disabled'}" onclick="${hasVision ? `runTest('${esc(name)}','vision')` : ''}">${t('test.vision')}</div>
           </div>
         </div>
-        <button class="btn btn-sm" onclick="editModel('${esc(name)}','${esc(prov)}')">Edit</button>
-        <button class="btn btn-sm btn-danger" onclick="deleteModel('${esc(name)}')">Delete</button>
+        <button class="btn btn-sm" onclick="editModel('${esc(name)}','${esc(prov)}')">${t('btn.edit')}</button>
+        <button class="btn btn-sm btn-danger" onclick="deleteModel('${esc(name)}')">${t('btn.delete')}</button>
       </td>
     </tr>`;
   }).join('');
@@ -616,17 +741,17 @@ async function saveProvider() {
   const baseUrl = document.getElementById('provBaseUrl').value.trim();
   const apiKey = document.getElementById('provApiKey').value.trim();
   const proxy = document.getElementById('provProxy').value.trim();
-  if (!name || !baseUrl || !apiKey) { showToast('Name, Base URL, and API Key are required', 'error'); return; }
+  if (!name || !baseUrl || !apiKey) { showToast(t('error.fieldsRequired'), 'error'); return; }
   const body = {api_key: apiKey, base_url: baseUrl, proxy};
   const res = await api.put(`/admin/api/config/providers/${encodeURIComponent(name)}`, body);
-  if (res.ok) { showToast(`Provider '${name}' saved`); closeModal('providerModal'); loadConfig(); }
+  if (res.ok) { showToast(t('toast.providerSaved',{name})); closeModal('providerModal'); loadConfig(); }
   else { showToast(res.error || 'Failed', 'error'); }
 }
 
 async function deleteProvider(name) {
-  if (!confirm(`Delete provider '${name}'?`)) return;
+  if (!confirm(t('confirm.deleteProvider',{name}))) return;
   const res = await api.del(`/admin/api/config/providers/${encodeURIComponent(name)}`);
-  if (res.ok) { showToast(`Provider '${name}' deleted`); loadConfig(); }
+  if (res.ok) { showToast(t('toast.providerDeleted',{name})); loadConfig(); }
   else { showToast(res.error || 'Failed', 'error'); }
 }
 
@@ -638,19 +763,19 @@ function editProvider(name) {
 async function saveModel() {
   const name = document.getElementById('modelName').value.trim();
   const provider = document.getElementById('modelProvider').value;
-  if (!name || !provider) { showToast('All fields are required', 'error'); return; }
+  if (!name || !provider) { showToast(t('error.modelRequired'), 'error'); return; }
   const capabilities = ['text'];
   if (document.getElementById('capVision').checked) capabilities.push('vision');
   if (document.getElementById('capTools').checked) capabilities.push('tools');
   const res = await api.put(`/admin/api/config/models/${encodeURIComponent(name)}`, {provider, capabilities});
-  if (res.ok) { showToast(`Model '${name}' saved`); closeModal('modelModal'); loadConfig(); }
+  if (res.ok) { showToast(t('toast.modelSaved',{name})); closeModal('modelModal'); loadConfig(); }
   else { showToast(res.error || 'Failed', 'error'); }
 }
 
 async function deleteModel(name) {
-  if (!confirm(`Delete model '${name}'?`)) return;
+  if (!confirm(t('confirm.deleteModel',{name}))) return;
   const res = await api.del(`/admin/api/config/models/${encodeURIComponent(name)}`);
-  if (res.ok) { showToast(`Model '${name}' deleted`); loadConfig(); }
+  if (res.ok) { showToast(t('toast.modelDeleted',{name})); loadConfig(); }
   else { showToast(res.error || 'Failed', 'error'); }
 }
 
@@ -673,10 +798,10 @@ function renderStats(d) {
   const uptime = formatDuration(d.uptime_seconds);
   const errRate = (d.error_rate * 100).toFixed(1) + '%';
   document.getElementById('statsGrid').innerHTML = `
-    <div class="stat-card"><div class="label">Total Requests</div><div class="value">${d.total_requests}</div></div>
-    <div class="stat-card"><div class="label">Error Rate</div><div class="value ${d.error_rate > 0.05 ? 'red' : 'green'}">${errRate}</div></div>
-    <div class="stat-card"><div class="label">Active Streams</div><div class="value blue">${d.active_streams}</div></div>
-    <div class="stat-card"><div class="label">Uptime</div><div class="value">${uptime}</div></div>
+    <div class="stat-card"><div class="label">${t('stat.totalRequests')}</div><div class="value">${d.total_requests}</div></div>
+    <div class="stat-card"><div class="label">${t('stat.errorRate')}</div><div class="value ${d.error_rate > 0.05 ? 'red' : 'green'}">${errRate}</div></div>
+    <div class="stat-card"><div class="label">${t('stat.activeStreams')}</div><div class="value blue">${d.active_streams}</div></div>
+    <div class="stat-card"><div class="label">${t('stat.uptime')}</div><div class="value">${uptime}</div></div>
   `;
 }
 
@@ -684,7 +809,7 @@ function renderProviderBreakdown(d) {
   const tbody = document.getElementById('providerBreakdown');
   const entries = Object.entries(d.by_target_provider || {}).sort((a,b) => b[1]-a[1]);
   if (entries.length === 0) {
-    tbody.innerHTML = '<tr><td colspan="2" style="color:var(--text-dim)">No data yet</td></tr>';
+    tbody.innerHTML = `<tr><td colspan="2" style="color:var(--text-dim)">${t('empty.data')}</td></tr>`;
     return;
   }
   tbody.innerHTML = entries.map(([p,c]) => `<tr><td>${esc(p)}</td><td>${c}</td></tr>`).join('');
@@ -778,7 +903,7 @@ async function loadLogs() {
 function renderLogs(entries, total) {
   const tbody = document.getElementById('logTable');
   if (entries.length === 0) {
-    tbody.innerHTML = '<tr><td colspan="6" style="color:var(--text-dim)">No requests logged yet</td></tr>';
+    tbody.innerHTML = `<tr><td colspan="6" style="color:var(--text-dim)">${t('empty.logs')}</td></tr>`;
   } else {
     tbody.innerHTML = entries.map(e => {
       const time = new Date(e.timestamp).toLocaleTimeString();
@@ -798,7 +923,7 @@ function renderLogs(entries, total) {
   // Pagination
   const totalPages = Math.ceil(total / LOG_LIMIT) || 1;
   const currentPage = Math.floor(logOffset / LOG_LIMIT) + 1;
-  document.getElementById('pageInfo').textContent = `Page ${currentPage} / ${totalPages} (${total} total)`;
+  document.getElementById('pageInfo').textContent = t('page.info', {current: currentPage, total: totalPages, count: total});
   document.getElementById('prevPage').disabled = logOffset === 0;
   document.getElementById('nextPage').disabled = logOffset + LOG_LIMIT >= total;
 }
@@ -809,11 +934,11 @@ function changePage(dir) {
 }
 
 async function clearLogs() {
-  if (!confirm('Clear all request logs?')) return;
+  if (!confirm(t('confirm.clearLogs'))) return;
   await api.del('/admin/api/requests');
   logOffset = 0;
   loadLogs();
-  showToast('Logs cleared');
+  showToast(t('toast.logCleared'));
 }
 
 function updateFilterOptions() {
@@ -824,8 +949,8 @@ function updateFilterOptions() {
   const pSel = document.getElementById('filterProvider');
   // preserve selection
   const mVal = mSel.value, pVal = pSel.value;
-  mSel.innerHTML = '<option value="">All Models</option>' + models.map(m => `<option value="${esc(m)}">${esc(m)}</option>`).join('');
-  pSel.innerHTML = '<option value="">All Providers</option>' + providers.map(p => `<option value="${esc(p)}">${esc(p)}</option>`).join('');
+  mSel.innerHTML = `<option value="">${t('filter.allModels')}</option>` + models.map(m => `<option value="${esc(m)}">${esc(m)}</option>`).join('');
+  pSel.innerHTML = `<option value="">${t('filter.allProviders')}</option>` + providers.map(p => `<option value="${esc(p)}">${esc(p)}</option>`).join('');
   mSel.value = mVal; pSel.value = pVal;
 }
 
@@ -875,7 +1000,7 @@ function formatDuration(seconds) {
 // Public domain test image (Wikimedia Commons — PNG transparency demo)
 const TEST_IMAGE_URL = 'https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png';
 
-const TEST_LABELS = {text:'Simple Text', stream:'Stream', tools:'Function Call', vision:'Image Understanding'};
+function getTestLabel(type) { return t('test.' + type); }
 
 function buildTestPayload(model, type) {
   const base = {model, max_tokens: 256};
@@ -919,7 +1044,7 @@ async function runTest(model, type) {
 
   const output = document.getElementById('testOutput');
   const meta = document.getElementById('testMeta');
-  document.getElementById('testModalTitle').textContent = `Test: ${TEST_LABELS[type]}`;
+  document.getElementById('testModalTitle').textContent = `Test: ${getTestLabel(type)}`;
   meta.innerHTML = `<div class="meta-item"><strong>Model:</strong> ${esc(model)}</div>`;
   output.textContent = '';
   output.className = 'test-output';
@@ -930,7 +1055,7 @@ async function runTest(model, type) {
 
   if (type === 'stream') {
     output.classList.add('streaming');
-    output.innerHTML = '<span class="test-spinner"></span>Connecting...';
+    output.innerHTML = `<span class="test-spinner"></span>${t('test.connecting')}`;
     try {
       const res = await fetch('/v1/chat/completions', {
         method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)
@@ -967,7 +1092,7 @@ async function runTest(model, type) {
         }
       }
       output.className = 'test-output';
-      if (!fullText) output.textContent = '(empty response)';
+      if (!fullText) output.textContent = t('test.emptyResponse');
       const elapsed = ((performance.now() - t0)/1000).toFixed(2);
       meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${elapsed}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--green)">OK (stream)</span></div>`;
     } catch(e) {
@@ -976,7 +1101,7 @@ async function runTest(model, type) {
     }
   } else {
     // Non-streaming
-    output.innerHTML = '<span class="test-spinner"></span>Sending request...';
+    output.innerHTML = `<span class="test-spinner"></span>${t('test.sending')}`;
     try {
       const res = await fetch('/v1/chat/completions', {
         method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)
@@ -1016,6 +1141,7 @@ async function runTest(model, type) {
 
 // ===================== Init =====================
 loadConfig();
+setLang(currentLang);
 </script>
 </body>
 </html>

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -33,7 +33,7 @@ a { color: var(--accent); text-decoration: none; }
 }
 .header h1 { font-size: 18px; font-weight: 600; }
 .header h1 span { color: var(--text-dim); font-weight: 400; }
-.header-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; }
+.header-right { display: flex; align-items: center; gap: 10px; }
 .header .config-path { font-size: 12px; color: var(--text-dim); font-family: var(--mono); }
 .header-select {
   padding: 4px 8px; font-size: 12px; background: var(--bg-card); border: 1px solid var(--border);
@@ -43,7 +43,7 @@ a { color: var(--accent); text-decoration: none; }
 /* Tabs */
 .tabs {
   display: flex; gap: 0; border-bottom: 1px solid var(--border);
-  padding: 0 24px;
+  padding: 0 24px; align-items: center;
 }
 .tab {
   padding: 12px 20px; cursor: pointer; font-size: 14px; color: var(--text-dim);
@@ -118,6 +118,12 @@ tr:hover td { background: var(--bg-hover); }
   padding: 2px 6px; border-radius: 4px; font-size: 11px;
 }
 .provider-card .actions { margin-top: 12px; display: flex; gap: 8px; }
+.key-field { display: flex; align-items: center; gap: 4px; }
+.key-btn {
+  background: none; border: none; cursor: pointer; padding: 1px 3px;
+  color: var(--text-dim); font-size: 13px; line-height: 1; border-radius: 3px;
+}
+.key-btn:hover { color: var(--accent); background: var(--bg-hover); }
 
 /* Modal */
 .modal-overlay {
@@ -247,23 +253,20 @@ canvas { width: 100%; height: 160px; }
     <h1>llm-rosetta <span>gateway admin</span></h1>
   </div>
   <div class="header-right">
-    <div style="display:flex;gap:8px;align-items:center">
-      <select id="themeSwitcher" class="header-select" onchange="setTheme(this.value)">
-        <option value="light">Light</option>
-        <option value="indigo">Indigo Dark</option>
-        <option value="dracula">Dracula</option>
-        <option value="nord">Nord</option>
-        <option value="solarized">Solarized</option>
-        <option value="osaka-jade">Osaka Jade</option>
-        <option value="one-dark">One Dark</option>
-        <option value="rosepine">Rosé Pine</option>
-      </select>
-      <select id="langSwitcher" class="header-select" onchange="setLang(this.value)">
-        <option value="en">EN</option>
-        <option value="zh">中文</option>
-      </select>
-    </div>
-    <div class="config-path" id="configPath"></div>
+    <select id="themeSwitcher" class="header-select" onchange="setTheme(this.value)">
+      <option value="light">Light</option>
+      <option value="indigo">Indigo Dark</option>
+      <option value="dracula">Dracula</option>
+      <option value="nord">Nord</option>
+      <option value="solarized">Solarized</option>
+      <option value="osaka-jade">Osaka Jade</option>
+      <option value="one-dark">One Dark</option>
+      <option value="rosepine">Rosé Pine</option>
+    </select>
+    <select id="langSwitcher" class="header-select" onchange="setLang(this.value)">
+      <option value="en">EN</option>
+      <option value="zh">中文</option>
+    </select>
   </div>
 </div>
 
@@ -271,6 +274,8 @@ canvas { width: 100%; height: 160px; }
   <div class="tab active" data-tab="config" data-i18n="tab.config">Configuration</div>
   <div class="tab" data-tab="dashboard" data-i18n="tab.dashboard">Dashboard</div>
   <div class="tab" data-tab="logs" data-i18n="tab.logs">Request Log</div>
+  <div style="flex:1"></div>
+  <div class="config-path" id="configPath"></div>
 </div>
 
 <div class="content">
@@ -488,8 +493,7 @@ function setTheme(name) {
   if (currentTab === 'dashboard') loadMetrics();
 }
 
-// Apply saved theme on load
-setTheme(currentTheme);
+// Theme is applied after state variables are declared (see below).
 
 // ===================== i18n =====================
 const I18N = {
@@ -622,6 +626,9 @@ const LOG_LIMIT = 30;
 let dashboardTimer = null;
 let logTimer = null;
 
+// Apply saved theme now that state vars are declared
+setTheme(currentTheme);
+
 // ===================== API =====================
 const api = {
   async get(url) {
@@ -653,10 +660,13 @@ function showToast(msg, type='success') {
 // ===================== Modal =====================
 function closeModal(id) { document.getElementById(id).classList.remove('open'); }
 
+let _editingProviderName = null; // original name when editing (for rename)
+
 function openProviderModal(name, baseUrl, apiKey, proxy, provType) {
+  _editingProviderName = name || null;
   document.getElementById('providerModalTitle').textContent = name ? t('modal.editProvider') : t('modal.addProvider');
   document.getElementById('provName').value = name || '';
-  document.getElementById('provName').readOnly = !!name;
+  document.getElementById('provName').readOnly = false;
   // Populate API Standard dropdown
   const typeSel = document.getElementById('provType');
   typeSel.innerHTML = '';
@@ -727,7 +737,10 @@ function renderProviders() {
       <div class="name">${esc(name)}</div>
       <div class="field">Type: <code>${esc(cfg.type || name)}</code></div>
       <div class="field">Base URL: <code>${esc(cfg.base_url || '')}</code></div>
-      <div class="field">API Key: <code>${esc(cfg.api_key || '')}</code></div>
+      <div class="field key-field">API Key: <code id="key-${esc(name)}" data-masked="${esc(cfg.api_key || '')}">${esc(cfg.api_key || '')}</code>
+        <button class="key-btn" title="Toggle visibility" onclick="toggleKeyVisibility('${esc(name)}')">&#128065;</button>
+        <button class="key-btn" title="Copy" onclick="copyKey('${esc(name)}')">&#128203;</button>
+      </div>
       ${cfg.proxy ? `<div class="field">Proxy: <code>${esc(cfg.proxy)}</code></div>` : ''}
       <div class="actions">
         <button class="btn btn-sm" onclick="editProvider('${esc(name)}')">${t('btn.edit')}</button>
@@ -785,6 +798,10 @@ async function saveProvider() {
   const proxy = document.getElementById('provProxy').value.trim();
   if (!name || !baseUrl || !apiKey) { showToast(t('error.fieldsRequired'), 'error'); return; }
   const body = {type: provType, api_key: apiKey, base_url: baseUrl, proxy};
+  // If editing and name changed, include rename_from so backend updates model references
+  if (_editingProviderName && _editingProviderName !== name) {
+    body.rename_from = _editingProviderName;
+  }
   const res = await api.put(`/admin/api/config/providers/${encodeURIComponent(name)}`, body);
   if (res.ok) { showToast(t('toast.providerSaved',{name})); closeModal('providerModal'); loadConfig(); }
   else { showToast(res.error || 'Failed', 'error'); }
@@ -800,6 +817,57 @@ async function deleteProvider(name) {
 function editProvider(name) {
   const cfg = configData.providers[name] || {};
   openProviderModal(name, cfg.base_url, cfg.api_key, cfg.proxy, cfg.type);
+}
+
+// Cache revealed keys so we don't re-fetch on every toggle
+const _revealedKeys = {};
+
+async function toggleKeyVisibility(name) {
+  const el = document.getElementById('key-' + name);
+  if (!el) return;
+  if (el.dataset.revealed === 'true') {
+    // Hide — restore masked value
+    el.textContent = el.dataset.masked;
+    el.dataset.revealed = 'false';
+    return;
+  }
+  // Reveal — fetch real key
+  if (_revealedKeys[name]) {
+    el.textContent = _revealedKeys[name];
+    el.dataset.revealed = 'true';
+    return;
+  }
+  try {
+    const res = await api.get(`/admin/api/config/providers/${encodeURIComponent(name)}/key`);
+    if (res.api_key) {
+      _revealedKeys[name] = res.api_key;
+      el.textContent = res.api_key;
+      el.dataset.revealed = 'true';
+    }
+  } catch(e) {
+    showToast('Failed to reveal key', 'error');
+  }
+}
+
+async function copyKey(name) {
+  let key = _revealedKeys[name];
+  if (!key) {
+    try {
+      const res = await api.get(`/admin/api/config/providers/${encodeURIComponent(name)}/key`);
+      key = res.api_key;
+      if (key) _revealedKeys[name] = key;
+    } catch(e) {
+      showToast('Failed to fetch key', 'error');
+      return;
+    }
+  }
+  if (!key) return;
+  try {
+    await navigator.clipboard.writeText(key);
+    showToast('API key copied');
+  } catch(e) {
+    showToast('Copy failed', 'error');
+  }
 }
 
 async function saveModel() {

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -249,10 +249,10 @@ canvas { width: 100%; height: 160px; }
   <div class="header-right">
     <select id="themeSwitcher" class="header-select" onchange="setTheme(this.value)">
       <option value="indigo">Indigo Dark</option>
-      <option value="linear">Linear</option>
-      <option value="github">GitHub Dark</option>
+      <option value="dracula">Dracula</option>
+      <option value="nord">Nord</option>
       <option value="light">Light</option>
-      <option value="vercel">Vercel</option>
+      <option value="solarized">Solarized</option>
     </select>
     <div class="config-path" id="configPath"></div>
   </div>
@@ -424,25 +424,25 @@ const THEMES = {
     '--text':'#e4e7ef','--text-dim':'#8b90a5','--accent':'#6366f1','--accent-hover':'#818cf8',
     '--green':'#22c55e','--red':'#ef4444','--orange':'#f59e0b','--blue':'#3b82f6',
   },
-  linear: {
-    '--bg':'#111113','--bg-card':'#191a1f','--bg-hover':'#232429','--border':'#2c2d33',
-    '--text':'#eeeffc','--text-dim':'#8a8f98','--accent':'#5e6ad2','--accent-hover':'#7c85d2',
-    '--green':'#4cc38a','--red':'#e5484d','--orange':'#f5a623','--blue':'#52a9ff',
+  dracula: {
+    '--bg':'#282a36','--bg-card':'#2d2f3d','--bg-hover':'#383a4a','--border':'#44475a',
+    '--text':'#f8f8f2','--text-dim':'#6272a4','--accent':'#bd93f9','--accent-hover':'#caa8fc',
+    '--green':'#50fa7b','--red':'#ff5555','--orange':'#ffb86c','--blue':'#8be9fd',
   },
-  github: {
-    '--bg':'#0d1117','--bg-card':'#161b22','--bg-hover':'#1c2128','--border':'#30363d',
-    '--text':'#e6edf3','--text-dim':'#7d8590','--accent':'#58a6ff','--accent-hover':'#79c0ff',
-    '--green':'#3fb950','--red':'#f85149','--orange':'#d29922','--blue':'#58a6ff',
+  nord: {
+    '--bg':'#2e3440','--bg-card':'#3b4252','--bg-hover':'#434c5e','--border':'#4c566a',
+    '--text':'#eceff4','--text-dim':'#81a1c1','--accent':'#88c0d0','--accent-hover':'#8fbcbb',
+    '--green':'#a3be8c','--red':'#bf616a','--orange':'#d08770','--blue':'#5e81ac',
   },
   light: {
     '--bg':'#ffffff','--bg-card':'#f6f8fa','--bg-hover':'#eef1f5','--border':'#d1d9e0',
     '--text':'#1f2328','--text-dim':'#656d76','--accent':'#0969da','--accent-hover':'#0550ae',
     '--green':'#1a7f37','--red':'#cf222e','--orange':'#bf8700','--blue':'#0969da',
   },
-  vercel: {
-    '--bg':'#000000','--bg-card':'#111111','--bg-hover':'#1a1a1a','--border':'#333333',
-    '--text':'#ededed','--text-dim':'#888888','--accent':'#0070f3','--accent-hover':'#3291ff',
-    '--green':'#50e3c2','--red':'#ee0000','--orange':'#f5a623','--blue':'#0070f3',
+  solarized: {
+    '--bg':'#002b36','--bg-card':'#073642','--bg-hover':'#0a4050','--border':'#586e75',
+    '--text':'#fdf6e3','--text-dim':'#839496','--accent':'#b58900','--accent-hover':'#cb9a09',
+    '--green':'#859900','--red':'#dc322f','--orange':'#cb4b16','--blue':'#268bd2',
   },
 };
 

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -33,7 +33,12 @@ a { color: var(--accent); text-decoration: none; }
 }
 .header h1 { font-size: 18px; font-weight: 600; }
 .header h1 span { color: var(--text-dim); font-weight: 400; }
+.header-right { display: flex; align-items: center; gap: 12px; }
 .header .config-path { font-size: 12px; color: var(--text-dim); font-family: var(--mono); }
+.header-select {
+  padding: 4px 8px; font-size: 12px; background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--radius); color: var(--text); cursor: pointer;
+}
 
 /* Tabs */
 .tabs {
@@ -241,7 +246,16 @@ canvas { width: 100%; height: 160px; }
   <div>
     <h1>llm-rosetta <span>gateway admin</span></h1>
   </div>
-  <div class="config-path" id="configPath"></div>
+  <div class="header-right">
+    <select id="themeSwitcher" class="header-select" onchange="setTheme(this.value)">
+      <option value="indigo">Indigo Dark</option>
+      <option value="linear">Linear</option>
+      <option value="github">GitHub Dark</option>
+      <option value="light">Light</option>
+      <option value="vercel">Vercel</option>
+    </select>
+    <div class="config-path" id="configPath"></div>
+  </div>
 </div>
 
 <div class="tabs">
@@ -403,6 +417,52 @@ canvas { width: 100%; height: 160px; }
 <div class="toast" id="toast"></div>
 
 <script>
+// ===================== Themes =====================
+const THEMES = {
+  indigo: {
+    '--bg':'#0f1117','--bg-card':'#1a1d27','--bg-hover':'#242838','--border':'#2d3148',
+    '--text':'#e4e7ef','--text-dim':'#8b90a5','--accent':'#6366f1','--accent-hover':'#818cf8',
+    '--green':'#22c55e','--red':'#ef4444','--orange':'#f59e0b','--blue':'#3b82f6',
+  },
+  linear: {
+    '--bg':'#111113','--bg-card':'#191a1f','--bg-hover':'#232429','--border':'#2c2d33',
+    '--text':'#eeeffc','--text-dim':'#8a8f98','--accent':'#5e6ad2','--accent-hover':'#7c85d2',
+    '--green':'#4cc38a','--red':'#e5484d','--orange':'#f5a623','--blue':'#52a9ff',
+  },
+  github: {
+    '--bg':'#0d1117','--bg-card':'#161b22','--bg-hover':'#1c2128','--border':'#30363d',
+    '--text':'#e6edf3','--text-dim':'#7d8590','--accent':'#58a6ff','--accent-hover':'#79c0ff',
+    '--green':'#3fb950','--red':'#f85149','--orange':'#d29922','--blue':'#58a6ff',
+  },
+  light: {
+    '--bg':'#ffffff','--bg-card':'#f6f8fa','--bg-hover':'#eef1f5','--border':'#d1d9e0',
+    '--text':'#1f2328','--text-dim':'#656d76','--accent':'#0969da','--accent-hover':'#0550ae',
+    '--green':'#1a7f37','--red':'#cf222e','--orange':'#bf8700','--blue':'#0969da',
+  },
+  vercel: {
+    '--bg':'#000000','--bg-card':'#111111','--bg-hover':'#1a1a1a','--border':'#333333',
+    '--text':'#ededed','--text-dim':'#888888','--accent':'#0070f3','--accent-hover':'#3291ff',
+    '--green':'#50e3c2','--red':'#ee0000','--orange':'#f5a623','--blue':'#0070f3',
+  },
+};
+
+let currentTheme = localStorage.getItem('llm-rosetta-theme') || 'indigo';
+
+function setTheme(name) {
+  const vars = THEMES[name];
+  if (!vars) return;
+  const root = document.documentElement;
+  for (const [k, v] of Object.entries(vars)) root.style.setProperty(k, v);
+  currentTheme = name;
+  localStorage.setItem('llm-rosetta-theme', name);
+  document.getElementById('themeSwitcher').value = name;
+  // Redraw charts if on dashboard tab
+  if (currentTab === 'dashboard') loadMetrics();
+}
+
+// Apply saved theme on load
+setTheme(currentTheme);
+
 // ===================== State =====================
 let currentTab = 'config';
 let configData = null;
@@ -643,6 +703,12 @@ function drawChart(canvasId, series, key, unit) {
 
   ctx.clearRect(0, 0, w, h);
 
+  // Read theme colors from CSS variables
+  const cs = getComputedStyle(document.documentElement);
+  const gridColor = cs.getPropertyValue('--border').trim();
+  const dimColor = cs.getPropertyValue('--text-dim').trim();
+  const accentColor = cs.getPropertyValue('--accent').trim();
+
   const values = series.map(s => s[key]);
   const maxVal = Math.max(...values, 1);
 
@@ -651,7 +717,7 @@ function drawChart(canvasId, series, key, unit) {
   const chartH = h - padT - padB;
 
   // Grid lines
-  ctx.strokeStyle = '#2d3148';
+  ctx.strokeStyle = gridColor;
   ctx.lineWidth = 0.5;
   for (let i = 0; i <= 4; i++) {
     const y = padT + (chartH / 4) * i;
@@ -659,7 +725,7 @@ function drawChart(canvasId, series, key, unit) {
   }
 
   // Y-axis labels
-  ctx.fillStyle = '#8b90a5';
+  ctx.fillStyle = dimColor;
   ctx.font = '10px sans-serif';
   ctx.textAlign = 'right';
   for (let i = 0; i <= 4; i++) {
@@ -677,7 +743,7 @@ function drawChart(canvasId, series, key, unit) {
   if (values.length === 0) return;
 
   // Line
-  ctx.strokeStyle = '#6366f1';
+  ctx.strokeStyle = accentColor;
   ctx.lineWidth = 1.5;
   ctx.beginPath();
   for (let i = 0; i < values.length; i++) {
@@ -691,7 +757,7 @@ function drawChart(canvasId, series, key, unit) {
   ctx.lineTo(padL + chartW, padT + chartH);
   ctx.lineTo(padL, padT + chartH);
   ctx.closePath();
-  ctx.fillStyle = 'rgba(99,102,241,0.08)';
+  ctx.fillStyle = accentColor.startsWith('#') ? accentColor + '14' : 'rgba(99,102,241,0.08)';
   ctx.fill();
 }
 

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -697,11 +697,15 @@ function openModelModal(model, provider, capabilities) {
 
 // ===================== Config Tab =====================
 async function loadConfig() {
-  configData = await api.get('/admin/api/config');
-  document.getElementById('configPath').textContent = configData.config_path || '';
-  document.getElementById('globalProxy').value = (configData.server && configData.server.proxy) || '';
-  renderProviders();
-  renderModels();
+  try {
+    configData = await api.get('/admin/api/config');
+    document.getElementById('configPath').textContent = configData.config_path || '';
+    document.getElementById('globalProxy').value = (configData.server && configData.server.proxy) || '';
+    renderProviders();
+    renderModels();
+  } catch(e) {
+    console.error('Failed to load config:', e);
+  }
 }
 
 async function saveServerSettings() {

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -376,8 +376,8 @@ canvas { width: 100%; height: 160px; }
       <label>Capabilities</label>
       <div class="checkbox-group">
         <label><input type="checkbox" id="capText" checked disabled> text</label>
-        <label><input type="checkbox" id="capVision"> vision</label>
-        <label><input type="checkbox" id="capTools"> tools</label>
+        <label><input type="checkbox" id="capVision" checked> vision</label>
+        <label><input type="checkbox" id="capTools" checked> tools</label>
       </div>
     </div>
     <div class="modal-actions">
@@ -467,8 +467,8 @@ function openModelModal(model, provider, capabilities) {
       sel.appendChild(opt);
     }
   }
-  // Set capability checkboxes
-  const caps = capabilities || ['text'];
+  // Set capability checkboxes (default all enabled for new models)
+  const caps = capabilities || ['text', 'vision', 'tools'];
   document.getElementById('capVision').checked = caps.includes('vision');
   document.getElementById('capTools').checked = caps.includes('tools');
   document.getElementById('modelModal').classList.add('open');

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -6,18 +6,18 @@
 <title>llm-rosetta Gateway — Admin</title>
 <style>
 :root {
-  --bg: #0f1117;
-  --bg-card: #1a1d27;
-  --bg-hover: #242838;
-  --border: #2d3148;
-  --text: #e4e7ef;
-  --text-dim: #8b90a5;
-  --accent: #6366f1;
-  --accent-hover: #818cf8;
-  --green: #22c55e;
-  --red: #ef4444;
-  --orange: #f59e0b;
-  --blue: #3b82f6;
+  --bg: #ffffff;
+  --bg-card: #f6f8fa;
+  --bg-hover: #eef1f5;
+  --border: #d1d9e0;
+  --text: #1f2328;
+  --text-dim: #656d76;
+  --accent: #0969da;
+  --accent-hover: #0550ae;
+  --green: #1a7f37;
+  --red: #cf222e;
+  --orange: #bf8700;
+  --blue: #0969da;
   --radius: 8px;
   --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --mono: 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
@@ -249,11 +249,14 @@ canvas { width: 100%; height: 160px; }
   <div class="header-right">
     <div style="display:flex;gap:8px;align-items:center">
       <select id="themeSwitcher" class="header-select" onchange="setTheme(this.value)">
+        <option value="light">Light</option>
         <option value="indigo">Indigo Dark</option>
         <option value="dracula">Dracula</option>
         <option value="nord">Nord</option>
-        <option value="light">Light</option>
         <option value="solarized">Solarized</option>
+        <option value="osaka-jade">Osaka Jade</option>
+        <option value="one-dark">One Dark</option>
+        <option value="rosepine">Rosé Pine</option>
       </select>
       <select id="langSwitcher" class="header-select" onchange="setLang(this.value)">
         <option value="en">EN</option>
@@ -454,9 +457,24 @@ const THEMES = {
     '--text':'#fdf6e3','--text-dim':'#839496','--accent':'#b58900','--accent-hover':'#cb9a09',
     '--green':'#859900','--red':'#dc322f','--orange':'#cb4b16','--blue':'#268bd2',
   },
+  'osaka-jade': {
+    '--bg':'#1a1f1e','--bg-card':'#222928','--bg-hover':'#2c3432','--border':'#3a4542',
+    '--text':'#d4ddd6','--text-dim':'#7a9486','--accent':'#5cba8c','--accent-hover':'#74d4a4',
+    '--green':'#5cba8c','--red':'#e06c6c','--orange':'#d4a24c','--blue':'#5c9aba',
+  },
+  'one-dark': {
+    '--bg':'#282c34','--bg-card':'#2c313c','--bg-hover':'#353b48','--border':'#3e4452',
+    '--text':'#abb2bf','--text-dim':'#636d83','--accent':'#61afef','--accent-hover':'#80bfff',
+    '--green':'#98c379','--red':'#e06c75','--orange':'#d19a66','--blue':'#61afef',
+  },
+  rosepine: {
+    '--bg':'#191724','--bg-card':'#1f1d2e','--bg-hover':'#26233a','--border':'#403d52',
+    '--text':'#e0def4','--text-dim':'#908caa','--accent':'#c4a7e7','--accent-hover':'#d4bff7',
+    '--green':'#9ccfd8','--red':'#eb6f92','--orange':'#f6c177','--blue':'#31748f',
+  },
 };
 
-let currentTheme = localStorage.getItem('llm-rosetta-theme') || 'indigo';
+let currentTheme = localStorage.getItem('llm-rosetta-theme') || 'light';
 
 function setTheme(name) {
   const vars = THEMES[name];

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -33,7 +33,7 @@ a { color: var(--accent); text-decoration: none; }
 }
 .header h1 { font-size: 18px; font-weight: 600; }
 .header h1 span { color: var(--text-dim); font-weight: 400; }
-.header-right { display: flex; align-items: center; gap: 12px; }
+.header-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; }
 .header .config-path { font-size: 12px; color: var(--text-dim); font-family: var(--mono); }
 .header-select {
   padding: 4px 8px; font-size: 12px; background: var(--bg-card); border: 1px solid var(--border);
@@ -247,17 +247,19 @@ canvas { width: 100%; height: 160px; }
     <h1>llm-rosetta <span>gateway admin</span></h1>
   </div>
   <div class="header-right">
-    <select id="themeSwitcher" class="header-select" onchange="setTheme(this.value)">
-      <option value="indigo">Indigo Dark</option>
-      <option value="dracula">Dracula</option>
-      <option value="nord">Nord</option>
-      <option value="light">Light</option>
-      <option value="solarized">Solarized</option>
-    </select>
-    <select id="langSwitcher" class="header-select" onchange="setLang(this.value)">
-      <option value="en">EN</option>
-      <option value="zh">中文</option>
-    </select>
+    <div style="display:flex;gap:8px;align-items:center">
+      <select id="themeSwitcher" class="header-select" onchange="setTheme(this.value)">
+        <option value="indigo">Indigo Dark</option>
+        <option value="dracula">Dracula</option>
+        <option value="nord">Nord</option>
+        <option value="light">Light</option>
+        <option value="solarized">Solarized</option>
+      </select>
+      <select id="langSwitcher" class="header-select" onchange="setLang(this.value)">
+        <option value="en">EN</option>
+        <option value="zh">中文</option>
+      </select>
+    </div>
     <div class="config-path" id="configPath"></div>
   </div>
 </div>
@@ -356,8 +358,12 @@ canvas { width: 100%; height: 160px; }
   <div class="modal">
     <h3 id="providerModalTitle" data-i18n="modal.addProvider">Add Provider</h3>
     <div class="form-group">
-      <label data-i18n="label.providerName">Provider Name / Type</label>
-      <input id="provName" placeholder="e.g. openai_chat, anthropic, my_custom">
+      <label data-i18n="label.providerName">Provider Name</label>
+      <input id="provName" placeholder="e.g. my-openai, openrouter-claude">
+    </div>
+    <div class="form-group">
+      <label data-i18n="label.apiStandard">API Standard</label>
+      <select id="provType"></select>
     </div>
     <div class="form-group">
       <label data-i18n="label.baseUrl">Base URL</label>
@@ -478,7 +484,8 @@ const I18N = {
     'btn.addProvider':'+ Add Provider', 'btn.addModel':'+ Add Model',
     'btn.edit':'Edit', 'btn.delete':'Delete', 'btn.clearLog':'Clear Log',
     'btn.prev':'Prev', 'btn.next':'Next', 'btn.test':'Test',
-    'label.providerName':'Provider Name / Type', 'label.baseUrl':'Base URL',
+    'label.providerName':'Provider Name', 'label.apiStandard':'API Standard',
+    'label.baseUrl':'Base URL',
     'label.apiKey':'API Key (or ${ENV_VAR} placeholder)',
     'label.proxyUrl':'Proxy URL (optional, overrides global)',
     'label.modelName':'Model Name', 'label.provider':'Provider', 'label.capabilities':'Capabilities',
@@ -521,7 +528,8 @@ const I18N = {
     'btn.addProvider':'+ \u6dfb\u52a0\u670d\u52a1\u5546', 'btn.addModel':'+ \u6dfb\u52a0\u6a21\u578b',
     'btn.edit':'\u7f16\u8f91', 'btn.delete':'\u5220\u9664', 'btn.clearLog':'\u6e05\u9664\u65e5\u5fd7',
     'btn.prev':'\u4e0a\u4e00\u9875', 'btn.next':'\u4e0b\u4e00\u9875', 'btn.test':'\u6d4b\u8bd5',
-    'label.providerName':'\u670d\u52a1\u5546\u540d\u79f0 / \u7c7b\u578b', 'label.baseUrl':'Base URL',
+    'label.providerName':'\u670d\u52a1\u5546\u540d\u79f0', 'label.apiStandard':'API \u6807\u51c6',
+    'label.baseUrl':'Base URL',
     'label.apiKey':'API Key\uff08\u6216 ${ENV_VAR} \u5360\u4f4d\u7b26\uff09',
     'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09',
     'label.modelName':'\u6a21\u578b\u540d\u79f0', 'label.provider':'\u670d\u52a1\u5546', 'label.capabilities':'\u80fd\u529b',
@@ -627,10 +635,20 @@ function showToast(msg, type='success') {
 // ===================== Modal =====================
 function closeModal(id) { document.getElementById(id).classList.remove('open'); }
 
-function openProviderModal(name, baseUrl, apiKey, proxy) {
+function openProviderModal(name, baseUrl, apiKey, proxy, provType) {
   document.getElementById('providerModalTitle').textContent = name ? t('modal.editProvider') : t('modal.addProvider');
   document.getElementById('provName').value = name || '';
   document.getElementById('provName').readOnly = !!name;
+  // Populate API Standard dropdown
+  const typeSel = document.getElementById('provType');
+  typeSel.innerHTML = '';
+  const knownTypes = (configData && configData.known_provider_types) || [];
+  for (const pt of knownTypes) {
+    const opt = document.createElement('option');
+    opt.value = pt; opt.textContent = pt;
+    if (pt === provType) opt.selected = true;
+    typeSel.appendChild(opt);
+  }
   document.getElementById('provBaseUrl').value = baseUrl || '';
   document.getElementById('provApiKey').value = apiKey || '';
   document.getElementById('provProxy').value = proxy || '';
@@ -685,6 +703,7 @@ function renderProviders() {
   grid.innerHTML = Object.entries(providers).map(([name, cfg]) => `
     <div class="provider-card">
       <div class="name">${esc(name)}</div>
+      <div class="field">Type: <code>${esc(cfg.type || name)}</code></div>
       <div class="field">Base URL: <code>${esc(cfg.base_url || '')}</code></div>
       <div class="field">API Key: <code>${esc(cfg.api_key || '')}</code></div>
       ${cfg.proxy ? `<div class="field">Proxy: <code>${esc(cfg.proxy)}</code></div>` : ''}
@@ -738,11 +757,12 @@ function renderModels() {
 
 async function saveProvider() {
   const name = document.getElementById('provName').value.trim();
+  const provType = document.getElementById('provType').value;
   const baseUrl = document.getElementById('provBaseUrl').value.trim();
   const apiKey = document.getElementById('provApiKey').value.trim();
   const proxy = document.getElementById('provProxy').value.trim();
   if (!name || !baseUrl || !apiKey) { showToast(t('error.fieldsRequired'), 'error'); return; }
-  const body = {api_key: apiKey, base_url: baseUrl, proxy};
+  const body = {type: provType, api_key: apiKey, base_url: baseUrl, proxy};
   const res = await api.put(`/admin/api/config/providers/${encodeURIComponent(name)}`, body);
   if (res.ok) { showToast(t('toast.providerSaved',{name})); closeModal('providerModal'); loadConfig(); }
   else { showToast(res.error || 'Failed', 'error'); }
@@ -757,7 +777,7 @@ async function deleteProvider(name) {
 
 function editProvider(name) {
   const cfg = configData.providers[name] || {};
-  openProviderModal(name, cfg.base_url, cfg.api_key, cfg.proxy);
+  openProviderModal(name, cfg.base_url, cfg.api_key, cfg.proxy, cfg.type);
 }
 
 async function saveModel() {

--- a/src/llm_rosetta/gateway/admin/metrics.py
+++ b/src/llm_rosetta/gateway/admin/metrics.py
@@ -1,0 +1,162 @@
+"""In-process metrics collector for the gateway admin panel.
+
+All data structures are plain Python objects.  Since the gateway runs
+on a single asyncio event loop thread, no locks are required.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+
+# ---------------------------------------------------------------------------
+# Rolling time-series window
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Bucket:
+    """Aggregation for a single second."""
+
+    count: int = 0
+    total_duration_ms: float = 0.0
+    error_count: int = 0
+
+
+class _RollingWindow:
+    """Per-second resolution time-series with auto-expiring buckets.
+
+    Buckets are keyed by ``int(time.monotonic())``.  Expired buckets are
+    cleaned up lazily during read operations — never on the hot write
+    path.
+    """
+
+    def __init__(self, window_seconds: int = 300) -> None:
+        self._buckets: dict[int, _Bucket] = {}
+        self._window = window_seconds
+
+    def record(self, duration_ms: float, *, is_error: bool = False) -> None:
+        """Record a single request in the current second's bucket."""
+        key = int(time.monotonic())
+        bucket = self._buckets.get(key)
+        if bucket is None:
+            bucket = _Bucket()
+            self._buckets[key] = bucket
+        bucket.count += 1
+        bucket.total_duration_ms += duration_ms
+        if is_error:
+            bucket.error_count += 1
+
+    def get_series(self, seconds: int = 60) -> list[dict]:
+        """Return per-second datapoints for the last *seconds*.
+
+        Each element is ``{"t": <offset_seconds_ago>, "count": …,
+        "avg_ms": …, "errors": …}``.
+
+        Also performs lazy cleanup of expired buckets.
+        """
+        now = int(time.monotonic())
+        cutoff = now - self._window
+
+        # Lazy cleanup
+        expired = [k for k in self._buckets if k < cutoff]
+        for k in expired:
+            del self._buckets[k]
+
+        start = now - seconds
+        series: list[dict] = []
+        for offset in range(seconds):
+            key = start + offset + 1
+            bucket = self._buckets.get(key)
+            if bucket is not None:
+                avg_ms = bucket.total_duration_ms / bucket.count if bucket.count else 0
+                series.append(
+                    {
+                        "t": key - now,  # negative offset (seconds ago)
+                        "count": bucket.count,
+                        "avg_ms": round(avg_ms, 2),
+                        "errors": bucket.error_count,
+                    }
+                )
+            else:
+                series.append({"t": key - now, "count": 0, "avg_ms": 0, "errors": 0})
+        return series
+
+
+# ---------------------------------------------------------------------------
+# Main collector
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MetricsCollector:
+    """Lightweight in-process metrics for the gateway."""
+
+    # Counters
+    total_requests: int = 0
+    total_errors: int = 0
+    total_streams: int = 0
+
+    # Breakdowns
+    by_model: dict[str, int] = field(default_factory=dict)
+    by_source_provider: dict[str, int] = field(default_factory=dict)
+    by_target_provider: dict[str, int] = field(default_factory=dict)
+    by_status_code: dict[int, int] = field(default_factory=dict)
+
+    # Gauge
+    active_streams: int = 0
+
+    # Time-series
+    _window: _RollingWindow = field(default_factory=_RollingWindow)
+
+    # Timing
+    _start_time: float = field(default_factory=time.monotonic)
+
+    def record_request(
+        self,
+        *,
+        model: str,
+        source: str,
+        target: str,
+        status_code: int,
+        duration_ms: float,
+        is_stream: bool,
+    ) -> None:
+        """Record a completed proxy request."""
+        self.total_requests += 1
+        is_error = status_code >= 400
+        if is_error:
+            self.total_errors += 1
+        if is_stream:
+            self.total_streams += 1
+
+        self.by_model[model] = self.by_model.get(model, 0) + 1
+        self.by_source_provider[source] = self.by_source_provider.get(source, 0) + 1
+        self.by_target_provider[target] = self.by_target_provider.get(target, 0) + 1
+        self.by_status_code[status_code] = self.by_status_code.get(status_code, 0) + 1
+
+        self._window.record(duration_ms, is_error=is_error)
+
+    def snapshot(self, series_seconds: int = 60) -> dict:
+        """Return a JSON-serializable metrics snapshot."""
+        uptime = time.monotonic() - self._start_time
+        error_rate = (
+            round(self.total_errors / self.total_requests, 4)
+            if self.total_requests
+            else 0
+        )
+
+        return {
+            "uptime_seconds": round(uptime, 1),
+            "total_requests": self.total_requests,
+            "total_errors": self.total_errors,
+            "total_streams": self.total_streams,
+            "error_rate": error_rate,
+            "active_streams": self.active_streams,
+            "by_model": dict(self.by_model),
+            "by_source_provider": dict(self.by_source_provider),
+            "by_target_provider": dict(self.by_target_provider),
+            "by_status_code": {str(k): v for k, v in self.by_status_code.items()},
+            "series": self._window.get_series(series_seconds),
+        }

--- a/src/llm_rosetta/gateway/admin/metrics.py
+++ b/src/llm_rosetta/gateway/admin/metrics.py
@@ -138,6 +138,30 @@ class MetricsCollector:
 
         self._window.record(duration_ms, is_error=is_error)
 
+    def export_counters(self) -> dict:
+        """Return counters suitable for persistence (no time-series)."""
+        return {
+            "total_requests": self.total_requests,
+            "total_errors": self.total_errors,
+            "total_streams": self.total_streams,
+            "by_model": dict(self.by_model),
+            "by_source_provider": dict(self.by_source_provider),
+            "by_target_provider": dict(self.by_target_provider),
+            "by_status_code": {str(k): v for k, v in self.by_status_code.items()},
+        }
+
+    def load_counters(self, data: dict) -> None:
+        """Restore counters from a previously exported dict."""
+        self.total_requests = data.get("total_requests", 0)
+        self.total_errors = data.get("total_errors", 0)
+        self.total_streams = data.get("total_streams", 0)
+        self.by_model = dict(data.get("by_model", {}))
+        self.by_source_provider = dict(data.get("by_source_provider", {}))
+        self.by_target_provider = dict(data.get("by_target_provider", {}))
+        self.by_status_code = {
+            int(k): v for k, v in data.get("by_status_code", {}).items()
+        }
+
     def snapshot(self, series_seconds: int = 60) -> dict:
         """Return a JSON-serializable metrics snapshot."""
         uptime = time.monotonic() - self._start_time

--- a/src/llm_rosetta/gateway/admin/persistence.py
+++ b/src/llm_rosetta/gateway/admin/persistence.py
@@ -1,0 +1,216 @@
+"""File-based persistence for metrics and request logs.
+
+Stores request log entries as JSONL and metrics counters as JSON,
+with size-based rotation and gzip compression.  All I/O uses the
+Python standard library for cross-platform compatibility.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger("llm-rosetta-gateway")
+
+_LOG_FILENAME = "request_log.jsonl"
+_METRICS_FILENAME = "metrics.json"
+
+
+class PersistenceManager:
+    """Manages on-disk persistence for gateway admin data.
+
+    Args:
+        data_dir: Directory for data files (created if missing).
+        max_file_size: Max size in bytes for ``request_log.jsonl``
+            before rotation (default 2 MB).
+        max_backups: Number of rotated ``.jsonl.gz`` files to keep.
+    """
+
+    def __init__(
+        self,
+        data_dir: str,
+        max_file_size: int = 2 * 1024 * 1024,
+        max_backups: int = 3,
+    ) -> None:
+        self._data_dir = Path(data_dir)
+        self._max_file_size = max_file_size
+        self._max_backups = max_backups
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def log_path(self) -> Path:
+        return self._data_dir / _LOG_FILENAME
+
+    @property
+    def metrics_path(self) -> Path:
+        return self._data_dir / _METRICS_FILENAME
+
+    # ------------------------------------------------------------------
+    # Request log
+    # ------------------------------------------------------------------
+
+    def append_log_entries(self, entries: list[dict]) -> None:
+        """Append *entries* to the JSONL log file, rotating if needed."""
+        if not entries:
+            return
+        self._rotate_if_needed()
+        with open(self.log_path, "a", encoding="utf-8") as f:
+            for entry in entries:
+                f.write(json.dumps(entry, ensure_ascii=False))
+                f.write("\n")
+
+    def load_log_entries(self, max_entries: int = 500) -> list[dict]:
+        """Load the most recent *max_entries* from the log file.
+
+        Reads the current JSONL first, then compressed backups if more
+        entries are needed.  Returns entries in chronological order
+        (oldest first).
+        """
+        entries: list[dict] = []
+
+        # Read current log file
+        entries.extend(self._read_jsonl(self.log_path))
+
+        # Read compressed backups (newest backup = .1) if we need more
+        if len(entries) < max_entries:
+            for i in range(1, self._max_backups + 1):
+                gz_path = self._data_dir / f"request_log.{i}.jsonl.gz"
+                if not gz_path.exists():
+                    break
+                backup_entries = self._read_jsonl_gz(gz_path)
+                entries = backup_entries + entries
+                if len(entries) >= max_entries:
+                    break
+
+        # Keep only the newest max_entries
+        if len(entries) > max_entries:
+            entries = entries[-max_entries:]
+        return entries
+
+    # ------------------------------------------------------------------
+    # Metrics
+    # ------------------------------------------------------------------
+
+    def save_metrics(self, data: dict) -> None:
+        """Atomically write metrics counters to ``metrics.json``."""
+        # Write to temp file then rename for crash safety
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(self._data_dir), suffix=".tmp", prefix="metrics_"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False)
+                f.write("\n")
+            # os.replace is atomic on all platforms
+            os.replace(tmp_path, str(self.metrics_path))
+        except Exception:
+            # Clean up temp file on failure
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def load_metrics(self) -> dict | None:
+        """Load metrics counters from ``metrics.json``.
+
+        Returns ``None`` if the file is missing or corrupt.
+        """
+        if not self.metrics_path.exists():
+            return None
+        try:
+            with open(self.metrics_path, encoding="utf-8") as f:
+                return json.load(f)
+        except Exception as exc:
+            logger.warning("Failed to load metrics from %s: %s", self.metrics_path, exc)
+            return None
+
+    # ------------------------------------------------------------------
+    # Rotation
+    # ------------------------------------------------------------------
+
+    def _rotate_if_needed(self) -> None:
+        """Rotate ``request_log.jsonl`` if it exceeds the size limit."""
+        if not self.log_path.exists():
+            return
+        try:
+            size = self.log_path.stat().st_size
+        except OSError:
+            return
+        if size < self._max_file_size:
+            return
+
+        # Shift existing backups: .3 -> delete, .2 -> .3, .1 -> .2
+        for i in range(self._max_backups, 0, -1):
+            src = self._data_dir / f"request_log.{i}.jsonl.gz"
+            if i == self._max_backups:
+                # Delete the oldest backup
+                if src.exists():
+                    src.unlink()
+            else:
+                dst = self._data_dir / f"request_log.{i + 1}.jsonl.gz"
+                if src.exists():
+                    src.rename(dst)
+
+        # Compress current log -> .1.jsonl.gz
+        gz_path = self._data_dir / "request_log.1.jsonl.gz"
+        try:
+            with open(self.log_path, "rb") as f_in:
+                with gzip.open(gz_path, "wb") as f_out:
+                    while True:
+                        chunk = f_in.read(65536)
+                        if not chunk:
+                            break
+                        f_out.write(chunk)
+            # Truncate the current log
+            with open(self.log_path, "w", encoding="utf-8"):
+                pass
+            logger.info("Rotated request log (%d bytes) -> %s", size, gz_path)
+        except Exception as exc:
+            logger.warning("Log rotation failed: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _read_jsonl(path: Path) -> list[dict]:
+        """Read a JSONL file, skipping malformed lines."""
+        if not path.exists():
+            return []
+        entries: list[dict] = []
+        try:
+            with open(path, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError as exc:
+            logger.warning("Failed to read %s: %s", path, exc)
+        return entries
+
+    @staticmethod
+    def _read_jsonl_gz(path: Path) -> list[dict]:
+        """Read a gzipped JSONL file, skipping malformed lines."""
+        entries: list[dict] = []
+        try:
+            with gzip.open(path, "rt", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except (OSError, gzip.BadGzipFile) as exc:
+            logger.warning("Failed to read %s: %s", path, exc)
+        return entries

--- a/src/llm_rosetta/gateway/admin/request_log.py
+++ b/src/llm_rosetta/gateway/admin/request_log.py
@@ -74,10 +74,12 @@ class RequestLog:
     def __init__(self, max_entries: int = 500) -> None:
         self._entries: deque[RequestLogEntry] = deque(maxlen=max_entries)
         self._max_entries = max_entries
+        self._pending: list[RequestLogEntry] = []
 
     def add(self, entry: RequestLogEntry) -> None:
         """Append *entry* to the log (oldest entry evicted if full)."""
         self._entries.append(entry)
+        self._pending.append(entry)
 
     def get_entries(
         self,
@@ -123,6 +125,25 @@ class RequestLog:
             if e.id == entry_id:
                 return e.to_dict()
         return None
+
+    def load_entries(self, entries: list[dict]) -> None:
+        """Bulk-load entries from persistence (oldest first)."""
+        for d in entries:
+            try:
+                entry = RequestLogEntry(**d)
+                self._entries.append(entry)
+            except (TypeError, KeyError):
+                continue  # skip malformed entries
+
+    def pending_entries(self) -> list[dict]:
+        """Return and clear entries added since last call.
+
+        Used by the persistence flush loop to get new entries
+        without re-writing the entire log.
+        """
+        entries = [e.to_dict() for e in self._pending]
+        self._pending.clear()
+        return entries
 
     def clear(self) -> None:
         """Remove all entries."""

--- a/src/llm_rosetta/gateway/admin/request_log.py
+++ b/src/llm_rosetta/gateway/admin/request_log.py
@@ -1,0 +1,132 @@
+"""Ring-buffer request log for the gateway admin panel."""
+
+from __future__ import annotations
+
+import uuid
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+
+@dataclass(frozen=True)
+class RequestLogEntry:
+    """A single logged proxy request."""
+
+    id: str
+    timestamp: str  # ISO 8601
+    model: str
+    source_provider: str
+    target_provider: str
+    is_stream: bool
+    status_code: int
+    duration_ms: float
+    error_detail: str | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        model: str,
+        source_provider: str,
+        target_provider: str,
+        is_stream: bool,
+        status_code: int,
+        duration_ms: float,
+        error_detail: str | None = None,
+    ) -> RequestLogEntry:
+        """Factory with auto-generated id and timestamp."""
+        return cls(
+            id=uuid.uuid4().hex,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            model=model,
+            source_provider=source_provider,
+            target_provider=target_provider,
+            is_stream=is_stream,
+            status_code=status_code,
+            duration_ms=round(duration_ms, 2),
+            error_detail=error_detail,
+        )
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable dict."""
+        d: dict = {
+            "id": self.id,
+            "timestamp": self.timestamp,
+            "model": self.model,
+            "source_provider": self.source_provider,
+            "target_provider": self.target_provider,
+            "is_stream": self.is_stream,
+            "status_code": self.status_code,
+            "duration_ms": self.duration_ms,
+        }
+        if self.error_detail is not None:
+            d["error_detail"] = self.error_detail
+        return d
+
+
+class RequestLog:
+    """Fixed-size ring buffer of recent proxy requests.
+
+    Uses :class:`collections.deque` with *maxlen* to automatically
+    evict the oldest entries when capacity is exceeded.
+    """
+
+    def __init__(self, max_entries: int = 500) -> None:
+        self._entries: deque[RequestLogEntry] = deque(maxlen=max_entries)
+        self._max_entries = max_entries
+
+    def add(self, entry: RequestLogEntry) -> None:
+        """Append *entry* to the log (oldest entry evicted if full)."""
+        self._entries.append(entry)
+
+    def get_entries(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        model: str | None = None,
+        provider: str | None = None,
+        status: str | None = None,
+    ) -> tuple[list[dict], int]:
+        """Return filtered entries (newest-first) and total count.
+
+        Args:
+            limit: Max entries to return.
+            offset: Number of entries to skip.
+            model: Filter by model name.
+            provider: Filter by target provider.
+            status: Filter by status category: ``"ok"`` (2xx/3xx) or
+                ``"error"`` (4xx/5xx).
+
+        Returns:
+            A ``(entries, total)`` tuple where *entries* is a list of
+            dicts and *total* is the filtered count before pagination.
+        """
+        filtered: list[RequestLogEntry] = list(reversed(self._entries))
+
+        if model:
+            filtered = [e for e in filtered if e.model == model]
+        if provider:
+            filtered = [e for e in filtered if e.target_provider == provider]
+        if status == "ok":
+            filtered = [e for e in filtered if e.status_code < 400]
+        elif status == "error":
+            filtered = [e for e in filtered if e.status_code >= 400]
+
+        total = len(filtered)
+        page = filtered[offset : offset + limit]
+        return [e.to_dict() for e in page], total
+
+    def get_entry(self, entry_id: str) -> dict | None:
+        """Return a single entry by id, or ``None``."""
+        for e in self._entries:
+            if e.id == entry_id:
+                return e.to_dict()
+        return None
+
+    def clear(self) -> None:
+        """Remove all entries."""
+        self._entries.clear()
+
+    def __len__(self) -> int:
+        return len(self._entries)

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -143,6 +143,13 @@ async def put_provider(request: Request) -> Response:
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
+    # If the submitted api_key is a masked value (contains ***), preserve the
+    # original key from the config file to prevent accidental overwrite.
+    existing_providers = data.get("providers", {})
+    resolve_name = body.get("rename_from", name) or name
+    if "***" in api_key and resolve_name in existing_providers:
+        api_key = existing_providers[resolve_name].get("api_key", api_key)
+
     provider_entry: dict[str, Any] = {"api_key": api_key, "base_url": base_url}
 
     # Include API standard type if provided
@@ -155,6 +162,31 @@ async def put_provider(request: Request) -> Response:
         proxy = body["proxy"]
         if proxy:
             provider_entry["proxy"] = proxy
+
+    # Handle rename: remove old entry and update model references
+    rename_from = body.get("rename_from")
+    if rename_from and rename_from != name:
+        providers = data.get("providers", {})
+        if rename_from not in providers:
+            return JSONResponse(
+                {"error": f"Original provider '{rename_from}' not found"},
+                status_code=404,
+            )
+        if name in providers:
+            return JSONResponse(
+                {"error": f"Provider '{name}' already exists"},
+                status_code=409,
+            )
+        del providers[rename_from]
+        # Update all model references from old name to new name
+        models = data.get("models", {})
+        for model_name, model_val in models.items():
+            if isinstance(model_val, str) and model_val == rename_from:
+                models[model_name] = name
+            elif (
+                isinstance(model_val, dict) and model_val.get("provider") == rename_from
+            ):
+                model_val["provider"] = name
 
     data.setdefault("providers", {})[name] = provider_entry
 
@@ -468,6 +500,26 @@ async def clear_requests(request: Request) -> Response:
     return JSONResponse({"ok": True})
 
 
+async def get_provider_key(request: Request) -> Response:
+    """Return the raw (unmasked) API key for a single provider."""
+    config_path = _get_config_path(request)
+    if not config_path:
+        return JSONResponse({"error": "No config file path available"}, status_code=500)
+
+    name = request.path_params["name"]
+
+    try:
+        data = load_config_raw(config_path)
+    except Exception as exc:
+        return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
+
+    provider = data.get("providers", {}).get(name)
+    if not provider:
+        return JSONResponse({"error": f"Provider '{name}' not found"}, status_code=404)
+
+    return JSONResponse({"api_key": provider.get("api_key", "")})
+
+
 # ---------------------------------------------------------------------------
 # Route table
 # ---------------------------------------------------------------------------
@@ -487,6 +539,11 @@ admin_routes: list[Route] = [
         "/admin/api/config/providers/{name}",
         delete_provider,
         methods=["DELETE"],
+    ),
+    Route(
+        "/admin/api/config/providers/{name}/key",
+        get_provider_key,
+        methods=["GET"],
     ),
     Route(
         "/admin/api/config/models/{name:path}",

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -89,11 +89,23 @@ async def get_config(request: Request) -> Response:
             masked["api_key"] = _mask_api_key(masked["api_key"])
         masked_providers[name] = masked
 
+    # Normalize models to dict format for consistent admin UI
+    raw_models = raw.get("models", {})
+    models_normalized: dict[str, Any] = {}
+    for name, value in raw_models.items():
+        if isinstance(value, str):
+            models_normalized[name] = {"provider": value, "capabilities": ["text"]}
+        elif isinstance(value, dict):
+            models_normalized[name] = {
+                "provider": value.get("provider", ""),
+                "capabilities": value.get("capabilities", ["text"]),
+            }
+
     return JSONResponse(
         {
             "config_path": config_path,
             "providers": masked_providers,
-            "models": raw.get("models", {}),
+            "models": models_normalized,
             "server": raw.get("server", {}),
             "known_provider_types": known_provider_types(),
         }
@@ -250,7 +262,11 @@ async def put_model(request: Request) -> Response:
             {"error": f"Provider '{provider}' not found in config"}, status_code=400
         )
 
-    data.setdefault("models", {})[name] = provider
+    capabilities = body.get("capabilities", ["text"])
+    data.setdefault("models", {})[name] = {
+        "provider": provider,
+        "capabilities": capabilities,
+    }
 
     try:
         write_config(config_path, data)
@@ -276,6 +292,7 @@ async def put_model(request: Request) -> Response:
             "ok": True,
             "model": name,
             "provider": provider,
+            "capabilities": capabilities,
             "models": dict(new_config.models),
         }
     )

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -61,7 +61,10 @@ async def serve_admin_html(request: Request) -> Response:
     global _admin_html
     if _admin_html is None:
         _admin_html = load_admin_html()
-    return HTMLResponse(_admin_html)
+    return HTMLResponse(
+        _admin_html,
+        headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -80,13 +80,16 @@ async def get_config(request: Request) -> Response:
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
-    # Mask API keys in the response
+    # Mask API keys and ensure each provider has a "type" field
     providers = raw.get("providers", {})
     masked_providers: dict[str, Any] = {}
     for name, cfg in providers.items():
         masked = dict(cfg)
         if "api_key" in masked:
             masked["api_key"] = _mask_api_key(masked["api_key"])
+        # Ensure explicit type — fall back to provider name for legacy configs
+        if "type" not in masked:
+            masked["type"] = name
         masked_providers[name] = masked
 
     # Normalize models to dict format for consistent admin UI
@@ -138,6 +141,11 @@ async def put_provider(request: Request) -> Response:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
     provider_entry: dict[str, Any] = {"api_key": api_key, "base_url": base_url}
+
+    # Include API standard type if provided
+    provider_type = body.get("type")
+    if provider_type:
+        provider_entry["type"] = provider_type
 
     # Include proxy if provided, empty string removes it
     if "proxy" in body:
@@ -194,7 +202,11 @@ async def delete_provider(request: Request) -> Response:
 
     # Check if any model still references this provider
     models = data.get("models", {})
-    referencing = [m for m, p in models.items() if p == name]
+    referencing = [
+        m
+        for m, p in models.items()
+        if (p["provider"] if isinstance(p, dict) else p) == name
+    ]
     if referencing:
         return JSONResponse(
             {

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -1,0 +1,476 @@
+"""Starlette route handlers for the admin panel API."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse, Response
+from starlette.routing import Route
+
+from ..config import GatewayConfig, load_config, load_config_raw, write_config
+from ..providers import known_provider_types
+from .static import load_admin_html
+
+# Cached HTML — loaded once on first request.
+_admin_html: str | None = None
+
+_ENV_VAR_RE = re.compile(r"^\$\{.+\}$")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mask_api_key(value: str) -> str:
+    """Mask a literal API key, leaving env-var placeholders intact."""
+    if _ENV_VAR_RE.match(value):
+        return value
+    if len(value) <= 8:
+        return "***"
+    return value[:4] + "***" + value[-4:]
+
+
+def _get_config_path(request: Request) -> str | None:
+    return getattr(request.app.state, "config_path", None)
+
+
+def _reload_gateway_config(request: Request, config_path: str) -> GatewayConfig:
+    """Re-read config from disk, rebuild GatewayConfig, swap into app state.
+
+    The import of ``app._config`` is deferred to avoid circular imports.
+    """
+    import llm_rosetta.gateway.app as _app_mod
+
+    raw = load_config(config_path)
+    new_config = GatewayConfig(raw)
+    _app_mod._config = new_config
+    request.app.state.gateway_config = new_config
+    return new_config
+
+
+# ---------------------------------------------------------------------------
+# HTML handler
+# ---------------------------------------------------------------------------
+
+
+async def serve_admin_html(request: Request) -> Response:
+    """Serve the admin panel SPA."""
+    global _admin_html
+    if _admin_html is None:
+        _admin_html = load_admin_html()
+    return HTMLResponse(_admin_html)
+
+
+# ---------------------------------------------------------------------------
+# Config API
+# ---------------------------------------------------------------------------
+
+
+async def get_config(request: Request) -> Response:
+    """Return the current (raw) gateway configuration."""
+    config_path = _get_config_path(request)
+    if not config_path:
+        return JSONResponse({"error": "No config file path available"}, status_code=500)
+
+    try:
+        raw = load_config_raw(config_path)
+    except Exception as exc:
+        return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
+
+    # Mask API keys in the response
+    providers = raw.get("providers", {})
+    masked_providers: dict[str, Any] = {}
+    for name, cfg in providers.items():
+        masked = dict(cfg)
+        if "api_key" in masked:
+            masked["api_key"] = _mask_api_key(masked["api_key"])
+        masked_providers[name] = masked
+
+    return JSONResponse(
+        {
+            "config_path": config_path,
+            "providers": masked_providers,
+            "models": raw.get("models", {}),
+            "server": raw.get("server", {}),
+            "known_provider_types": known_provider_types(),
+        }
+    )
+
+
+async def put_provider(request: Request) -> Response:
+    """Add or update a provider entry."""
+    config_path = _get_config_path(request)
+    if not config_path:
+        return JSONResponse({"error": "No config file path available"}, status_code=500)
+
+    name = request.path_params["name"]
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    api_key = body.get("api_key")
+    base_url = body.get("base_url")
+    if not api_key or not base_url:
+        return JSONResponse(
+            {"error": "Both 'api_key' and 'base_url' are required"}, status_code=400
+        )
+
+    try:
+        data = load_config_raw(config_path)
+    except Exception as exc:
+        return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
+
+    provider_entry: dict[str, Any] = {"api_key": api_key, "base_url": base_url}
+
+    # Include proxy if provided, empty string removes it
+    if "proxy" in body:
+        proxy = body["proxy"]
+        if proxy:
+            provider_entry["proxy"] = proxy
+
+    data.setdefault("providers", {})[name] = provider_entry
+
+    try:
+        write_config(config_path, data)
+    except Exception as exc:
+        return JSONResponse(
+            {"error": f"Failed to write config: {exc}"}, status_code=500
+        )
+
+    try:
+        new_config = _reload_gateway_config(request, config_path)
+    except Exception as exc:
+        return JSONResponse(
+            {
+                "error": f"Config saved but reload failed: {exc}",
+                "saved": True,
+                "reloaded": False,
+            },
+            status_code=500,
+        )
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "provider": name,
+            "providers": list(new_config.providers.keys()),
+        }
+    )
+
+
+async def delete_provider(request: Request) -> Response:
+    """Remove a provider entry."""
+    config_path = _get_config_path(request)
+    if not config_path:
+        return JSONResponse({"error": "No config file path available"}, status_code=500)
+
+    name = request.path_params["name"]
+
+    try:
+        data = load_config_raw(config_path)
+    except Exception as exc:
+        return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
+
+    providers = data.get("providers", {})
+    if name not in providers:
+        return JSONResponse({"error": f"Provider '{name}' not found"}, status_code=404)
+
+    # Check if any model still references this provider
+    models = data.get("models", {})
+    referencing = [m for m, p in models.items() if p == name]
+    if referencing:
+        return JSONResponse(
+            {
+                "error": f"Cannot delete provider '{name}': referenced by models: {referencing}"
+            },
+            status_code=409,
+        )
+
+    del providers[name]
+
+    try:
+        write_config(config_path, data)
+    except Exception as exc:
+        return JSONResponse(
+            {"error": f"Failed to write config: {exc}"}, status_code=500
+        )
+
+    try:
+        new_config = _reload_gateway_config(request, config_path)
+    except Exception as exc:
+        return JSONResponse(
+            {
+                "error": f"Config saved but reload failed: {exc}",
+                "saved": True,
+                "reloaded": False,
+            },
+            status_code=500,
+        )
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "deleted": name,
+            "providers": list(new_config.providers.keys()),
+        }
+    )
+
+
+async def put_model(request: Request) -> Response:
+    """Add or update a model routing entry."""
+    config_path = _get_config_path(request)
+    if not config_path:
+        return JSONResponse({"error": "No config file path available"}, status_code=500)
+
+    name = request.path_params["name"]
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    provider = body.get("provider")
+    if not provider:
+        return JSONResponse({"error": "'provider' is required"}, status_code=400)
+
+    try:
+        data = load_config_raw(config_path)
+    except Exception as exc:
+        return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
+
+    # Validate that the provider exists
+    providers = data.get("providers", {})
+    if provider not in providers:
+        return JSONResponse(
+            {"error": f"Provider '{provider}' not found in config"}, status_code=400
+        )
+
+    data.setdefault("models", {})[name] = provider
+
+    try:
+        write_config(config_path, data)
+    except Exception as exc:
+        return JSONResponse(
+            {"error": f"Failed to write config: {exc}"}, status_code=500
+        )
+
+    try:
+        new_config = _reload_gateway_config(request, config_path)
+    except Exception as exc:
+        return JSONResponse(
+            {
+                "error": f"Config saved but reload failed: {exc}",
+                "saved": True,
+                "reloaded": False,
+            },
+            status_code=500,
+        )
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "model": name,
+            "provider": provider,
+            "models": dict(new_config.models),
+        }
+    )
+
+
+async def delete_model(request: Request) -> Response:
+    """Remove a model routing entry."""
+    config_path = _get_config_path(request)
+    if not config_path:
+        return JSONResponse({"error": "No config file path available"}, status_code=500)
+
+    name = request.path_params["name"]
+
+    try:
+        data = load_config_raw(config_path)
+    except Exception as exc:
+        return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
+
+    models = data.get("models", {})
+    if name not in models:
+        return JSONResponse({"error": f"Model '{name}' not found"}, status_code=404)
+
+    del models[name]
+
+    try:
+        write_config(config_path, data)
+    except Exception as exc:
+        return JSONResponse(
+            {"error": f"Failed to write config: {exc}"}, status_code=500
+        )
+
+    try:
+        new_config = _reload_gateway_config(request, config_path)
+    except Exception as exc:
+        return JSONResponse(
+            {
+                "error": f"Config saved but reload failed: {exc}",
+                "saved": True,
+                "reloaded": False,
+            },
+            status_code=500,
+        )
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "deleted": name,
+            "models": dict(new_config.models),
+        }
+    )
+
+
+async def put_server_settings(request: Request) -> Response:
+    """Update server settings (e.g. global proxy)."""
+    config_path = _get_config_path(request)
+    if not config_path:
+        return JSONResponse({"error": "No config file path available"}, status_code=500)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    try:
+        data = load_config_raw(config_path)
+    except Exception as exc:
+        return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
+
+    server = data.setdefault("server", {})
+
+    # Update proxy — empty string removes it
+    if "proxy" in body:
+        proxy = body["proxy"]
+        if proxy:
+            server["proxy"] = proxy
+        else:
+            server.pop("proxy", None)
+
+    try:
+        write_config(config_path, data)
+    except Exception as exc:
+        return JSONResponse(
+            {"error": f"Failed to write config: {exc}"}, status_code=500
+        )
+
+    try:
+        _reload_gateway_config(request, config_path)
+    except Exception as exc:
+        return JSONResponse(
+            {
+                "error": f"Config saved but reload failed: {exc}",
+                "saved": True,
+                "reloaded": False,
+            },
+            status_code=500,
+        )
+
+    return JSONResponse({"ok": True, "server": data.get("server", {})})
+
+
+async def reload_config(request: Request) -> Response:
+    """Force hot-reload of the config from disk."""
+    config_path = _get_config_path(request)
+    if not config_path:
+        return JSONResponse({"error": "No config file path available"}, status_code=500)
+
+    try:
+        new_config = _reload_gateway_config(request, config_path)
+    except Exception as exc:
+        return JSONResponse({"error": f"Reload failed: {exc}"}, status_code=500)
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "providers": list(new_config.providers.keys()),
+            "models": dict(new_config.models),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Metrics API
+# ---------------------------------------------------------------------------
+
+
+async def get_metrics(request: Request) -> Response:
+    """Return a full metrics snapshot."""
+    metrics = request.app.state.metrics
+    seconds = int(request.query_params.get("seconds", "60"))
+    seconds = max(1, min(seconds, 300))
+    return JSONResponse(metrics.snapshot(series_seconds=seconds))
+
+
+# ---------------------------------------------------------------------------
+# Request log API
+# ---------------------------------------------------------------------------
+
+
+async def get_requests(request: Request) -> Response:
+    """Return paginated, filtered request log entries."""
+    log = request.app.state.request_log
+    limit = int(request.query_params.get("limit", "50"))
+    offset = int(request.query_params.get("offset", "0"))
+    model = request.query_params.get("model")
+    provider = request.query_params.get("provider")
+    status = request.query_params.get("status")
+
+    entries, total = log.get_entries(
+        limit=limit, offset=offset, model=model, provider=provider, status=status
+    )
+    return JSONResponse({"entries": entries, "total": total})
+
+
+async def clear_requests(request: Request) -> Response:
+    """Clear the request log."""
+    log = request.app.state.request_log
+    log.clear()
+    return JSONResponse({"ok": True})
+
+
+# ---------------------------------------------------------------------------
+# Route table
+# ---------------------------------------------------------------------------
+
+admin_routes: list[Route] = [
+    # HTML
+    Route("/admin", serve_admin_html, methods=["GET"]),
+    Route("/admin/", serve_admin_html, methods=["GET"]),
+    # Config CRUD
+    Route("/admin/api/config", get_config, methods=["GET"]),
+    Route(
+        "/admin/api/config/providers/{name}",
+        put_provider,
+        methods=["PUT"],
+    ),
+    Route(
+        "/admin/api/config/providers/{name}",
+        delete_provider,
+        methods=["DELETE"],
+    ),
+    Route(
+        "/admin/api/config/models/{name:path}",
+        put_model,
+        methods=["PUT"],
+    ),
+    Route(
+        "/admin/api/config/models/{name:path}",
+        delete_model,
+        methods=["DELETE"],
+    ),
+    Route("/admin/api/config/server", put_server_settings, methods=["PUT"]),
+    Route("/admin/api/config/reload", reload_config, methods=["POST"]),
+    # Metrics
+    Route("/admin/api/metrics", get_metrics, methods=["GET"]),
+    # Request log
+    Route("/admin/api/requests", get_requests, methods=["GET"]),
+    Route("/admin/api/requests", clear_requests, methods=["DELETE"]),
+]

--- a/src/llm_rosetta/gateway/admin/static.py
+++ b/src/llm_rosetta/gateway/admin/static.py
@@ -8,5 +8,7 @@ import importlib.resources
 def load_admin_html() -> str:
     """Return the contents of ``admin.html`` bundled with this package."""
     return (
-        importlib.resources.files(__package__).joinpath("admin.html").read_text("utf-8")
+        importlib.resources.files(__package__ or __name__)
+        .joinpath("admin.html")
+        .read_text("utf-8")
     )

--- a/src/llm_rosetta/gateway/admin/static.py
+++ b/src/llm_rosetta/gateway/admin/static.py
@@ -1,0 +1,12 @@
+"""Load the admin panel HTML from package resources."""
+
+from __future__ import annotations
+
+import importlib.resources
+
+
+def load_admin_html() -> str:
+    """Return the contents of ``admin.html`` bundled with this package."""
+    return (
+        importlib.resources.files(__package__).joinpath("admin.html").read_text("utf-8")
+    )

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
@@ -251,6 +252,70 @@ async def handle_health(request: Request) -> Response:
 
 
 # ---------------------------------------------------------------------------
+# Persistence flush helpers
+# ---------------------------------------------------------------------------
+
+_FLUSH_LOG_INTERVAL = 10  # seconds
+_FLUSH_METRICS_INTERVAL = 30  # seconds
+
+
+async def _periodic_flush(app: Starlette) -> None:
+    """Periodically flush request log and metrics to disk."""
+    ticks = 0
+    while True:
+        await asyncio.sleep(_FLUSH_LOG_INTERVAL)
+        ticks += _FLUSH_LOG_INTERVAL
+        persistence = getattr(app.state, "persistence", None)
+        if persistence is None:
+            continue
+
+        # Flush pending request log entries every tick
+        request_log = getattr(app.state, "request_log", None)
+        if request_log is not None:
+            entries = request_log.pending_entries()
+            if entries:
+                try:
+                    persistence.append_log_entries(entries)
+                except Exception as exc:
+                    logger.warning("Failed to flush request log: %s", exc)
+
+        # Flush metrics counters less frequently
+        if ticks >= _FLUSH_METRICS_INTERVAL:
+            ticks = 0
+            metrics = getattr(app.state, "metrics", None)
+            if metrics is not None:
+                try:
+                    persistence.save_metrics(metrics.export_counters())
+                except Exception as exc:
+                    logger.warning("Failed to flush metrics: %s", exc)
+
+
+def _flush_now(app: Starlette) -> None:
+    """Final synchronous flush on shutdown."""
+    persistence = getattr(app.state, "persistence", None)
+    if persistence is None:
+        return
+
+    request_log = getattr(app.state, "request_log", None)
+    if request_log is not None:
+        entries = request_log.pending_entries()
+        if entries:
+            try:
+                persistence.append_log_entries(entries)
+            except Exception as exc:
+                logger.warning("Shutdown: failed to flush request log: %s", exc)
+
+    metrics = getattr(app.state, "metrics", None)
+    if metrics is not None:
+        try:
+            persistence.save_metrics(metrics.export_counters())
+        except Exception as exc:
+            logger.warning("Shutdown: failed to flush metrics: %s", exc)
+
+    logger.info("Persistence flushed on shutdown")
+
+
+# ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
 
@@ -278,7 +343,14 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> Starlet
 
     @asynccontextmanager
     async def lifespan(app: Starlette) -> AsyncGenerator[None, None]:
+        flush_task = asyncio.create_task(_periodic_flush(app))
         yield
+        flush_task.cancel()
+        try:
+            await flush_task
+        except asyncio.CancelledError:
+            pass
+        _flush_now(app)
         await close_resources(metadata_store=metadata_store)
 
     middleware = [

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -141,7 +141,7 @@ async def _proxy_handler(
                 duration_ms=duration_ms,
                 is_stream=is_stream,
             )
-        if request_log:
+        if request_log is not None:
             from .admin.request_log import RequestLogEntry
 
             request_log.add(

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -92,26 +93,68 @@ async def _proxy_handler(
     if or_version:
         extra_headers = {"OpenResponses-Version": or_version}
 
-    if is_stream:
-        return await handle_streaming(
-            source_provider,
-            target_provider,
-            provider_info,
-            body,
-            model,
-            metadata_store=store,
-            extra_headers=extra_headers,
-        )
-    else:
-        return await handle_non_streaming(
-            source_provider,
-            target_provider,
-            provider_info,
-            body,
-            model,
-            metadata_store=store,
-            extra_headers=extra_headers,
-        )
+    # --- Metrics instrumentation ---
+    metrics = getattr(request.app.state, "metrics", None)
+    request_log = getattr(request.app.state, "request_log", None)
+    t0 = time.monotonic()
+    status_code = 500
+    error_detail: str | None = None
+
+    try:
+        if is_stream:
+            if metrics:
+                metrics.active_streams += 1
+            response = await handle_streaming(
+                source_provider,
+                target_provider,
+                provider_info,
+                body,
+                model,
+                metadata_store=store,
+                extra_headers=extra_headers,
+            )
+        else:
+            response = await handle_non_streaming(
+                source_provider,
+                target_provider,
+                provider_info,
+                body,
+                model,
+                metadata_store=store,
+                extra_headers=extra_headers,
+            )
+        status_code = response.status_code
+        return response
+    except Exception as exc:
+        error_detail = str(exc)
+        raise
+    finally:
+        duration_ms = (time.monotonic() - t0) * 1000
+        if is_stream and metrics:
+            metrics.active_streams -= 1
+        if metrics:
+            metrics.record_request(
+                model=model,
+                source=source_provider,
+                target=target_provider,
+                status_code=status_code,
+                duration_ms=duration_ms,
+                is_stream=is_stream,
+            )
+        if request_log:
+            from .admin.request_log import RequestLogEntry
+
+            request_log.add(
+                RequestLogEntry.create(
+                    model=model,
+                    source_provider=source_provider,
+                    target_provider=target_provider,
+                    is_stream=is_stream,
+                    status_code=status_code,
+                    duration_ms=duration_ms,
+                    error_detail=error_detail,
+                )
+            )
 
 
 # --- Endpoint handlers ---
@@ -212,7 +255,7 @@ async def handle_health(request: Request) -> Response:
 # ---------------------------------------------------------------------------
 
 
-def create_app(config: GatewayConfig) -> Starlette:
+def create_app(config: GatewayConfig, config_path: str | None = None) -> Starlette:
     """Create the Starlette ASGI application."""
     global _config
     _config = config
@@ -247,6 +290,16 @@ def create_app(config: GatewayConfig) -> Starlette:
         ),
     ]
 
+    # Append admin panel routes before constructing the app so that
+    # Starlette's Router compiles them into its lookup structures.
+    from .admin import setup_admin
+    from .admin.routes import admin_routes
+
+    routes.extend(admin_routes)
+
     app = Starlette(routes=routes, lifespan=lifespan, middleware=middleware)
     app.state.metadata_store = metadata_store
+
+    setup_admin(app, config, config_path)
+
     return app

--- a/src/llm_rosetta/gateway/cli.py
+++ b/src/llm_rosetta/gateway/cli.py
@@ -21,6 +21,7 @@ from .config import (
     discover_config,
     load_config,
     load_config_raw,
+    write_config,
 )
 from .logging import get_logger, setup_logging
 from .providers import (
@@ -88,10 +89,7 @@ def _load_or_create_config(path: str) -> tuple[dict[str, Any], str]:
 
 
 def _write_jsonc(path: str, data: dict[str, Any]) -> None:
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
-        f.write("\n")
+    write_config(path, data)
 
 
 # ---------------------------------------------------------------------------
@@ -348,7 +346,7 @@ def main() -> None:
     if config.log_bodies:
         logger.info("Request/response body logging enabled")
 
-    app = create_app(config)
+    app = create_app(config, config_path=config_path)
     uvicorn.run(
         app,
         host=host,

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -120,6 +120,14 @@ class GatewayConfig:
     def __init__(self, raw: dict[str, Any]) -> None:
         self._raw_providers: dict[str, dict[str, str]] = raw.get("providers", {})
 
+        # Map provider name → API standard type.
+        # If the provider config has a "type" field, use it; otherwise the
+        # provider name itself is treated as the type (backward compatible).
+        self.provider_types: dict[str, ProviderType] = {
+            name: cfg.get("type", name)
+            for name, cfg in self._raw_providers.items()
+        }
+
         # Parse models — supports both string and dict formats:
         #   "model": "provider"                     (legacy)
         #   "model": {"provider": "p", "capabilities": ["text", "vision"]}
@@ -155,7 +163,9 @@ class GatewayConfig:
 
         # Build ProviderInfo objects (with key rotation support)
         self.providers: dict[str, ProviderInfo] = {
-            name: build_provider_info(name, cfg, global_proxy=self.proxy)
+            name: build_provider_info(
+                self.provider_types[name], cfg, global_proxy=self.proxy
+            )
             for name, cfg in self._raw_providers.items()
         }
 
@@ -173,7 +183,11 @@ class GatewayConfig:
     def resolve_model(self, model: str) -> tuple[ProviderType, ProviderInfo]:
         """Return (provider_type, provider_info) for a model name.
 
+        ``provider_type`` is the API standard (e.g. ``"openai_chat"``),
+        resolved from the provider's ``type`` field or its name as fallback.
+
         Raises KeyError if the model is not in the routing table.
         """
-        provider_type = self.models[model]
-        return provider_type, self.providers[provider_type]
+        provider_name = self.models[model]
+        provider_type = self.provider_types[provider_name]
+        return provider_type, self.providers[provider_name]

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -114,9 +114,30 @@ def discover_config(explicit_path: str | None = None) -> str | None:
 class GatewayConfig:
     """Parsed and validated gateway configuration."""
 
+    # Default capabilities when not specified in config.
+    DEFAULT_CAPABILITIES: list[str] = ["text"]
+
     def __init__(self, raw: dict[str, Any]) -> None:
         self._raw_providers: dict[str, dict[str, str]] = raw.get("providers", {})
-        self.models: dict[str, ProviderType] = raw.get("models", {})
+
+        # Parse models — supports both string and dict formats:
+        #   "model": "provider"                     (legacy)
+        #   "model": {"provider": "p", "capabilities": ["text", "vision"]}
+        raw_models = raw.get("models", {})
+        self.models: dict[str, ProviderType] = {}
+        self.model_capabilities: dict[str, list[str]] = {}
+        for name, value in raw_models.items():
+            if isinstance(value, str):
+                self.models[name] = value
+                self.model_capabilities[name] = list(self.DEFAULT_CAPABILITIES)
+            elif isinstance(value, dict):
+                self.models[name] = value["provider"]
+                self.model_capabilities[name] = value.get(
+                    "capabilities", list(self.DEFAULT_CAPABILITIES)
+                )
+            else:
+                raise ValueError(f"config: invalid model entry for '{name}'")
+
         self.host: str = raw.get("server", {}).get("host", "0.0.0.0")
         self.port: int = raw.get("server", {}).get("port", 8765)
         self.proxy: str | None = raw.get("server", {}).get("proxy")

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -68,6 +68,18 @@ def load_config(path: str) -> dict[str, Any]:
     return json.loads(substituted)
 
 
+def write_config(path: str, data: dict[str, Any]) -> None:
+    """Write a config dict as formatted JSON to *path*.
+
+    Creates parent directories if needed.  Comments in the original
+    JSONC file (if any) are **not** preserved.
+    """
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
 def load_config_raw(path: str) -> dict[str, Any]:
     """Load and parse a JSONC config file *without* env-var substitution.
 

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -124,8 +124,7 @@ class GatewayConfig:
         # If the provider config has a "type" field, use it; otherwise the
         # provider name itself is treated as the type (backward compatible).
         self.provider_types: dict[str, ProviderType] = {
-            name: cfg.get("type", name)
-            for name, cfg in self._raw_providers.items()
+            name: cfg.get("type", name) for name, cfg in self._raw_providers.items()
         }
 
         # Parse models — supports both string and dict formats:

--- a/tests/gateway/test_admin_metrics.py
+++ b/tests/gateway/test_admin_metrics.py
@@ -1,0 +1,107 @@
+"""Tests for the admin panel MetricsCollector."""
+
+from llm_rosetta.gateway.admin.metrics import MetricsCollector, _RollingWindow
+
+
+class TestRollingWindow:
+    def test_record_and_get_series(self):
+        w = _RollingWindow(window_seconds=300)
+        w.record(100.0, is_error=False)
+        w.record(200.0, is_error=True)
+        series = w.get_series(seconds=5)
+        assert len(series) == 5
+        # The last bucket should have our data
+        last = series[-1]
+        assert last["count"] == 2
+        assert last["errors"] == 1
+        assert last["avg_ms"] == 150.0
+
+    def test_empty_series(self):
+        w = _RollingWindow()
+        series = w.get_series(seconds=10)
+        assert len(series) == 10
+        assert all(s["count"] == 0 for s in series)
+
+
+class TestMetricsCollector:
+    def test_record_request(self):
+        m = MetricsCollector()
+        m.record_request(
+            model="gpt-4o",
+            source="openai_chat",
+            target="anthropic",
+            status_code=200,
+            duration_ms=150.0,
+            is_stream=False,
+        )
+        assert m.total_requests == 1
+        assert m.total_errors == 0
+        assert m.total_streams == 0
+        assert m.by_model["gpt-4o"] == 1
+        assert m.by_source_provider["openai_chat"] == 1
+        assert m.by_target_provider["anthropic"] == 1
+        assert m.by_status_code[200] == 1
+
+    def test_record_error(self):
+        m = MetricsCollector()
+        m.record_request(
+            model="gpt-4o",
+            source="openai_chat",
+            target="anthropic",
+            status_code=500,
+            duration_ms=50.0,
+            is_stream=True,
+        )
+        assert m.total_requests == 1
+        assert m.total_errors == 1
+        assert m.total_streams == 1
+
+    def test_snapshot(self):
+        m = MetricsCollector()
+        m.record_request(
+            model="gpt-4o",
+            source="openai_chat",
+            target="anthropic",
+            status_code=200,
+            duration_ms=100.0,
+            is_stream=False,
+        )
+        snap = m.snapshot(series_seconds=5)
+        assert snap["total_requests"] == 1
+        assert snap["error_rate"] == 0
+        assert "series" in snap
+        assert len(snap["series"]) == 5
+        assert snap["uptime_seconds"] >= 0
+        assert snap["by_model"] == {"gpt-4o": 1}
+
+    def test_active_streams_gauge(self):
+        m = MetricsCollector()
+        m.active_streams += 1
+        assert m.active_streams == 1
+        m.active_streams -= 1
+        assert m.active_streams == 0
+
+    def test_multiple_models(self):
+        m = MetricsCollector()
+        for _ in range(3):
+            m.record_request(
+                model="gpt-4o",
+                source="openai_chat",
+                target="openai_chat",
+                status_code=200,
+                duration_ms=10.0,
+                is_stream=False,
+            )
+        for _ in range(2):
+            m.record_request(
+                model="claude",
+                source="anthropic",
+                target="anthropic",
+                status_code=200,
+                duration_ms=20.0,
+                is_stream=True,
+            )
+        assert m.total_requests == 5
+        assert m.by_model["gpt-4o"] == 3
+        assert m.by_model["claude"] == 2
+        assert m.total_streams == 2

--- a/tests/gateway/test_admin_request_log.py
+++ b/tests/gateway/test_admin_request_log.py
@@ -1,0 +1,139 @@
+"""Tests for the admin panel RequestLog."""
+
+from llm_rosetta.gateway.admin.request_log import RequestLog, RequestLogEntry
+
+
+class TestRequestLogEntry:
+    def test_create(self):
+        e = RequestLogEntry.create(
+            model="gpt-4o",
+            source_provider="openai_chat",
+            target_provider="anthropic",
+            is_stream=False,
+            status_code=200,
+            duration_ms=123.456,
+        )
+        assert e.model == "gpt-4o"
+        assert e.duration_ms == 123.46  # rounded
+        assert e.id  # non-empty uuid
+        assert e.timestamp  # non-empty ISO timestamp
+        assert e.error_detail is None
+
+    def test_to_dict(self):
+        e = RequestLogEntry.create(
+            model="gpt-4o",
+            source_provider="openai_chat",
+            target_provider="anthropic",
+            is_stream=True,
+            status_code=500,
+            duration_ms=50.0,
+            error_detail="connection refused",
+        )
+        d = e.to_dict()
+        assert d["model"] == "gpt-4o"
+        assert d["is_stream"] is True
+        assert d["status_code"] == 500
+        assert d["error_detail"] == "connection refused"
+
+
+class TestRequestLog:
+    def _make_entry(self, model="gpt-4o", status=200, provider="openai_chat"):
+        return RequestLogEntry.create(
+            model=model,
+            source_provider="openai_chat",
+            target_provider=provider,
+            is_stream=False,
+            status_code=status,
+            duration_ms=10.0,
+        )
+
+    def test_add_and_get(self):
+        log = RequestLog(max_entries=100)
+        log.add(self._make_entry())
+        entries, total = log.get_entries()
+        assert total == 1
+        assert len(entries) == 1
+
+    def test_max_entries_eviction(self):
+        log = RequestLog(max_entries=3)
+        for i in range(5):
+            log.add(self._make_entry(model=f"model-{i}"))
+        assert len(log) == 3
+        entries, total = log.get_entries(limit=10)
+        assert total == 3
+        # Should have models 2, 3, 4 (oldest evicted)
+        models = [e["model"] for e in entries]
+        assert "model-0" not in models
+        assert "model-1" not in models
+        assert "model-4" in models
+
+    def test_filter_by_model(self):
+        log = RequestLog()
+        log.add(self._make_entry(model="gpt-4o"))
+        log.add(self._make_entry(model="claude"))
+        log.add(self._make_entry(model="gpt-4o"))
+        entries, total = log.get_entries(model="gpt-4o")
+        assert total == 2
+        assert all(e["model"] == "gpt-4o" for e in entries)
+
+    def test_filter_by_provider(self):
+        log = RequestLog()
+        log.add(self._make_entry(provider="openai_chat"))
+        log.add(self._make_entry(provider="anthropic"))
+        entries, total = log.get_entries(provider="anthropic")
+        assert total == 1
+        assert entries[0]["target_provider"] == "anthropic"
+
+    def test_filter_by_status(self):
+        log = RequestLog()
+        log.add(self._make_entry(status=200))
+        log.add(self._make_entry(status=500))
+        log.add(self._make_entry(status=404))
+
+        ok_entries, ok_total = log.get_entries(status="ok")
+        assert ok_total == 1
+
+        err_entries, err_total = log.get_entries(status="error")
+        assert err_total == 2
+
+    def test_pagination(self):
+        log = RequestLog()
+        for i in range(10):
+            log.add(self._make_entry(model=f"m-{i}"))
+
+        entries, total = log.get_entries(limit=3, offset=0)
+        assert total == 10
+        assert len(entries) == 3
+
+        entries2, _ = log.get_entries(limit=3, offset=3)
+        assert len(entries2) == 3
+        # Different entries
+        assert entries[0]["id"] != entries2[0]["id"]
+
+    def test_newest_first(self):
+        log = RequestLog()
+        log.add(self._make_entry(model="first"))
+        log.add(self._make_entry(model="second"))
+        entries, _ = log.get_entries()
+        assert entries[0]["model"] == "second"
+        assert entries[1]["model"] == "first"
+
+    def test_get_entry_by_id(self):
+        log = RequestLog()
+        e = self._make_entry()
+        log.add(e)
+        found = log.get_entry(e.id)
+        assert found is not None
+        assert found["id"] == e.id
+
+    def test_get_entry_not_found(self):
+        log = RequestLog()
+        assert log.get_entry("nonexistent") is None
+
+    def test_clear(self):
+        log = RequestLog()
+        log.add(self._make_entry())
+        log.add(self._make_entry())
+        assert len(log) == 2
+        log.clear()
+        assert len(log) == 0


### PR DESCRIPTION
## Summary

- Add a single-page admin panel at `/admin/` for the gateway with configuration management, real-time metrics dashboard, and request log viewer
- Support provider CRUD (create, rename, delete) with API key security (masked display, reveal-on-demand in edit modal)
- Support model management with capabilities (text/vision/tools) and provider assignment
- Add 5 themes (Light, Dark, Osaka Jade, One Dark, Rosé Pine) with English/Chinese i18n
- Add file-based persistence for metrics counters (JSON) and request log (JSONL) with size-limited rotation and gzip compression
- Include unit tests for metrics collector and request log

## Details

### Admin Panel (`/admin/`)
- Single HTML file SPA served via Starlette, no external dependencies
- Provider cards with masked API keys, edit modal with key visibility toggle and copy button
- Model table with inline editing for capabilities and provider assignment
- Real-time metrics: request counts, error rates, per-second time series chart
- Request log with filtering by model, provider, and status

### Persistence
- Data stored alongside config file (e.g. `~/.config/llm-rosetta-gateway/data/`)
- Request log: JSONL with 2MB rotation limit and gzip-compressed backups (max 3)
- Metrics: atomic JSON writes via tempfile + `os.replace`
- Periodic flush (log every 10s, metrics every 30s) + shutdown flush
- Pure stdlib (cross-platform): `json`, `gzip`, `os`, `pathlib`

### Infrastructure
- Extract `write_config()` to `config.py` for shared use
- All external resources use jsdelivr/fastly CDN (China mainland accessible)

## Test plan
- [x] Unit tests for MetricsCollector and RequestLog
- [ ] Manual: start gateway, open `/admin/`, verify all tabs render
- [ ] Manual: add/edit/rename/delete providers and models via admin UI
- [ ] Manual: make proxy requests, verify metrics and request log update
- [ ] Manual: restart gateway, verify persisted data survives reboot
- [ ] Manual: generate >2MB of logs, verify rotation creates `.jsonl.gz` backups