### PR TITLE
fix: include FilePart in UserContentPart for PDF/document support

### DIFF
--- a/src/llm_rosetta/types/ir/parts.py
+++ b/src/llm_rosetta/types/ir/parts.py
@@ -256,12 +256,13 @@ class AudioPart(TypedDict):
 # 系统消息内容类型 - 目前只允许文本
 SystemContentPart = TextPart
 
-# 用户消息内容类型 - 文本、图像，未来支持文件、音频
+# 用户消息内容类型 - 文本、图像、文件，未来支持音频
+# User message content types - text, images, files, future support for audio
 UserContentPart = Union[
     TextPart,
     ImagePart,
+    FilePart,
     # 未来支持 Future support:
-    # FilePart,
     # AudioPart,
 ]
 


### PR DESCRIPTION
## Summary

- Uncomment `FilePart` in `UserContentPart` union type — the conversion logic is already fully implemented for Anthropic, Google, and OpenAI Responses

## Context

`UserContentPart` excluded `FilePart` as "future support", but all three providers with file support already have complete bidirectional conversion:

| Provider | Provider → IR | IR → Provider |
|----------|--------------|---------------|
| Anthropic | `document` → `FilePart` ✅ | `FilePart` → `document` ✅ |
| Google | `inlineData` → `FilePart` ✅ | `FilePart` → `inlineData` ✅ |
| OpenAI Responses | `input_file` → `FilePart` ✅ | `FilePart` → `input_file` ✅ |

This caused `validate_ir_request()` to reject any user message containing file content (e.g., PDF attachments sent by Claude Code), with error:
```
Value at 'messages[N].content[0]' does not match any variant of TextPart | ImagePart
```

## Test plan

- [x] Verified two-stage roundtrip: Anthropic `document` → IR `FilePart` → Anthropic `document`
- [x] Tested end-to-end through argo-proxy with force-conversion enabled
- [x] CI passes

Closes #160