### PR TITLE
fix: prevent streaming round-trip event inflation

### DIFF
--- a/dev_scripts/test_roundtrip_inflation.py
+++ b/dev_scripts/test_roundtrip_inflation.py
@@ -12,7 +12,6 @@ Usage:
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from llm_rosetta import get_converter_for_provider
@@ -60,7 +59,7 @@ def _event_label(provider: str, e: dict[str, Any]) -> str:
         if "role" in delta:
             return "role_delta"
         if "content" in delta:
-            return f"content_delta"
+            return "content_delta"
         if "tool_calls" in delta:
             return "tool_calls_delta"
         return "choice_chunk"
@@ -85,12 +84,20 @@ def print_comparison(
     in_types = [_event_label(provider, e) for e in input_events]
     out_types = [_event_label(provider, e) for e in output_events]
 
-    inflated = len(out_types) != len(in_types) or in_types != out_types
+    # Only flag when output has MORE events than input (inflation).
+    # Deflation (output < input) is legitimate — compound chunks can
+    # merge during round-trip (e.g. role + first content merge).
+    inflated = len(out_types) > len(in_types)
 
-    status = "INFLATED" if inflated else "OK"
-    print(f"\n{'='*60}")
+    if len(out_types) == len(in_types):
+        status = "OK (exact)"
+    elif len(out_types) < len(in_types):
+        status = f"OK (deflated {len(in_types)}→{len(out_types)})"
+    else:
+        status = "INFLATED"
+    print(f"\n{'=' * 60}")
     print(f"  {provider}: {len(in_types)} → {len(out_types)} events  [{status}]")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
     print(f"  INPUT  ({len(in_types)}): {in_types}")
     print(f"  OUTPUT ({len(out_types)}): {out_types}")
 
@@ -98,7 +105,7 @@ def print_comparison(
         # Show detailed diff
         max_len = max(len(in_types), len(out_types))
         print(f"\n  {'#':>3}  {'INPUT':<30} {'OUTPUT':<30} {'DIFF'}")
-        print(f"  {'---':>3}  {'-'*30} {'-'*30} {'----'}")
+        print(f"  {'---':>3}  {'-' * 30} {'-' * 30} {'----'}")
         for i in range(max_len):
             inp = in_types[i] if i < len(in_types) else "(none)"
             out = out_types[i] if i < len(out_types) else "(none)"
@@ -157,7 +164,9 @@ OPENAI_CHAT_EVENTS: list[dict[str, Any]] = [
         "object": "chat.completion.chunk",
         "model": "gpt-4o",
         "created": 1700000000,
-        "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+        "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+        ],
     },
     {
         "id": "chatcmpl-001",
@@ -542,9 +551,7 @@ OPENAI_CHAT_TOOL_EVENTS: list[dict[str, Any]] = [
         "object": "chat.completion.chunk",
         "model": "gpt-4o",
         "created": 1700000000,
-        "choices": [
-            {"index": 0, "delta": {}, "finish_reason": "tool_calls"}
-        ],
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
     },
     {
         "id": "chatcmpl-002",
@@ -839,18 +846,14 @@ OPENAI_CHAT_ROLE_EMPTY_CONTENT_EVENTS: list[dict[str, Any]] = [
         "object": "chat.completion.chunk",
         "model": "gpt-5-nano",
         "created": 1700000000,
-        "choices": [
-            {"index": 0, "delta": {"content": "2 + 2"}, "finish_reason": None}
-        ],
+        "choices": [{"index": 0, "delta": {"content": "2 + 2"}, "finish_reason": None}],
     },
     {
         "id": "chatcmpl-002",
         "object": "chat.completion.chunk",
         "model": "gpt-5-nano",
         "created": 1700000000,
-        "choices": [
-            {"index": 0, "delta": {"content": " = 4."}, "finish_reason": None}
-        ],
+        "choices": [{"index": 0, "delta": {"content": " = 4."}, "finish_reason": None}],
     },
     {
         "id": "chatcmpl-002",
@@ -924,9 +927,9 @@ def run_test_case(
         results[key] = inflated
     except Exception as exc:
         key = f"{provider}/{label}"
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"  {key}: ERROR — {exc}")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
         import traceback
 
         traceback.print_exc()
@@ -971,9 +974,9 @@ def main() -> None:
     for label, provider, events in edge_cases:
         run_test_case(label, provider, events, results)
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print("  SUMMARY")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
     any_failed = False
     for key, inflated in results.items():
         status = "INFLATED" if inflated else "OK"
@@ -982,9 +985,9 @@ def main() -> None:
         print(f"  {key:<40} {status}")
 
     if any_failed:
-        print(f"\n  *** SOME TESTS FAILED ***")
+        print("\n  *** SOME TESTS FAILED ***")
     else:
-        print(f"\n  ALL TESTS PASSED")
+        print("\n  ALL TESTS PASSED")
 
 
 if __name__ == "__main__":

--- a/dev_scripts/test_roundtrip_inflation.py
+++ b/dev_scripts/test_roundtrip_inflation.py
@@ -815,6 +815,101 @@ OPENAI_RESPONSES_TOOL_EVENTS: list[dict[str, Any]] = [
 ]
 
 
+# ============================================================
+# Edge Case: OpenAI Chat role chunk with empty content
+# (gpt-5-nano sends delta: {role: "assistant", content: "", refusal: null})
+# ============================================================
+OPENAI_CHAT_ROLE_EMPTY_CONTENT_EVENTS: list[dict[str, Any]] = [
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-5-nano",
+        "created": 1700000000,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": "", "refusal": None},
+                "finish_reason": None,
+            }
+        ],
+        "usage": None,
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-5-nano",
+        "created": 1700000000,
+        "choices": [
+            {"index": 0, "delta": {"content": "2 + 2"}, "finish_reason": None}
+        ],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-5-nano",
+        "created": 1700000000,
+        "choices": [
+            {"index": 0, "delta": {"content": " = 4."}, "finish_reason": None}
+        ],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-5-nano",
+        "created": 1700000000,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-5-nano",
+        "created": 1700000000,
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 8,
+            "total_tokens": 18,
+        },
+    },
+]
+
+# ============================================================
+# Edge Case: Google compound text+finish chunk
+# (gemini-2.5-flash returns text AND finishReason in the same chunk)
+# ============================================================
+GOOGLE_COMPOUND_TEXT_FINISH_EVENTS: list[dict[str, Any]] = [
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "2 plus "}], "role": "model"},
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 6,
+            "candidatesTokenCount": 3,
+            "totalTokenCount": 9,
+        },
+        "modelVersion": "gemini-2.5-flash",
+    },
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "2 equals 4."}], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 6,
+            "candidatesTokenCount": 8,
+            "totalTokenCount": 14,
+        },
+        "modelVersion": "gemini-2.5-flash",
+    },
+]
+
+
 def run_test_case(
     label: str,
     provider: str,
@@ -859,6 +954,8 @@ def main() -> None:
         ("tool-call", "google", GOOGLE_TOOL_EVENTS),
         ("thinking", "google", GOOGLE_THINKING_EVENTS),
         ("no-empty-text", "google", GOOGLE_NO_EMPTY_TEXT_EVENTS),
+        ("role-empty-content", "openai_chat", OPENAI_CHAT_ROLE_EMPTY_CONTENT_EVENTS),
+        ("compound-text-finish", "google", GOOGLE_COMPOUND_TEXT_FINISH_EVENTS),
         ("tool-call", "openai_responses", OPENAI_RESPONSES_TOOL_EVENTS),
     ]
 

--- a/dev_scripts/test_roundtrip_inflation.py
+++ b/dev_scripts/test_roundtrip_inflation.py
@@ -1,0 +1,894 @@
+#!/usr/bin/env python3
+"""Test streaming round-trip event inflation for all providers.
+
+For each provider, sends a realistic SSE event sequence through:
+  stream_response_from_provider → IR events → stream_response_to_provider
+
+Compares input event count vs output event count to detect inflation.
+
+Usage:
+    python dev_scripts/test_roundtrip_inflation.py
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from llm_rosetta import get_converter_for_provider
+from llm_rosetta.converters.base.context import StreamContext
+
+
+def run_roundtrip(
+    provider: str,
+    input_events: list[dict[str, Any]],
+    label: str = "",
+) -> list[dict[str, Any]]:
+    """Run a streaming round-trip and return output events."""
+    converter = get_converter_for_provider(provider)
+    from_ctx = StreamContext()
+    to_ctx = StreamContext()
+
+    output_events: list[dict[str, Any]] = []
+
+    for inp in input_events:
+        ir_events = converter.stream_response_from_provider(inp, context=from_ctx)
+        for ir_event in ir_events:
+            result = converter.stream_response_to_provider(ir_event, context=to_ctx)
+            if isinstance(result, list):
+                output_events.extend(e for e in result if e)
+            elif result:
+                output_events.append(result)
+
+    return output_events
+
+
+def _event_label(provider: str, e: dict[str, Any]) -> str:
+    """Extract a meaningful label from a provider event."""
+    t = e.get("type")
+    if t:
+        return t
+    # OpenAI Chat: describe by choices/usage structure
+    if "choices" in e:
+        choices = e["choices"]
+        if not choices:
+            return "usage_chunk" if "usage" in e else "empty_choices"
+        delta = choices[0].get("delta", {})
+        fr = choices[0].get("finish_reason")
+        if fr:
+            return f"finish({fr})"
+        if "role" in delta:
+            return "role_delta"
+        if "content" in delta:
+            return f"content_delta"
+        if "tool_calls" in delta:
+            return "tool_calls_delta"
+        return "choice_chunk"
+    # Google: describe by candidates structure
+    if "candidates" in e:
+        cand = e["candidates"][0] if e.get("candidates") else {}
+        if cand.get("finishReason"):
+            return f"finish({cand['finishReason']})"
+        parts = cand.get("content", {}).get("parts", [])
+        if parts:
+            return "text_chunk"
+        return "candidate_chunk"
+    return "unknown"
+
+
+def print_comparison(
+    provider: str,
+    input_events: list[dict[str, Any]],
+    output_events: list[dict[str, Any]],
+) -> bool:
+    """Print comparison and return True if inflated."""
+    in_types = [_event_label(provider, e) for e in input_events]
+    out_types = [_event_label(provider, e) for e in output_events]
+
+    inflated = len(out_types) != len(in_types) or in_types != out_types
+
+    status = "INFLATED" if inflated else "OK"
+    print(f"\n{'='*60}")
+    print(f"  {provider}: {len(in_types)} → {len(out_types)} events  [{status}]")
+    print(f"{'='*60}")
+    print(f"  INPUT  ({len(in_types)}): {in_types}")
+    print(f"  OUTPUT ({len(out_types)}): {out_types}")
+
+    if inflated:
+        # Show detailed diff
+        max_len = max(len(in_types), len(out_types))
+        print(f"\n  {'#':>3}  {'INPUT':<30} {'OUTPUT':<30} {'DIFF'}")
+        print(f"  {'---':>3}  {'-'*30} {'-'*30} {'----'}")
+        for i in range(max_len):
+            inp = in_types[i] if i < len(in_types) else "(none)"
+            out = out_types[i] if i < len(out_types) else "(none)"
+            diff = "<<<" if inp != out else ""
+            print(f"  {i:>3}  {inp:<30} {out:<30} {diff}")
+
+    return inflated
+
+
+# ============================================================
+# Anthropic
+# ============================================================
+ANTHROPIC_EVENTS: list[dict[str, Any]] = [
+    {
+        "type": "message_start",
+        "message": {
+            "id": "msg_001",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-20250514",
+            "content": [],
+            "stop_reason": None,
+            "usage": {"input_tokens": 12, "output_tokens": 1},
+        },
+    },
+    {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "text", "text": ""},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": "Hello"},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": " world!"},
+    },
+    {"type": "content_block_stop", "index": 0},
+    {
+        "type": "message_delta",
+        "delta": {"stop_reason": "end_turn"},
+        "usage": {"output_tokens": 5},
+    },
+    {"type": "message_stop"},
+]
+
+# ============================================================
+# OpenAI Chat
+# ============================================================
+OPENAI_CHAT_EVENTS: list[dict[str, Any]] = [
+    {
+        "id": "chatcmpl-001",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+    },
+    {
+        "id": "chatcmpl-001",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [{"index": 0, "delta": {"content": "Hello"}, "finish_reason": None}],
+    },
+    {
+        "id": "chatcmpl-001",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [
+            {"index": 0, "delta": {"content": " world!"}, "finish_reason": None}
+        ],
+    },
+    {
+        "id": "chatcmpl-001",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+    },
+    {
+        "id": "chatcmpl-001",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 12,
+            "completion_tokens": 5,
+            "total_tokens": 17,
+        },
+    },
+]
+
+# ============================================================
+# OpenAI Responses
+# ============================================================
+OPENAI_RESPONSES_EVENTS: list[dict[str, Any]] = [
+    {
+        "type": "response.created",
+        "response": {
+            "id": "resp_001",
+            "object": "response",
+            "model": "gpt-4o",
+            "status": "in_progress",
+            "output": [],
+            "usage": None,
+        },
+    },
+    {
+        "type": "response.output_item.added",
+        "output_index": 0,
+        "item": {
+            "type": "message",
+            "id": "msg_001",
+            "role": "assistant",
+            "content": [],
+        },
+    },
+    {
+        "type": "response.content_part.added",
+        "item_id": "msg_001",
+        "output_index": 0,
+        "content_index": 0,
+        "part": {"type": "output_text", "text": "", "annotations": []},
+    },
+    {
+        "type": "response.output_text.delta",
+        "item_id": "msg_001",
+        "output_index": 0,
+        "content_index": 0,
+        "delta": "Hello",
+    },
+    {
+        "type": "response.output_text.delta",
+        "item_id": "msg_001",
+        "output_index": 0,
+        "content_index": 0,
+        "delta": " world!",
+    },
+    {
+        "type": "response.output_text.done",
+        "item_id": "msg_001",
+        "output_index": 0,
+        "content_index": 0,
+        "text": "Hello world!",
+    },
+    {
+        "type": "response.content_part.done",
+        "item_id": "msg_001",
+        "output_index": 0,
+        "content_index": 0,
+        "part": {
+            "type": "output_text",
+            "text": "Hello world!",
+            "annotations": [],
+        },
+    },
+    {
+        "type": "response.output_item.done",
+        "output_index": 0,
+        "item": {
+            "type": "message",
+            "id": "msg_001",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Hello world!",
+                    "annotations": [],
+                }
+            ],
+        },
+    },
+    {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_001",
+            "object": "response",
+            "model": "gpt-4o",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_001",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Hello world!",
+                            "annotations": [],
+                        }
+                    ],
+                }
+            ],
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 5,
+                "total_tokens": 17,
+            },
+        },
+    },
+]
+
+# ============================================================
+# Google GenAI
+# ============================================================
+GOOGLE_EVENTS: list[dict[str, Any]] = [
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello"}], "role": "model"},
+                "index": 0,
+            }
+        ],
+        "modelVersion": "gemini-2.0-flash",
+    },
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": " world!"}], "role": "model"},
+                "index": 0,
+            }
+        ],
+    },
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": ""}], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 12,
+            "candidatesTokenCount": 5,
+            "totalTokenCount": 17,
+        },
+        "modelVersion": "gemini-2.0-flash",
+    },
+]
+
+
+# ============================================================
+# Edge Cases: Anthropic with thinking + tool call
+# ============================================================
+ANTHROPIC_THINKING_TOOL_EVENTS: list[dict[str, Any]] = [
+    {
+        "type": "message_start",
+        "message": {
+            "id": "msg_002",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-20250514",
+            "content": [],
+            "stop_reason": None,
+            "usage": {"input_tokens": 50, "output_tokens": 1},
+        },
+    },
+    # Block 0: thinking
+    {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "thinking", "thinking": ""},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "thinking_delta", "thinking": "Let me search for"},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "thinking_delta", "thinking": " the answer."},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "signature_delta", "signature": "sig_abc123"},
+    },
+    {"type": "content_block_stop", "index": 0},
+    # Block 1: tool_use
+    {
+        "type": "content_block_start",
+        "index": 1,
+        "content_block": {
+            "type": "tool_use",
+            "id": "toolu_abc",
+            "name": "web_search",
+            "input": {},
+        },
+    },
+    {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {"type": "input_json_delta", "partial_json": '{"query":'},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {"type": "input_json_delta", "partial_json": '"hello"}'},
+    },
+    {"type": "content_block_stop", "index": 1},
+    # Finish
+    {
+        "type": "message_delta",
+        "delta": {"stop_reason": "tool_use"},
+        "usage": {"output_tokens": 42},
+    },
+    {"type": "message_stop"},
+]
+
+# ============================================================
+# Edge Cases: Anthropic with no usage in message_start
+# ============================================================
+ANTHROPIC_NO_INITIAL_USAGE_EVENTS: list[dict[str, Any]] = [
+    {
+        "type": "message_start",
+        "message": {
+            "id": "msg_003",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-20250514",
+            "content": [],
+            "stop_reason": None,
+        },
+    },
+    {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "text", "text": ""},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": "Hi"},
+    },
+    {"type": "content_block_stop", "index": 0},
+    {
+        "type": "message_delta",
+        "delta": {"stop_reason": "end_turn"},
+        "usage": {"output_tokens": 1},
+    },
+    {"type": "message_stop"},
+]
+
+# ============================================================
+# Edge Cases: Anthropic finish without usage (stop only)
+# ============================================================
+ANTHROPIC_FINISH_NO_USAGE_EVENTS: list[dict[str, Any]] = [
+    {
+        "type": "message_start",
+        "message": {
+            "id": "msg_004",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-20250514",
+            "content": [],
+            "stop_reason": None,
+            "usage": {"input_tokens": 5, "output_tokens": 0},
+        },
+    },
+    {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "text", "text": ""},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": "OK"},
+    },
+    {"type": "content_block_stop", "index": 0},
+    {
+        "type": "message_delta",
+        "delta": {"stop_reason": "end_turn"},
+    },
+    {"type": "message_stop"},
+]
+
+# ============================================================
+# Edge Cases: OpenAI Chat with tool calls
+# ============================================================
+OPENAI_CHAT_TOOL_EVENTS: list[dict[str, Any]] = [
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+        ],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_abc",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": ""},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"arguments": '{"city":"NYC"}'},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [
+            {"index": 0, "delta": {}, "finish_reason": "tool_calls"}
+        ],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 30,
+            "completion_tokens": 15,
+            "total_tokens": 45,
+        },
+    },
+]
+
+# ============================================================
+# Edge Cases: OpenAI Chat with reasoning_content
+# ============================================================
+OPENAI_CHAT_REASONING_EVENTS: list[dict[str, Any]] = [
+    {
+        "id": "chatcmpl-003",
+        "object": "chat.completion.chunk",
+        "model": "o3-mini",
+        "created": 1700000000,
+        "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+        ],
+    },
+    {
+        "id": "chatcmpl-003",
+        "object": "chat.completion.chunk",
+        "model": "o3-mini",
+        "created": 1700000000,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"reasoning_content": "Let me think..."},
+                "finish_reason": None,
+            }
+        ],
+    },
+    {
+        "id": "chatcmpl-003",
+        "object": "chat.completion.chunk",
+        "model": "o3-mini",
+        "created": 1700000000,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": "The answer is 42."},
+                "finish_reason": None,
+            }
+        ],
+    },
+    {
+        "id": "chatcmpl-003",
+        "object": "chat.completion.chunk",
+        "model": "o3-mini",
+        "created": 1700000000,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+    },
+    {
+        "id": "chatcmpl-003",
+        "object": "chat.completion.chunk",
+        "model": "o3-mini",
+        "created": 1700000000,
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 20,
+            "completion_tokens": 30,
+            "total_tokens": 50,
+        },
+    },
+]
+
+# ============================================================
+# Edge Cases: Google with tool call (functionCall)
+# ============================================================
+GOOGLE_TOOL_EVENTS: list[dict[str, Any]] = [
+    {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "get_weather",
+                                "args": {"city": "NYC"},
+                            }
+                        }
+                    ],
+                    "role": "model",
+                },
+                "index": 0,
+            }
+        ],
+        "modelVersion": "gemini-2.0-flash",
+    },
+    {
+        "candidates": [
+            {
+                "content": {"parts": [], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 25,
+            "candidatesTokenCount": 10,
+            "totalTokenCount": 35,
+        },
+        "modelVersion": "gemini-2.0-flash",
+    },
+]
+
+# ============================================================
+# Edge Cases: Google with thinking (thought parts)
+# ============================================================
+GOOGLE_THINKING_EVENTS: list[dict[str, Any]] = [
+    {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [{"text": "Analyzing...", "thought": True}],
+                    "role": "model",
+                },
+                "index": 0,
+            }
+        ],
+        "modelVersion": "gemini-2.5-flash",
+    },
+    {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [{"text": "The answer is 42."}],
+                    "role": "model",
+                },
+                "index": 0,
+            }
+        ],
+    },
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": ""}], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 15,
+            "candidatesTokenCount": 20,
+            "totalTokenCount": 35,
+            "thoughtsTokenCount": 10,
+        },
+        "modelVersion": "gemini-2.5-flash",
+    },
+]
+
+# ============================================================
+# Edge Cases: Google finish without empty text padding
+# ============================================================
+GOOGLE_NO_EMPTY_TEXT_EVENTS: list[dict[str, Any]] = [
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello!"}], "role": "model"},
+                "index": 0,
+            }
+        ],
+        "modelVersion": "gemini-2.0-flash",
+    },
+    {
+        "candidates": [
+            {
+                "content": {"parts": [], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 5,
+            "candidatesTokenCount": 2,
+            "totalTokenCount": 7,
+        },
+    },
+]
+
+# ============================================================
+# Edge Cases: OpenAI Responses with tool call
+# ============================================================
+OPENAI_RESPONSES_TOOL_EVENTS: list[dict[str, Any]] = [
+    {
+        "type": "response.created",
+        "response": {
+            "id": "resp_002",
+            "object": "response",
+            "model": "gpt-4o",
+            "status": "in_progress",
+            "output": [],
+            "usage": None,
+        },
+    },
+    {
+        "type": "response.output_item.added",
+        "output_index": 0,
+        "item": {
+            "type": "function_call",
+            "id": "fc_001",
+            "call_id": "call_xyz",
+            "name": "get_weather",
+            "arguments": "",
+        },
+    },
+    {
+        "type": "response.function_call_arguments.delta",
+        "item_id": "fc_001",
+        "output_index": 0,
+        "delta": '{"city":',
+    },
+    {
+        "type": "response.function_call_arguments.delta",
+        "item_id": "fc_001",
+        "output_index": 0,
+        "delta": '"NYC"}',
+    },
+    {
+        "type": "response.function_call_arguments.done",
+        "item_id": "fc_001",
+        "output_index": 0,
+        "arguments": '{"city":"NYC"}',
+    },
+    {
+        "type": "response.output_item.done",
+        "output_index": 0,
+        "item": {
+            "type": "function_call",
+            "id": "fc_001",
+            "call_id": "call_xyz",
+            "name": "get_weather",
+            "arguments": '{"city":"NYC"}',
+        },
+    },
+    {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_002",
+            "object": "response",
+            "model": "gpt-4o",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "function_call",
+                    "id": "fc_001",
+                    "call_id": "call_xyz",
+                    "name": "get_weather",
+                    "arguments": '{"city":"NYC"}',
+                }
+            ],
+            "usage": {
+                "input_tokens": 20,
+                "output_tokens": 10,
+                "total_tokens": 30,
+            },
+        },
+    },
+]
+
+
+def run_test_case(
+    label: str,
+    provider: str,
+    events: list[dict[str, Any]],
+    results: dict[str, bool],
+) -> None:
+    """Run a single test case and record the result."""
+    try:
+        output = run_roundtrip(provider, events)
+        inflated = print_comparison(f"{provider} ({label})", events, output)
+        key = f"{provider}/{label}"
+        results[key] = inflated
+    except Exception as exc:
+        key = f"{provider}/{label}"
+        print(f"\n{'='*60}")
+        print(f"  {key}: ERROR — {exc}")
+        print(f"{'='*60}")
+        import traceback
+
+        traceback.print_exc()
+        results[key] = True
+
+
+def main() -> None:
+    results: dict[str, bool] = {}
+
+    # Basic cases
+    basic_cases = [
+        ("basic", "anthropic", ANTHROPIC_EVENTS),
+        ("basic", "openai_chat", OPENAI_CHAT_EVENTS),
+        ("basic", "openai_responses", OPENAI_RESPONSES_EVENTS),
+        ("basic", "google", GOOGLE_EVENTS),
+    ]
+
+    # Edge cases
+    edge_cases = [
+        ("thinking+tool", "anthropic", ANTHROPIC_THINKING_TOOL_EVENTS),
+        ("no-initial-usage", "anthropic", ANTHROPIC_NO_INITIAL_USAGE_EVENTS),
+        ("finish-no-usage", "anthropic", ANTHROPIC_FINISH_NO_USAGE_EVENTS),
+        ("tool-calls", "openai_chat", OPENAI_CHAT_TOOL_EVENTS),
+        ("reasoning", "openai_chat", OPENAI_CHAT_REASONING_EVENTS),
+        ("tool-call", "google", GOOGLE_TOOL_EVENTS),
+        ("thinking", "google", GOOGLE_THINKING_EVENTS),
+        ("no-empty-text", "google", GOOGLE_NO_EMPTY_TEXT_EVENTS),
+        ("tool-call", "openai_responses", OPENAI_RESPONSES_TOOL_EVENTS),
+    ]
+
+    print("\n" + "=" * 60)
+    print("  BASIC CASES")
+    print("=" * 60)
+    for label, provider, events in basic_cases:
+        run_test_case(label, provider, events, results)
+
+    print("\n\n" + "=" * 60)
+    print("  EDGE CASES")
+    print("=" * 60)
+    for label, provider, events in edge_cases:
+        run_test_case(label, provider, events, results)
+
+    print(f"\n{'='*60}")
+    print("  SUMMARY")
+    print(f"{'='*60}")
+    any_failed = False
+    for key, inflated in results.items():
+        status = "INFLATED" if inflated else "OK"
+        if inflated:
+            any_failed = True
+        print(f"  {key:<40} {status}")
+
+    if any_failed:
+        print(f"\n  *** SOME TESTS FAILED ***")
+    else:
+        print(f"\n  ALL TESTS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev_scripts/test_roundtrip_live.py
+++ b/dev_scripts/test_roundtrip_live.py
@@ -4,12 +4,17 @@
 Captures a real streaming response from each provider, then runs it
 through the round-trip pipeline to verify no event inflation occurs.
 
+Supports two test modes:
+  - text:  longer text generation (levels out chunk counts across providers)
+  - tools: tool-call flow (each provider invokes get_weather)
+
 Requires API keys in .env (or environment variables).
 
 Usage:
-    python dev_scripts/test_roundtrip_live.py
-    python dev_scripts/test_roundtrip_live.py --provider anthropic
-    python dev_scripts/test_roundtrip_live.py --prompt "Use a tool to get the weather in NYC"
+    python dev_scripts/test_roundtrip_live.py                    # both modes
+    python dev_scripts/test_roundtrip_live.py --mode text         # text only
+    python dev_scripts/test_roundtrip_live.py --mode tools        # tools only
+    python dev_scripts/test_roundtrip_live.py --provider google
 """
 
 from __future__ import annotations
@@ -25,6 +30,24 @@ import httpx
 
 from llm_rosetta import get_converter_for_provider
 from llm_rosetta.converters.base.context import StreamContext
+
+# ============================================================
+# Prompts & tool schema
+# ============================================================
+
+TEXT_PROMPT = "List 5 fun facts about the number 42, one per line. Be concise."
+TOOL_PROMPT = (
+    "What is the current weather in New York City? "
+    "Use the get_weather tool to find out."
+)
+
+TOOL_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "city": {"type": "string", "description": "City name"},
+    },
+    "required": ["city"],
+}
 
 
 def load_env() -> None:
@@ -50,7 +73,9 @@ def load_env() -> None:
 # ============================================================
 
 
-def capture_anthropic(prompt: str) -> tuple[list[dict[str, Any]], str]:
+def capture_anthropic(
+    prompt: str, use_tools: bool = False
+) -> tuple[list[dict[str, Any]], str]:
     """Capture real Anthropic SSE events."""
     api_key = os.environ.get("ANTHROPIC_API_KEY", "")
     base_url = os.environ.get("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
@@ -61,12 +86,20 @@ def capture_anthropic(prompt: str) -> tuple[list[dict[str, Any]], str]:
         "anthropic-version": "2023-06-01",
         "content-type": "application/json",
     }
-    body = {
+    body: dict[str, Any] = {
         "model": model,
-        "max_tokens": 300,
+        "max_tokens": 512,
         "stream": True,
         "messages": [{"role": "user", "content": prompt}],
     }
+    if use_tools:
+        body["tools"] = [
+            {
+                "name": "get_weather",
+                "description": "Get weather for a city",
+                "input_schema": TOOL_SCHEMA,
+            }
+        ]
 
     events: list[dict[str, Any]] = []
     with httpx.stream(
@@ -74,28 +107,28 @@ def capture_anthropic(prompt: str) -> tuple[list[dict[str, Any]], str]:
         f"{base_url}/v1/messages",
         headers=headers,
         json=body,
-        timeout=30.0,
+        timeout=60.0,
     ) as resp:
         if resp.status_code != 200:
             err = resp.read().decode()
-            raise RuntimeError(f"Anthropic HTTP {resp.status_code}: {err[:200]}")
-        current_event = None
+            raise RuntimeError(f"Anthropic HTTP {resp.status_code}: {err[:300]}")
         for line in resp.iter_lines():
             if not line:
                 continue
             if line.startswith("event: "):
-                current_event = line[7:].strip()
-            elif line.startswith("data: "):
+                continue
+            if line.startswith("data: "):
                 try:
-                    data = json.loads(line[6:])
-                    events.append(data)
+                    events.append(json.loads(line[6:]))
                 except json.JSONDecodeError:
                     pass
 
     return events, model
 
 
-def capture_openai_chat(prompt: str) -> tuple[list[dict[str, Any]], str]:
+def capture_openai_chat(
+    prompt: str, use_tools: bool = False
+) -> tuple[list[dict[str, Any]], str]:
     """Capture real OpenAI Chat SSE events."""
     api_key = os.environ.get("OPENAI_API_KEY", "")
     base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
@@ -105,13 +138,24 @@ def capture_openai_chat(prompt: str) -> tuple[list[dict[str, Any]], str]:
         "authorization": f"Bearer {api_key}",
         "content-type": "application/json",
     }
-    body = {
+    body: dict[str, Any] = {
         "model": model,
-        "max_completion_tokens": 300,
+        "max_completion_tokens": 512,
         "stream": True,
         "stream_options": {"include_usage": True},
         "messages": [{"role": "user", "content": prompt}],
     }
+    if use_tools:
+        body["tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather for a city",
+                    "parameters": TOOL_SCHEMA,
+                },
+            }
+        ]
 
     events: list[dict[str, Any]] = []
     with httpx.stream(
@@ -119,11 +163,11 @@ def capture_openai_chat(prompt: str) -> tuple[list[dict[str, Any]], str]:
         f"{base_url}/chat/completions",
         headers=headers,
         json=body,
-        timeout=30.0,
+        timeout=60.0,
     ) as resp:
         if resp.status_code != 200:
             err = resp.read().decode()
-            raise RuntimeError(f"OpenAI Chat HTTP {resp.status_code}: {err[:200]}")
+            raise RuntimeError(f"OpenAI Chat HTTP {resp.status_code}: {err[:300]}")
         for line in resp.iter_lines():
             if not line or not line.startswith("data: "):
                 continue
@@ -138,24 +182,33 @@ def capture_openai_chat(prompt: str) -> tuple[list[dict[str, Any]], str]:
     return events, model
 
 
-def capture_openai_responses(prompt: str) -> tuple[list[dict[str, Any]], str]:
+def capture_openai_responses(
+    prompt: str, use_tools: bool = False
+) -> tuple[list[dict[str, Any]], str]:
     """Capture real OpenAI Responses SSE events."""
     api_key = os.environ.get("OPENAI_RESPONSES_API_KEY", "")
-    base_url = os.environ.get(
-        "OPENAI_RESPONSES_BASE_URL", "https://api.openai.com/v1"
-    )
+    base_url = os.environ.get("OPENAI_RESPONSES_BASE_URL", "https://api.openai.com/v1")
     model = os.environ.get("OPENAI_RESPONSES_MODEL", "gpt-4o-mini")
 
     headers = {
         "authorization": f"Bearer {api_key}",
         "content-type": "application/json",
     }
-    body = {
+    body: dict[str, Any] = {
         "model": model,
-        "max_output_tokens": 300,
+        "max_output_tokens": 512,
         "stream": True,
         "input": [{"role": "user", "content": prompt}],
     }
+    if use_tools:
+        body["tools"] = [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get weather for a city",
+                "parameters": TOOL_SCHEMA,
+            }
+        ]
 
     events: list[dict[str, Any]] = []
     with httpx.stream(
@@ -163,11 +216,11 @@ def capture_openai_responses(prompt: str) -> tuple[list[dict[str, Any]], str]:
         f"{base_url}/responses",
         headers=headers,
         json=body,
-        timeout=30.0,
+        timeout=60.0,
     ) as resp:
         if resp.status_code != 200:
             err = resp.read().decode()
-            raise RuntimeError(f"OpenAI Responses HTTP {resp.status_code}: {err[:200]}")
+            raise RuntimeError(f"OpenAI Responses HTTP {resp.status_code}: {err[:300]}")
         for line in resp.iter_lines():
             if not line:
                 continue
@@ -185,7 +238,9 @@ def capture_openai_responses(prompt: str) -> tuple[list[dict[str, Any]], str]:
     return events, model
 
 
-def capture_google(prompt: str) -> tuple[list[dict[str, Any]], str]:
+def capture_google(
+    prompt: str, use_tools: bool = False
+) -> tuple[list[dict[str, Any]], str]:
     """Capture real Google GenAI SSE events."""
     api_key = os.environ.get("GOOGLE_API_KEY", "")
     base_url = os.environ.get(
@@ -194,10 +249,22 @@ def capture_google(prompt: str) -> tuple[list[dict[str, Any]], str]:
     )
     model = os.environ.get("GOOGLE_MODEL", "gemini-2.0-flash")
 
-    body = {
+    body: dict[str, Any] = {
         "contents": [{"role": "user", "parts": [{"text": prompt}]}],
-        "generationConfig": {"maxOutputTokens": 300},
+        "generationConfig": {"maxOutputTokens": 512},
     }
+    if use_tools:
+        body["tools"] = [
+            {
+                "functionDeclarations": [
+                    {
+                        "name": "get_weather",
+                        "description": "Get weather for a city",
+                        "parameters": TOOL_SCHEMA,
+                    }
+                ]
+            }
+        ]
 
     events: list[dict[str, Any]] = []
     url = f"{base_url}/models/{model}:streamGenerateContent?alt=sse&key={api_key}"
@@ -205,11 +272,11 @@ def capture_google(prompt: str) -> tuple[list[dict[str, Any]], str]:
         "POST",
         url,
         json=body,
-        timeout=30.0,
+        timeout=60.0,
     ) as resp:
         if resp.status_code != 200:
             err = resp.read().decode()
-            raise RuntimeError(f"Google HTTP {resp.status_code}: {err[:200]}")
+            raise RuntimeError(f"Google HTTP {resp.status_code}: {err[:300]}")
         for line in resp.iter_lines():
             if not line or not line.startswith("data: "):
                 continue
@@ -271,7 +338,10 @@ def event_type_label(provider: str, e: dict[str, Any]) -> str:
         if "reasoning_content" in delta:
             return "reasoning_delta"
         if "tool_calls" in delta:
-            return "tool_calls_delta"
+            tc = delta["tool_calls"][0]
+            if tc.get("id"):
+                return "tool_call_start"
+            return "tool_call_args"
         return "choice_chunk"
     if "candidates" in e:
         cand = e["candidates"][0] if e.get("candidates") else {}
@@ -290,6 +360,7 @@ def event_type_label(provider: str, e: dict[str, Any]) -> str:
 
 
 def print_result(
+    label: str,
     provider: str,
     model: str,
     input_events: list[dict[str, Any]],
@@ -301,10 +372,6 @@ def print_result(
     out_types = [event_type_label(provider, e) for e in output_events]
     ir_types = [e.get("type", "?") for e in ir_events]
 
-    # "Inflated" means output has MORE events than input.
-    # output < input is OK (compound chunks decompose legitimately).
-    # output == input is ideal (perfect round-trip).
-    # output > input is the bug we're fixing.
     inflated = len(out_types) > len(in_types)
     if len(out_types) == len(in_types):
         status = "OK (exact)"
@@ -313,10 +380,13 @@ def print_result(
     else:
         status = "INFLATED"
 
-    print(f"\n{'='*70}")
-    print(f"  {provider} ({model})")
-    print(f"  {len(in_types)} input → {len(ir_types)} IR → {len(out_types)} output  [{status}]")
-    print(f"{'='*70}")
+    print(f"\n{'=' * 70}")
+    print(f"  {label} — {provider} ({model})")
+    print(
+        f"  {len(in_types)} input → {len(ir_types)} IR → {len(out_types)} output"
+        f"  [{status}]"
+    )
+    print(f"{'=' * 70}")
     print(f"  INPUT  ({len(in_types):>2}): {in_types}")
     print(f"  IR     ({len(ir_types):>2}): {ir_types}")
     print(f"  OUTPUT ({len(out_types):>2}): {out_types}")
@@ -324,7 +394,7 @@ def print_result(
     if inflated:
         max_len = max(len(in_types), len(out_types))
         print(f"\n  {'#':>3}  {'INPUT':<30} {'OUTPUT':<30} {'DIFF'}")
-        print(f"  {'---':>3}  {'-'*30} {'-'*30} {'----'}")
+        print(f"  {'---':>3}  {'-' * 30} {'-' * 30} {'----'}")
         for i in range(max_len):
             inp = in_types[i] if i < len(in_types) else "(none)"
             out = out_types[i] if i < len(out_types) else "(none)"
@@ -342,6 +412,52 @@ PROVIDERS = {
 }
 
 
+def run_pass(
+    pass_label: str,
+    prompt: str,
+    use_tools: bool,
+    providers: list[str],
+    save_dir: Path | None,
+    results: dict[str, bool],
+) -> None:
+    """Run one test pass (text or tools) across selected providers."""
+    print(f"\n{'#' * 70}")
+    print(f"  {pass_label}")
+    print(f"{'#' * 70}")
+
+    for provider in providers:
+        capture_fn = PROVIDERS[provider]
+        key = f"{pass_label}/{provider}"
+        try:
+            print(f"\n  Capturing {provider} ({pass_label})...", end="", flush=True)
+            raw_events, model = capture_fn(prompt, use_tools=use_tools)
+            print(f" {len(raw_events)} events captured.")
+
+            if save_dir:
+                suffix = "tools" if use_tools else "text"
+                out_file = save_dir / f"{provider}_{suffix}_raw.jsonl"
+                with open(out_file, "w") as f:
+                    for e in raw_events:
+                        f.write(json.dumps(e, ensure_ascii=False) + "\n")
+                print(f"  Saved to {out_file}")
+
+            ir_events, output_events = run_roundtrip(provider, raw_events)
+            inflated = print_result(
+                pass_label, provider, model, raw_events, ir_events, output_events
+            )
+            results[key] = inflated
+
+        except Exception as exc:
+            print(" ERROR")
+            print(f"\n{'=' * 70}")
+            print(f"  {key}: ERROR — {exc}")
+            print(f"{'=' * 70}")
+            import traceback
+
+            traceback.print_exc()
+            results[key] = True
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Live SSE round-trip test")
     parser.add_argument(
@@ -351,9 +467,15 @@ def main() -> None:
         help="Test only this provider (default: all)",
     )
     parser.add_argument(
+        "--mode",
+        choices=["text", "tools", "all"],
+        default="all",
+        help="Test mode: text-only, tools-only, or both (default: all)",
+    )
+    parser.add_argument(
         "--prompt",
-        default="What is 2+2? Answer in one sentence.",
-        help="Prompt to send",
+        default=None,
+        help="Override default prompt (applies to selected mode)",
     )
     parser.add_argument(
         "--save",
@@ -365,55 +487,48 @@ def main() -> None:
     load_env()
 
     providers = [args.provider] if args.provider else list(PROVIDERS.keys())
+    save_dir = Path(args.save) if args.save else None
+    if save_dir:
+        save_dir.mkdir(parents=True, exist_ok=True)
+
     results: dict[str, bool] = {}
 
-    for provider in providers:
-        capture_fn = PROVIDERS[provider]
-        try:
-            print(f"\n  Capturing {provider}...", end="", flush=True)
-            raw_events, model = capture_fn(args.prompt)
-            print(f" {len(raw_events)} events captured.")
+    if args.mode in ("text", "all"):
+        run_pass(
+            pass_label="text",
+            prompt=args.prompt or TEXT_PROMPT,
+            use_tools=False,
+            providers=providers,
+            save_dir=save_dir,
+            results=results,
+        )
 
-            if args.save:
-                save_dir = Path(args.save)
-                save_dir.mkdir(parents=True, exist_ok=True)
-                out_file = save_dir / f"{provider}_raw.jsonl"
-                with open(out_file, "w") as f:
-                    for e in raw_events:
-                        f.write(json.dumps(e, ensure_ascii=False) + "\n")
-                print(f"  Saved to {out_file}")
+    if args.mode in ("tools", "all"):
+        run_pass(
+            pass_label="tools",
+            prompt=args.prompt or TOOL_PROMPT,
+            use_tools=True,
+            providers=providers,
+            save_dir=save_dir,
+            results=results,
+        )
 
-            ir_events, output_events = run_roundtrip(provider, raw_events)
-            inflated = print_result(
-                provider, model, raw_events, ir_events, output_events
-            )
-            results[provider] = inflated
-
-        except Exception as exc:
-            print(f" ERROR")
-            print(f"\n{'='*70}")
-            print(f"  {provider}: ERROR — {exc}")
-            print(f"{'='*70}")
-            import traceback
-
-            traceback.print_exc()
-            results[provider] = True
-
-    print(f"\n{'='*70}")
+    # Summary
+    print(f"\n{'=' * 70}")
     print("  SUMMARY")
-    print(f"{'='*70}")
+    print(f"{'=' * 70}")
     any_failed = False
-    for provider, inflated in results.items():
+    for key, inflated in results.items():
         status = "INFLATED" if inflated else "OK"
         if inflated:
             any_failed = True
-        print(f"  {provider:<25} {status}")
+        print(f"  {key:<40} {status}")
 
     if any_failed:
-        print(f"\n  *** SOME TESTS FAILED ***")
+        print("\n  *** SOME TESTS FAILED ***")
         sys.exit(1)
     else:
-        print(f"\n  ALL TESTS PASSED")
+        print("\n  ALL TESTS PASSED")
 
 
 if __name__ == "__main__":

--- a/dev_scripts/test_roundtrip_live.py
+++ b/dev_scripts/test_roundtrip_live.py
@@ -88,7 +88,7 @@ def capture_anthropic(
     }
     body: dict[str, Any] = {
         "model": model,
-        "max_tokens": 512,
+        "max_tokens": 2048,
         "stream": True,
         "messages": [{"role": "user", "content": prompt}],
     }
@@ -140,7 +140,7 @@ def capture_openai_chat(
     }
     body: dict[str, Any] = {
         "model": model,
-        "max_completion_tokens": 512,
+        "max_completion_tokens": 2048,
         "stream": True,
         "stream_options": {"include_usage": True},
         "messages": [{"role": "user", "content": prompt}],
@@ -196,7 +196,7 @@ def capture_openai_responses(
     }
     body: dict[str, Any] = {
         "model": model,
-        "max_output_tokens": 512,
+        "max_output_tokens": 2048,
         "stream": True,
         "input": [{"role": "user", "content": prompt}],
     }
@@ -251,7 +251,7 @@ def capture_google(
 
     body: dict[str, Any] = {
         "contents": [{"role": "user", "parts": [{"text": prompt}]}],
-        "generationConfig": {"maxOutputTokens": 512},
+        "generationConfig": {"maxOutputTokens": 2048},
     }
     if use_tools:
         body["tools"] = [

--- a/dev_scripts/test_roundtrip_live.py
+++ b/dev_scripts/test_roundtrip_live.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Test streaming round-trip with REAL provider SSE flows.
+
+Captures a real streaming response from each provider, then runs it
+through the round-trip pipeline to verify no event inflation occurs.
+
+Requires API keys in .env (or environment variables).
+
+Usage:
+    python dev_scripts/test_roundtrip_live.py
+    python dev_scripts/test_roundtrip_live.py --provider anthropic
+    python dev_scripts/test_roundtrip_live.py --prompt "Use a tool to get the weather in NYC"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from llm_rosetta import get_converter_for_provider
+from llm_rosetta.converters.base.context import StreamContext
+
+
+def load_env() -> None:
+    """Load .env file from project root."""
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if not env_path.exists():
+        return
+    for line in env_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and value:
+            os.environ.setdefault(key, value)
+
+
+# ============================================================
+# Provider-specific capture functions
+# ============================================================
+
+
+def capture_anthropic(prompt: str) -> tuple[list[dict[str, Any]], str]:
+    """Capture real Anthropic SSE events."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    base_url = os.environ.get("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
+    model = os.environ.get("ANTHROPIC_MODEL", "claude-haiku-4.5")
+
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    }
+    body = {
+        "model": model,
+        "max_tokens": 300,
+        "stream": True,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+
+    events: list[dict[str, Any]] = []
+    with httpx.stream(
+        "POST",
+        f"{base_url}/v1/messages",
+        headers=headers,
+        json=body,
+        timeout=30.0,
+    ) as resp:
+        if resp.status_code != 200:
+            err = resp.read().decode()
+            raise RuntimeError(f"Anthropic HTTP {resp.status_code}: {err[:200]}")
+        current_event = None
+        for line in resp.iter_lines():
+            if not line:
+                continue
+            if line.startswith("event: "):
+                current_event = line[7:].strip()
+            elif line.startswith("data: "):
+                try:
+                    data = json.loads(line[6:])
+                    events.append(data)
+                except json.JSONDecodeError:
+                    pass
+
+    return events, model
+
+
+def capture_openai_chat(prompt: str) -> tuple[list[dict[str, Any]], str]:
+    """Capture real OpenAI Chat SSE events."""
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    model = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+    headers = {
+        "authorization": f"Bearer {api_key}",
+        "content-type": "application/json",
+    }
+    body = {
+        "model": model,
+        "max_completion_tokens": 300,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "messages": [{"role": "user", "content": prompt}],
+    }
+
+    events: list[dict[str, Any]] = []
+    with httpx.stream(
+        "POST",
+        f"{base_url}/chat/completions",
+        headers=headers,
+        json=body,
+        timeout=30.0,
+    ) as resp:
+        if resp.status_code != 200:
+            err = resp.read().decode()
+            raise RuntimeError(f"OpenAI Chat HTTP {resp.status_code}: {err[:200]}")
+        for line in resp.iter_lines():
+            if not line or not line.startswith("data: "):
+                continue
+            data_str = line[6:].strip()
+            if data_str == "[DONE]":
+                continue
+            try:
+                events.append(json.loads(data_str))
+            except json.JSONDecodeError:
+                pass
+
+    return events, model
+
+
+def capture_openai_responses(prompt: str) -> tuple[list[dict[str, Any]], str]:
+    """Capture real OpenAI Responses SSE events."""
+    api_key = os.environ.get("OPENAI_RESPONSES_API_KEY", "")
+    base_url = os.environ.get(
+        "OPENAI_RESPONSES_BASE_URL", "https://api.openai.com/v1"
+    )
+    model = os.environ.get("OPENAI_RESPONSES_MODEL", "gpt-4o-mini")
+
+    headers = {
+        "authorization": f"Bearer {api_key}",
+        "content-type": "application/json",
+    }
+    body = {
+        "model": model,
+        "max_output_tokens": 300,
+        "stream": True,
+        "input": [{"role": "user", "content": prompt}],
+    }
+
+    events: list[dict[str, Any]] = []
+    with httpx.stream(
+        "POST",
+        f"{base_url}/responses",
+        headers=headers,
+        json=body,
+        timeout=30.0,
+    ) as resp:
+        if resp.status_code != 200:
+            err = resp.read().decode()
+            raise RuntimeError(f"OpenAI Responses HTTP {resp.status_code}: {err[:200]}")
+        for line in resp.iter_lines():
+            if not line:
+                continue
+            if line.startswith("event: "):
+                continue
+            if line.startswith("data: "):
+                data_str = line[6:].strip()
+                if data_str == "[DONE]":
+                    continue
+                try:
+                    events.append(json.loads(data_str))
+                except json.JSONDecodeError:
+                    pass
+
+    return events, model
+
+
+def capture_google(prompt: str) -> tuple[list[dict[str, Any]], str]:
+    """Capture real Google GenAI SSE events."""
+    api_key = os.environ.get("GOOGLE_API_KEY", "")
+    base_url = os.environ.get(
+        "GOOGLE_BASE_URL",
+        "https://generativelanguage.googleapis.com/v1beta",
+    )
+    model = os.environ.get("GOOGLE_MODEL", "gemini-2.0-flash")
+
+    body = {
+        "contents": [{"role": "user", "parts": [{"text": prompt}]}],
+        "generationConfig": {"maxOutputTokens": 300},
+    }
+
+    events: list[dict[str, Any]] = []
+    url = f"{base_url}/models/{model}:streamGenerateContent?alt=sse&key={api_key}"
+    with httpx.stream(
+        "POST",
+        url,
+        json=body,
+        timeout=30.0,
+    ) as resp:
+        if resp.status_code != 200:
+            err = resp.read().decode()
+            raise RuntimeError(f"Google HTTP {resp.status_code}: {err[:200]}")
+        for line in resp.iter_lines():
+            if not line or not line.startswith("data: "):
+                continue
+            try:
+                events.append(json.loads(line[6:]))
+            except json.JSONDecodeError:
+                pass
+
+    return events, model
+
+
+# ============================================================
+# Round-trip logic
+# ============================================================
+
+
+def run_roundtrip(
+    provider: str,
+    input_events: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Run round-trip and return (ir_events, output_events)."""
+    converter = get_converter_for_provider(provider)
+    from_ctx = StreamContext()
+    to_ctx = StreamContext()
+
+    all_ir: list[dict[str, Any]] = []
+    output_events: list[dict[str, Any]] = []
+
+    for inp in input_events:
+        ir_events = converter.stream_response_from_provider(inp, context=from_ctx)
+        for ir_event in ir_events:
+            all_ir.append(ir_event)
+            result = converter.stream_response_to_provider(ir_event, context=to_ctx)
+            if isinstance(result, list):
+                output_events.extend(e for e in result if e)
+            elif result:
+                output_events.append(result)
+
+    return all_ir, output_events
+
+
+def event_type_label(provider: str, e: dict[str, Any]) -> str:
+    """Get a short type label for a provider event."""
+    t = e.get("type")
+    if t:
+        return t
+    if "choices" in e:
+        choices = e["choices"]
+        if not choices:
+            return "usage_chunk" if "usage" in e else "empty_choices"
+        delta = choices[0].get("delta", {})
+        fr = choices[0].get("finish_reason")
+        if fr:
+            return f"finish({fr})"
+        if "role" in delta:
+            return "role_delta"
+        if "content" in delta:
+            return "content_delta"
+        if "reasoning_content" in delta:
+            return "reasoning_delta"
+        if "tool_calls" in delta:
+            return "tool_calls_delta"
+        return "choice_chunk"
+    if "candidates" in e:
+        cand = e["candidates"][0] if e.get("candidates") else {}
+        if cand.get("finishReason"):
+            return f"finish({cand['finishReason']})"
+        parts = cand.get("content", {}).get("parts", [])
+        if parts:
+            p0 = parts[0]
+            if p0.get("thought"):
+                return "thought_chunk"
+            if "functionCall" in p0:
+                return "func_call_chunk"
+            return "text_chunk"
+        return "candidate_chunk"
+    return "unknown"
+
+
+def print_result(
+    provider: str,
+    model: str,
+    input_events: list[dict[str, Any]],
+    ir_events: list[dict[str, Any]],
+    output_events: list[dict[str, Any]],
+) -> bool:
+    """Print detailed result and return True if inflated."""
+    in_types = [event_type_label(provider, e) for e in input_events]
+    out_types = [event_type_label(provider, e) for e in output_events]
+    ir_types = [e.get("type", "?") for e in ir_events]
+
+    # "Inflated" means output has MORE events than input.
+    # output < input is OK (compound chunks decompose legitimately).
+    # output == input is ideal (perfect round-trip).
+    # output > input is the bug we're fixing.
+    inflated = len(out_types) > len(in_types)
+    if len(out_types) == len(in_types):
+        status = "OK (exact)"
+    elif len(out_types) < len(in_types):
+        status = "OK (deflated)"
+    else:
+        status = "INFLATED"
+
+    print(f"\n{'='*70}")
+    print(f"  {provider} ({model})")
+    print(f"  {len(in_types)} input → {len(ir_types)} IR → {len(out_types)} output  [{status}]")
+    print(f"{'='*70}")
+    print(f"  INPUT  ({len(in_types):>2}): {in_types}")
+    print(f"  IR     ({len(ir_types):>2}): {ir_types}")
+    print(f"  OUTPUT ({len(out_types):>2}): {out_types}")
+
+    if inflated:
+        max_len = max(len(in_types), len(out_types))
+        print(f"\n  {'#':>3}  {'INPUT':<30} {'OUTPUT':<30} {'DIFF'}")
+        print(f"  {'---':>3}  {'-'*30} {'-'*30} {'----'}")
+        for i in range(max_len):
+            inp = in_types[i] if i < len(in_types) else "(none)"
+            out = out_types[i] if i < len(out_types) else "(none)"
+            diff = "<<<" if inp != out else ""
+            print(f"  {i:>3}  {inp:<30} {out:<30} {diff}")
+
+    return inflated
+
+
+PROVIDERS = {
+    "anthropic": capture_anthropic,
+    "openai_chat": capture_openai_chat,
+    "openai_responses": capture_openai_responses,
+    "google": capture_google,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Live SSE round-trip test")
+    parser.add_argument(
+        "--provider",
+        choices=list(PROVIDERS.keys()),
+        default=None,
+        help="Test only this provider (default: all)",
+    )
+    parser.add_argument(
+        "--prompt",
+        default="What is 2+2? Answer in one sentence.",
+        help="Prompt to send",
+    )
+    parser.add_argument(
+        "--save",
+        default=None,
+        help="Save captured events to directory as JSONL files",
+    )
+    args = parser.parse_args()
+
+    load_env()
+
+    providers = [args.provider] if args.provider else list(PROVIDERS.keys())
+    results: dict[str, bool] = {}
+
+    for provider in providers:
+        capture_fn = PROVIDERS[provider]
+        try:
+            print(f"\n  Capturing {provider}...", end="", flush=True)
+            raw_events, model = capture_fn(args.prompt)
+            print(f" {len(raw_events)} events captured.")
+
+            if args.save:
+                save_dir = Path(args.save)
+                save_dir.mkdir(parents=True, exist_ok=True)
+                out_file = save_dir / f"{provider}_raw.jsonl"
+                with open(out_file, "w") as f:
+                    for e in raw_events:
+                        f.write(json.dumps(e, ensure_ascii=False) + "\n")
+                print(f"  Saved to {out_file}")
+
+            ir_events, output_events = run_roundtrip(provider, raw_events)
+            inflated = print_result(
+                provider, model, raw_events, ir_events, output_events
+            )
+            results[provider] = inflated
+
+        except Exception as exc:
+            print(f" ERROR")
+            print(f"\n{'='*70}")
+            print(f"  {provider}: ERROR — {exc}")
+            print(f"{'='*70}")
+            import traceback
+
+            traceback.print_exc()
+            results[provider] = True
+
+    print(f"\n{'='*70}")
+    print("  SUMMARY")
+    print(f"{'='*70}")
+    any_failed = False
+    for provider, inflated in results.items():
+        status = "INFLATED" if inflated else "OK"
+        if inflated:
+            any_failed = True
+        print(f"  {provider:<25} {status}")
+
+    if any_failed:
+        print(f"\n  *** SOME TESTS FAILED ***")
+        sys.exit(1)
+    else:
+        print(f"\n  ALL TESTS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -838,11 +838,15 @@ class AnthropicConverter(BaseConverter):
         if context is not None:
             # Flush any buffered finish that never got a UsageEvent
             if context.pending_finish is not None:
+                output_tokens = 0
+                if context.pending_usage is not None:
+                    output_tokens = context.pending_usage.get("completion_tokens") or 0
+                    context.pending_usage = None
                 results.append(
                     {
                         "type": AnthropicEventType.MESSAGE_DELTA,
                         "delta": context.pending_finish,
-                        "usage": {"output_tokens": 0},
+                        "usage": {"output_tokens": output_tokens},
                     }
                 )
                 context.pending_finish = None
@@ -879,6 +883,8 @@ class AnthropicConverter(BaseConverter):
         self, event: ContentBlockEndEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ContentBlockEndEvent → content_block_stop."""
+        if context is not None:
+            context.current_block_index = -1
         return {
             "type": AnthropicEventType.CONTENT_BLOCK_STOP,
             "index": event["block_index"],
@@ -998,7 +1004,22 @@ class AnthropicConverter(BaseConverter):
                         "index": context.current_block_index,
                     }
                 )
-            context.pending_finish = {"stop_reason": stop_reason}
+                context.current_block_index = -1
+            if context.pending_usage is not None:
+                # Usage already buffered — merge and emit immediately.
+                usage = context.pending_usage
+                context.pending_usage = None
+                output_tokens = usage.get("completion_tokens") or 0
+                results.append(
+                    {
+                        "type": AnthropicEventType.MESSAGE_DELTA,
+                        "delta": {"stop_reason": stop_reason},
+                        "usage": {"output_tokens": output_tokens},
+                    }
+                )
+            else:
+                # Buffer finish for later UsageEvent or StreamEnd flush.
+                context.pending_finish = {"stop_reason": stop_reason}
             return results if results else {}
         return {
             "type": AnthropicEventType.MESSAGE_DELTA,
@@ -1009,16 +1030,32 @@ class AnthropicConverter(BaseConverter):
     def _handle_usage_to_p(
         self, event: UsageEvent, context: StreamContext | None
     ) -> dict[str, Any]:
-        """Handle UsageEvent → message_delta (merged with pending finish)."""
+        """Handle UsageEvent → message_delta (merged with pending finish).
+
+        When a pending_finish exists, merges usage into it and emits a
+        message_delta immediately.  Otherwise buffers the usage for a
+        later FinishEvent or StreamEndEvent to consume, preventing the
+        extra empty message_delta that caused round-trip inflation.
+        """
         usage = event["usage"]
+        if context is not None:
+            if context.pending_finish is not None:
+                # Merge with buffered finish and emit.
+                delta = context.pending_finish
+                context.pending_finish = None
+                output_tokens = usage.get("completion_tokens") or 0
+                return {
+                    "type": AnthropicEventType.MESSAGE_DELTA,
+                    "delta": delta,
+                    "usage": {"output_tokens": output_tokens},
+                }
+            # No pending finish — buffer for later merge.
+            context.pending_usage = dict(usage)
+            return {}
         output_tokens = usage.get("completion_tokens") or 0
-        delta: dict[str, Any] = {}
-        if context is not None and context.pending_finish is not None:
-            delta = context.pending_finish
-            context.pending_finish = None
         return {
             "type": AnthropicEventType.MESSAGE_DELTA,
-            "delta": delta,
+            "delta": {},
             "usage": {"output_tokens": output_tokens},
         }
 

--- a/src/llm_rosetta/converters/base/context.py
+++ b/src/llm_rosetta/converters/base/context.py
@@ -110,6 +110,9 @@ class StreamContext(ConversionContext):
         pending_finish: Deferred finish event payload.
         pending_response: Deferred response.completed payload stored by
             FinishEvent, emitted by StreamEndEvent after usage is merged.
+        pending_text: Text content deferred from a compound text+finish
+            chunk (e.g. Google GenAI) so that it can be merged into the
+            finish event and avoid inflating the output event count.
     """
 
     # Session-level metadata
@@ -126,6 +129,7 @@ class StreamContext(ConversionContext):
     pending_usage: dict | None = None
     pending_finish: dict | None = None
     pending_response: dict | None = None
+    pending_text: str | None = None
 
     # Lifecycle flags
     _started: bool = field(default=False, repr=False)

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -1107,39 +1107,21 @@ class GoogleGenAIConverter(BaseConverter):
 
         chunks: list[dict[str, Any]] = []
 
-        # Flush accumulated tool calls as complete function_call chunks.
-        if context is not None:
-            for call_id, tool_name, args_str in context.get_pending_tool_calls():
-                try:
-                    args = json.loads(args_str) if args_str else {}
-                except (json.JSONDecodeError, TypeError):
-                    args = {}
-                chunks.append(
-                    {
-                        "candidates": [
-                            {
-                                "index": choice_index,
-                                "content": {
-                                    "role": "model",
-                                    "parts": [
-                                        {
-                                            "functionCall": {
-                                                "name": tool_name,
-                                                "args": args,
-                                            }
-                                        }
-                                    ],
-                                },
-                            }
-                        ]
-                    }
-                )
-
-        # Merge deferred text from compound text+finish chunks.
+        # Merge deferred text and tool calls into the finish chunk's
+        # parts array, matching Google's native format where a single
+        # candidate carries content parts alongside finishReason.
         parts: list[dict[str, Any]] = []
         if context is not None and context.pending_text is not None:
             parts.append({"text": context.pending_text})
             context.pending_text = None
+
+        if context is not None:
+            for _call_id, tool_name, args_str in context.get_pending_tool_calls():
+                try:
+                    args = json.loads(args_str) if args_str else {}
+                except (json.JSONDecodeError, TypeError):
+                    args = {}
+                parts.append({"functionCall": {"name": tool_name, "args": args}})
 
         finish_chunk: dict[str, Any] = {
             "candidates": [

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -1020,7 +1020,13 @@ class GoogleGenAIConverter(BaseConverter):
     def _handle_text_delta_to_p(
         self, event: TextDeltaEvent, context: StreamContext | None
     ) -> dict[str, Any]:
-        """Handle TextDeltaEvent → text part chunk."""
+        """Handle TextDeltaEvent → text part chunk.
+
+        Returns empty for empty-text deltas (e.g. padding in Google
+        finish chunks) to avoid inflating the output event count.
+        """
+        if not event["text"]:
+            return {}
         choice_index = event.get("choice_index", 0)
         return {
             "candidates": [
@@ -1106,25 +1112,49 @@ class GoogleGenAIConverter(BaseConverter):
                     }
                 )
 
-        chunks.append(
-            {
-                "candidates": [
-                    {
-                        "index": choice_index,
-                        "content": {"role": "model", "parts": []},
-                        "finishReason": GOOGLE_REASON_TO_PROVIDER.get(reason, "STOP"),
-                    }
-                ]
+        finish_chunk: dict[str, Any] = {
+            "candidates": [
+                {
+                    "index": choice_index,
+                    "content": {"role": "model", "parts": []},
+                    "finishReason": GOOGLE_REASON_TO_PROVIDER.get(reason, "STOP"),
+                }
+            ]
+        }
+
+        # Merge buffered usage into the finish chunk so that
+        # finishReason and usageMetadata stay in a single chunk,
+        # matching the original Google format.
+        if context is not None and context.pending_usage is not None:
+            usage = context.pending_usage
+            context.pending_usage = None
+            usage_metadata: dict[str, Any] = {
+                "promptTokenCount": usage.get("prompt_tokens") or 0,
+                "candidatesTokenCount": usage.get("completion_tokens") or 0,
+                "totalTokenCount": usage.get("total_tokens") or 0,
             }
-        )
+            if "reasoning_tokens" in usage:
+                usage_metadata["thoughtsTokenCount"] = usage["reasoning_tokens"]
+            finish_chunk["usageMetadata"] = usage_metadata
+
+        chunks.append(finish_chunk)
 
         return chunks
 
     def _handle_usage_to_p(
         self, event: UsageEvent, context: StreamContext | None
     ) -> dict[str, Any]:
-        """Handle UsageEvent → usageMetadata chunk."""
+        """Handle UsageEvent → buffer for FinishEvent merge.
+
+        When context is provided, buffers usage in pending_usage so
+        FinishEvent can emit a single combined chunk with both
+        finishReason and usageMetadata, matching the original Google
+        format and preventing round-trip inflation.
+        """
         usage = event["usage"]
+        if context is not None:
+            context.pending_usage = dict(usage)
+            return {}
         usage_metadata: dict[str, Any] = {
             "promptTokenCount": usage.get("prompt_tokens") or 0,
             "candidatesTokenCount": usage.get("completion_tokens") or 0,

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -802,12 +802,35 @@ class GoogleGenAIConverter(BaseConverter):
             choice_index = candidate.get("index", 0)
             content = candidate.get("content", {})
 
-            for part in content.get("parts", []):
-                self._handle_part_from_p(part, choice_index, context, events)
-
             finish_reason = candidate.get("finish_reason") or candidate.get(
                 "finishReason"
             )
+
+            # Track how many events existed before processing this
+            # candidate's parts, so we can identify which text_delta
+            # events belong to this compound chunk.
+            pre_parts_len = len(events)
+
+            for part in content.get("parts", []):
+                self._handle_part_from_p(part, choice_index, context, events)
+
+            # When a compound chunk has both text and finishReason,
+            # defer the text into context so _handle_finish_to_p can
+            # merge it into the finish candidate's parts, avoiding
+            # an extra output event.
+            if finish_reason and context is not None:
+                new_events = events[pre_parts_len:]
+                deferred_texts: list[str] = []
+                kept_new: list[IRStreamEvent] = []
+                for ev in new_events:
+                    if ev["type"] == "text_delta":
+                        deferred_texts.append(ev["text"])  # type: ignore[typeddict-item]
+                    else:
+                        kept_new.append(ev)
+                if deferred_texts:
+                    context.pending_text = "".join(deferred_texts)
+                    events[pre_parts_len:] = kept_new
+
             if finish_reason:
                 has_finish_reason = True
                 deferred_finish = FinishEvent(
@@ -1112,11 +1135,17 @@ class GoogleGenAIConverter(BaseConverter):
                     }
                 )
 
+        # Merge deferred text from compound text+finish chunks.
+        parts: list[dict[str, Any]] = []
+        if context is not None and context.pending_text is not None:
+            parts.append({"text": context.pending_text})
+            context.pending_text = None
+
         finish_chunk: dict[str, Any] = {
             "candidates": [
                 {
                     "index": choice_index,
-                    "content": {"role": "model", "parts": []},
+                    "content": {"role": "model", "parts": parts},
                     "finishReason": GOOGLE_REASON_TO_PROVIDER.get(reason, "STOP"),
                 }
             ]

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -856,14 +856,35 @@ class OpenAIChatConverter(BaseConverter):
     def _handle_stream_end_to_p(
         self, event: StreamEndEvent, context: StreamContext | None
     ) -> dict[str, Any]:
-        """Handle StreamEndEvent → empty choices chunk."""
+        """Handle StreamEndEvent → usage chunk (if buffered) or empty.
+
+        When pending_usage was buffered by a preceding UsageEvent,
+        emits a single combined choices=[]+usage chunk.  Otherwise
+        returns empty to avoid a redundant empty-choices chunk.
+        """
         if context is not None:
             context.mark_ended()
+            if context.pending_usage is not None:
+                usage = context.pending_usage
+                context.pending_usage = None
+                return {
+                    "id": context.response_id,
+                    "object": "chat.completion.chunk",
+                    "model": context.model,
+                    "created": context.created,
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": usage.get("prompt_tokens") or 0,
+                        "completion_tokens": usage.get("completion_tokens") or 0,
+                        "total_tokens": usage.get("total_tokens") or 0,
+                    },
+                }
+            return {}
         return {
-            "id": context.response_id if context else "",
+            "id": "",
             "object": "chat.completion.chunk",
-            "model": context.model if context else "",
-            "created": context.created if context else 0,
+            "model": "",
+            "created": 0,
             "choices": [],
         }
 
@@ -971,8 +992,16 @@ class OpenAIChatConverter(BaseConverter):
     def _handle_usage_to_p(
         self, event: UsageEvent, context: StreamContext | None
     ) -> dict[str, Any]:
-        """Handle UsageEvent → usage chunk with empty choices."""
+        """Handle UsageEvent → buffer for StreamEndEvent merge.
+
+        When context is provided, buffers usage in pending_usage so
+        StreamEndEvent can emit a single combined chunk, preventing
+        the extra empty-choices chunk that caused round-trip inflation.
+        """
         usage = event["usage"]
+        if context is not None:
+            context.pending_usage = dict(usage)
+            return {}
         return {
             "choices": [],
             "usage": {

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -833,13 +833,14 @@ class OpenAIChatConverter(BaseConverter):
     def _handle_stream_start_to_p(
         self, event: StreamStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
-        """Handle StreamStartEvent → initial chunk with role delta."""
-        if context is not None:
-            context.response_id = event["response_id"]
-            context.model = event["model"]
-            context.created = event.get("created", 0)
-            context.mark_started()
-        return {
+        """Handle StreamStartEvent → initial chunk with role delta.
+
+        When context is available the role chunk is buffered so that it
+        can be merged into the first content event (text delta or tool
+        call start), matching the original OpenAI format where the first
+        chunk carries both ``role`` and the first content delta.
+        """
+        chunk = {
             "id": event["response_id"],
             "object": "chat.completion.chunk",
             "model": event["model"],
@@ -852,6 +853,16 @@ class OpenAIChatConverter(BaseConverter):
                 }
             ],
         }
+        if context is not None:
+            context.response_id = event["response_id"]
+            context.model = event["model"]
+            context.created = event.get("created", 0)
+            context.mark_started()
+            # Buffer the role chunk; the first content handler will
+            # merge it and emit a combined chunk.
+            context.pending_response = chunk
+            return {}
+        return chunk
 
     def _handle_stream_end_to_p(
         self, event: StreamEndEvent, context: StreamContext | None
@@ -900,12 +911,34 @@ class OpenAIChatConverter(BaseConverter):
         """Handle ContentBlockEndEvent → no-op for OpenAI Chat."""
         return {}
 
+    def _merge_pending_role(
+        self, chunk: dict[str, Any], context: StreamContext | None
+    ) -> dict[str, Any]:
+        """Merge a buffered role chunk into the given content chunk.
+
+        When stream_start buffers its role chunk in context.pending_response,
+        this merges the role and envelope fields (id, model, created) into
+        the first real content chunk, matching the original OpenAI format.
+        """
+        if context is None or context.pending_response is None:
+            return chunk
+        role_chunk = context.pending_response
+        context.pending_response = None
+        # Copy envelope fields from the role chunk.
+        for key in ("id", "object", "model", "created"):
+            if key in role_chunk:
+                chunk[key] = role_chunk[key]
+        # Merge role into the delta.
+        if chunk.get("choices"):
+            chunk["choices"][0].setdefault("delta", {})["role"] = "assistant"
+        return chunk
+
     def _handle_text_delta_to_p(
         self, event: TextDeltaEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle TextDeltaEvent → content delta chunk."""
         choice_index = event.get("choice_index", 0)
-        return {
+        chunk = {
             "choices": [
                 {
                     "index": choice_index,
@@ -913,6 +946,7 @@ class OpenAIChatConverter(BaseConverter):
                 }
             ]
         }
+        return self._merge_pending_role(chunk, context)
 
     def _handle_reasoning_delta_to_p(
         self, event: ReasoningDeltaEvent, context: StreamContext | None
@@ -943,7 +977,7 @@ class OpenAIChatConverter(BaseConverter):
                 "arguments": "",
             },
         }
-        return {
+        chunk = {
             "choices": [
                 {
                     "index": choice_index,
@@ -951,6 +985,7 @@ class OpenAIChatConverter(BaseConverter):
                 }
             ]
         }
+        return self._merge_pending_role(chunk, context)
 
     def _handle_tool_call_delta_to_p(
         self, event: ToolCallDeltaEvent, context: StreamContext | None

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -620,9 +620,9 @@ class OpenAIChatConverter(BaseConverter):
         choice_index = p_choice.get("index", 0)
         delta = p_choice.get("delta", {})
 
-        # Text delta
+        # Text delta (skip empty content from role-only chunks)
         content = delta.get("content")
-        if content is not None:
+        if content:
             events.append(
                 TextDeltaEvent(
                     type="text_delta",

--- a/tests/converters/anthropic/test_stream.py
+++ b/tests/converters/anthropic/test_stream.py
@@ -479,6 +479,78 @@ class TestStreamRoundTrip:
         )
         assert restored["delta"]["stop_reason"] == "end_turn"
 
+    def test_full_stream_round_trip_no_inflation(self):
+        """Full stream round-trip produces same event count (7→7)."""
+        input_events = [
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_001",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-20250514",
+                    "content": [],
+                    "stop_reason": None,
+                    "usage": {"input_tokens": 12, "output_tokens": 1},
+                },
+            },
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "Hello"},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": " world!"},
+            },
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 5},
+            },
+            {"type": "message_stop"},
+        ]
+
+        from_ctx = StreamContext()
+        to_ctx = StreamContext()
+        output_events: list[dict[str, Any]] = []
+
+        for inp in input_events:
+            ir_events = self.converter.stream_response_from_provider(
+                inp, context=from_ctx
+            )
+            for ir_event in ir_events:
+                result = self.converter.stream_response_to_provider(
+                    ir_event, context=to_ctx
+                )
+                if isinstance(result, list):
+                    output_events.extend(e for e in result if e)
+                elif result:
+                    output_events.append(result)
+
+        assert len(output_events) == 7
+        out_types = [e["type"] for e in output_events]
+        assert out_types == [
+            "message_start",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]
+        # Verify the message_delta has stop_reason and usage merged
+        msg_delta = output_events[5]
+        assert msg_delta["delta"]["stop_reason"] == "end_turn"
+        assert msg_delta["usage"]["output_tokens"] == 5
+
 
 class TestStreamResponseFromProviderWithContext:
     """Tests for stream_response_from_provider with StreamContext."""

--- a/tests/converters/google_genai/test_stream.py
+++ b/tests/converters/google_genai/test_stream.py
@@ -746,6 +746,81 @@ class TestStreamRoundTrip:
         )
         assert restored["usageMetadata"]["totalTokenCount"] == 30
 
+    def test_full_stream_round_trip_no_inflation(self):
+        """Full stream round-trip produces same event count (3→3)."""
+        input_events = [
+            {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [{"text": "Hello"}],
+                            "role": "model",
+                        },
+                        "index": 0,
+                    }
+                ],
+                "modelVersion": "gemini-2.0-flash",
+            },
+            {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [{"text": " world!"}],
+                            "role": "model",
+                        },
+                        "index": 0,
+                    }
+                ],
+            },
+            {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [{"text": ""}],
+                            "role": "model",
+                        },
+                        "finishReason": "STOP",
+                        "index": 0,
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 12,
+                    "candidatesTokenCount": 5,
+                    "totalTokenCount": 17,
+                },
+                "modelVersion": "gemini-2.0-flash",
+            },
+        ]
+
+        from_ctx = StreamContext()
+        to_ctx = StreamContext()
+        output_events: list[dict[str, Any]] = []
+
+        for inp in input_events:
+            ir_events = self.converter.stream_response_from_provider(
+                inp, context=from_ctx
+            )
+            for ir_event in ir_events:
+                result = self.converter.stream_response_to_provider(
+                    ir_event, context=to_ctx
+                )
+                if isinstance(result, list):
+                    output_events.extend(e for e in result if e)
+                elif result:
+                    output_events.append(result)
+
+        assert len(output_events) == 3
+        # text, text, finish+usage
+        assert (
+            output_events[0]["candidates"][0]["content"]["parts"][0]["text"] == "Hello"
+        )
+        assert (
+            output_events[1]["candidates"][0]["content"]["parts"][0]["text"]
+            == " world!"
+        )
+        assert output_events[2]["candidates"][0]["finishReason"] == "STOP"
+        assert output_events[2]["usageMetadata"]["totalTokenCount"] == 17
+
 
 class TestStreamResponseFromProviderWithContext:
     """Tests for stream_response_from_provider with StreamContext."""

--- a/tests/converters/google_genai/test_stream.py
+++ b/tests/converters/google_genai/test_stream.py
@@ -529,7 +529,12 @@ class TestStreamResponseToProvider:
         assert ctx.get_tool_call_args("call_1") == '{"q": "test"}'
 
     def test_finish_emits_accumulated_tool_calls(self):
-        """FinishEvent with tool_calls flushes accumulated function_calls."""
+        """FinishEvent merges accumulated tool_calls into finish chunk.
+
+        Tool call parts are included in the finish candidate's content
+        parts, matching Google's native format where functionCall and
+        finishReason appear in the same chunk.
+        """
         ctx = StreamContext()
         ctx.register_tool_call("call_1", "search")
         ctx.append_tool_call_args("call_1", '{"q": "test"}')
@@ -546,12 +551,13 @@ class TestStreamResponseToProvider:
             list[dict[str, Any]],
             self.converter.stream_response_to_provider(event, context=ctx),
         )
-        # Should be [function_call_chunk, finish_chunk]
-        assert len(result) == 2
-        fc = result[0]["candidates"][0]["content"]["parts"][0]["functionCall"]
+        # Tool calls merged into the single finish chunk.
+        assert len(result) == 1
+        candidate = result[0]["candidates"][0]
+        fc = candidate["content"]["parts"][0]["functionCall"]
         assert fc["name"] == "search"
         assert fc["args"] == {"q": "test"}
-        assert result[1]["candidates"][0]["finishReason"] == "STOP"
+        assert candidate["finishReason"] == "STOP"
 
     def test_finish_event_stop(self):
         """FinishEvent with 'stop' → [finish_chunk] with STOP."""
@@ -1197,7 +1203,7 @@ class TestStreamResponseToProviderWithContext:
         assert result == {}
 
     def test_finish_flushes_tool_calls_from_context(self):
-        """FinishEvent flushes accumulated tool calls from context."""
+        """FinishEvent merges accumulated tool calls into finish chunk."""
         context = StreamContext()
         context.register_tool_call("call_1", "get_weather")
         context.append_tool_call_args("call_1", '{"city": "NYC"}')
@@ -1214,11 +1220,12 @@ class TestStreamResponseToProviderWithContext:
             list[dict[str, Any]],
             self.converter.stream_response_to_provider(event, context=context),
         )
-        assert len(result) == 2
-        fc = result[0]["candidates"][0]["content"]["parts"][0]["functionCall"]
+        assert len(result) == 1
+        candidate = result[0]["candidates"][0]
+        fc = candidate["content"]["parts"][0]["functionCall"]
         assert fc["name"] == "get_weather"
         assert fc["args"] == {"city": "NYC"}
-        assert result[1]["candidates"][0]["finishReason"] == "STOP"
+        assert candidate["finishReason"] == "STOP"
 
     def test_stream_start_without_context(self):
         """StreamStartEvent without context returns empty dict."""

--- a/tests/converters/openai_chat/test_stream.py
+++ b/tests/converters/openai_chat/test_stream.py
@@ -540,7 +540,11 @@ class TestStreamRoundTrip:
         assert restored["usage"]["total_tokens"] == 30
 
     def test_full_stream_round_trip_no_inflation(self):
-        """Full stream round-trip produces same event count (5→5)."""
+        """Full stream round-trip: output ≤ input (no inflation).
+
+        With context, the role chunk is buffered and merged into the
+        first content delta.  5 input → 4 output (deflated, not inflated).
+        """
         input_events = [
             {
                 "id": "chatcmpl-001",
@@ -619,14 +623,14 @@ class TestStreamRoundTrip:
                 elif result:
                     output_events.append(result)
 
-        assert len(output_events) == 5
-        # role_delta, content, content, finish, usage
+        # Role merged into first content delta → 4 output from 5 input.
+        assert len(output_events) == 4
         assert output_events[0]["choices"][0]["delta"]["role"] == "assistant"
-        assert output_events[1]["choices"][0]["delta"]["content"] == "Hello"
-        assert output_events[2]["choices"][0]["delta"]["content"] == " world!"
-        assert output_events[3]["choices"][0]["finish_reason"] == "stop"
-        assert output_events[4]["choices"] == []
-        assert output_events[4]["usage"]["total_tokens"] == 17
+        assert output_events[0]["choices"][0]["delta"]["content"] == "Hello"
+        assert output_events[1]["choices"][0]["delta"]["content"] == " world!"
+        assert output_events[2]["choices"][0]["finish_reason"] == "stop"
+        assert output_events[3]["choices"] == []
+        assert output_events[3]["usage"]["total_tokens"] == 17
 
 
 class TestStreamResponseFromProviderWithContext:

--- a/tests/converters/openai_chat/test_stream.py
+++ b/tests/converters/openai_chat/test_stream.py
@@ -41,15 +41,17 @@ class TestStreamResponseFromProvider:
         assert events[0]["text"] == "Hello"
         assert events[0]["choice_index"] == 0
 
-    def test_text_delta_empty_string(self):
-        """Empty string content should still produce a TextDeltaEvent."""
+    def test_text_delta_empty_string_is_skipped(self):
+        """Empty string content is skipped to avoid inflating events.
+
+        The first OpenAI chunk typically has delta: {role: "assistant",
+        content: ""} — the empty content should NOT produce a TextDeltaEvent.
+        """
         chunk = {
             "choices": [{"index": 0, "delta": {"content": ""}, "finish_reason": None}]
         }
         events = cast(list[Any], self.converter.stream_response_from_provider(chunk))
-        assert len(events) == 1
-        assert events[0]["type"] == "text_delta"
-        assert events[0]["text"] == ""
+        assert len(events) == 0
 
     def test_text_delta_choice_index(self):
         """Choice index is preserved in the event."""

--- a/tests/converters/openai_chat/test_stream.py
+++ b/tests/converters/openai_chat/test_stream.py
@@ -537,6 +537,95 @@ class TestStreamRoundTrip:
         )
         assert restored["usage"]["total_tokens"] == 30
 
+    def test_full_stream_round_trip_no_inflation(self):
+        """Full stream round-trip produces same event count (5→5)."""
+        input_events = [
+            {
+                "id": "chatcmpl-001",
+                "object": "chat.completion.chunk",
+                "model": "gpt-4o",
+                "created": 1700000000,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant"},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl-001",
+                "object": "chat.completion.chunk",
+                "model": "gpt-4o",
+                "created": 1700000000,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": "Hello"},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl-001",
+                "object": "chat.completion.chunk",
+                "model": "gpt-4o",
+                "created": 1700000000,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": " world!"},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl-001",
+                "object": "chat.completion.chunk",
+                "model": "gpt-4o",
+                "created": 1700000000,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            },
+            {
+                "id": "chatcmpl-001",
+                "object": "chat.completion.chunk",
+                "model": "gpt-4o",
+                "created": 1700000000,
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 12,
+                    "completion_tokens": 5,
+                    "total_tokens": 17,
+                },
+            },
+        ]
+
+        from_ctx = StreamContext()
+        to_ctx = StreamContext()
+        output_events: list[dict[str, Any]] = []
+
+        for inp in input_events:
+            ir_events = self.converter.stream_response_from_provider(
+                inp, context=from_ctx
+            )
+            for ir_event in ir_events:
+                result = self.converter.stream_response_to_provider(
+                    ir_event, context=to_ctx
+                )
+                if isinstance(result, list):
+                    output_events.extend(e for e in result if e)
+                elif result:
+                    output_events.append(result)
+
+        assert len(output_events) == 5
+        # role_delta, content, content, finish, usage
+        assert output_events[0]["choices"][0]["delta"]["role"] == "assistant"
+        assert output_events[1]["choices"][0]["delta"]["content"] == "Hello"
+        assert output_events[2]["choices"][0]["delta"]["content"] == " world!"
+        assert output_events[3]["choices"][0]["finish_reason"] == "stop"
+        assert output_events[4]["choices"] == []
+        assert output_events[4]["usage"]["total_tokens"] == 17
+
 
 class TestStreamResponseFromProviderWithContext:
     """Tests for stream_response_from_provider with StreamContext."""
@@ -872,8 +961,8 @@ class TestStreamResponseToProviderWithContext:
         assert "id" not in result
         assert "object" not in result
 
-    def test_stream_end_event_to_empty_choices_chunk(self):
-        """StreamEndEvent produces chunk with empty choices."""
+    def test_stream_end_event_no_pending_usage_returns_empty(self):
+        """StreamEndEvent without pending_usage returns empty dict."""
         ctx = StreamContext()
         ctx.response_id = "chatcmpl-abc123"
         ctx.model = "gpt-4"
@@ -885,12 +974,37 @@ class TestStreamResponseToProviderWithContext:
             dict[str, Any],
             self.converter.stream_response_to_provider(event, context=ctx),
         )
+        assert result == {}
+        assert ctx.is_ended is True
+
+    def test_stream_end_event_flushes_pending_usage(self):
+        """StreamEndEvent with pending_usage emits combined usage chunk."""
+        ctx = StreamContext()
+        ctx.response_id = "chatcmpl-abc123"
+        ctx.model = "gpt-4"
+        ctx.created = 1700000000
+        ctx.mark_started()
+        ctx.pending_usage = {
+            "prompt_tokens": 12,
+            "completion_tokens": 5,
+            "total_tokens": 17,
+        }
+
+        event = cast(StreamEndEvent, {"type": "stream_end"})
+        result = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(event, context=ctx),
+        )
         assert result["id"] == "chatcmpl-abc123"
         assert result["object"] == "chat.completion.chunk"
         assert result["model"] == "gpt-4"
         assert result["created"] == 1700000000
         assert result["choices"] == []
+        assert result["usage"]["prompt_tokens"] == 12
+        assert result["usage"]["completion_tokens"] == 5
+        assert result["usage"]["total_tokens"] == 17
         assert ctx.is_ended is True
+        assert ctx.pending_usage is None
 
     def test_stream_end_without_context(self):
         """StreamEndEvent without context produces chunk with empty fields."""
@@ -946,8 +1060,8 @@ class TestStreamResponseToProviderWithContext:
         assert result["id"] == "chatcmpl-abc123"
         assert result["choices"][0]["finish_reason"] == "stop"
 
-    def test_usage_event_with_context_has_top_level_fields(self):
-        """UsageEvent includes top-level fields when context is started."""
+    def test_usage_event_with_context_buffers_pending_usage(self):
+        """UsageEvent with context buffers into pending_usage instead of emitting."""
         ctx = StreamContext()
         ctx.response_id = "chatcmpl-abc123"
         ctx.model = "gpt-4"
@@ -969,5 +1083,6 @@ class TestStreamResponseToProviderWithContext:
             dict[str, Any],
             self.converter.stream_response_to_provider(event, context=ctx),
         )
-        assert result["id"] == "chatcmpl-abc123"
-        assert result["usage"]["total_tokens"] == 15
+        assert result == {}
+        assert ctx.pending_usage is not None
+        assert ctx.pending_usage["total_tokens"] == 15


### PR DESCRIPTION
## Summary

Fixes the streaming round-trip event inflation bug where `stream_response_from_provider → IR → stream_response_to_provider` produces more output events than input events. This is the root cause of message duplication in argo-proxy `--force-conversion` mode and llm-rosetta gateway.

**Root cause**: Compound provider events are split into multiple IR events, each generating a separate output event.

**Fix strategy**: Buffer-and-merge — buffer usage/role/text events in `StreamContext`, merge them into the next structural event (finish/stream_end) to reconstruct the original chunk structure.

### Changes by provider

- **Anthropic**: Buffer `UsageEvent` in `pending_usage`, merge into `FinishEvent`; prevent duplicate `content_block_stop` from both `ContentBlockEndEvent` and `FinishEvent`
- **OpenAI Chat**: Skip empty `content: ""` from role chunks; buffer `UsageEvent`; buffer role chunk and merge into first content event (text_delta or tool_call_start)
- **Google GenAI**: Filter empty text deltas; buffer `UsageEvent`; defer text from compound text+finish chunks into `pending_text`; merge tool call parts into finish chunk
- **OpenAI Responses**: Already OK (3-tier dedup guards)
- **StreamContext**: Added `pending_text` field for compound chunk deferral

### Test coverage

- 15/15 synthetic round-trip scenarios (basic + edge cases: thinking, tool calls, reasoning, compound chunks)
- 8/8 live SSE tests (4 providers × text + tools modes) against real APIs
- 1463/1463 pytest regression tests pass

## Test plan

- [ ] CI passes (pytest, ruff)
- [ ] Rebase merge into master
- [ ] Follow-up PR: unify buffer-and-merge pattern into base class