### PR TITLE
fix: handle empty Google response when thinking consumes all tokens

### DIFF
--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -406,11 +406,7 @@ class GoogleGenAIConverter(BaseConverter):
 
         for p_candidate in candidates:
             content = p_candidate.get("content")
-            message = (
-                self.message_ops._p_message_to_ir(content)
-                if content
-                else None
-            )
+            message = self.message_ops._p_message_to_ir(content) if content else None
             # Fallback for empty candidates (e.g. thinking consumed all tokens)
             if message is None:
                 message = {"role": "assistant", "content": []}

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -409,8 +409,11 @@ class GoogleGenAIConverter(BaseConverter):
             message = (
                 self.message_ops._p_message_to_ir(content)
                 if content
-                else {"role": "assistant", "content": []}
+                else None
             )
+            # Fallback for empty candidates (e.g. thinking consumed all tokens)
+            if message is None:
+                message = {"role": "assistant", "content": []}
 
             finish_reason_val = p_candidate.get("finish_reason") or p_candidate.get(
                 "finishReason"


### PR DESCRIPTION
## Summary

- Fixes #152
- When Gemini 2.5 Pro (thinking-enabled) has a small `max_tokens` budget, thinking can consume all tokens, producing a response with `content: {"role": "model"}` and no `parts`
- `_p_message_to_ir()` returns `None` for this case, which then fails IR validation with `got None at choices[0].message`
- Added a fallback: when the message conversion returns `None`, produce an empty assistant message `{"role": "assistant", "content": []}` instead

## Test plan

- [x] All 1459 unit tests pass
- [x] Verified locally: `gemini-2.5-pro` with `max_tokens=100` no longer returns 502
- [x] Verified locally: `gemini-2.5-pro` with `max_tokens=2000` returns normal content