### PR TITLE
refactor: extract stream_response_to_provider dispatch into BaseConverter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[all]"
-          pip install ruff ty
 
       - name: Lint with ruff
         run: ruff check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Type check with ty
         run: ty check
 
+      - name: Run converter tests
+        run: python -m pytest tests/converters/ -v
+
       - name: Run type compatibility tests
         run: python -m pytest tests/test_types/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ dev = [
     "pytest",
     "pytest-cov",
     "complexipy>=5.2.0",
-    "ty>=0.0.21",
+    "ruff>=0.15.0",
+    "ty>=0.0.31",
     "build>=1.2.2.post1",
     "twine>=6.1.0",
 ]

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -791,24 +791,6 @@ class AnthropicConverter(BaseConverter):
 
     # --- to_provider ---
 
-    def stream_response_to_provider(
-        self,
-        event: IRStreamEvent,
-        context: StreamContext | None = None,
-    ) -> dict[str, Any] | list[dict[str, Any]]:
-        """Convert an IR stream event to an Anthropic SSE event.
-
-        Args:
-            event: IR stream event.
-
-        Returns:
-            Anthropic SSE event dict.
-        """
-        handler_name = self._TO_P_DISPATCH.get(event.get("type", ""))
-        if handler_name is None:
-            return {}
-        return getattr(self, handler_name)(event, context)
-
     def _handle_stream_start_to_p(
         self, event: StreamStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
@@ -837,19 +819,19 @@ class AnthropicConverter(BaseConverter):
         results: list[dict[str, Any]] = []
         if context is not None:
             # Flush any buffered finish that never got a UsageEvent
-            if context.pending_finish is not None:
+            finish = context.pop_pending_finish()
+            if finish is not None:
                 output_tokens = 0
-                if context.pending_usage is not None:
-                    output_tokens = context.pending_usage.get("completion_tokens") or 0
-                    context.pending_usage = None
+                usage = context.pop_pending_usage()
+                if usage is not None:
+                    output_tokens = usage.get("completion_tokens") or 0
                 results.append(
                     {
                         "type": AnthropicEventType.MESSAGE_DELTA,
-                        "delta": context.pending_finish,
+                        "delta": finish,
                         "usage": {"output_tokens": output_tokens},
                     }
                 )
-                context.pending_finish = None
             context.mark_ended()
         results.append({"type": AnthropicEventType.MESSAGE_STOP})
         return results if len(results) > 1 else results[0]
@@ -1005,10 +987,9 @@ class AnthropicConverter(BaseConverter):
                     }
                 )
                 context.current_block_index = -1
-            if context.pending_usage is not None:
+            usage = context.pop_pending_usage()
+            if usage is not None:
                 # Usage already buffered — merge and emit immediately.
-                usage = context.pending_usage
-                context.pending_usage = None
                 output_tokens = usage.get("completion_tokens") or 0
                 results.append(
                     {
@@ -1019,7 +1000,7 @@ class AnthropicConverter(BaseConverter):
                 )
             else:
                 # Buffer finish for later UsageEvent or StreamEnd flush.
-                context.pending_finish = {"stop_reason": stop_reason}
+                context.buffer_finish({"stop_reason": stop_reason})
             return results if results else {}
         return {
             "type": AnthropicEventType.MESSAGE_DELTA,
@@ -1039,10 +1020,9 @@ class AnthropicConverter(BaseConverter):
         """
         usage = event["usage"]
         if context is not None:
-            if context.pending_finish is not None:
+            delta = context.pop_pending_finish()
+            if delta is not None:
                 # Merge with buffered finish and emit.
-                delta = context.pending_finish
-                context.pending_finish = None
                 output_tokens = usage.get("completion_tokens") or 0
                 return {
                     "type": AnthropicEventType.MESSAGE_DELTA,
@@ -1050,7 +1030,7 @@ class AnthropicConverter(BaseConverter):
                     "usage": {"output_tokens": output_tokens},
                 }
             # No pending finish — buffer for later merge.
-            context.pending_usage = dict(usage)
+            context.buffer_usage(usage)
             return {}
         output_tokens = usage.get("completion_tokens") or 0
         return {
@@ -1058,16 +1038,3 @@ class AnthropicConverter(BaseConverter):
             "delta": {},
             "usage": {"output_tokens": output_tokens},
         }
-
-    _TO_P_DISPATCH: dict[str, str] = {
-        "stream_start": "_handle_stream_start_to_p",
-        "stream_end": "_handle_stream_end_to_p",
-        "content_block_start": "_handle_content_block_start_to_p",
-        "content_block_end": "_handle_content_block_end_to_p",
-        "text_delta": "_handle_text_delta_to_p",
-        "reasoning_delta": "_handle_reasoning_delta_to_p",
-        "tool_call_start": "_handle_tool_call_start_to_p",
-        "tool_call_delta": "_handle_tool_call_delta_to_p",
-        "finish": "_handle_finish_to_p",
-        "usage": "_handle_usage_to_p",
-    }

--- a/src/llm_rosetta/converters/base/context.py
+++ b/src/llm_rosetta/converters/base/context.py
@@ -14,6 +14,7 @@ Provides the context hierarchy for conversion pipelines:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from collections.abc import Mapping
 from typing import Any, Literal
 
 MetadataMode = Literal["strip", "preserve"]
@@ -259,21 +260,21 @@ class StreamContext(ConversionContext):
 
     # Buffer convenience methods
 
-    def buffer_usage(self, usage: dict) -> None:
+    def buffer_usage(self, usage: Mapping[str, Any]) -> None:
         """Store usage info for later merging into a terminal event."""
         self.pending_usage = dict(usage)
 
-    def pop_pending_usage(self) -> dict | None:
+    def pop_pending_usage(self) -> dict[str, Any] | None:
         """Return and clear buffered pending usage, if any."""
         usage = self.pending_usage
         self.pending_usage = None
         return usage
 
-    def buffer_finish(self, finish: dict) -> None:
+    def buffer_finish(self, finish: dict[str, Any]) -> None:
         """Store finish event payload for later merging."""
         self.pending_finish = dict(finish)
 
-    def pop_pending_finish(self) -> dict | None:
+    def pop_pending_finish(self) -> dict[str, Any] | None:
         """Return and clear buffered pending finish, if any."""
         finish = self.pending_finish
         self.pending_finish = None

--- a/src/llm_rosetta/converters/base/context.py
+++ b/src/llm_rosetta/converters/base/context.py
@@ -256,3 +256,25 @@ class StreamContext(ConversionContext):
     def is_ended(self) -> bool:
         """Whether the stream has been ended."""
         return self._ended
+
+    # Buffer convenience methods
+
+    def buffer_usage(self, usage: dict) -> None:
+        """Store usage info for later merging into a terminal event."""
+        self.pending_usage = dict(usage)
+
+    def pop_pending_usage(self) -> dict | None:
+        """Return and clear buffered pending usage, if any."""
+        usage = self.pending_usage
+        self.pending_usage = None
+        return usage
+
+    def buffer_finish(self, finish: dict) -> None:
+        """Store finish event payload for later merging."""
+        self.pending_finish = dict(finish)
+
+    def pop_pending_finish(self) -> dict | None:
+        """Return and clear buffered pending finish, if any."""
+        finish = self.pending_finish
+        self.pending_finish = None
+        return finish

--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -45,6 +45,22 @@ class BaseConverter(ABC):
     # Enable/disable IR validation on from_provider output
     validate_output: bool = True
 
+    # Default dispatch table for stream_response_to_provider.
+    # Maps IR stream event types to handler method names.
+    # Subclasses may override to extend or customise the mapping.
+    _TO_P_DISPATCH: dict[str, str] = {
+        "stream_start": "_handle_stream_start_to_p",
+        "stream_end": "_handle_stream_end_to_p",
+        "content_block_start": "_handle_content_block_start_to_p",
+        "content_block_end": "_handle_content_block_end_to_p",
+        "text_delta": "_handle_text_delta_to_p",
+        "reasoning_delta": "_handle_reasoning_delta_to_p",
+        "tool_call_start": "_handle_tool_call_start_to_p",
+        "tool_call_delta": "_handle_tool_call_delta_to_p",
+        "finish": "_handle_finish_to_p",
+        "usage": "_handle_usage_to_p",
+    }
+
     # ==================== 顶层转换接口 Top-level conversion interface ====================
 
     @abstractmethod
@@ -226,7 +242,6 @@ class BaseConverter(ABC):
         """
         pass
 
-    @abstractmethod
     def stream_response_to_provider(
         self,
         event: IRStreamEvent,
@@ -234,8 +249,13 @@ class BaseConverter(ABC):
     ) -> dict[str, Any] | list[dict[str, Any]]:
         """Convert an IR stream event to provider-native stream chunk(s).
 
-        Some IR events (e.g., lifecycle events) may need to produce multiple
-        provider chunks, or may be silently consumed (returning an empty list).
+        Uses ``_TO_P_DISPATCH`` to route each event type to its handler,
+        then applies ``_post_process_to_provider`` for any provider-specific
+        decoration of the result.
+
+        Subclasses that need pre-dispatch logic (e.g., context upgrades)
+        may override this method, perform their pre-processing, and call
+        ``super().stream_response_to_provider(event, context)``.
 
         Args:
             event: IR stream event to convert.
@@ -245,7 +265,33 @@ class BaseConverter(ABC):
             A single provider-native stream chunk dict, or a list of chunk
             dicts when the event maps to multiple provider-level messages.
         """
-        pass
+        handler_name = self._TO_P_DISPATCH.get(event.get("type", ""))
+        if handler_name is None:
+            return {}
+        result = getattr(self, handler_name)(event, context)
+        return self._post_process_to_provider(result, event, context)
+
+    def _post_process_to_provider(
+        self,
+        result: dict[str, Any] | list[dict[str, Any]],
+        event: IRStreamEvent,
+        context: StreamContext | None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        """Hook for provider-specific post-processing of stream handler results.
+
+        Called by ``stream_response_to_provider`` after the dispatch handler
+        produces its result.  The default implementation is a no-op;
+        subclasses override to inject provider-specific envelope fields.
+
+        Args:
+            result: The handler's raw result (dict or list of dicts).
+            event: The original IR stream event (for reference).
+            context: The stream context.
+
+        Returns:
+            The (possibly modified) result.
+        """
+        return result
 
     # ==================== Provider-specific helpers (abstract) ====================
 

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -988,28 +988,6 @@ class GoogleGenAIConverter(BaseConverter):
 
     # --- to_provider ---
 
-    def stream_response_to_provider(
-        self,
-        event: IRStreamEvent,
-        context: StreamContext | None = None,
-    ) -> dict[str, Any] | list[dict[str, Any]]:
-        """Convert an IR stream event to a Google GenAI stream chunk.
-
-        Reconstructs a ``GenerateContentResponse``-shaped chunk from an IR
-        stream event.
-
-        Args:
-            event: IR stream event.
-            context: Optional stream context for stateful conversions.
-
-        Returns:
-            Google GenAI stream chunk dict.
-        """
-        handler_name = self._TO_P_DISPATCH.get(event.get("type", ""))
-        if handler_name is None:
-            return {}
-        return getattr(self, handler_name)(event, context)
-
     def _handle_stream_start_to_p(
         self, event: StreamStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
@@ -1136,9 +1114,11 @@ class GoogleGenAIConverter(BaseConverter):
         # Merge buffered usage into the finish chunk so that
         # finishReason and usageMetadata stay in a single chunk,
         # matching the original Google format.
-        if context is not None and context.pending_usage is not None:
-            usage = context.pending_usage
-            context.pending_usage = None
+        if context is not None:
+            usage = context.pop_pending_usage()
+        else:
+            usage = None
+        if usage is not None:
             usage_metadata: dict[str, Any] = {
                 "promptTokenCount": usage.get("prompt_tokens") or 0,
                 "candidatesTokenCount": usage.get("completion_tokens") or 0,
@@ -1164,7 +1144,7 @@ class GoogleGenAIConverter(BaseConverter):
         """
         usage = event["usage"]
         if context is not None:
-            context.pending_usage = dict(usage)
+            context.buffer_usage(usage)
             return {}
         usage_metadata: dict[str, Any] = {
             "promptTokenCount": usage.get("prompt_tokens") or 0,
@@ -1176,19 +1156,6 @@ class GoogleGenAIConverter(BaseConverter):
             usage_metadata["thoughtsTokenCount"] = usage["reasoning_tokens"]
 
         return {"usageMetadata": usage_metadata}
-
-    _TO_P_DISPATCH: dict[str, str] = {
-        "stream_start": "_handle_stream_start_to_p",
-        "stream_end": "_handle_stream_end_to_p",
-        "content_block_start": "_handle_content_block_start_to_p",
-        "content_block_end": "_handle_content_block_end_to_p",
-        "text_delta": "_handle_text_delta_to_p",
-        "reasoning_delta": "_handle_reasoning_delta_to_p",
-        "tool_call_start": "_handle_tool_call_start_to_p",
-        "tool_call_delta": "_handle_tool_call_delta_to_p",
-        "finish": "_handle_finish_to_p",
-        "usage": "_handle_usage_to_p",
-    }
 
 
 # Backward compatibility alias

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -824,7 +824,7 @@ class GoogleGenAIConverter(BaseConverter):
                 kept_new: list[IRStreamEvent] = []
                 for ev in new_events:
                     if ev["type"] == "text_delta":
-                        deferred_texts.append(ev["text"])  # type: ignore[typeddict-item]
+                        deferred_texts.append(ev["text"])
                     else:
                         kept_new.append(ev)
                 if deferred_texts:

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -789,45 +789,23 @@ class OpenAIChatConverter(BaseConverter):
 
     # --- to_provider ---
 
-    def stream_response_to_provider(
+    def _post_process_to_provider(
         self,
+        result: dict[str, Any] | list[dict[str, Any]],
         event: IRStreamEvent,
-        context: StreamContext | None = None,
+        context: StreamContext | None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
-        """Convert an IR stream event to an OpenAI SSE chunk.
-
-        When a ``context`` is provided and the stream has been started,
-        top-level fields (``id``, ``object``, ``model``, ``created``) are
-        populated on every output chunk.
-
-        Args:
-            event: IR stream event.
-            context: Optional stream context for stateful conversions.
-
-        Returns:
-            OpenAI SSE chunk dict, or a list of chunk dicts.
-        """
-        handler_name = self._TO_P_DISPATCH.get(event.get("type", ""))
-        if handler_name is None:
-            return {}
-        result = getattr(self, handler_name)(event, context)
-
-        # Populate top-level fields when context is available and started
+        """Inject top-level envelope fields (id, object, model, created)."""
         if (
             context is not None
             and context.is_started
             and isinstance(result, dict)
             and result
         ):
-            if "id" not in result:
-                result["id"] = context.response_id
-            if "object" not in result:
-                result["object"] = "chat.completion.chunk"
-            if "model" not in result:
-                result["model"] = context.model
-            if "created" not in result:
-                result["created"] = context.created
-
+            result.setdefault("id", context.response_id)
+            result.setdefault("object", "chat.completion.chunk")
+            result.setdefault("model", context.model)
+            result.setdefault("created", context.created)
         return result
 
     def _handle_stream_start_to_p(
@@ -875,9 +853,8 @@ class OpenAIChatConverter(BaseConverter):
         """
         if context is not None:
             context.mark_ended()
-            if context.pending_usage is not None:
-                usage = context.pending_usage
-                context.pending_usage = None
+            usage = context.pop_pending_usage()
+            if usage is not None:
                 return {
                     "id": context.response_id,
                     "object": "chat.completion.chunk",
@@ -1035,7 +1012,7 @@ class OpenAIChatConverter(BaseConverter):
         """
         usage = event["usage"]
         if context is not None:
-            context.pending_usage = dict(usage)
+            context.buffer_usage(usage)
             return {}
         return {
             "choices": [],
@@ -1045,16 +1022,3 @@ class OpenAIChatConverter(BaseConverter):
                 "total_tokens": usage.get("total_tokens") or 0,
             },
         }
-
-    _TO_P_DISPATCH: dict[str, str] = {
-        "stream_start": "_handle_stream_start_to_p",
-        "stream_end": "_handle_stream_end_to_p",
-        "content_block_start": "_handle_content_block_start_to_p",
-        "content_block_end": "_handle_content_block_end_to_p",
-        "text_delta": "_handle_text_delta_to_p",
-        "reasoning_delta": "_handle_reasoning_delta_to_p",
-        "tool_call_start": "_handle_tool_call_start_to_p",
-        "tool_call_delta": "_handle_tool_call_delta_to_p",
-        "finish": "_handle_finish_to_p",
-        "usage": "_handle_usage_to_p",
-    }

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -1043,23 +1043,11 @@ class OpenAIResponsesConverter(BaseConverter):
         event: IRStreamEvent,
         context: StreamContext | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
-        """Convert an IR stream event to an OpenAI Responses SSE event.
-
-        When a ``context`` is provided, ``UsageEvent`` stores usage info in
-        the context instead of emitting a duplicate ``response.completed``,
-        and ``FinishEvent`` merges any pending usage into its
-        ``response.completed`` output.
+        """Convert IR stream event with automatic context upgrade.
 
         If a base ``StreamContext`` is passed, it is automatically upgraded
         to ``OpenAIResponsesStreamContext`` (preserving existing state) so
         that callers do not need to know about the provider-specific subclass.
-
-        Args:
-            event: IR stream event.
-            context: Optional stream context for stateful conversions.
-
-        Returns:
-            OpenAI Responses SSE event dict, or a list of dicts.
         """
         # Auto-upgrade base StreamContext to the provider-specific subclass.
         # Cache the upgraded instance in metadata so state persists across calls.
@@ -1072,21 +1060,25 @@ class OpenAIResponsesConverter(BaseConverter):
                 context.metadata["_responses_stream_ctx"] = cached
             context = cached
 
-        handler_name = self._TO_P_DISPATCH.get(event["type"])
-        if handler_name is not None:
-            result = getattr(self, handler_name)(event, context)
-            # Inject sequence_number into emitted events
-            if isinstance(context, OpenAIResponsesStreamContext):
-                if isinstance(result, list):
-                    for r in result:
-                        if isinstance(r, dict) and "type" in r:
-                            context._sequence_number += 1
-                            r["sequence_number"] = context._sequence_number
-                elif isinstance(result, dict) and "type" in result:
-                    context._sequence_number += 1
-                    result["sequence_number"] = context._sequence_number
-            return result
-        return {}
+        return super().stream_response_to_provider(event, context)
+
+    def _post_process_to_provider(
+        self,
+        result: dict[str, Any] | list[dict[str, Any]],
+        event: IRStreamEvent,
+        context: StreamContext | None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        """Inject sequence_number into emitted Responses events."""
+        if isinstance(context, OpenAIResponsesStreamContext):
+            if isinstance(result, list):
+                for r in result:
+                    if isinstance(r, dict) and "type" in r:
+                        context._sequence_number += 1
+                        r["sequence_number"] = context._sequence_number
+            elif isinstance(result, dict) and "type" in result:
+                context._sequence_number += 1
+                result["sequence_number"] = context._sequence_number
+        return result
 
     # --- to_provider handlers ---
 
@@ -1597,7 +1589,7 @@ class OpenAIResponsesConverter(BaseConverter):
         # With context: store usage for later merging, avoid duplicate
         # response.completed
         if context is not None:
-            context.pending_usage = dict(usage)
+            context.buffer_usage(usage)
             return {}
 
         # Without context: preserve backward-compatible behavior
@@ -1614,19 +1606,6 @@ class OpenAIResponsesConverter(BaseConverter):
             "type": ResponsesEventType.RESPONSE_COMPLETED,
             "response": resp,
         }
-
-    _TO_P_DISPATCH: dict[str, str] = {
-        "stream_start": "_handle_stream_start_to_p",
-        "stream_end": "_handle_stream_end_to_p",
-        "content_block_start": "_handle_content_block_start_to_p",
-        "content_block_end": "_handle_content_block_end_to_p",
-        "text_delta": "_handle_text_delta_to_p",
-        "reasoning_delta": "_handle_reasoning_delta_to_p",
-        "tool_call_start": "_handle_tool_call_start_to_p",
-        "tool_call_delta": "_handle_tool_call_delta_to_p",
-        "finish": "_handle_finish_to_p",
-        "usage": "_handle_usage_to_p",
-    }
 
     # ==================== Backward Compatibility ====================
 

--- a/tests/converters/base/test_conversion_context.py
+++ b/tests/converters/base/test_conversion_context.py
@@ -1,6 +1,6 @@
 """Tests for ConversionContext and StreamContext inheritance."""
 
-from typing import cast
+from typing import Any, cast
 
 from llm_rosetta.converters.base import BaseConverter
 from llm_rosetta.converters.base.context import ConversionContext, StreamContext
@@ -123,6 +123,7 @@ class TestStreamContextBufferMethods:
         original = {"prompt_tokens": 10}
         ctx.buffer_usage(original)
         original["prompt_tokens"] = 99
+        assert ctx.pending_usage is not None
         assert ctx.pending_usage["prompt_tokens"] == 10
 
     def test_pop_pending_usage_returns_and_clears(self):
@@ -146,6 +147,7 @@ class TestStreamContextBufferMethods:
         original = {"stop_reason": "end_turn"}
         ctx.buffer_finish(original)
         original["stop_reason"] = "changed"
+        assert ctx.pending_finish is not None
         assert ctx.pending_finish["stop_reason"] == "end_turn"
 
     def test_pop_pending_finish_returns_and_clears(self):
@@ -182,17 +184,21 @@ class TestBaseConverterDispatch:
         assert set(BaseConverter._TO_P_DISPATCH.keys()) == expected
 
     def test_post_process_noop(self):
-        converter = OpenAIChatConverter()
-        # Call the base _post_process_to_provider directly via BaseConverter
-        result = {"test": True}
-        out = BaseConverter._post_process_to_provider(
-            converter, result, {"type": "text_delta"}, None
+        # Google inherits base _post_process_to_provider without override
+        converter = GoogleGenAIConverter()
+        result: dict[str, Any] = {"test": True}
+        out = converter._post_process_to_provider(
+            result,
+            {"type": "text_delta"},  # ty: ignore[invalid-argument-type]
+            None,
         )
         assert out is result
 
     def test_unknown_event_returns_empty(self):
         converter = OpenAIChatConverter()
-        result = converter.stream_response_to_provider({"type": "nonexistent"})
+        result = converter.stream_response_to_provider(
+            {"type": "nonexistent"}  # ty: ignore[invalid-argument-type]
+        )
         assert result == {}
 
 

--- a/tests/converters/base/test_conversion_context.py
+++ b/tests/converters/base/test_conversion_context.py
@@ -110,6 +110,92 @@ class TestOpenAIResponsesStreamContextInheritance:
         assert ctx.output_item_emitted is False
 
 
+class TestStreamContextBufferMethods:
+    """Test StreamContext buffer/pop convenience methods."""
+
+    def test_buffer_usage_sets_pending(self):
+        ctx = StreamContext()
+        ctx.buffer_usage({"prompt_tokens": 10, "completion_tokens": 5})
+        assert ctx.pending_usage == {"prompt_tokens": 10, "completion_tokens": 5}
+
+    def test_buffer_usage_copies_dict(self):
+        ctx = StreamContext()
+        original = {"prompt_tokens": 10}
+        ctx.buffer_usage(original)
+        original["prompt_tokens"] = 99
+        assert ctx.pending_usage["prompt_tokens"] == 10
+
+    def test_pop_pending_usage_returns_and_clears(self):
+        ctx = StreamContext()
+        ctx.buffer_usage({"prompt_tokens": 10})
+        result = ctx.pop_pending_usage()
+        assert result == {"prompt_tokens": 10}
+        assert ctx.pending_usage is None
+
+    def test_pop_pending_usage_returns_none_when_empty(self):
+        ctx = StreamContext()
+        assert ctx.pop_pending_usage() is None
+
+    def test_buffer_finish_sets_pending(self):
+        ctx = StreamContext()
+        ctx.buffer_finish({"stop_reason": "end_turn"})
+        assert ctx.pending_finish == {"stop_reason": "end_turn"}
+
+    def test_buffer_finish_copies_dict(self):
+        ctx = StreamContext()
+        original = {"stop_reason": "end_turn"}
+        ctx.buffer_finish(original)
+        original["stop_reason"] = "changed"
+        assert ctx.pending_finish["stop_reason"] == "end_turn"
+
+    def test_pop_pending_finish_returns_and_clears(self):
+        ctx = StreamContext()
+        ctx.buffer_finish({"stop_reason": "end_turn"})
+        result = ctx.pop_pending_finish()
+        assert result == {"stop_reason": "end_turn"}
+        assert ctx.pending_finish is None
+
+    def test_pop_pending_finish_returns_none_when_empty(self):
+        ctx = StreamContext()
+        assert ctx.pop_pending_finish() is None
+
+
+class TestBaseConverterDispatch:
+    """Test BaseConverter._TO_P_DISPATCH and dispatch skeleton."""
+
+    def test_dispatch_table_has_10_entries(self):
+        assert len(BaseConverter._TO_P_DISPATCH) == 10
+
+    def test_dispatch_table_keys(self):
+        expected = {
+            "stream_start",
+            "stream_end",
+            "content_block_start",
+            "content_block_end",
+            "text_delta",
+            "reasoning_delta",
+            "tool_call_start",
+            "tool_call_delta",
+            "finish",
+            "usage",
+        }
+        assert set(BaseConverter._TO_P_DISPATCH.keys()) == expected
+
+    def test_post_process_noop(self):
+        converter = OpenAIChatConverter()
+        # Call the base _post_process_to_provider directly via BaseConverter
+        result = {"test": True}
+        out = BaseConverter._post_process_to_provider(
+            converter, result, {"type": "text_delta"}, None
+        )
+        assert out is result
+
+    def test_unknown_event_returns_empty(self):
+        converter = OpenAIChatConverter()
+        result = converter.stream_response_to_provider({"type": "nonexistent"})
+        assert result == {}
+
+
 class TestFactoryMethods:
     """Test create_conversion_context and create_stream_context."""
 

--- a/tests/converters/test_roundtrip_inflation.py
+++ b/tests/converters/test_roundtrip_inflation.py
@@ -839,7 +839,7 @@ ROUNDTRIP_CASES = [
 @pytest.mark.parametrize(
     ("provider", "label", "input_events"),
     ROUNDTRIP_CASES,
-    ids=[f"{p}/{l}" for p, l, _ in ROUNDTRIP_CASES],
+    ids=[f"{p}/{label}" for p, label, _ in ROUNDTRIP_CASES],
 )
 def test_no_roundtrip_inflation(
     provider: str,

--- a/tests/converters/test_roundtrip_inflation.py
+++ b/tests/converters/test_roundtrip_inflation.py
@@ -15,6 +15,7 @@ from typing import Any
 import pytest
 
 from llm_rosetta import get_converter_for_provider
+from llm_rosetta.auto_detect import ProviderType
 from llm_rosetta.converters.base.context import StreamContext
 
 
@@ -24,7 +25,7 @@ from llm_rosetta.converters.base.context import StreamContext
 
 
 def run_roundtrip(
-    provider: str,
+    provider: ProviderType,
     input_events: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Run a streaming round-trip and return output events."""
@@ -842,7 +843,7 @@ ROUNDTRIP_CASES = [
     ids=[f"{p}/{label}" for p, label, _ in ROUNDTRIP_CASES],
 )
 def test_no_roundtrip_inflation(
-    provider: str,
+    provider: ProviderType,
     label: str,
     input_events: list[dict[str, Any]],
 ) -> None:

--- a/tests/converters/test_roundtrip_inflation.py
+++ b/tests/converters/test_roundtrip_inflation.py
@@ -1,0 +1,853 @@
+"""Streaming round-trip inflation regression tests.
+
+For each provider, sends a realistic SSE event sequence through:
+  stream_response_from_provider → IR events → stream_response_to_provider
+
+Verifies that the output event count does NOT exceed the input event count
+(no inflation).  Deflation (output < input) is acceptable because compound
+chunks may legitimately merge during round-trip.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from llm_rosetta import get_converter_for_provider
+from llm_rosetta.converters.base.context import StreamContext
+
+
+# ============================================================
+# Helper
+# ============================================================
+
+
+def run_roundtrip(
+    provider: str,
+    input_events: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Run a streaming round-trip and return output events."""
+    converter = get_converter_for_provider(provider)
+    from_ctx = StreamContext()
+    to_ctx = StreamContext()
+
+    output_events: list[dict[str, Any]] = []
+
+    for inp in input_events:
+        ir_events = converter.stream_response_from_provider(inp, context=from_ctx)
+        for ir_event in ir_events:
+            result = converter.stream_response_to_provider(ir_event, context=to_ctx)
+            if isinstance(result, list):
+                output_events.extend(e for e in result if e)
+            elif result:
+                output_events.append(result)
+
+    return output_events
+
+
+# ============================================================
+# Fixtures — Anthropic
+# ============================================================
+
+ANTHROPIC_BASIC: list[dict[str, Any]] = [
+    {
+        "type": "message_start",
+        "message": {
+            "id": "msg_001",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-20250514",
+            "content": [],
+            "stop_reason": None,
+            "usage": {"input_tokens": 12, "output_tokens": 1},
+        },
+    },
+    {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "text", "text": ""},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": "Hello"},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": " world!"},
+    },
+    {"type": "content_block_stop", "index": 0},
+    {
+        "type": "message_delta",
+        "delta": {"stop_reason": "end_turn"},
+        "usage": {"output_tokens": 5},
+    },
+    {"type": "message_stop"},
+]
+
+ANTHROPIC_THINKING_TOOL: list[dict[str, Any]] = [
+    {
+        "type": "message_start",
+        "message": {
+            "id": "msg_002",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-20250514",
+            "content": [],
+            "stop_reason": None,
+            "usage": {"input_tokens": 50, "output_tokens": 1},
+        },
+    },
+    {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "thinking", "thinking": ""},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "thinking_delta", "thinking": "Let me search for"},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "thinking_delta", "thinking": " the answer."},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "signature_delta", "signature": "sig_abc123"},
+    },
+    {"type": "content_block_stop", "index": 0},
+    {
+        "type": "content_block_start",
+        "index": 1,
+        "content_block": {
+            "type": "tool_use",
+            "id": "toolu_abc",
+            "name": "web_search",
+            "input": {},
+        },
+    },
+    {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {"type": "input_json_delta", "partial_json": '{"query":'},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 1,
+        "delta": {"type": "input_json_delta", "partial_json": '"hello"}'},
+    },
+    {"type": "content_block_stop", "index": 1},
+    {
+        "type": "message_delta",
+        "delta": {"stop_reason": "tool_use"},
+        "usage": {"output_tokens": 42},
+    },
+    {"type": "message_stop"},
+]
+
+ANTHROPIC_NO_INITIAL_USAGE: list[dict[str, Any]] = [
+    {
+        "type": "message_start",
+        "message": {
+            "id": "msg_003",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-20250514",
+            "content": [],
+            "stop_reason": None,
+        },
+    },
+    {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "text", "text": ""},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": "Hi"},
+    },
+    {"type": "content_block_stop", "index": 0},
+    {
+        "type": "message_delta",
+        "delta": {"stop_reason": "end_turn"},
+        "usage": {"output_tokens": 1},
+    },
+    {"type": "message_stop"},
+]
+
+ANTHROPIC_FINISH_NO_USAGE: list[dict[str, Any]] = [
+    {
+        "type": "message_start",
+        "message": {
+            "id": "msg_004",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-20250514",
+            "content": [],
+            "stop_reason": None,
+            "usage": {"input_tokens": 5, "output_tokens": 0},
+        },
+    },
+    {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "text", "text": ""},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": "OK"},
+    },
+    {"type": "content_block_stop", "index": 0},
+    {
+        "type": "message_delta",
+        "delta": {"stop_reason": "end_turn"},
+    },
+    {"type": "message_stop"},
+]
+
+# ============================================================
+# Fixtures — OpenAI Chat
+# ============================================================
+
+OPENAI_CHAT_BASIC: list[dict[str, Any]] = [
+    {
+        "id": "chatcmpl-001",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+        ],
+    },
+    {
+        "id": "chatcmpl-001",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [{"index": 0, "delta": {"content": "Hello"}, "finish_reason": None}],
+    },
+    {
+        "id": "chatcmpl-001",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [
+            {"index": 0, "delta": {"content": " world!"}, "finish_reason": None}
+        ],
+    },
+    {
+        "id": "chatcmpl-001",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+    },
+    {
+        "id": "chatcmpl-001",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 12,
+            "completion_tokens": 5,
+            "total_tokens": 17,
+        },
+    },
+]
+
+OPENAI_CHAT_TOOL_CALLS: list[dict[str, Any]] = [
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+        ],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_abc",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": ""},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"arguments": '{"city":"NYC"}'},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-4o",
+        "created": 1700000000,
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 30,
+            "completion_tokens": 15,
+            "total_tokens": 45,
+        },
+    },
+]
+
+OPENAI_CHAT_REASONING: list[dict[str, Any]] = [
+    {
+        "id": "chatcmpl-003",
+        "object": "chat.completion.chunk",
+        "model": "o3-mini",
+        "created": 1700000000,
+        "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+        ],
+    },
+    {
+        "id": "chatcmpl-003",
+        "object": "chat.completion.chunk",
+        "model": "o3-mini",
+        "created": 1700000000,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"reasoning_content": "Let me think..."},
+                "finish_reason": None,
+            }
+        ],
+    },
+    {
+        "id": "chatcmpl-003",
+        "object": "chat.completion.chunk",
+        "model": "o3-mini",
+        "created": 1700000000,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": "The answer is 42."},
+                "finish_reason": None,
+            }
+        ],
+    },
+    {
+        "id": "chatcmpl-003",
+        "object": "chat.completion.chunk",
+        "model": "o3-mini",
+        "created": 1700000000,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+    },
+    {
+        "id": "chatcmpl-003",
+        "object": "chat.completion.chunk",
+        "model": "o3-mini",
+        "created": 1700000000,
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 20,
+            "completion_tokens": 30,
+            "total_tokens": 50,
+        },
+    },
+]
+
+OPENAI_CHAT_ROLE_EMPTY_CONTENT: list[dict[str, Any]] = [
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-5-nano",
+        "created": 1700000000,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": "", "refusal": None},
+                "finish_reason": None,
+            }
+        ],
+        "usage": None,
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-5-nano",
+        "created": 1700000000,
+        "choices": [{"index": 0, "delta": {"content": "2 + 2"}, "finish_reason": None}],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-5-nano",
+        "created": 1700000000,
+        "choices": [{"index": 0, "delta": {"content": " = 4."}, "finish_reason": None}],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-5-nano",
+        "created": 1700000000,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+    },
+    {
+        "id": "chatcmpl-002",
+        "object": "chat.completion.chunk",
+        "model": "gpt-5-nano",
+        "created": 1700000000,
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 8,
+            "total_tokens": 18,
+        },
+    },
+]
+
+# ============================================================
+# Fixtures — OpenAI Responses
+# ============================================================
+
+OPENAI_RESPONSES_BASIC: list[dict[str, Any]] = [
+    {
+        "type": "response.created",
+        "response": {
+            "id": "resp_001",
+            "object": "response",
+            "model": "gpt-4o",
+            "status": "in_progress",
+            "output": [],
+            "usage": None,
+        },
+    },
+    {
+        "type": "response.output_item.added",
+        "output_index": 0,
+        "item": {
+            "type": "message",
+            "id": "msg_001",
+            "role": "assistant",
+            "content": [],
+        },
+    },
+    {
+        "type": "response.content_part.added",
+        "item_id": "msg_001",
+        "output_index": 0,
+        "content_index": 0,
+        "part": {"type": "output_text", "text": "", "annotations": []},
+    },
+    {
+        "type": "response.output_text.delta",
+        "item_id": "msg_001",
+        "output_index": 0,
+        "content_index": 0,
+        "delta": "Hello",
+    },
+    {
+        "type": "response.output_text.delta",
+        "item_id": "msg_001",
+        "output_index": 0,
+        "content_index": 0,
+        "delta": " world!",
+    },
+    {
+        "type": "response.output_text.done",
+        "item_id": "msg_001",
+        "output_index": 0,
+        "content_index": 0,
+        "text": "Hello world!",
+    },
+    {
+        "type": "response.content_part.done",
+        "item_id": "msg_001",
+        "output_index": 0,
+        "content_index": 0,
+        "part": {
+            "type": "output_text",
+            "text": "Hello world!",
+            "annotations": [],
+        },
+    },
+    {
+        "type": "response.output_item.done",
+        "output_index": 0,
+        "item": {
+            "type": "message",
+            "id": "msg_001",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Hello world!",
+                    "annotations": [],
+                }
+            ],
+        },
+    },
+    {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_001",
+            "object": "response",
+            "model": "gpt-4o",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_001",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Hello world!",
+                            "annotations": [],
+                        }
+                    ],
+                }
+            ],
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 5,
+                "total_tokens": 17,
+            },
+        },
+    },
+]
+
+OPENAI_RESPONSES_TOOL_CALL: list[dict[str, Any]] = [
+    {
+        "type": "response.created",
+        "response": {
+            "id": "resp_002",
+            "object": "response",
+            "model": "gpt-4o",
+            "status": "in_progress",
+            "output": [],
+            "usage": None,
+        },
+    },
+    {
+        "type": "response.output_item.added",
+        "output_index": 0,
+        "item": {
+            "type": "function_call",
+            "id": "fc_001",
+            "call_id": "call_xyz",
+            "name": "get_weather",
+            "arguments": "",
+        },
+    },
+    {
+        "type": "response.function_call_arguments.delta",
+        "item_id": "fc_001",
+        "output_index": 0,
+        "delta": '{"city":',
+    },
+    {
+        "type": "response.function_call_arguments.delta",
+        "item_id": "fc_001",
+        "output_index": 0,
+        "delta": '"NYC"}',
+    },
+    {
+        "type": "response.function_call_arguments.done",
+        "item_id": "fc_001",
+        "output_index": 0,
+        "arguments": '{"city":"NYC"}',
+    },
+    {
+        "type": "response.output_item.done",
+        "output_index": 0,
+        "item": {
+            "type": "function_call",
+            "id": "fc_001",
+            "call_id": "call_xyz",
+            "name": "get_weather",
+            "arguments": '{"city":"NYC"}',
+        },
+    },
+    {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_002",
+            "object": "response",
+            "model": "gpt-4o",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "function_call",
+                    "id": "fc_001",
+                    "call_id": "call_xyz",
+                    "name": "get_weather",
+                    "arguments": '{"city":"NYC"}',
+                }
+            ],
+            "usage": {
+                "input_tokens": 20,
+                "output_tokens": 10,
+                "total_tokens": 30,
+            },
+        },
+    },
+]
+
+# ============================================================
+# Fixtures — Google GenAI
+# ============================================================
+
+GOOGLE_BASIC: list[dict[str, Any]] = [
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello"}], "role": "model"},
+                "index": 0,
+            }
+        ],
+        "modelVersion": "gemini-2.0-flash",
+    },
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": " world!"}], "role": "model"},
+                "index": 0,
+            }
+        ],
+    },
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": ""}], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 12,
+            "candidatesTokenCount": 5,
+            "totalTokenCount": 17,
+        },
+        "modelVersion": "gemini-2.0-flash",
+    },
+]
+
+GOOGLE_TOOL_CALL: list[dict[str, Any]] = [
+    {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "get_weather",
+                                "args": {"city": "NYC"},
+                            }
+                        }
+                    ],
+                    "role": "model",
+                },
+                "index": 0,
+            }
+        ],
+        "modelVersion": "gemini-2.0-flash",
+    },
+    {
+        "candidates": [
+            {
+                "content": {"parts": [], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 25,
+            "candidatesTokenCount": 10,
+            "totalTokenCount": 35,
+        },
+        "modelVersion": "gemini-2.0-flash",
+    },
+]
+
+GOOGLE_THINKING: list[dict[str, Any]] = [
+    {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [{"text": "Analyzing...", "thought": True}],
+                    "role": "model",
+                },
+                "index": 0,
+            }
+        ],
+        "modelVersion": "gemini-2.5-flash",
+    },
+    {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [{"text": "The answer is 42."}],
+                    "role": "model",
+                },
+                "index": 0,
+            }
+        ],
+    },
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": ""}], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 15,
+            "candidatesTokenCount": 20,
+            "totalTokenCount": 35,
+            "thoughtsTokenCount": 10,
+        },
+        "modelVersion": "gemini-2.5-flash",
+    },
+]
+
+GOOGLE_NO_EMPTY_TEXT: list[dict[str, Any]] = [
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello!"}], "role": "model"},
+                "index": 0,
+            }
+        ],
+        "modelVersion": "gemini-2.0-flash",
+    },
+    {
+        "candidates": [
+            {
+                "content": {"parts": [], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 5,
+            "candidatesTokenCount": 2,
+            "totalTokenCount": 7,
+        },
+    },
+]
+
+GOOGLE_COMPOUND_TEXT_FINISH: list[dict[str, Any]] = [
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "2 plus "}], "role": "model"},
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 6,
+            "candidatesTokenCount": 3,
+            "totalTokenCount": 9,
+        },
+        "modelVersion": "gemini-2.5-flash",
+    },
+    {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "2 equals 4."}], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 6,
+            "candidatesTokenCount": 8,
+            "totalTokenCount": 14,
+        },
+        "modelVersion": "gemini-2.5-flash",
+    },
+]
+
+
+# ============================================================
+# Parametrized test
+# ============================================================
+
+ROUNDTRIP_CASES = [
+    # Basic cases
+    ("anthropic", "basic", ANTHROPIC_BASIC),
+    ("openai_chat", "basic", OPENAI_CHAT_BASIC),
+    ("openai_responses", "basic", OPENAI_RESPONSES_BASIC),
+    ("google", "basic", GOOGLE_BASIC),
+    # Anthropic edge cases
+    ("anthropic", "thinking+tool", ANTHROPIC_THINKING_TOOL),
+    ("anthropic", "no-initial-usage", ANTHROPIC_NO_INITIAL_USAGE),
+    ("anthropic", "finish-no-usage", ANTHROPIC_FINISH_NO_USAGE),
+    # OpenAI Chat edge cases
+    ("openai_chat", "tool-calls", OPENAI_CHAT_TOOL_CALLS),
+    ("openai_chat", "reasoning", OPENAI_CHAT_REASONING),
+    ("openai_chat", "role-empty-content", OPENAI_CHAT_ROLE_EMPTY_CONTENT),
+    # Google edge cases
+    ("google", "tool-call", GOOGLE_TOOL_CALL),
+    ("google", "thinking", GOOGLE_THINKING),
+    ("google", "no-empty-text", GOOGLE_NO_EMPTY_TEXT),
+    ("google", "compound-text-finish", GOOGLE_COMPOUND_TEXT_FINISH),
+    # OpenAI Responses edge cases
+    ("openai_responses", "tool-call", OPENAI_RESPONSES_TOOL_CALL),
+]
+
+
+@pytest.mark.parametrize(
+    ("provider", "label", "input_events"),
+    ROUNDTRIP_CASES,
+    ids=[f"{p}/{l}" for p, l, _ in ROUNDTRIP_CASES],
+)
+def test_no_roundtrip_inflation(
+    provider: str,
+    label: str,
+    input_events: list[dict[str, Any]],
+) -> None:
+    """Output event count must not exceed input event count."""
+    output_events = run_roundtrip(provider, input_events)
+    assert len(output_events) <= len(input_events), (
+        f"{provider}/{label}: inflated {len(input_events)} → {len(output_events)} events"
+    )


### PR DESCRIPTION
## Summary

- Extract identical `_TO_P_DISPATCH` table and dispatch skeleton from all 4 converters into `BaseConverter`, with `_post_process_to_provider` hook for provider-specific post-processing
- Add `buffer_usage`/`pop_pending_usage`/`buffer_finish`/`pop_pending_finish` convenience methods to `StreamContext`
- Adopt convenience methods across all converter handler call sites (~12 replacements)
- Add roundtrip inflation regression tests as pytest parametrized cases (15 scenarios)
- Add `tests/converters/` to CI workflow (1086 converter tests + 15 roundtrip inflation tests were not in CI before)

## Per-converter changes

| Converter | Change |
|---|---|
| Anthropic | Delete `stream_response_to_provider` + `_TO_P_DISPATCH` (inherit base) |
| Google GenAI | Delete `stream_response_to_provider` + `_TO_P_DISPATCH` (inherit base) |
| OpenAI Chat | Replace dispatch with `_post_process_to_provider` override (id/object/model/created injection) |
| OpenAI Responses | Slim `stream_response_to_provider` to context-upgrade + `super()` call; add `_post_process_to_provider` for sequence_number |

## Test plan

- [x] All 1329 tests pass locally (1086 converter + 228 type + 15 roundtrip inflation)
- [x] 15/15 synthetic roundtrip inflation scenarios pass
- [ ] CI passes

Closes #157