### PR TITLE
refactor: reduce cyclomatic complexity, enforce C901 ≤ 15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ select = ["E", "F", "UP", "C901"]
 ignore = ["UP007", "E501"]  # Allow Union[X, Y] syntax; tolerate long lines
 
 [tool.ruff.lint.mccabe]
-max-complexity = 20
+max-complexity = 15
 
 [tool.ruff.lint.per-file-ignores]
 "src/llm_rosetta/_vendor/*" = ["C901"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "python-dotenv",
     "pytest",
     "pytest-cov",
+    "complexipy>=5.2.0",
     "ty>=0.0.21",
     "build>=1.2.2.post1",
     "twine>=6.1.0",
@@ -80,5 +81,16 @@ include = ["src", "tests"]
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "UP"]
+select = ["E", "F", "UP", "C901"]
 ignore = ["UP007", "E501"]  # Allow Union[X, Y] syntax; tolerate long lines
+
+[tool.ruff.lint.mccabe]
+max-complexity = 25
+
+[tool.ruff.lint.per-file-ignores]
+"src/llm_rosetta/_vendor/*" = ["C901"]
+
+[tool.complexipy]
+paths = ["src"]
+max-complexity-allowed = 15
+exclude = ["src/llm_rosetta/_vendor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ select = ["E", "F", "UP", "C901"]
 ignore = ["UP007", "E501"]  # Allow Union[X, Y] syntax; tolerate long lines
 
 [tool.ruff.lint.mccabe]
-max-complexity = 25
+max-complexity = 20
 
 [tool.ruff.lint.per-file-ignores]
 "src/llm_rosetta/_vendor/*" = ["C901"]

--- a/src/llm_rosetta/auto_detect.py
+++ b/src/llm_rosetta/auto_detect.py
@@ -12,140 +12,121 @@ ProviderType = Literal[
 ]
 
 
-def detect_provider(body: dict[str, Any]) -> ProviderType | None:
-    """自动检测 provider 类型
-    Auto-detect provider type
+_RESPONSES_ITEM_TYPES = frozenset(
+    {
+        "message",
+        "function_call",
+        "function_call_output",
+        "mcp_call",
+        "mcp_call_output",
+        "reasoning",
+        "system_event",
+        "input_text",
+        "output_text",
+    }
+)
 
-    基于请求体的结构特征识别 provider 类型。
-    Identify provider type based on request body structure features.
+_ANTHROPIC_CONTENT_TYPES = frozenset(
+    {"image", "tool_use", "tool_result", "thinking", "document"}
+)
+
+
+def _is_google_format(body: dict[str, Any]) -> bool:
+    """Check if body matches Google GenAI format (contents with parts)."""
+    contents = body.get("contents")
+    if not isinstance(contents, list) or len(contents) == 0:
+        return False
+    first = contents[0]
+    return isinstance(first, dict) and "parts" in first
+
+
+def _is_responses_format(body: dict[str, Any]) -> bool:
+    """Check if body matches OpenAI Responses API format (input/output with typed items)."""
+    items = body.get("input") or body.get("output")
+    if not isinstance(items, list) or len(items) == 0:
+        return False
+    first = items[0]
+    return isinstance(first, dict) and first.get("type") in _RESPONSES_ITEM_TYPES
+
+
+def _has_anthropic_content_blocks(content: list[Any]) -> bool:
+    """Check if any content block in a message uses Anthropic-specific types."""
+    for part in content:
+        if isinstance(part, dict) and part.get("type") in _ANTHROPIC_CONTENT_TYPES:
+            return True
+    return False
+
+
+def _is_anthropic_messages(body: dict[str, Any]) -> bool:
+    """Check if a messages-based body is Anthropic rather than OpenAI Chat.
+
+    Both Anthropic and OpenAI Chat use ``messages``, so this inspects
+    top-level fields and content-block types to disambiguate.
+    """
+    # Anthropic-specific top-level fields
+    if "system" in body and isinstance(body["system"], (str, list)):
+        return True
+    if "anthropic_version" in body or "max_tokens_to_sample" in body:
+        return True
+
+    messages = body.get("messages")
+    if not isinstance(messages, list) or len(messages) == 0:
+        return False
+
+    first_message = messages[0]
+    if not isinstance(first_message, dict):
+        return False
+
+    content = first_message.get("content")
+    if not isinstance(content, list) or len(content) == 0:
+        return False
+
+    return _has_anthropic_content_blocks(content)
+
+
+def detect_provider(body: dict[str, Any]) -> ProviderType | None:
+    """Auto-detect provider type from request body structure.
 
     Args:
-        body: Provider 请求体字典 Provider request body dict
+        body: Provider request body dict.
 
     Returns:
-        检测到的 provider 类型，如果无法识别则返回 None Detected provider type, returns None if not recognized
+        Detected provider type, or ``None`` if unrecognised.
 
     Examples:
-        >>> # OpenAI Chat Completions
         >>> detect_provider({"messages": [{"role": "user", "content": "Hello"}]})
         'openai_chat'
-
-        >>> # OpenAI Responses API
         >>> detect_provider({"input": [{"type": "message", "role": "user"}]})
         'openai_responses'
-
-        >>> # Anthropic
         >>> detect_provider({"messages": [{"role": "user", "content": [{"type": "text"}]}]})
         'anthropic'
-
-        >>> # Google GenAI
         >>> detect_provider({"contents": [{"role": "user", "parts": [{"text": "Hi"}]}]})
         'google'
     """
     if not isinstance(body, dict):
         return None
 
-    # 检测 Google GenAI: 必有 contents 字段 Detect Google GenAI: must have contents field
-    if "contents" in body:
-        contents = body["contents"]
-        if isinstance(contents, list) and len(contents) > 0:
-            # 验证是否有 parts 结构
-            first_content = contents[0]
-            if isinstance(first_content, dict) and "parts" in first_content:
-                return "google"
+    if _is_google_format(body):
+        return "google"
 
-    # 检测 OpenAI Responses API: 必有 input 或 output 字段 Detect OpenAI Responses API: must have input or output field
-    if "input" in body or "output" in body:
-        items = body.get("input") or body.get("output")
-        if isinstance(items, list) and len(items) > 0:
-            # 验证是否有 type 字段（message, function_call, etc.） Verify if there is a type field (message, function_call, etc.)
-            first_item = items[0]
-            if isinstance(first_item, dict) and "type" in first_item:
-                item_type = first_item["type"]
-                # Responses API 特有的类型 Types specific to Responses API
-                if item_type in [
-                    "message",
-                    "function_call",
-                    "function_call_output",
-                    "mcp_call",
-                    "mcp_call_output",
-                    "reasoning",
-                    "system_event",
-                    "input_text",
-                    "output_text",
-                ]:
-                    return "openai_responses"
+    if ("input" in body or "output" in body) and _is_responses_format(body):
+        return "openai_responses"
 
-    # 检测 Anthropic 和 OpenAI Chat: 都有 messages 字段 Detect Anthropic and OpenAI Chat: both have messages field
-    if "messages" in body:
-        # Anthropic 特有字段检测（优先） Anthropic specific field detection (priority)
-        if "system" in body and isinstance(body["system"], (str, list)):
-            # Anthropic 使用独立的 system 参数 Anthropic uses a separate system parameter
-            return "anthropic"
+    if "messages" not in body:
+        return None
 
-        if "anthropic_version" in body or "max_tokens_to_sample" in body:
-            return "anthropic"
+    if _is_anthropic_messages(body):
+        return "anthropic"
 
-        messages = body["messages"]
-        if isinstance(messages, list) and len(messages) > 0:
-            first_message = messages[0]
-            if isinstance(first_message, dict) and "content" in first_message:
-                content = first_message["content"]
+    # Check for OpenAI-specific tool_calls in message history
+    messages = body.get("messages")
+    if isinstance(messages, list):
+        for msg in messages:
+            if isinstance(msg, dict) and "tool_calls" in msg:
+                return "openai_chat"
 
-                # OpenAI Chat: content 是字符串 OpenAI Chat: content is string
-                if isinstance(content, str):
-                    return "openai_chat"
-
-                # 如果 content 是列表，需要区分 OpenAI 和 Anthropic If content is a list, need to distinguish OpenAI and Anthropic
-                if isinstance(content, list) and len(content) > 0:
-                    first_part = content[0]
-                    if isinstance(first_part, dict) and "type" in first_part:
-                        part_type = first_part["type"]
-
-                        # OpenAI Chat 特有的内容类型 Content types specific to OpenAI Chat
-                        if part_type in ["image_url", "input_audio"]:
-                            return "openai_chat"
-
-                        # Anthropic 特有的内容类型 Content types specific to Anthropic
-                        if part_type in [
-                            "image",
-                            "tool_use",
-                            "tool_result",
-                            "thinking",
-                            "document",
-                        ]:
-                            return "anthropic"
-
-                        # 对于 "text" 类型，检查更深层的结构 For "text" type, check deeper structure
-                        if part_type == "text":
-                            # 检查是否有 Anthropic 特有的嵌套结构
-                            # Anthropic 的 image 有 source 字段 Anthropic's image has source field
-                            for part in content:
-                                if isinstance(part, dict):
-                                    if part.get("type") == "image" and "source" in part:
-                                        return "anthropic"
-                                    if part.get("type") in [
-                                        "tool_use",
-                                        "thinking",
-                                        "document",
-                                    ]:
-                                        return "anthropic"
-
-                            # 默认 text 类型无法明确区分，返回 openai_chat Default text type cannot be clearly distinguished, return openai_chat
-                            # 因为 OpenAI 也支持 [{"type": "text", "text": "..."}] 格式 Because OpenAI also supports [{"type": "text", "text": "..."}] format
-                            pass
-
-        # 检查消息中是否有 tool_calls（OpenAI 特有） Check if there are tool_calls in messages (OpenAI specific)
-        if messages and isinstance(messages, list):
-            for msg in messages:
-                if isinstance(msg, dict) and "tool_calls" in msg:
-                    return "openai_chat"
-
-        # 如果无法明确区分，默认为 OpenAI Chat（更常见） If cannot be clearly distinguished, default to OpenAI Chat (more common)
-        return "openai_chat"
-
-    # 无法识别 Cannot recognize
-    return None
+    # Default: OpenAI Chat is the most common messages-based format
+    return "openai_chat"
 
 
 def get_converter_for_provider(provider: ProviderType):

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -359,7 +359,7 @@ class AnthropicConverter(BaseConverter):
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            provider_response["usage"] = self._build_provider_usage(ir_usage)
+            provider_response["usage"] = self._build_provider_usage(ir_usage)  # ty: ignore[invalid-argument-type]
 
         # Preserve mode: inject captured extra fields
         ctx = context if context is not None else ConversionContext()
@@ -762,7 +762,7 @@ class AnthropicConverter(BaseConverter):
                 FinishEvent(
                     type="finish",
                     finish_reason={
-                        "reason": ANTHROPIC_REASON_FROM_PROVIDER.get(
+                        "reason": ANTHROPIC_REASON_FROM_PROVIDER.get(  # ty: ignore[invalid-argument-type]
                             stop_reason, "stop"
                         )
                     },

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -296,7 +296,7 @@ class AnthropicConverter(BaseConverter):
         # Preserve mode: capture extra fields for lossless round-trip
         ctx = context if context is not None else ConversionContext()
         if ctx.metadata_mode == "preserve":
-            self._capture_preserve_metadata(provider_response, p_usage, ctx)
+            self._capture_preserve_metadata(provider_response, ctx)
 
         return self._validate_ir_response(ir_response)
 
@@ -445,10 +445,10 @@ class AnthropicConverter(BaseConverter):
     @staticmethod
     def _capture_preserve_metadata(
         provider_response: dict[str, Any],
-        p_usage: dict[str, Any] | None,
         ctx: ConversionContext,
     ) -> None:
         """Capture extra fields from provider response for lossless round-trip."""
+        p_usage = provider_response.get("usage")
         _ANTHROPIC_CORE_KEYS = {
             "id",
             "type",

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -130,28 +130,8 @@ class AnthropicConverter(BaseConverter):
             # Anthropic requires max_tokens
             result["max_tokens"] = 4096
 
-        # 4. Tools
-        tools = ir_request.get("tools")
-        if tools:
-            result["tools"] = [self.tool_ops.ir_tool_definition_to_p(t) for t in tools]
-
-        # 5. Tool choice
-        tool_choice = ir_request.get("tool_choice")
-        if tool_choice:
-            result["tool_choice"] = self.tool_ops.ir_tool_choice_to_p(tool_choice)
-
-        # 6. Tool config (disable_parallel_tool_use merges into tool_choice)
-        tool_config = ir_request.get("tool_config")
-        if tool_config:
-            tc_fields = self.tool_ops.ir_tool_config_to_p(tool_config)
-            if tc_fields:
-                if "tool_choice" not in result:
-                    result["tool_choice"] = {"type": "auto"}
-                result["tool_choice"].update(tc_fields)
-            if "max_calls" in tool_config:
-                ctx.warnings.append(
-                    "Anthropic does not support max_tool_calls, ignored"
-                )
+        # 4-6. Tools, tool choice, tool config
+        self._apply_tool_config(ir_request, result, ctx)
 
         # 7. Response format (not supported)
         resp_format = ir_request.get("response_format")
@@ -227,23 +207,7 @@ class AnthropicConverter(BaseConverter):
         # 3. Tools
         tools = provider_request.get("tools")
         if tools:
-            ir_tools = []
-            for t in tools:
-                try:
-                    ir_tools.append(self.tool_ops.p_tool_definition_to_ir(t))
-                except Exception as e:
-                    tool_type = (
-                        t.get("type", "unknown")
-                        if isinstance(t, dict)
-                        else type(t).__name__
-                    )
-                    tool_name = (
-                        t.get("name", "unnamed") if isinstance(t, dict) else str(t)
-                    )
-                    raise ValueError(
-                        f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
-                    ) from e
-            ir_request["tools"] = ir_tools
+            ir_request["tools"] = self._convert_tools_from_p(tools)
 
         # 4. Tool choice
         tool_choice = provider_request.get("tool_choice")
@@ -327,66 +291,12 @@ class AnthropicConverter(BaseConverter):
         # Usage
         p_usage = provider_response.get("usage")
         if p_usage:
-            input_tokens = p_usage.get("input_tokens") or 0
-            output_tokens = p_usage.get("output_tokens") or 0
-            usage_info: dict[str, Any] = {
-                "prompt_tokens": input_tokens,
-                "completion_tokens": output_tokens,
-                "total_tokens": input_tokens + output_tokens,
-            }
-
-            if "cache_read_input_tokens" in p_usage:
-                usage_info["cache_read_tokens"] = p_usage["cache_read_input_tokens"]
-
-            ir_response["usage"] = usage_info
+            ir_response["usage"] = self._build_ir_usage(p_usage)
 
         # Preserve mode: capture extra fields for lossless round-trip
         ctx = context if context is not None else ConversionContext()
         if ctx.metadata_mode == "preserve":
-            # Top-level extras (e.g. OpenRouter's "provider", "container")
-            _ANTHROPIC_CORE_KEYS = {
-                "id",
-                "type",
-                "role",
-                "content",
-                "model",
-                "stop_reason",
-                "stop_sequence",
-                "usage",
-            }
-            extras = {
-                k: v
-                for k, v in provider_response.items()
-                if k not in _ANTHROPIC_CORE_KEYS
-            }
-            # Extended usage fields (OpenRouter adds cost, speed, etc.)
-            _USAGE_CORE_KEYS = {
-                "input_tokens",
-                "output_tokens",
-                "cache_read_input_tokens",
-            }
-            if p_usage:
-                usage_extras = {
-                    k: v for k, v in p_usage.items() if k not in _USAGE_CORE_KEYS
-                }
-                if usage_extras:
-                    extras["_usage_extras"] = usage_extras
-            if extras:
-                ctx.store_response_extras(extras)
-
-            # Per-content-block metadata (citations etc.)
-            content_blocks = provider_response.get("content", [])
-            items_meta: list[dict[str, Any]] = []
-            for block in content_blocks:
-                if not isinstance(block, dict):
-                    items_meta.append({})
-                    continue
-                meta: dict[str, Any] = {}
-                if "citations" in block:
-                    meta["citations"] = block["citations"]
-                items_meta.append(meta)
-            if any(m for m in items_meta):
-                ctx.store_output_items_meta(items_meta)
+            self._capture_preserve_metadata(provider_response, p_usage, ctx)
 
         return self._validate_ir_response(ir_response)
 
@@ -449,49 +359,167 @@ class AnthropicConverter(BaseConverter):
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            usage: dict[str, Any] = {
-                "input_tokens": ir_usage.get("prompt_tokens") or 0,
-                "output_tokens": ir_usage.get("completion_tokens") or 0,
-            }
-
-            if "cache_read_tokens" in ir_usage:
-                usage["cache_read_input_tokens"] = ir_usage["cache_read_tokens"]
-
-            provider_response["usage"] = usage
+            provider_response["usage"] = self._build_provider_usage(ir_usage)
 
         # Preserve mode: inject captured extra fields
         ctx = context if context is not None else ConversionContext()
         if ctx.metadata_mode == "preserve":
-            echo = ctx.get_echo_fields()
-            # Merge usage extras back into usage dict
-            usage_extras = echo.pop("_usage_extras", None)
-            if usage_extras and "usage" in provider_response:
-                provider_response["usage"].update(usage_extras)
-            # Merge top-level extras
-            _CORE_KEYS = {
-                "id",
-                "type",
-                "role",
-                "content",
-                "model",
-                "stop_reason",
-                "stop_sequence",
-                "usage",
-            }
-            for k, v in echo.items():
-                if k not in _CORE_KEYS:
-                    provider_response[k] = v
-
-            # Restore per-content-block metadata
-            items_meta = ctx.get_output_items_meta()
-            content = provider_response.get("content", [])
-            for i, meta in enumerate(items_meta):
-                if i >= len(content):
-                    break
-                for k, v in meta.items():
-                    content[i][k] = v
+            self._apply_preserve_metadata(provider_response, ctx)
 
         return provider_response
+
+    # ------------------------------------------------------------------
+    # Cross-provider consistency helpers
+    # ------------------------------------------------------------------
+
+    def _apply_tool_config(
+        self,
+        ir_request: IRRequest,
+        result: dict[str, Any],
+        ctx: ConversionContext,
+    ) -> None:
+        """Apply tools, tool_choice, and tool_config to provider request."""
+        tools = ir_request.get("tools")
+        if tools:
+            result["tools"] = [self.tool_ops.ir_tool_definition_to_p(t) for t in tools]
+
+        tool_choice = ir_request.get("tool_choice")
+        if tool_choice:
+            result["tool_choice"] = self.tool_ops.ir_tool_choice_to_p(tool_choice)
+
+        tool_config = ir_request.get("tool_config")
+        if tool_config:
+            tc_fields = self.tool_ops.ir_tool_config_to_p(tool_config)
+            if tc_fields:
+                if "tool_choice" not in result:
+                    result["tool_choice"] = {"type": "auto"}
+                result["tool_choice"].update(tc_fields)
+            if "max_calls" in tool_config:
+                ctx.warnings.append(
+                    "Anthropic does not support max_tool_calls, ignored"
+                )
+
+    @staticmethod
+    def _build_ir_usage(p_usage: dict[str, Any]) -> dict[str, Any]:
+        """Build IR usage dict from Anthropic usage."""
+        input_tokens = p_usage.get("input_tokens") or 0
+        output_tokens = p_usage.get("output_tokens") or 0
+        usage_info: dict[str, Any] = {
+            "prompt_tokens": input_tokens,
+            "completion_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        }
+        if "cache_read_input_tokens" in p_usage:
+            usage_info["cache_read_tokens"] = p_usage["cache_read_input_tokens"]
+        return usage_info
+
+    @staticmethod
+    def _build_provider_usage(ir_usage: dict[str, Any]) -> dict[str, Any]:
+        """Build Anthropic usage dict from IR usage."""
+        usage: dict[str, Any] = {
+            "input_tokens": ir_usage.get("prompt_tokens") or 0,
+            "output_tokens": ir_usage.get("completion_tokens") or 0,
+        }
+        if "cache_read_tokens" in ir_usage:
+            usage["cache_read_input_tokens"] = ir_usage["cache_read_tokens"]
+        return usage
+
+    def _convert_tools_from_p(self, tools: list[Any]) -> list[Any]:
+        """Convert provider tool definitions to IR."""
+        ir_tools = []
+        for t in tools:
+            try:
+                ir_tools.append(self.tool_ops.p_tool_definition_to_ir(t))
+            except Exception as e:
+                tool_type = (
+                    t.get("type", "unknown")
+                    if isinstance(t, dict)
+                    else type(t).__name__
+                )
+                tool_name = t.get("name", "unnamed") if isinstance(t, dict) else str(t)
+                raise ValueError(
+                    f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
+                ) from e
+        return ir_tools
+
+    @staticmethod
+    def _capture_preserve_metadata(
+        provider_response: dict[str, Any],
+        p_usage: dict[str, Any] | None,
+        ctx: ConversionContext,
+    ) -> None:
+        """Capture extra fields from provider response for lossless round-trip."""
+        _ANTHROPIC_CORE_KEYS = {
+            "id",
+            "type",
+            "role",
+            "content",
+            "model",
+            "stop_reason",
+            "stop_sequence",
+            "usage",
+        }
+        extras = {
+            k: v for k, v in provider_response.items() if k not in _ANTHROPIC_CORE_KEYS
+        }
+        _USAGE_CORE_KEYS = {
+            "input_tokens",
+            "output_tokens",
+            "cache_read_input_tokens",
+        }
+        if p_usage:
+            usage_extras = {
+                k: v for k, v in p_usage.items() if k not in _USAGE_CORE_KEYS
+            }
+            if usage_extras:
+                extras["_usage_extras"] = usage_extras
+        if extras:
+            ctx.store_response_extras(extras)
+
+        content_blocks = provider_response.get("content", [])
+        items_meta: list[dict[str, Any]] = []
+        for block in content_blocks:
+            if not isinstance(block, dict):
+                items_meta.append({})
+                continue
+            meta: dict[str, Any] = {}
+            if "citations" in block:
+                meta["citations"] = block["citations"]
+            items_meta.append(meta)
+        if any(m for m in items_meta):
+            ctx.store_output_items_meta(items_meta)
+
+    @staticmethod
+    def _apply_preserve_metadata(
+        provider_response: dict[str, Any],
+        ctx: ConversionContext,
+    ) -> None:
+        """Re-inject captured metadata fields in preserve mode."""
+        echo = ctx.get_echo_fields()
+        usage_extras = echo.pop("_usage_extras", None)
+        if usage_extras and "usage" in provider_response:
+            provider_response["usage"].update(usage_extras)
+        _CORE_KEYS = {
+            "id",
+            "type",
+            "role",
+            "content",
+            "model",
+            "stop_reason",
+            "stop_sequence",
+            "usage",
+        }
+        for k, v in echo.items():
+            if k not in _CORE_KEYS:
+                provider_response[k] = v
+
+        items_meta = ctx.get_output_items_meta()
+        content = provider_response.get("content", [])
+        for i, meta in enumerate(items_meta):
+            if i >= len(content):
+                break
+            for k, v in meta.items():
+                content[i][k] = v
 
     def messages_to_provider(
         self,

--- a/src/llm_rosetta/converters/anthropic/tool_ops.py
+++ b/src/llm_rosetta/converters/anthropic/tool_ops.py
@@ -36,6 +36,30 @@ logger = logging.getLogger(__name__)
 # ==================== Orphaned Tool Call Fix ====================
 
 
+def _collect_anthropic_tool_ids(
+    messages: list[dict[str, Any]],
+) -> tuple[set[str], set[str]]:
+    """Collect all tool_use IDs and answered (tool_result) IDs."""
+    known_use_ids: set[str] = set()
+    answered_ids: set[str] = set()
+    for msg in messages:
+        content = msg.get("content", [])
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "tool_use":
+                use_id = block.get("id")
+                if use_id:
+                    known_use_ids.add(use_id)
+            elif block.get("type") == "tool_result":
+                use_id = block.get("tool_use_id")
+                if use_id:
+                    answered_ids.add(use_id)
+    return known_use_ids, answered_ids
+
+
 def fix_orphaned_tool_calls(
     messages: list[dict[str, Any]],
     *,
@@ -71,30 +95,13 @@ def fix_orphaned_tool_calls(
     Returns:
         A new messages list with orphaned tool_use/results fixed.
     """
-    # --- Pass 1: collect known tool_use ids and answered ids ---
-    known_use_ids: set[str] = set()
-    answered_ids: set[str] = set()
-    for msg in messages:
-        content = msg.get("content", [])
-        if not isinstance(content, list):
-            continue
-        for block in content:
-            if not isinstance(block, dict):
-                continue
-            if block.get("type") == "tool_use":
-                use_id = block.get("id")
-                if use_id:
-                    known_use_ids.add(use_id)
-            elif block.get("type") == "tool_result":
-                use_id = block.get("tool_use_id")
-                if use_id:
-                    answered_ids.add(use_id)
+    known_use_ids, answered_ids = _collect_anthropic_tool_ids(messages)
 
     # Fast path: nothing to fix
     if not known_use_ids and not answered_ids:
         return messages
 
-    # --- Pass 2: walk messages, inject/remove as needed ---
+    # --- Walk messages, inject/remove as needed ---
     patched: list[dict[str, Any]] = []
     orphaned_use_ids: list[str] = []
     orphaned_result_ids: list[str] = []

--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -68,6 +68,9 @@ class BaseConverter(ABC):
         - Uses config_ops to handle generation, stream and other config fields
         - Uses tool_ops to handle tools, tool_choice and other tool fields
 
+        Subclass helper: call ``self._apply_tool_config(ir_request, result, ctx)``
+        to handle the tools / tool_choice / tool_config fields.
+
         Args:
             ir_request: IR格式的完整请求
             context: Optional conversion context for carrying warnings,
@@ -90,6 +93,9 @@ class BaseConverter(ABC):
         """将provider请求转换为IRRequest
         Convert provider request to IRRequest
 
+        Subclass helper: call ``self._convert_tools_from_p(tools)`` to convert
+        provider tool definitions to IR format.
+
         Args:
             provider_request: Provider格式的请求
             context: Optional conversion context.
@@ -111,6 +117,9 @@ class BaseConverter(ABC):
         """将provider响应转换为IRResponse
         Convert provider response to IRResponse
 
+        Subclass helper: call ``self._build_ir_usage(p_usage)`` to convert
+        provider usage to IR format.
+
         Args:
             provider_response: Provider格式的响应
             context: Optional conversion context.
@@ -131,6 +140,9 @@ class BaseConverter(ABC):
     ) -> dict[str, Any]:
         """将IRResponse转换为provider响应
         Convert IRResponse to provider response
+
+        Subclass helper: call ``self._build_provider_usage(ir_usage)`` to convert
+        IR usage to provider format.
 
         Args:
             ir_response: IR格式的响应
@@ -234,6 +246,64 @@ class BaseConverter(ABC):
             dicts when the event maps to multiple provider-level messages.
         """
         pass
+
+    # ==================== Provider-specific helpers (abstract) ====================
+
+    @staticmethod
+    @abstractmethod
+    def _build_ir_usage(p_usage: dict[str, Any]) -> dict[str, Any]:
+        """Convert provider usage dict to IR usage format.
+
+        Called by ``response_from_provider`` to normalize provider-specific
+        token usage fields (e.g. ``input_tokens``, ``prompt_token_count``)
+        into the IR schema (``prompt_tokens``, ``completion_tokens``, ...).
+        """
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def _build_provider_usage(ir_usage: dict[str, Any]) -> dict[str, Any]:
+        """Convert IR usage dict to provider-specific usage format.
+
+        Called by ``response_to_provider`` to map IR token usage fields
+        back to the provider's native naming (e.g. ``promptTokenCount``
+        for Google, ``input_tokens`` for Anthropic).
+        """
+        ...
+
+    @abstractmethod
+    def _convert_tools_from_p(self, tools: list[Any]) -> list[Any]:
+        """Convert provider tool definitions to IR ToolDefinition list.
+
+        Called by ``request_from_provider`` to normalize the provider's
+        tool schema into IR format.  Implementations should iterate
+        ``tools``, call ``self.tool_ops.p_tool_definition_to_ir()``,
+        and raise ``ValueError`` for unsupported tool types.
+        """
+        ...
+
+    @abstractmethod
+    def _apply_tool_config(
+        self,
+        ir_request: IRRequest,
+        result: dict[str, Any],
+        ctx: "ConversionContext",
+    ) -> None:
+        """Apply tools, tool_choice, and tool_config from IR to provider request.
+
+        Called by ``request_to_provider`` to populate tool-related fields in
+        the provider request dict.  Implementations should handle all three
+        IR fields (``tools``, ``tool_choice``, ``tool_config``) and emit
+        warnings to ``ctx`` for unsupported options.
+        """
+        ...
+
+    # Optional preserve-mode hooks (implement if provider supports lossless
+    # round-trip, currently anthropic and openai_responses):
+    #   _capture_preserve_metadata(provider_response: dict, ctx) -> None
+    #       Called in response_from_provider to capture non-core fields.
+    #   _apply_preserve_metadata(provider_response: dict, ctx) -> None
+    #       Called in response_to_provider to re-inject captured metadata.
 
     # ==================== Normalization ====================
 

--- a/src/llm_rosetta/converters/base/tools.py
+++ b/src/llm_rosetta/converters/base/tools.py
@@ -210,6 +210,28 @@ def sanitize_schema(
 # ==================== Orphaned Tool Call Fix (IR level) ====================
 
 
+def _collect_ir_tool_ids(
+    messages: Sequence[Message],
+) -> tuple[set[str], set[str]]:
+    """Collect all tool_call IDs and answered (tool_result) IDs from IR messages."""
+    known_call_ids: set[str] = set()
+    answered_ids: set[str] = set()
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            for part in msg.get("content", []):
+                if isinstance(part, dict) and part.get("type") == "tool_call":
+                    tc_id = part.get("tool_call_id")
+                    if tc_id:
+                        known_call_ids.add(tc_id)
+        elif msg.get("role") == "tool":
+            for part in msg.get("content", []):
+                if isinstance(part, dict) and part.get("type") == "tool_result":
+                    tc_id = part.get("tool_call_id")
+                    if tc_id:
+                        answered_ids.add(tc_id)
+    return known_call_ids, answered_ids
+
+
 def fix_orphaned_tool_calls_ir(
     messages: Sequence[Message],
     *,
@@ -250,30 +272,13 @@ def fix_orphaned_tool_calls_ir(
     """
     msg_list = list(messages)
 
-    # --- Pass 1: collect known tool_call_ids and answered ids ---
-    known_call_ids: set[str] = set()
-    answered_ids: set[str] = set()
-    for msg in msg_list:
-        if msg.get("role") == "assistant":
-            content = msg.get("content", [])
-            for part in content:
-                if isinstance(part, dict) and part.get("type") == "tool_call":
-                    tc_id = part.get("tool_call_id")
-                    if tc_id:
-                        known_call_ids.add(tc_id)
-        elif msg.get("role") == "tool":
-            content = msg.get("content", [])
-            for part in content:
-                if isinstance(part, dict) and part.get("type") == "tool_result":
-                    tc_id = part.get("tool_call_id")
-                    if tc_id:
-                        answered_ids.add(tc_id)
+    known_call_ids, answered_ids = _collect_ir_tool_ids(msg_list)
 
     # Fast path: nothing to fix
     if not known_call_ids and not answered_ids:
         return msg_list
 
-    # --- Pass 2: walk messages, inject/remove as needed ---
+    # --- Walk messages, inject/remove as needed ---
     patched: list[Message] = []
     orphaned_call_ids: list[str] = []
     orphaned_result_ids: list[str] = []

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -496,7 +496,7 @@ class GoogleGenAIConverter(BaseConverter):
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            provider_response["usageMetadata"] = self._build_provider_usage(ir_usage)
+            provider_response["usageMetadata"] = self._build_provider_usage(ir_usage)  # ty: ignore[invalid-argument-type]
 
         return provider_response
 
@@ -814,7 +814,7 @@ class GoogleGenAIConverter(BaseConverter):
                 deferred_finish = FinishEvent(
                     type="finish",
                     finish_reason={
-                        "reason": GOOGLE_REASON_FROM_PROVIDER.get(finish_reason, "stop")
+                        "reason": GOOGLE_REASON_FROM_PROVIDER.get(finish_reason, "stop")  # ty: ignore[invalid-argument-type]
                     },
                     choice_index=choice_index,
                 )

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -258,17 +258,8 @@ class GoogleGenAIConverter(BaseConverter):
         # 3. Build config dict
         config: dict[str, Any] = {}
 
-        # Tools
-        tools = ir_request.get("tools")
-        if tools:
-            config["tools"] = [self.tool_ops.ir_tool_definition_to_p(t) for t in tools]
-
-        # Tool choice
-        tool_choice = ir_request.get("tool_choice")
-        if tool_choice:
-            tc_p = self.tool_ops.ir_tool_choice_to_p(tool_choice)
-            if tc_p:
-                config["tool_config"] = tc_p
+        # Tools + tool choice
+        self._apply_tool_config(ir_request, config)
 
         # Generation config
         gen_config = ir_request.get("generation")
@@ -337,16 +328,9 @@ class GoogleGenAIConverter(BaseConverter):
         # 1. System instruction
         system_instruction = provider_request.get("system_instruction")
         if system_instruction:
-            if isinstance(system_instruction, str):
-                ir_request["system_instruction"] = system_instruction
-            elif isinstance(system_instruction, dict):
-                parts = system_instruction.get("parts", [])
-                text_parts = []
-                for part in parts:
-                    if isinstance(part, dict) and "text" in part:
-                        text_parts.append(part["text"])
-                if text_parts:
-                    ir_request["system_instruction"] = " ".join(text_parts)
+            parsed = self._parse_system_instruction(system_instruction)
+            if parsed:
+                ir_request["system_instruction"] = parsed
 
         # 2. Messages
         contents = provider_request.get("contents", [])
@@ -364,29 +348,7 @@ class GoogleGenAIConverter(BaseConverter):
         # Tools — check SDK config first, then REST top-level
         tools = config.get("tools") or provider_request.get("tools")
         if tools:
-            ir_tools: list = []
-            for t in tools:
-                try:
-                    result = self.tool_ops.p_tool_definition_to_ir(t)
-                except Exception as e:
-                    tool_type = (
-                        t.get("type", "unknown")
-                        if isinstance(t, dict)
-                        else type(t).__name__
-                    )
-                    tool_name = (
-                        t.get("name", "unnamed") if isinstance(t, dict) else str(t)
-                    )
-                    raise ValueError(
-                        f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
-                    ) from e
-                if result is None:
-                    continue
-                if isinstance(result, list):
-                    ir_tools.extend(result)
-                else:
-                    ir_tools.append(result)
-            ir_request["tools"] = ir_tools
+            ir_request["tools"] = self._convert_tools_from_p(tools)
 
         # Tool choice — check SDK/REST snake_case/camelCase
         tool_config = (
@@ -483,58 +445,7 @@ class GoogleGenAIConverter(BaseConverter):
             "usageMetadata"
         )
         if p_usage:
-            usage_info: dict[str, Any] = {
-                "prompt_tokens": p_usage.get(
-                    "prompt_token_count", p_usage.get("promptTokenCount", 0)
-                ),
-                "completion_tokens": p_usage.get(
-                    "candidates_token_count",
-                    p_usage.get("candidatesTokenCount", 0),
-                ),
-                "total_tokens": p_usage.get(
-                    "total_token_count", p_usage.get("totalTokenCount", 0)
-                ),
-            }
-
-            # Reasoning tokens
-            thoughts = p_usage.get("thoughts_token_count") or p_usage.get(
-                "thoughtsTokenCount"
-            )
-            if thoughts is not None:
-                usage_info["reasoning_tokens"] = thoughts
-
-            # Cached content tokens
-            cached = p_usage.get("cached_content_token_count") or p_usage.get(
-                "cachedContentTokenCount"
-            )
-            if cached is not None:
-                usage_info["cache_read_tokens"] = cached
-
-            # Modality breakdowns (Google-specific)
-            # Google returns list[ModalityTokenCount] e.g.
-            # [{"modality": "TEXT", "token_count": 42}];
-            # IR expects dict[str, int] e.g. {"text_tokens": 42}.
-            prompt_details = p_usage.get("prompt_tokens_details") or p_usage.get(
-                "promptTokensDetails"
-            )
-            if prompt_details:
-                usage_info["prompt_tokens_details"] = (
-                    _modality_list_to_dict(prompt_details)
-                    if isinstance(prompt_details, list)
-                    else prompt_details
-                )
-
-            candidates_details = p_usage.get(
-                "candidates_tokens_details"
-            ) or p_usage.get("candidatesTokensDetails")
-            if candidates_details:
-                usage_info["completion_tokens_details"] = (
-                    _modality_list_to_dict(candidates_details)
-                    if isinstance(candidates_details, list)
-                    else candidates_details
-                )
-
-            ir_response["usage"] = usage_info
+            ir_response["usage"] = self._build_ir_usage(p_usage)
 
         return self._validate_ir_response(ir_response)
 
@@ -589,39 +500,152 @@ class GoogleGenAIConverter(BaseConverter):
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            usage_metadata: dict[str, Any] = {
-                "promptTokenCount": ir_usage.get("prompt_tokens") or 0,
-                "candidatesTokenCount": ir_usage.get("completion_tokens") or 0,
-                "totalTokenCount": ir_usage.get("total_tokens") or 0,
-            }
-
-            if "reasoning_tokens" in ir_usage:
-                usage_metadata["thoughtsTokenCount"] = ir_usage["reasoning_tokens"]
-
-            if "cache_read_tokens" in ir_usage:
-                usage_metadata["cachedContentTokenCount"] = ir_usage[
-                    "cache_read_tokens"
-                ]
-
-            if "prompt_tokens_details" in ir_usage:
-                details = ir_usage["prompt_tokens_details"]
-                usage_metadata["promptTokensDetails"] = (
-                    _dict_to_modality_list(details)
-                    if isinstance(details, dict)
-                    else details
-                )
-
-            if "completion_tokens_details" in ir_usage:
-                details = ir_usage["completion_tokens_details"]
-                usage_metadata["candidatesTokensDetails"] = (
-                    _dict_to_modality_list(details)
-                    if isinstance(details, dict)
-                    else details
-                )
-
-            provider_response["usageMetadata"] = usage_metadata
+            provider_response["usageMetadata"] = self._build_provider_usage(ir_usage)
 
         return provider_response
+
+    # ------------------------------------------------------------------
+    # Cross-provider consistency helpers
+    # ------------------------------------------------------------------
+
+    def _apply_tool_config(
+        self,
+        ir_request: IRRequest,
+        config: dict[str, Any],
+    ) -> None:
+        """Apply tools and tool_choice to provider config dict."""
+        tools = ir_request.get("tools")
+        if tools:
+            config["tools"] = [self.tool_ops.ir_tool_definition_to_p(t) for t in tools]
+
+        tool_choice = ir_request.get("tool_choice")
+        if tool_choice:
+            tc_p = self.tool_ops.ir_tool_choice_to_p(tool_choice)
+            if tc_p:
+                config["tool_config"] = tc_p
+
+    @staticmethod
+    def _build_ir_usage(p_usage: dict[str, Any]) -> dict[str, Any]:
+        """Build IR usage dict from Google usage metadata."""
+        usage_info: dict[str, Any] = {
+            "prompt_tokens": p_usage.get(
+                "prompt_token_count", p_usage.get("promptTokenCount", 0)
+            ),
+            "completion_tokens": p_usage.get(
+                "candidates_token_count",
+                p_usage.get("candidatesTokenCount", 0),
+            ),
+            "total_tokens": p_usage.get(
+                "total_token_count", p_usage.get("totalTokenCount", 0)
+            ),
+        }
+
+        thoughts = p_usage.get("thoughts_token_count") or p_usage.get(
+            "thoughtsTokenCount"
+        )
+        if thoughts is not None:
+            usage_info["reasoning_tokens"] = thoughts
+
+        cached = p_usage.get("cached_content_token_count") or p_usage.get(
+            "cachedContentTokenCount"
+        )
+        if cached is not None:
+            usage_info["cache_read_tokens"] = cached
+
+        prompt_details = p_usage.get("prompt_tokens_details") or p_usage.get(
+            "promptTokensDetails"
+        )
+        if prompt_details:
+            usage_info["prompt_tokens_details"] = (
+                _modality_list_to_dict(prompt_details)
+                if isinstance(prompt_details, list)
+                else prompt_details
+            )
+
+        candidates_details = p_usage.get("candidates_tokens_details") or p_usage.get(
+            "candidatesTokensDetails"
+        )
+        if candidates_details:
+            usage_info["completion_tokens_details"] = (
+                _modality_list_to_dict(candidates_details)
+                if isinstance(candidates_details, list)
+                else candidates_details
+            )
+
+        return usage_info
+
+    @staticmethod
+    def _build_provider_usage(ir_usage: dict[str, Any]) -> dict[str, Any]:
+        """Build Google usage metadata dict from IR usage."""
+        usage_metadata: dict[str, Any] = {
+            "promptTokenCount": ir_usage.get("prompt_tokens") or 0,
+            "candidatesTokenCount": ir_usage.get("completion_tokens") or 0,
+            "totalTokenCount": ir_usage.get("total_tokens") or 0,
+        }
+
+        if "reasoning_tokens" in ir_usage:
+            usage_metadata["thoughtsTokenCount"] = ir_usage["reasoning_tokens"]
+
+        if "cache_read_tokens" in ir_usage:
+            usage_metadata["cachedContentTokenCount"] = ir_usage["cache_read_tokens"]
+
+        if "prompt_tokens_details" in ir_usage:
+            details = ir_usage["prompt_tokens_details"]
+            usage_metadata["promptTokensDetails"] = (
+                _dict_to_modality_list(details)
+                if isinstance(details, dict)
+                else details
+            )
+
+        if "completion_tokens_details" in ir_usage:
+            details = ir_usage["completion_tokens_details"]
+            usage_metadata["candidatesTokensDetails"] = (
+                _dict_to_modality_list(details)
+                if isinstance(details, dict)
+                else details
+            )
+
+        return usage_metadata
+
+    @staticmethod
+    def _parse_system_instruction(system_instruction: Any) -> str | None:
+        """Parse Google GenAI system_instruction to plain text."""
+        if isinstance(system_instruction, str):
+            return system_instruction
+        if isinstance(system_instruction, dict):
+            parts = system_instruction.get("parts", [])
+            text_parts = [
+                part["text"]
+                for part in parts
+                if isinstance(part, dict) and "text" in part
+            ]
+            if text_parts:
+                return " ".join(text_parts)
+        return None
+
+    def _convert_tools_from_p(self, tools: list[Any]) -> list[Any]:
+        """Convert provider tool definitions to IR."""
+        ir_tools: list[Any] = []
+        for t in tools:
+            try:
+                result = self.tool_ops.p_tool_definition_to_ir(t)
+            except Exception as e:
+                tool_type = (
+                    t.get("type", "unknown")
+                    if isinstance(t, dict)
+                    else type(t).__name__
+                )
+                tool_name = t.get("name", "unnamed") if isinstance(t, dict) else str(t)
+                raise ValueError(
+                    f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
+                ) from e
+            if result is None:
+                continue
+            if isinstance(result, list):
+                ir_tools.extend(result)
+            else:
+                ir_tools.append(result)
+        return ir_tools
 
     def messages_to_provider(
         self,

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -255,11 +255,9 @@ class GoogleGenAIConverter(BaseConverter):
         if system_instruction:
             result["system_instruction"] = system_instruction
 
-        # 3. Build config dict
-        config: dict[str, Any] = {}
-
-        # Tools + tool choice
-        self._apply_tool_config(ir_request, config)
+        # 3. Build config dict (tools written by _apply_tool_config)
+        self._apply_tool_config(ir_request, result, ctx)
+        config = result.setdefault("config", {})
 
         # Generation config
         gen_config = ir_request.get("generation")
@@ -295,8 +293,6 @@ class GoogleGenAIConverter(BaseConverter):
         extensions = ir_request.get("provider_extensions")
         if extensions:
             config.update(extensions)
-
-        result["config"] = config
 
         if output_format == "rest":
             return self._to_rest_body(result), ctx.warnings
@@ -511,9 +507,11 @@ class GoogleGenAIConverter(BaseConverter):
     def _apply_tool_config(
         self,
         ir_request: IRRequest,
-        config: dict[str, Any],
+        result: dict[str, Any],
+        ctx: ConversionContext,
     ) -> None:
         """Apply tools and tool_choice to provider config dict."""
+        config = result.setdefault("config", {})
         tools = ir_request.get("tools")
         if tools:
             config["tools"] = [self.tool_ops.ir_tool_definition_to_p(t) for t in tools]

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -462,14 +462,14 @@ class OpenAIChatConverter(BaseConverter):
         }
 
         for choice in ir_response.get("choices", []):
-            openai_choice = self._build_choice_to_provider(choice)
+            openai_choice = self._build_choice_to_provider(choice)  # ty: ignore[invalid-argument-type]
             if openai_choice is not None:
                 provider_response["choices"].append(openai_choice)
 
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            provider_response["usage"] = self._build_provider_usage(ir_usage)
+            provider_response["usage"] = self._build_provider_usage(ir_usage)  # ty: ignore[invalid-argument-type]
 
         if "service_tier" in ir_response:
             provider_response["service_tier"] = ir_response["service_tier"]
@@ -727,7 +727,7 @@ class OpenAIChatConverter(BaseConverter):
             FinishEvent(
                 type="finish",
                 finish_reason={
-                    "reason": OPENAI_CHAT_REASON_FROM_PROVIDER.get(
+                    "reason": OPENAI_CHAT_REASON_FROM_PROVIDER.get(  # ty: ignore[invalid-argument-type]
                         finish_reason, "stop"
                     )
                 },

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -159,6 +159,35 @@ class OpenAIChatConverter(BaseConverter):
 
         return result, ctx.warnings
 
+    def _extract_system_and_messages(
+        self, messages: list[Any]
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        """Split system messages from user/assistant messages.
+
+        Returns:
+            Tuple of (non-system IR messages, system text or None).
+        """
+        ir_messages: list[dict[str, Any]] = []
+        system_text: str | None = None
+        for msg in messages:
+            if isinstance(msg, dict) and msg.get("role") == "system":
+                content = msg.get("content", "")
+                if isinstance(content, str):
+                    system_text = content
+                elif isinstance(content, list):
+                    text_parts = [
+                        part["text"]
+                        for part in content
+                        if isinstance(part, dict) and part.get("type") == "text"
+                    ]
+                    if text_parts:
+                        system_text = " ".join(text_parts)
+            else:
+                converted = self.message_ops._p_message_to_ir(msg)
+                if converted:
+                    ir_messages.append(converted)
+        return ir_messages, system_text
+
     def request_from_provider(
         self,
         provider_request: dict[str, Any],
@@ -183,26 +212,10 @@ class OpenAIChatConverter(BaseConverter):
 
         # 1. Messages - separate system messages as system_instruction
         messages = provider_request.get("messages", [])
-        ir_messages: list[dict[str, Any]] = []
-
-        for msg in messages:
-            if isinstance(msg, dict) and msg.get("role") == "system":
-                content = msg.get("content", "")
-                if isinstance(content, str):
-                    ir_request["system_instruction"] = content
-                elif isinstance(content, list):
-                    text_parts = []
-                    for part in content:
-                        if isinstance(part, dict) and part.get("type") == "text":
-                            text_parts.append(part["text"])
-                    if text_parts:
-                        ir_request["system_instruction"] = " ".join(text_parts)
-            else:
-                converted = self.message_ops._p_message_to_ir(msg)
-                if converted:
-                    ir_messages.append(converted)
-
+        ir_messages, system_text = self._extract_system_and_messages(messages)
         ir_request["messages"] = ir_messages
+        if system_text:
+            ir_request["system_instruction"] = system_text
 
         # 2. Tools
         tools = provider_request.get("tools")
@@ -437,35 +450,7 @@ class OpenAIChatConverter(BaseConverter):
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            usage: dict[str, Any] = {
-                "prompt_tokens": ir_usage.get("prompt_tokens") or 0,
-                "completion_tokens": ir_usage.get("completion_tokens") or 0,
-                "total_tokens": ir_usage.get("total_tokens") or 0,
-            }
-
-            if "prompt_tokens_details" in ir_usage:
-                usage["prompt_tokens_details"] = ir_usage["prompt_tokens_details"]
-
-            if "completion_tokens_details" in ir_usage:
-                usage["completion_tokens_details"] = ir_usage[
-                    "completion_tokens_details"
-                ]
-
-            if "cache_read_tokens" in ir_usage:
-                if "prompt_tokens_details" not in usage:
-                    usage["prompt_tokens_details"] = {}
-                usage["prompt_tokens_details"]["cached_tokens"] = ir_usage[
-                    "cache_read_tokens"
-                ]
-
-            if "reasoning_tokens" in ir_usage:
-                if "completion_tokens_details" not in usage:
-                    usage["completion_tokens_details"] = {}
-                usage["completion_tokens_details"]["reasoning_tokens"] = ir_usage[
-                    "reasoning_tokens"
-                ]
-
-            provider_response["usage"] = usage
+            provider_response["usage"] = self._build_provider_usage(ir_usage)
 
         if "service_tier" in ir_response:
             provider_response["service_tier"] = ir_response["service_tier"]
@@ -474,6 +459,31 @@ class OpenAIChatConverter(BaseConverter):
             provider_response["system_fingerprint"] = ir_response["system_fingerprint"]
 
         return provider_response
+
+    @staticmethod
+    def _build_provider_usage(ir_usage: dict[str, Any]) -> dict[str, Any]:
+        """Build OpenAI Chat usage dict from IR usage."""
+        usage: dict[str, Any] = {
+            "prompt_tokens": ir_usage.get("prompt_tokens") or 0,
+            "completion_tokens": ir_usage.get("completion_tokens") or 0,
+            "total_tokens": ir_usage.get("total_tokens") or 0,
+        }
+
+        if "prompt_tokens_details" in ir_usage:
+            usage["prompt_tokens_details"] = ir_usage["prompt_tokens_details"]
+        if "completion_tokens_details" in ir_usage:
+            usage["completion_tokens_details"] = ir_usage["completion_tokens_details"]
+
+        if "cache_read_tokens" in ir_usage:
+            usage.setdefault("prompt_tokens_details", {})["cached_tokens"] = ir_usage[
+                "cache_read_tokens"
+            ]
+        if "reasoning_tokens" in ir_usage:
+            usage.setdefault("completion_tokens_details", {})["reasoning_tokens"] = (
+                ir_usage["reasoning_tokens"]
+            )
+
+        return usage
 
     def messages_to_provider(
         self,

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -102,25 +102,8 @@ class OpenAIChatConverter(BaseConverter):
         ctx.warnings.extend(msg_warnings)
         result["messages"] = messages
 
-        # 3. Tools
-        tools = ir_request.get("tools")
-        if tools:
-            result["tools"] = [self.tool_ops.ir_tool_definition_to_p(t) for t in tools]
-
-        # 4. Tool choice
-        tool_choice = ir_request.get("tool_choice")
-        if tool_choice:
-            result["tool_choice"] = self.tool_ops.ir_tool_choice_to_p(tool_choice)
-
-        # 5. Tool config
-        tool_config = ir_request.get("tool_config")
-        if tool_config:
-            tc_fields = self.tool_ops.ir_tool_config_to_p(tool_config)
-            result.update(tc_fields)
-            if "max_calls" in tool_config:
-                ctx.warnings.append(
-                    "OpenAI Chat does not support max_tool_calls, ignored"
-                )
+        # 3-5. Tools + tool_choice + tool_config
+        self._apply_tool_config(ir_request, result, ctx)
 
         # 6. Generation config
         gen_config = ir_request.get("generation")
@@ -158,6 +141,128 @@ class OpenAIChatConverter(BaseConverter):
             result.update(extensions)
 
         return result, ctx.warnings
+
+    @staticmethod
+    def _build_ir_usage(p_usage: dict[str, Any]) -> dict[str, Any]:
+        """Build IR usage dict from OpenAI Chat usage."""
+        usage_info: dict[str, Any] = {
+            "prompt_tokens": p_usage.get("prompt_tokens") or 0,
+            "completion_tokens": p_usage.get("completion_tokens") or 0,
+            "total_tokens": p_usage.get("total_tokens") or 0,
+        }
+        p_prompt_details = p_usage.get("prompt_tokens_details")
+        if p_prompt_details:
+            usage_info["prompt_tokens_details"] = p_prompt_details
+            if "cached_tokens" in p_prompt_details:
+                usage_info["cache_read_tokens"] = p_prompt_details["cached_tokens"]
+        p_completion_details = p_usage.get("completion_tokens_details")
+        if p_completion_details:
+            usage_info["completion_tokens_details"] = p_completion_details
+            if "reasoning_tokens" in p_completion_details:
+                usage_info["reasoning_tokens"] = p_completion_details[
+                    "reasoning_tokens"
+                ]
+        return usage_info
+
+    def _convert_tools_from_p(self, tools: list[Any]) -> list[Any]:
+        """Convert provider tool definitions to IR."""
+        ir_tools = []
+        for t in tools:
+            try:
+                ir_tools.append(self.tool_ops.p_tool_definition_to_ir(t))
+            except Exception as e:
+                tool_type = (
+                    t.get("type", "unknown")
+                    if isinstance(t, dict)
+                    else type(t).__name__
+                )
+                tool_name = (
+                    (t.get("function", {}).get("name") or t.get("name", "unnamed"))
+                    if isinstance(t, dict)
+                    else str(t)
+                )
+                raise ValueError(
+                    f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
+                ) from e
+        return ir_tools
+
+    def _apply_tool_config(
+        self,
+        ir_request: IRRequest,
+        result: dict[str, Any],
+        ctx: ConversionContext,
+    ) -> None:
+        """Apply tools, tool_choice, and tool_config to provider request."""
+        tools = ir_request.get("tools")
+        if tools:
+            result["tools"] = [self.tool_ops.ir_tool_definition_to_p(t) for t in tools]
+        tool_choice = ir_request.get("tool_choice")
+        if tool_choice:
+            result["tool_choice"] = self.tool_ops.ir_tool_choice_to_p(tool_choice)
+        tool_config = ir_request.get("tool_config")
+        if tool_config:
+            tc_fields = self.tool_ops.ir_tool_config_to_p(tool_config)
+            result.update(tc_fields)
+            if "max_calls" in tool_config:
+                ctx.warnings.append(
+                    "OpenAI Chat does not support max_tool_calls, ignored"
+                )
+
+    def _build_choice_to_provider(
+        self, choice: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Build a single OpenAI Chat choice dict from an IR choice."""
+        message = choice.get("message")
+        if not message:
+            return None
+
+        openai_message: dict[str, Any] = {"role": message.get("role", "assistant")}
+
+        content_parts = message.get("content", [])
+        text_parts: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        refusal_text: str | None = None
+        annotations: list[dict[str, Any]] = []
+
+        for part in content_parts:
+            if is_text_part(part):
+                text_parts.append(part["text"])
+            elif is_tool_call_part(part):
+                tool_calls.append(self.tool_ops.ir_tool_call_to_p(part))
+            elif is_refusal_part(part):
+                refusal_text = part.get("refusal", "")
+            elif is_citation_part(part):
+                ann = self.content_ops.ir_citation_to_p(part)
+                if ann:
+                    annotations.append(ann)
+
+        if text_parts:
+            openai_message["content"] = " ".join(text_parts)
+        elif not tool_calls:
+            openai_message["content"] = ""
+
+        if tool_calls:
+            openai_message["tool_calls"] = tool_calls
+            if not text_parts:
+                openai_message["content"] = None
+
+        if refusal_text is not None:
+            openai_message["refusal"] = refusal_text
+
+        if annotations:
+            openai_message["annotations"] = annotations
+
+        reason = choice.get("finish_reason", {}).get("reason", "stop")
+        openai_choice: dict[str, Any] = {
+            "index": choice.get("index", 0),
+            "message": openai_message,
+            "finish_reason": OPENAI_CHAT_REASON_TO_PROVIDER.get(reason, "stop"),
+        }
+
+        if "logprobs" in choice:
+            openai_choice["logprobs"] = choice["logprobs"]
+
+        return openai_choice
 
     def _extract_system_and_messages(
         self, messages: list[Any]
@@ -220,25 +325,7 @@ class OpenAIChatConverter(BaseConverter):
         # 2. Tools
         tools = provider_request.get("tools")
         if tools:
-            ir_tools = []
-            for t in tools:
-                try:
-                    ir_tools.append(self.tool_ops.p_tool_definition_to_ir(t))
-                except Exception as e:
-                    tool_type = (
-                        t.get("type", "unknown")
-                        if isinstance(t, dict)
-                        else type(t).__name__
-                    )
-                    tool_name = (
-                        (t.get("function", {}).get("name") or t.get("name", "unnamed"))
-                        if isinstance(t, dict)
-                        else str(t)
-                    )
-                    raise ValueError(
-                        f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
-                    ) from e
-            ir_request["tools"] = ir_tools
+            ir_request["tools"] = self._convert_tools_from_p(tools)
 
         # 3. Tool choice
         tool_choice = provider_request.get("tool_choice")
@@ -341,27 +428,7 @@ class OpenAIChatConverter(BaseConverter):
         # Usage
         p_usage = provider_response.get("usage")
         if p_usage:
-            usage_info: dict[str, Any] = {
-                "prompt_tokens": p_usage.get("prompt_tokens") or 0,
-                "completion_tokens": p_usage.get("completion_tokens") or 0,
-                "total_tokens": p_usage.get("total_tokens") or 0,
-            }
-
-            p_prompt_details = p_usage.get("prompt_tokens_details")
-            if p_prompt_details:
-                usage_info["prompt_tokens_details"] = p_prompt_details
-                if "cached_tokens" in p_prompt_details:
-                    usage_info["cache_read_tokens"] = p_prompt_details["cached_tokens"]
-
-            p_completion_details = p_usage.get("completion_tokens_details")
-            if p_completion_details:
-                usage_info["completion_tokens_details"] = p_completion_details
-                if "reasoning_tokens" in p_completion_details:
-                    usage_info["reasoning_tokens"] = p_completion_details[
-                        "reasoning_tokens"
-                    ]
-
-            ir_response["usage"] = usage_info
+            ir_response["usage"] = self._build_ir_usage(p_usage)
 
         if provider_response.get("service_tier") is not None:
             ir_response["service_tier"] = provider_response["service_tier"]
@@ -395,57 +462,9 @@ class OpenAIChatConverter(BaseConverter):
         }
 
         for choice in ir_response.get("choices", []):
-            message = choice.get("message")
-            if not message:
-                continue
-
-            openai_message: dict[str, Any] = {"role": message.get("role", "assistant")}
-
-            content_parts = message.get("content", [])
-            text_parts: list[str] = []
-            tool_calls: list[dict[str, Any]] = []
-            refusal_text: str | None = None
-            annotations: list[dict[str, Any]] = []
-
-            for part in content_parts:
-                if is_text_part(part):
-                    text_parts.append(part["text"])
-                elif is_tool_call_part(part):
-                    tool_calls.append(self.tool_ops.ir_tool_call_to_p(part))
-                elif is_refusal_part(part):
-                    refusal_text = part.get("refusal", "")
-                elif is_citation_part(part):
-                    ann = self.content_ops.ir_citation_to_p(part)
-                    if ann:
-                        annotations.append(ann)
-
-            if text_parts:
-                openai_message["content"] = " ".join(text_parts)
-            elif not tool_calls:
-                openai_message["content"] = ""
-
-            if tool_calls:
-                openai_message["tool_calls"] = tool_calls
-                if not text_parts:
-                    openai_message["content"] = None
-
-            if refusal_text is not None:
-                openai_message["refusal"] = refusal_text
-
-            if annotations:
-                openai_message["annotations"] = annotations
-
-            reason = choice.get("finish_reason", {}).get("reason", "stop")
-            openai_choice: dict[str, Any] = {
-                "index": choice.get("index", 0),
-                "message": openai_message,
-                "finish_reason": OPENAI_CHAT_REASON_TO_PROVIDER.get(reason, "stop"),
-            }
-
-            if "logprobs" in choice:
-                openai_choice["logprobs"] = choice["logprobs"]
-
-            provider_response["choices"].append(openai_choice)
+            openai_choice = self._build_choice_to_provider(choice)
+            if openai_choice is not None:
+                provider_response["choices"].append(openai_choice)
 
         # Usage
         ir_usage = ir_response.get("usage")

--- a/src/llm_rosetta/converters/openai_chat/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/tool_ops.py
@@ -32,6 +32,31 @@ logger = logging.getLogger(__name__)
 # ==================== Orphaned Tool Call Fix ====================
 
 
+def _collect_openai_tool_ids(
+    messages: list[dict[str, Any]],
+) -> tuple[set[str], set[str]]:
+    """Collect tool_call_ids from assistant messages and answered ids from tool messages.
+
+    Returns:
+        Tuple of (known_call_ids, answered_ids).
+    """
+    known_call_ids: set[str] = set()
+    answered_ids: set[str] = set()
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            tool_calls = msg.get("tool_calls")
+            if tool_calls and isinstance(tool_calls, list):
+                for tc in tool_calls:
+                    tc_id = tc.get("id")
+                    if tc_id:
+                        known_call_ids.add(tc_id)
+        elif msg.get("role") == "tool":
+            tc_id = msg.get("tool_call_id")
+            if tc_id:
+                answered_ids.add(tc_id)
+    return known_call_ids, answered_ids
+
+
 def fix_orphaned_tool_calls(
     messages: list[dict[str, Any]],
     *,
@@ -68,20 +93,7 @@ def fix_orphaned_tool_calls(
         A new messages list with orphaned tool_calls/results fixed.
     """
     # --- Pass 1: collect known tool_call_ids and answered ids ---
-    known_call_ids: set[str] = set()
-    answered_ids: set[str] = set()
-    for msg in messages:
-        if msg.get("role") == "assistant":
-            tool_calls = msg.get("tool_calls")
-            if tool_calls and isinstance(tool_calls, list):
-                for tc in tool_calls:
-                    tc_id = tc.get("id")
-                    if tc_id:
-                        known_call_ids.add(tc_id)
-        elif msg.get("role") == "tool":
-            tc_id = msg.get("tool_call_id")
-            if tc_id:
-                answered_ids.add(tc_id)
+    known_call_ids, answered_ids = _collect_openai_tool_ids(messages)
 
     # Fast path: nothing to fix
     if not known_call_ids and not answered_ids:

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -335,7 +335,7 @@ class OpenAIResponsesConverter(BaseConverter):
         # Preserve mode: capture extra fields for lossless round-trip
         ctx = context if context is not None else ConversionContext()
         if ctx.metadata_mode == "preserve":
-            self._capture_preserve_metadata(provider_response, output_items, ctx)
+            self._capture_preserve_metadata(provider_response, ctx)
 
         return self._validate_ir_response(ir_response)
 
@@ -542,10 +542,10 @@ class OpenAIResponsesConverter(BaseConverter):
     @staticmethod
     def _capture_preserve_metadata(
         provider_response: dict[str, Any],
-        output_items: list[Any],
         ctx: ConversionContext,
     ) -> None:
         """Capture extra fields from provider response for lossless round-trip."""
+        output_items = provider_response.get("output", [])
         extras = {
             k: v
             for k, v in provider_response.items()

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -216,25 +216,7 @@ class OpenAIResponsesConverter(BaseConverter):
         # 3. Tools
         tools = provider_request.get("tools")
         if tools:
-            ir_tools = []
-            for t in tools:
-                # Skip disabled tools (e.g. web_search with external_web_access=false)
-                if isinstance(t, dict) and t.get("external_web_access") is False:
-                    continue
-                try:
-                    ir_tools.append(self.tool_ops.p_tool_definition_to_ir(t))
-                except Exception as e:
-                    tool_type = (
-                        t.get("type", "unknown")
-                        if isinstance(t, dict)
-                        else type(t).__name__
-                    )
-                    tool_name = (
-                        t.get("name", "unnamed") if isinstance(t, dict) else str(t)
-                    )
-                    raise ValueError(
-                        f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
-                    ) from e
+            ir_tools = self._convert_tools_from_p(tools)
             if ir_tools:
                 ir_request["tools"] = ir_tools
 
@@ -408,43 +390,7 @@ class OpenAIResponsesConverter(BaseConverter):
         # Preserve mode: capture extra fields for lossless round-trip
         ctx = context if context is not None else ConversionContext()
         if ctx.metadata_mode == "preserve":
-            # Top-level extra fields
-            extras = {
-                k: v
-                for k, v in provider_response.items()
-                if k in RESPONSES_PRESERVE_FIELDS and v is not None
-            }
-            if extras:
-                ctx.store_response_extras(extras)
-
-            # Per-output-item metadata (id, status, content-part annotations/logprobs)
-            items_meta: list[dict[str, Any]] = []
-            for item in output_items:
-                if not isinstance(item, dict):
-                    continue
-                meta: dict[str, Any] = {}
-                if "id" in item:
-                    meta["id"] = item["id"]
-                if "status" in item:
-                    meta["status"] = item["status"]
-                # Per-content-part metadata
-                content = item.get("content", [])
-                if isinstance(content, list):
-                    parts_meta: list[dict[str, Any]] = []
-                    for cp in content:
-                        if not isinstance(cp, dict):
-                            continue
-                        pm: dict[str, Any] = {}
-                        if "annotations" in cp:
-                            pm["annotations"] = cp["annotations"]
-                        if "logprobs" in cp:
-                            pm["logprobs"] = cp["logprobs"]
-                        parts_meta.append(pm)
-                    if parts_meta:
-                        meta["content_meta"] = parts_meta
-                items_meta.append(meta)
-            if items_meta:
-                ctx.store_output_items_meta(items_meta)
+            self._capture_preserve_metadata(provider_response, output_items, ctx)
 
         return self._validate_ir_response(ir_response)
 
@@ -551,6 +497,68 @@ class OpenAIResponsesConverter(BaseConverter):
     # ------------------------------------------------------------------
     # Preserve-mode helpers
     # ------------------------------------------------------------------
+
+    def _convert_tools_from_p(self, tools: list[Any]) -> list[Any]:
+        """Convert provider tool definitions to IR, skipping disabled tools."""
+        ir_tools = []
+        for t in tools:
+            if isinstance(t, dict) and t.get("external_web_access") is False:
+                continue
+            try:
+                ir_tools.append(self.tool_ops.p_tool_definition_to_ir(t))
+            except Exception as e:
+                tool_type = (
+                    t.get("type", "unknown")
+                    if isinstance(t, dict)
+                    else type(t).__name__
+                )
+                tool_name = t.get("name", "unnamed") if isinstance(t, dict) else str(t)
+                raise ValueError(
+                    f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
+                ) from e
+        return ir_tools
+
+    @staticmethod
+    def _capture_preserve_metadata(
+        provider_response: dict[str, Any],
+        output_items: list[Any],
+        ctx: ConversionContext,
+    ) -> None:
+        """Capture extra fields from provider response for lossless round-trip."""
+        extras = {
+            k: v
+            for k, v in provider_response.items()
+            if k in RESPONSES_PRESERVE_FIELDS and v is not None
+        }
+        if extras:
+            ctx.store_response_extras(extras)
+
+        items_meta: list[dict[str, Any]] = []
+        for item in output_items:
+            if not isinstance(item, dict):
+                continue
+            meta: dict[str, Any] = {}
+            if "id" in item:
+                meta["id"] = item["id"]
+            if "status" in item:
+                meta["status"] = item["status"]
+            content = item.get("content", [])
+            if isinstance(content, list):
+                parts_meta: list[dict[str, Any]] = []
+                for cp in content:
+                    if not isinstance(cp, dict):
+                        continue
+                    pm: dict[str, Any] = {}
+                    if "annotations" in cp:
+                        pm["annotations"] = cp["annotations"]
+                    if "logprobs" in cp:
+                        pm["logprobs"] = cp["logprobs"]
+                    parts_meta.append(pm)
+                if parts_meta:
+                    meta["content_meta"] = parts_meta
+            items_meta.append(meta)
+        if items_meta:
+            ctx.store_output_items_meta(items_meta)
 
     @staticmethod
     def _apply_preserve_metadata(

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -119,21 +119,8 @@ class OpenAIResponsesConverter(BaseConverter):
         ctx.warnings.extend(msg_warnings)
         result["input"] = items
 
-        # 3. Tools
-        tools = ir_request.get("tools")
-        if tools:
-            result["tools"] = [self.tool_ops.ir_tool_definition_to_p(t) for t in tools]
-
-        # 4. Tool choice
-        tool_choice = ir_request.get("tool_choice")
-        if tool_choice:
-            result["tool_choice"] = self.tool_ops.ir_tool_choice_to_p(tool_choice)
-
-        # 5. Tool config
-        tool_config = ir_request.get("tool_config")
-        if tool_config:
-            tc_fields = self.tool_ops.ir_tool_config_to_p(tool_config)
-            result.update(tc_fields)
+        # 3-5. Tools + tool_choice + tool_config
+        self._apply_tool_config(ir_request, result, ctx)
 
         # 6. Generation config
         gen_config = ir_request.get("generation")
@@ -220,23 +207,8 @@ class OpenAIResponsesConverter(BaseConverter):
             if ir_tools:
                 ir_request["tools"] = ir_tools
 
-        # 4. Tool choice
-        tool_choice = provider_request.get("tool_choice")
-        if tool_choice is not None:
-            ir_request["tool_choice"] = self.tool_ops.p_tool_choice_to_ir(tool_choice)
-
-        # 5. Tool config
-        tool_config_fields = {}
-        if "parallel_tool_calls" in provider_request:
-            tool_config_fields["parallel_tool_calls"] = provider_request[
-                "parallel_tool_calls"
-            ]
-        if "max_tool_calls" in provider_request:
-            tool_config_fields["max_tool_calls"] = provider_request["max_tool_calls"]
-        if tool_config_fields:
-            ir_request["tool_config"] = self.tool_ops.p_tool_config_to_ir(
-                tool_config_fields
-            )
+        # 4-5. Tool choice + tool config
+        self._convert_tool_config_from_p(provider_request, ir_request)
 
         # 6. Generation config
         gen_config = self.config_ops.p_generation_config_to_ir(provider_request)
@@ -264,15 +236,7 @@ class OpenAIResponsesConverter(BaseConverter):
             )
 
         # 10. Cache config
-        cache_fields = {}
-        if "prompt_cache_key" in provider_request:
-            cache_fields["prompt_cache_key"] = provider_request["prompt_cache_key"]
-        if "prompt_cache_retention" in provider_request:
-            cache_fields["prompt_cache_retention"] = provider_request[
-                "prompt_cache_retention"
-            ]
-        if cache_fields:
-            ir_request["cache"] = self.config_ops.p_cache_config_to_ir(cache_fields)
+        self._convert_cache_from_p(provider_request, ir_request)
 
         # 11. Provider extensions (passthrough fields like allowed_tools)
         allowed_tools = provider_request.get("allowed_tools")
@@ -363,26 +327,7 @@ class OpenAIResponsesConverter(BaseConverter):
         # Handle usage
         p_usage = provider_response.get("usage")
         if p_usage:
-            usage_info: dict[str, Any] = {
-                "prompt_tokens": p_usage.get("input_tokens") or 0,
-                "completion_tokens": p_usage.get("output_tokens") or 0,
-                "total_tokens": p_usage.get("total_tokens") or 0,
-            }
-
-            # Handle detailed statistics
-            p_input_details = p_usage.get("input_tokens_details")
-            if p_input_details:
-                if "cached_tokens" in p_input_details:
-                    usage_info["cache_read_tokens"] = p_input_details["cached_tokens"]
-
-            p_output_details = p_usage.get("output_tokens_details")
-            if p_output_details:
-                if "reasoning_tokens" in p_output_details:
-                    usage_info["reasoning_tokens"] = p_output_details[
-                        "reasoning_tokens"
-                    ]
-
-            ir_response["usage"] = usage_info
+            ir_response["usage"] = self._build_ir_usage(p_usage)
 
         if provider_response.get("service_tier") is not None:
             ir_response["service_tier"] = provider_response["service_tier"]
@@ -470,19 +415,7 @@ class OpenAIResponsesConverter(BaseConverter):
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            usage: dict[str, Any] = {
-                "input_tokens": ir_usage.get("prompt_tokens") or 0,
-                "output_tokens": ir_usage.get("completion_tokens") or 0,
-                "total_tokens": ir_usage.get("total_tokens") or 0,
-                "input_tokens_details": {
-                    "cached_tokens": ir_usage.get("cache_read_tokens", 0),
-                },
-                "output_tokens_details": {
-                    "reasoning_tokens": ir_usage.get("reasoning_tokens", 0),
-                },
-            }
-
-            provider_response["usage"] = usage
+            provider_response["usage"] = self._build_provider_usage(ir_usage)
 
         if "service_tier" in ir_response:
             provider_response["service_tier"] = ir_response["service_tier"]
@@ -495,8 +428,41 @@ class OpenAIResponsesConverter(BaseConverter):
         return provider_response
 
     # ------------------------------------------------------------------
-    # Preserve-mode helpers
+    # Cross-provider consistency helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_ir_usage(p_usage: dict[str, Any]) -> dict[str, Any]:
+        """Build IR usage dict from Responses API usage."""
+        usage_info: dict[str, Any] = {
+            "prompt_tokens": p_usage.get("input_tokens") or 0,
+            "completion_tokens": p_usage.get("output_tokens") or 0,
+            "total_tokens": p_usage.get("total_tokens") or 0,
+        }
+        p_input_details = p_usage.get("input_tokens_details")
+        if p_input_details:
+            if "cached_tokens" in p_input_details:
+                usage_info["cache_read_tokens"] = p_input_details["cached_tokens"]
+        p_output_details = p_usage.get("output_tokens_details")
+        if p_output_details:
+            if "reasoning_tokens" in p_output_details:
+                usage_info["reasoning_tokens"] = p_output_details["reasoning_tokens"]
+        return usage_info
+
+    @staticmethod
+    def _build_provider_usage(ir_usage: dict[str, Any]) -> dict[str, Any]:
+        """Build Responses API usage dict from IR usage."""
+        return {
+            "input_tokens": ir_usage.get("prompt_tokens") or 0,
+            "output_tokens": ir_usage.get("completion_tokens") or 0,
+            "total_tokens": ir_usage.get("total_tokens") or 0,
+            "input_tokens_details": {
+                "cached_tokens": ir_usage.get("cache_read_tokens", 0),
+            },
+            "output_tokens_details": {
+                "reasoning_tokens": ir_usage.get("reasoning_tokens", 0),
+            },
+        }
 
     def _convert_tools_from_p(self, tools: list[Any]) -> list[Any]:
         """Convert provider tool definitions to IR, skipping disabled tools."""
@@ -517,6 +483,61 @@ class OpenAIResponsesConverter(BaseConverter):
                     f"Unsupported tool type={tool_type!r} name={tool_name!r}: {e}"
                 ) from e
         return ir_tools
+
+    def _apply_tool_config(
+        self,
+        ir_request: IRRequest,
+        result: dict[str, Any],
+        ctx: ConversionContext,
+    ) -> None:
+        """Apply tools, tool_choice, and tool_config to provider request."""
+        tools = ir_request.get("tools")
+        if tools:
+            result["tools"] = [self.tool_ops.ir_tool_definition_to_p(t) for t in tools]
+        tool_choice = ir_request.get("tool_choice")
+        if tool_choice:
+            result["tool_choice"] = self.tool_ops.ir_tool_choice_to_p(tool_choice)
+        tool_config = ir_request.get("tool_config")
+        if tool_config:
+            tc_fields = self.tool_ops.ir_tool_config_to_p(tool_config)
+            result.update(tc_fields)
+
+    def _convert_tool_config_from_p(
+        self,
+        provider_request: dict[str, Any],
+        ir_request: dict[str, Any],
+    ) -> None:
+        """Extract tool_choice and tool_config from provider request into IR."""
+        tool_choice = provider_request.get("tool_choice")
+        if tool_choice is not None:
+            ir_request["tool_choice"] = self.tool_ops.p_tool_choice_to_ir(tool_choice)
+        tool_config_fields: dict[str, Any] = {}
+        if "parallel_tool_calls" in provider_request:
+            tool_config_fields["parallel_tool_calls"] = provider_request[
+                "parallel_tool_calls"
+            ]
+        if "max_tool_calls" in provider_request:
+            tool_config_fields["max_tool_calls"] = provider_request["max_tool_calls"]
+        if tool_config_fields:
+            ir_request["tool_config"] = self.tool_ops.p_tool_config_to_ir(
+                tool_config_fields
+            )
+
+    def _convert_cache_from_p(
+        self,
+        provider_request: dict[str, Any],
+        ir_request: dict[str, Any],
+    ) -> None:
+        """Extract cache config from provider request into IR."""
+        cache_fields: dict[str, Any] = {}
+        if "prompt_cache_key" in provider_request:
+            cache_fields["prompt_cache_key"] = provider_request["prompt_cache_key"]
+        if "prompt_cache_retention" in provider_request:
+            cache_fields["prompt_cache_retention"] = provider_request[
+                "prompt_cache_retention"
+            ]
+        if cache_fields:
+            ir_request["cache"] = self.config_ops.p_cache_config_to_ir(cache_fields)
 
     @staticmethod
     def _capture_preserve_metadata(
@@ -1362,40 +1383,7 @@ class OpenAIResponsesConverter(BaseConverter):
         finish_reason: str = "length",
     ) -> dict[str, Any]:
         """Build the response dict for a FinishEvent."""
-        output: list[dict[str, Any]] = []
-        if context is not None:
-            accumulated = context.accumulated_text
-            item_id = context.item_id
-            if accumulated:
-                msg_item: dict[str, Any] = {
-                    "id": item_id,
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [{"type": "output_text", "text": accumulated}],
-                }
-                if context.metadata_mode == "preserve":
-                    msg_item["status"] = "completed"
-                    for part in msg_item.get("content", []):
-                        part.setdefault("annotations", [])
-                        part.setdefault("logprobs", [])
-                output.append(msg_item)
-
-            # Add accumulated function calls to output
-            for call_id in context._tool_call_order:
-                tool_name = context.get_tool_name(call_id)
-                arguments = context._tool_call_args.get(call_id, "")
-                tc_item_id = context.get_tool_call_item_id(call_id) or call_id
-                output.append(
-                    {
-                        "id": tc_item_id,
-                        "type": "function_call",
-                        "call_id": call_id,
-                        "name": tool_name,
-                        "arguments": arguments,
-                        "status": "completed",
-                    }
-                )
-
+        output = self._collect_finish_output(context)
         response: dict[str, Any] = {"status": status, "output": output}
 
         # Populate id, object, model, created_at from context so clients can
@@ -1414,45 +1402,92 @@ class OpenAIResponsesConverter(BaseConverter):
 
         # Merge pending usage from context if available
         if context is not None and context.pending_usage is not None:
-            usage: dict[str, Any] = {
-                "input_tokens": context.pending_usage.get("prompt_tokens") or 0,
-                "output_tokens": context.pending_usage.get("completion_tokens") or 0,
-                "total_tokens": context.pending_usage.get("total_tokens") or 0,
-            }
-            # Include token detail breakdowns if available
-            cache_read = context.pending_usage.get("cache_read_tokens")
-            if cache_read is not None:
-                usage["input_tokens_details"] = {"cached_tokens": cache_read}
-            else:
-                usage["input_tokens_details"] = {"cached_tokens": 0}
-            reasoning = context.pending_usage.get("reasoning_tokens")
-            if reasoning is not None:
-                usage["output_tokens_details"] = {"reasoning_tokens": reasoning}
-            else:
-                usage["output_tokens_details"] = {"reasoning_tokens": 0}
-            response["usage"] = usage
+            response["usage"] = self._build_finish_usage(context.pending_usage)
 
         # Preserve mode: inject echo fields into the response.completed payload
         if context is not None and context.metadata_mode == "preserve":
-            echo = context.get_echo_fields()
-            core_keys = {
-                "id",
-                "object",
-                "created_at",
-                "model",
-                "output",
-                "status",
-                "usage",
-            }
-            # Apply required defaults first, then override with actual echo
-            for k, v in RESPONSES_REQUIRED_DEFAULTS.items():
-                if k not in core_keys and k not in response:
-                    response[k] = v
-            for k, v in echo.items():
-                if k not in core_keys:
-                    response[k] = v
+            self._apply_finish_echo(response, context)
 
         return response
+
+    def _collect_finish_output(
+        self, context: OpenAIResponsesStreamContext | None
+    ) -> list[dict[str, Any]]:
+        """Collect text and tool call output items from stream context."""
+        output: list[dict[str, Any]] = []
+        if context is None:
+            return output
+
+        accumulated = context.accumulated_text
+        if accumulated:
+            msg_item: dict[str, Any] = {
+                "id": context.item_id,
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": accumulated}],
+            }
+            if context.metadata_mode == "preserve":
+                msg_item["status"] = "completed"
+                for part in msg_item.get("content", []):
+                    part.setdefault("annotations", [])
+                    part.setdefault("logprobs", [])
+            output.append(msg_item)
+
+        for call_id in context._tool_call_order:
+            tool_name = context.get_tool_name(call_id)
+            arguments = context._tool_call_args.get(call_id, "")
+            tc_item_id = context.get_tool_call_item_id(call_id) or call_id
+            output.append(
+                {
+                    "id": tc_item_id,
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": tool_name,
+                    "arguments": arguments,
+                    "status": "completed",
+                }
+            )
+        return output
+
+    @staticmethod
+    def _build_finish_usage(pending_usage: dict[str, Any]) -> dict[str, Any]:
+        """Build usage dict for the finish response from pending IR usage."""
+        usage: dict[str, Any] = {
+            "input_tokens": pending_usage.get("prompt_tokens") or 0,
+            "output_tokens": pending_usage.get("completion_tokens") or 0,
+            "total_tokens": pending_usage.get("total_tokens") or 0,
+        }
+        cache_read = pending_usage.get("cache_read_tokens")
+        usage["input_tokens_details"] = {
+            "cached_tokens": cache_read if cache_read is not None else 0
+        }
+        reasoning = pending_usage.get("reasoning_tokens")
+        usage["output_tokens_details"] = {
+            "reasoning_tokens": reasoning if reasoning is not None else 0
+        }
+        return usage
+
+    @staticmethod
+    def _apply_finish_echo(
+        response: dict[str, Any], context: OpenAIResponsesStreamContext
+    ) -> None:
+        """Inject preserve-mode echo fields into the finish response."""
+        echo = context.get_echo_fields()
+        core_keys = {
+            "id",
+            "object",
+            "created_at",
+            "model",
+            "output",
+            "status",
+            "usage",
+        }
+        for k, v in RESPONSES_REQUIRED_DEFAULTS.items():
+            if k not in core_keys and k not in response:
+                response[k] = v
+        for k, v in echo.items():
+            if k not in core_keys:
+                response[k] = v
 
     def _emit_text_done_events(
         self,

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -544,53 +544,64 @@ class OpenAIResponsesConverter(BaseConverter):
         # Preserve mode: inject captured extra fields
         ctx = context if context is not None else ConversionContext()
         if ctx.metadata_mode == "preserve":
-            echo = ctx.get_echo_fields()
-            # Merge echo fields, but don't overwrite core fields already set
-            core_keys = {
-                "id",
-                "object",
-                "created_at",
-                "model",
-                "output",
-                "status",
-                "usage",
-            }
-            # Apply required defaults first, then override with actual echo
-            for k, v in RESPONSES_REQUIRED_DEFAULTS.items():
-                if k not in core_keys and k not in provider_response:
-                    provider_response[k] = v
-            for k, v in echo.items():
-                if k not in core_keys:
-                    provider_response[k] = v
-
-            # Ensure echoed tools have required 'strict' field
-            for tool in provider_response.get("tools", []):
-                if isinstance(tool, dict) and tool.get("type") == "function":
-                    tool.setdefault("strict", None)
-
-            # Restore per-output-item metadata
-            items_meta = ctx.get_output_items_meta()
-            output = provider_response.get("output", [])
-            for i, meta in enumerate(items_meta):
-                if i >= len(output):
-                    break
-                item = output[i]
-                if "id" in meta:
-                    item["id"] = meta["id"]
-                if "status" in meta:
-                    item["status"] = meta["status"]
-                # Restore per-content-part metadata
-                content_meta = meta.get("content_meta", [])
-                content = item.get("content", [])
-                for j, pm in enumerate(content_meta):
-                    if j >= len(content):
-                        break
-                    if "annotations" in pm:
-                        content[j]["annotations"] = pm["annotations"]
-                    if "logprobs" in pm:
-                        content[j]["logprobs"] = pm["logprobs"]
+            self._apply_preserve_metadata(provider_response, ctx)
 
         return provider_response
+
+    # ------------------------------------------------------------------
+    # Preserve-mode helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _apply_preserve_metadata(
+        provider_response: dict[str, Any],
+        ctx: ConversionContext,
+    ) -> None:
+        """Re-inject captured metadata fields in *preserve* mode."""
+        echo = ctx.get_echo_fields()
+        core_keys = {
+            "id",
+            "object",
+            "created_at",
+            "model",
+            "output",
+            "status",
+            "usage",
+        }
+        # Apply required defaults first, then override with actual echo
+        for k, v in RESPONSES_REQUIRED_DEFAULTS.items():
+            if k not in core_keys and k not in provider_response:
+                provider_response[k] = v
+        for k, v in echo.items():
+            if k not in core_keys:
+                provider_response[k] = v
+
+        # Ensure echoed tools have required 'strict' field
+        for tool in provider_response.get("tools", []):
+            if isinstance(tool, dict) and tool.get("type") == "function":
+                tool.setdefault("strict", None)
+
+        # Restore per-output-item metadata
+        items_meta = ctx.get_output_items_meta()
+        output = provider_response.get("output", [])
+        for i, meta in enumerate(items_meta):
+            if i >= len(output):
+                break
+            item = output[i]
+            if "id" in meta:
+                item["id"] = meta["id"]
+            if "status" in meta:
+                item["status"] = meta["status"]
+            # Restore per-content-part metadata
+            content_meta = meta.get("content_meta", [])
+            content = item.get("content", [])
+            for j, pm in enumerate(content_meta):
+                if j >= len(content):
+                    break
+                if "annotations" in pm:
+                    content[j]["annotations"] = pm["annotations"]
+                if "logprobs" in pm:
+                    content[j]["logprobs"] = pm["logprobs"]
 
     def messages_to_provider(
         self,

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -415,7 +415,7 @@ class OpenAIResponsesConverter(BaseConverter):
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            provider_response["usage"] = self._build_provider_usage(ir_usage)
+            provider_response["usage"] = self._build_provider_usage(ir_usage)  # ty: ignore[invalid-argument-type]
 
         if "service_tier" in ir_response:
             provider_response["service_tier"] = ir_response["service_tier"]
@@ -997,7 +997,7 @@ class OpenAIResponsesConverter(BaseConverter):
         events.append(
             FinishEvent(
                 type="finish",
-                finish_reason={"reason": reason},
+                finish_reason={"reason": reason},  # ty: ignore[invalid-argument-type]
             )
         )
 

--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -281,6 +281,55 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
 
     # ==================== Provider → IR ====================
 
+    @staticmethod
+    def _normalize_shorthand_item(item: dict[str, Any]) -> dict[str, Any]:
+        """Normalize shorthand ``{"role": ..., "content": ...}`` to typed item.
+
+        Converts plain ``{"role": "user", "content": "hi"}`` into
+        ``{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}``.
+        """
+        content = item.get("content", "")
+        if isinstance(content, str):
+            content = [{"type": "input_text", "text": content}]
+        elif isinstance(content, list):
+            normalized = []
+            for part in content:
+                if isinstance(part, str):
+                    normalized.append({"type": "input_text", "text": part})
+                elif isinstance(part, dict) and "type" not in part:
+                    normalized.append({"type": "input_text", **part})
+                else:
+                    normalized.append(part)
+            content = normalized
+        return {"type": "message", "role": item["role"], "content": content}
+
+    @staticmethod
+    def _append_or_start(
+        ir_input: list[Any],
+        current_message: dict[str, Any] | None,
+        part: Any,
+        target_role: str,
+    ) -> dict[str, Any]:
+        """Append *part* to *current_message* if roles match, else flush and start a new message."""
+        if current_message and current_message.get("role") == target_role:
+            cast(list, current_message["content"]).append(part)
+            return current_message
+        if current_message:
+            ir_input.append(current_message)
+        return {"role": target_role, "content": [part]}
+
+    _TOOL_CALL_TYPES = frozenset(
+        {
+            "function_call",
+            "mcp_call",
+            "shell_call",
+            "computer_call",
+            "code_interpreter_call",
+        }
+    )
+
+    _TOOL_RESULT_TYPES = frozenset({"function_call_output", "mcp_call_output"})
+
     def p_messages_to_ir(
         self,
         provider_messages: list[Any],
@@ -301,75 +350,38 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
         current_message: dict[str, Any] | None = None
 
         for item in provider_messages:
-            # Normalize shorthand items: {"role": "user", "content": "..."}
-            # → {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "..."}]}
             if isinstance(item, dict) and "type" not in item and "role" in item:
-                content = item.get("content", "")
-                if isinstance(content, str):
-                    content = [{"type": "input_text", "text": content}]
-                elif isinstance(content, list):
-                    normalized = []
-                    for part in content:
-                        if isinstance(part, str):
-                            normalized.append({"type": "input_text", "text": part})
-                        elif isinstance(part, dict) and "type" not in part:
-                            normalized.append({"type": "input_text", **part})
-                        else:
-                            normalized.append(part)
-                    content = normalized
-                item = {"type": "message", "role": item["role"], "content": content}
+                item = self._normalize_shorthand_item(item)
 
             item_type = item.get("type") if isinstance(item, dict) else None
 
             if item_type == "message":
-                # Message type: create new message
                 new_message = self._p_message_to_ir(item)
                 if new_message:
                     if current_message:
                         ir_input.append(current_message)
                     current_message = new_message
 
-            elif item_type in (
-                "function_call",
-                "mcp_call",
-                "shell_call",
-                "computer_call",
-                "code_interpreter_call",
-            ):
-                # Tool call: convert to ToolCallPart
+            elif item_type in self._TOOL_CALL_TYPES:
                 tool_call = self.tool_ops.p_tool_call_to_ir(item)
-                if current_message and current_message.get("role") == "assistant":
-                    cast(list, current_message["content"]).append(tool_call)
-                else:
-                    if current_message:
-                        ir_input.append(current_message)
-                    current_message = {"role": "assistant", "content": [tool_call]}
+                current_message = self._append_or_start(
+                    ir_input, current_message, tool_call, "assistant"
+                )
 
-            elif item_type in ("function_call_output", "mcp_call_output"):
-                # Tool result: convert to ToolResultPart
-                # Use role="tool" (not "user") so fix_orphaned_tool_calls_ir
-                # can correctly detect answered tool calls across formats.
+            elif item_type in self._TOOL_RESULT_TYPES:
                 tool_result = self.tool_ops.p_tool_result_to_ir(item)
-                if current_message and current_message.get("role") == "tool":
-                    cast(list, current_message["content"]).append(tool_result)
-                else:
-                    if current_message:
-                        ir_input.append(current_message)
-                    current_message = {"role": "tool", "content": [tool_result]}
+                current_message = self._append_or_start(
+                    ir_input, current_message, tool_result, "tool"
+                )
 
             elif item_type == "reasoning":
-                # Reasoning content
                 reasoning = self.content_ops.p_reasoning_to_ir(item)
                 if reasoning:
-                    if current_message and current_message.get("role") == "assistant":
-                        cast(list, current_message["content"]).append(reasoning)
-                    else:
-                        if current_message:
-                            ir_input.append(current_message)
-                        current_message = {"role": "assistant", "content": [reasoning]}
+                    current_message = self._append_or_start(
+                        ir_input, current_message, reasoning, "assistant"
+                    )
 
             elif item_type == "system_event":
-                # System event: add as extension item
                 if current_message:
                     ir_input.append(current_message)
                     current_message = None
@@ -383,8 +395,7 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
                 )
 
             elif isinstance(item_type, str) and ":" in item_type:
-                # Slug-prefixed extension item (e.g. "openai:web_search_call")
-                # Preserve opaquely as a passthrough item on an assistant message
+                # Slug-prefixed extension item — preserve opaquely on assistant
                 if current_message and current_message.get("role") == "assistant":
                     metadata = current_message.setdefault("metadata", {})
                     custom = metadata.setdefault("custom", {})
@@ -398,10 +409,8 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
                         "metadata": {"custom": {"_passthrough_items": [dict(item)]}},
                     }
 
-        # Handle the last message
-        if current_message:
-            if current_message.get("content"):
-                ir_input.append(current_message)
+        if current_message and current_message.get("content"):
+            ir_input.append(current_message)
 
         return ir_input
 

--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -385,34 +385,47 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
                 if current_message:
                     ir_input.append(current_message)
                     current_message = None
-                ir_input.append(
-                    {
-                        "type": "system_event",
-                        "event_type": item.get("event_type", "unknown"),
-                        "timestamp": item.get("timestamp", ""),
-                        "message": item.get("message", ""),
-                    }
-                )
+                ir_input.append(self._make_system_event(item))
 
             elif isinstance(item_type, str) and ":" in item_type:
-                # Slug-prefixed extension item — preserve opaquely on assistant
-                if current_message and current_message.get("role") == "assistant":
-                    metadata = current_message.setdefault("metadata", {})
-                    custom = metadata.setdefault("custom", {})
-                    custom.setdefault("_passthrough_items", []).append(dict(item))
-                else:
-                    if current_message:
-                        ir_input.append(current_message)
-                    current_message = {
-                        "role": "assistant",
-                        "content": [],
-                        "metadata": {"custom": {"_passthrough_items": [dict(item)]}},
-                    }
+                current_message = self._handle_p_extension_item(
+                    item, current_message, ir_input
+                )
 
         if current_message and current_message.get("content"):
             ir_input.append(current_message)
 
         return ir_input
+
+    @staticmethod
+    def _make_system_event(item: dict[str, Any]) -> dict[str, Any]:
+        """Build an IR system_event from a Responses API system_event item."""
+        return {
+            "type": "system_event",
+            "event_type": item.get("event_type", "unknown"),
+            "timestamp": item.get("timestamp", ""),
+            "message": item.get("message", ""),
+        }
+
+    @staticmethod
+    def _handle_p_extension_item(
+        item: dict[str, Any],
+        current_message: dict[str, Any] | None,
+        ir_input: list[Any],
+    ) -> dict[str, Any]:
+        """Handle a slug-prefixed extension item, preserving it opaquely."""
+        if current_message and current_message.get("role") == "assistant":
+            metadata = current_message.setdefault("metadata", {})
+            custom = metadata.setdefault("custom", {})
+            custom.setdefault("_passthrough_items", []).append(dict(item))
+            return current_message
+        if current_message:
+            ir_input.append(current_message)
+        return {
+            "role": "assistant",
+            "content": [],
+            "metadata": {"custom": {"_passthrough_items": [dict(item)]}},
+        }
 
     def _p_message_to_ir(self, provider_message: Any) -> Any:
         """Convert a single Responses API message item to IR format.

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -72,6 +72,64 @@ def _sync_auth_middleware(app: Any, config: GatewayConfig) -> None:
         layer = getattr(layer, "app", None)
 
 
+def _build_provider_entry(
+    body: dict[str, Any],
+    api_key: str,
+    base_url: str,
+    existing_providers: dict[str, Any],
+    resolve_name: str,
+) -> dict[str, Any]:
+    """Build a provider entry dict from request body, resolving masked keys."""
+    if "***" in api_key and resolve_name in existing_providers:
+        api_key = existing_providers[resolve_name].get("api_key", api_key)
+
+    entry: dict[str, Any] = {"api_key": api_key, "base_url": base_url}
+
+    provider_type = body.get("type")
+    if provider_type:
+        entry["type"] = provider_type
+
+    if "proxy" in body:
+        proxy = body["proxy"]
+        if proxy:
+            entry["proxy"] = proxy
+
+    if resolve_name in existing_providers:
+        existing_enabled = existing_providers[resolve_name].get("enabled")
+        if existing_enabled is not None:
+            entry["enabled"] = existing_enabled
+
+    return entry
+
+
+def _handle_provider_rename(
+    data: dict[str, Any], rename_from: str, name: str
+) -> Response | None:
+    """Handle provider rename: remove old entry, update model refs.
+
+    Returns a JSONResponse on error, or None on success.
+    """
+    providers = data.get("providers", {})
+    if rename_from not in providers:
+        return JSONResponse(
+            {"error": f"Original provider '{rename_from}' not found"},
+            status_code=404,
+        )
+    if name in providers:
+        return JSONResponse(
+            {"error": f"Provider '{name}' already exists"},
+            status_code=409,
+        )
+    del providers[rename_from]
+    models = data.get("models", {})
+    for model_name, model_val in models.items():
+        if isinstance(model_val, str) and model_val == rename_from:
+            models[model_name] = name
+        elif isinstance(model_val, dict) and model_val.get("provider") == rename_from:
+            model_val["provider"] = name
+    return None
+
+
 # ---------------------------------------------------------------------------
 # HTML handler
 # ---------------------------------------------------------------------------
@@ -174,56 +232,18 @@ async def put_provider(request: Request) -> Response:
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
-    # If the submitted api_key is a masked value (contains ***), preserve the
-    # original key from the config file to prevent accidental overwrite.
     existing_providers = data.get("providers", {})
     resolve_name = body.get("rename_from", name) or name
-    if "***" in api_key and resolve_name in existing_providers:
-        api_key = existing_providers[resolve_name].get("api_key", api_key)
-
-    provider_entry: dict[str, Any] = {"api_key": api_key, "base_url": base_url}
-
-    # Include API standard type if provided
-    provider_type = body.get("type")
-    if provider_type:
-        provider_entry["type"] = provider_type
-
-    # Include proxy if provided, empty string removes it
-    if "proxy" in body:
-        proxy = body["proxy"]
-        if proxy:
-            provider_entry["proxy"] = proxy
-
-    # Preserve enabled state from existing entry (toggle is separate endpoint)
-    if resolve_name in existing_providers:
-        existing_enabled = existing_providers[resolve_name].get("enabled")
-        if existing_enabled is not None:
-            provider_entry["enabled"] = existing_enabled
+    provider_entry = _build_provider_entry(
+        body, api_key, base_url, existing_providers, resolve_name
+    )
 
     # Handle rename: remove old entry and update model references
     rename_from = body.get("rename_from")
     if rename_from and rename_from != name:
-        providers = data.get("providers", {})
-        if rename_from not in providers:
-            return JSONResponse(
-                {"error": f"Original provider '{rename_from}' not found"},
-                status_code=404,
-            )
-        if name in providers:
-            return JSONResponse(
-                {"error": f"Provider '{name}' already exists"},
-                status_code=409,
-            )
-        del providers[rename_from]
-        # Update all model references from old name to new name
-        models = data.get("models", {})
-        for model_name, model_val in models.items():
-            if isinstance(model_val, str) and model_val == rename_from:
-                models[model_name] = name
-            elif (
-                isinstance(model_val, dict) and model_val.get("provider") == rename_from
-            ):
-                model_val["provider"] = name
+        rename_err = _handle_provider_rename(data, rename_from, name)
+        if rename_err is not None:
+            return rename_err
 
     data.setdefault("providers", {})[name] = provider_entry
 

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -455,6 +455,47 @@ async def handle_non_streaming(
     return JSONResponse(source_response)
 
 
+_SENTINEL_DONE = object()
+
+
+def _parse_sse_data(line: str) -> Any:
+    """Parse a single SSE line and return the JSON chunk, or None to skip.
+
+    Returns ``_SENTINEL_DONE`` when the stream signals completion.
+    """
+    parsed = _iter_sse_lines(line)
+    if parsed is None:
+        return None
+    field, value = parsed
+    if field == "event" or field != "data" or value is None:
+        return None
+    if _is_openai_done(value):
+        return _SENTINEL_DONE
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        logger.warning("Skipping malformed SSE data: %s", value[:200])
+        return None
+
+
+async def _format_upstream_error(upstream_resp: Any, endpoint: str) -> str:
+    """Read an error response from upstream and format it as an SSE data line."""
+    await upstream_resp.aread()
+    error_text = upstream_resp.text
+    log_upstream_error(
+        upstream_resp.status_code,
+        error_text,
+        endpoint=endpoint,
+        is_streaming=True,
+    )
+    try:
+        error_body = json.loads(error_text)
+        error_msg = json.dumps(error_body)
+    except json.JSONDecodeError:
+        error_msg = error_text
+    return f"data: {error_msg}\n\n"
+
+
 async def _stream_event_generator(
     *,
     source_provider: ProviderType,
@@ -488,39 +529,17 @@ async def _stream_event_generator(
         "POST", url, json=upstream_body, headers=headers
     ) as upstream_resp:
         if upstream_resp.status_code >= 400:
-            await upstream_resp.aread()
-            error_text = upstream_resp.text
-            log_upstream_error(
-                upstream_resp.status_code,
-                error_text,
-                endpoint=str(target_provider),
-                is_streaming=True,
+            error_sse = await _format_upstream_error(
+                upstream_resp, str(target_provider)
             )
-            try:
-                error_body = json.loads(error_text)
-                error_msg = json.dumps(error_body)
-            except json.JSONDecodeError:
-                error_msg = error_text
-            yield f"data: {error_msg}\n\n"
+            yield error_sse
             return
 
         async for line in upstream_resp.aiter_lines():
-            parsed = _iter_sse_lines(line)
-            if parsed is None:
-                continue
-            field, value = parsed
-
-            if field == "event":
-                continue
-            if field != "data" or value is None:
-                continue
-            if _is_openai_done(value):
+            chunk = _parse_sse_data(line)
+            if chunk is _SENTINEL_DONE:
                 break
-
-            try:
-                chunk = json.loads(value)
-            except json.JSONDecodeError:
-                logger.warning("Skipping malformed SSE data: %s", value[:200])
+            if chunk is None:
                 continue
 
             chunk_count += 1

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -455,6 +455,107 @@ async def handle_non_streaming(
     return JSONResponse(source_response)
 
 
+async def _stream_event_generator(
+    *,
+    source_provider: ProviderType,
+    target_provider: ProviderType,
+    source_converter: Any,
+    target_converter: Any,
+    ctx: ConversionContext,
+    provider_info: ProviderInfo,
+    url: str,
+    upstream_body: dict[str, Any],
+    headers: dict[str, str],
+    format_sse: Any,
+    store: ProviderMetadataStore,
+    model: str,
+) -> AsyncIterator[str]:
+    """Stream SSE events from upstream, converting each chunk."""
+    from_ctx = target_converter.create_stream_context()  # upstream -> IR
+    to_ctx = source_converter.create_stream_context()  # IR -> source
+
+    # Bridge preserve-mode metadata from request phase to streaming context
+    to_ctx.options["metadata_mode"] = "preserve"
+    from_ctx.options["metadata_mode"] = "preserve"
+    if "_request_echo" in ctx.metadata:
+        to_ctx.metadata["_request_echo"] = ctx.metadata["_request_echo"]
+
+    chunk_count = 0
+    t0 = time.monotonic()
+
+    client = get_client(provider_info.proxy_url)
+    async with client.stream(
+        "POST", url, json=upstream_body, headers=headers
+    ) as upstream_resp:
+        if upstream_resp.status_code >= 400:
+            await upstream_resp.aread()
+            error_text = upstream_resp.text
+            log_upstream_error(
+                upstream_resp.status_code,
+                error_text,
+                endpoint=str(target_provider),
+                is_streaming=True,
+            )
+            try:
+                error_body = json.loads(error_text)
+                error_msg = json.dumps(error_body)
+            except json.JSONDecodeError:
+                error_msg = error_text
+            yield f"data: {error_msg}\n\n"
+            return
+
+        async for line in upstream_resp.aiter_lines():
+            parsed = _iter_sse_lines(line)
+            if parsed is None:
+                continue
+            field, value = parsed
+
+            if field == "event":
+                continue
+            if field != "data" or value is None:
+                continue
+            if _is_openai_done(value):
+                break
+
+            try:
+                chunk = json.loads(value)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed SSE data: %s", value[:200])
+                continue
+
+            chunk_count += 1
+
+            ir_events = target_converter.stream_response_from_provider(
+                chunk, context=from_ctx
+            )
+
+            if "_response_extras" in from_ctx.metadata:
+                to_ctx.metadata["_response_extras"] = from_ctx.metadata[
+                    "_response_extras"
+                ]
+
+            for ir_event in ir_events:
+                store.cache_from_stream_event(ir_event)
+                source_chunks = source_converter.stream_response_to_provider(
+                    ir_event, context=to_ctx
+                )
+                if isinstance(source_chunks, list):
+                    for sc in source_chunks:
+                        if sc:
+                            yield format_sse(sc)
+                elif source_chunks:
+                    yield format_sse(source_chunks)
+
+    if source_provider == "openai_chat":
+        yield _format_sse_openai_chat_done()
+
+    log_stream_summary(
+        model=model,
+        duration_s=time.monotonic() - t0,
+        chunk_count=chunk_count,
+    )
+
+
 async def handle_streaming(
     source_provider: ProviderType,
     target_provider: ProviderType,
@@ -515,102 +616,20 @@ async def handle_streaming(
 
     format_sse = SSE_FORMATTERS[source_provider]
 
-    async def event_generator() -> AsyncIterator[str]:
-        """Stream SSE events from upstream, converting each chunk."""
-        from_ctx = target_converter.create_stream_context()  # upstream -> IR
-        to_ctx = source_converter.create_stream_context()  # IR -> source
-
-        # Bridge preserve-mode metadata from request phase to streaming context
-        to_ctx.options["metadata_mode"] = "preserve"
-        from_ctx.options["metadata_mode"] = "preserve"
-        if "_request_echo" in ctx.metadata:
-            to_ctx.metadata["_request_echo"] = ctx.metadata["_request_echo"]
-
-        chunk_count = 0
-        t0 = time.monotonic()
-
-        client = get_client(provider_info.proxy_url)
-        async with client.stream(
-            "POST", url, json=upstream_body, headers=headers
-        ) as upstream_resp:
-            if upstream_resp.status_code >= 400:
-                # Read error body and yield as error
-                await upstream_resp.aread()
-                error_text = upstream_resp.text
-                log_upstream_error(
-                    upstream_resp.status_code,
-                    error_text,
-                    endpoint=str(target_provider),
-                    is_streaming=True,
-                )
-                try:
-                    error_body = json.loads(error_text)
-                    error_msg = json.dumps(error_body)
-                except json.JSONDecodeError:
-                    error_msg = error_text
-                yield f"data: {error_msg}\n\n"
-                return
-
-            async for line in upstream_resp.aiter_lines():
-                parsed = _iter_sse_lines(line)
-                if parsed is None:
-                    continue
-                field, value = parsed
-
-                # Skip event-type lines (type info is inside the data JSON)
-                if field == "event":
-                    continue
-
-                if field != "data" or value is None:
-                    continue
-
-                # OpenAI [DONE] signal
-                if _is_openai_done(value):
-                    break
-
-                try:
-                    chunk = json.loads(value)
-                except json.JSONDecodeError:
-                    logger.warning("Skipping malformed SSE data: %s", value[:200])
-                    continue
-
-                chunk_count += 1
-
-                # Upstream chunk -> IR events
-                ir_events = target_converter.stream_response_from_provider(
-                    chunk, context=from_ctx
-                )
-
-                # Bridge response extras captured during streaming
-                if "_response_extras" in from_ctx.metadata:
-                    to_ctx.metadata["_response_extras"] = from_ctx.metadata[
-                        "_response_extras"
-                    ]
-
-                # IR events -> source-format chunks
-                for ir_event in ir_events:
-                    # Cache provider_metadata from tool_call_start events
-                    store.cache_from_stream_event(ir_event)
-
-                    source_chunks = source_converter.stream_response_to_provider(
-                        ir_event, context=to_ctx
-                    )
-                    if isinstance(source_chunks, list):
-                        for sc in source_chunks:
-                            if sc:
-                                yield format_sse(sc)
-                    elif source_chunks:
-                        yield format_sse(source_chunks)
-
-        # Emit end-of-stream marker for OpenAI Chat format
-        if source_provider == "openai_chat":
-            yield _format_sse_openai_chat_done()
-
-        # -- stream summary (no per-chunk spam) --
-        log_stream_summary(
+    return StreamingResponse(
+        _stream_event_generator(
+            source_provider=source_provider,
+            target_provider=target_provider,
+            source_converter=source_converter,
+            target_converter=target_converter,
+            ctx=ctx,
+            provider_info=provider_info,
+            url=url,
+            upstream_body=upstream_body,
+            headers=headers,
+            format_sse=format_sse,
+            store=store,
             model=model,
-            duration_s=time.monotonic() - t0,
-            chunk_count=chunk_count,
-        )
-
-    return StreamingResponse(event_generator(), media_type="text/event-stream")
+        ),
+        media_type="text/event-stream",
+    )

--- a/tests/converters/anthropic/test_converter.py
+++ b/tests/converters/anthropic/test_converter.py
@@ -296,7 +296,7 @@ class TestAnthropicConverter:
         choice = result["choices"][0]
         assert choice["index"] == 0
         assert choice["message"]["role"] == "assistant"
-        assert list(choice["message"]["content"])[0]["text"] == "Hello! How can I help?"
+        assert list(choice["message"]["content"])[0]["text"] == "Hello! How can I help?"  # ty: ignore[invalid-key]
         assert choice["finish_reason"]["reason"] == "stop"
 
         assert result["usage"]["prompt_tokens"] == 15

--- a/tests/converters/google_genai/test_converter.py
+++ b/tests/converters/google_genai/test_converter.py
@@ -378,7 +378,7 @@ class TestGoogleGenAIConverter:
         choice = result["choices"][0]
         assert choice["index"] == 0
         assert choice["message"]["role"] == "assistant"
-        assert list(choice["message"]["content"])[0]["text"] == "Hello! How can I help?"
+        assert list(choice["message"]["content"])[0]["text"] == "Hello! How can I help?"  # ty: ignore[invalid-key]
         assert choice["finish_reason"]["reason"] == "stop"
 
         assert result["usage"]["prompt_tokens"] == 15

--- a/tests/test_converters_base.py
+++ b/tests/test_converters_base.py
@@ -473,6 +473,25 @@ class MockConverter(BaseConverter):
     ) -> Union[dict[str, Any], list[dict[str, Any]]]:
         return {}
 
+    @staticmethod
+    def _build_ir_usage(p_usage: dict[str, Any]) -> dict[str, Any]:
+        return p_usage
+
+    @staticmethod
+    def _build_provider_usage(ir_usage: dict[str, Any]) -> dict[str, Any]:
+        return ir_usage
+
+    def _convert_tools_from_p(self, tools: list[Any]) -> list[Any]:
+        return tools
+
+    def _apply_tool_config(
+        self,
+        ir_request: IRRequest,
+        result: dict[str, Any],
+        ctx: ConversionContext,
+    ) -> None:
+        pass
+
 
 # ============================================================================
 # Test classes

--- a/tests/test_converters_base.py
+++ b/tests/test_converters_base.py
@@ -570,7 +570,7 @@ class TestBaseConverter:
         ir_request = self.converter.request_from_provider(provider_request)
 
         assert ir_request["model"] == "test-model"
-        messages_list = cast(list[Message], ir_request["messages"])
+        messages_list = ir_request["messages"]
         assert len(messages_list) == 1
         assert cast(UserMessage, messages_list[0])["role"] == "user"
 


### PR DESCRIPTION
Closes #150

## Summary

- Enable ruff C901 (McCabe cyclomatic complexity) checking with progressive threshold reduction: 25 → 20 → **15**
- Extract cross-provider consistency helpers with identical names across all 4 converters: `_build_ir_usage`, `_build_provider_usage`, `_convert_tools_from_p`, `_apply_tool_config`
- Add these as **abstract methods** in `BaseConverter` with docstring guidance in top-level interface methods
- Document preserve-mode hooks (`_capture/_apply_preserve_metadata`) as convention for providers that support lossless round-trip
- Refactor gateway functions (`put_provider`, `_stream_event_generator`) to reduce complexity

## Changes

| Commit | Description |
|--------|-------------|
| `f2feb03` | Enable ruff C901 with threshold 25 |
| `166f2ba` | Extract `detect_provider` into focused helpers |
| `99f3a6a` | Reduce complexity in OpenAI Responses converter |
| `6be4f64` | Lower threshold to 20, fix all violations |
| `f2ff871` | Cross-provider consistency helpers, lower to 15 |
| `6e0a467` | Unify signatures, add abstract methods to BaseConverter |

**0 C901 violations** at `max-complexity = 15` (excluding vendored code).

## Test plan

- [x] `ruff check` — 0 violations at threshold 15
- [x] `ruff format --check` — all formatted
- [x] `pytest tests/ --ignore=tests/integration` — 1438 passed, 4 skipped
- [x] Removing any of the 4 new abstract methods from a concrete converter causes `TypeError`