### PR TITLE
fix: replace httpx with urllib.request in google_genai content_ops

### DIFF
--- a/src/llm_rosetta/converters/google_genai/content_ops.py
+++ b/src/llm_rosetta/converters/google_genai/content_ops.py
@@ -14,7 +14,7 @@ import mimetypes
 import warnings
 from typing import Any, cast
 
-import httpx
+import urllib.request
 
 from ...types.ir import (
     AudioData,
@@ -117,24 +117,26 @@ class GoogleGenAIContentOps(BaseContentOps):
                 import os
 
                 proxy = os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
-                headers = {
-                    "User-Agent": "llm-rosetta/1.0 (image fetch)",
-                }
-                client_kwargs: dict[str, Any] = {
-                    "timeout": 30,
-                    "follow_redirects": True,
-                    "headers": headers,
-                }
+                req = urllib.request.Request(
+                    url,
+                    headers={"User-Agent": "llm-rosetta/1.0 (image fetch)"},
+                )
                 if proxy:
-                    client_kwargs["proxy"] = proxy
-                resp = httpx.get(url, **client_kwargs)
-                resp.raise_for_status()
+                    handler = urllib.request.ProxyHandler(
+                        {"https": proxy, "http": proxy}
+                    )
+                    opener = urllib.request.build_opener(handler)
+                else:
+                    opener = urllib.request.build_opener()
+                resp = opener.open(req, timeout=30)
+                data = resp.read()
+                content_type = resp.headers.get("Content-Type", "")
                 mime = (
-                    resp.headers.get("content-type", "").split(";")[0].strip()
+                    content_type.split(";")[0].strip()
                     or mimetypes.guess_type(url)[0]
                     or "image/jpeg"
                 )
-                b64 = base64.b64encode(resp.content).decode()
+                b64 = base64.b64encode(data).decode()
                 return {"inlineData": {"mimeType": mime, "data": b64}}
             except Exception as exc:
                 logging.getLogger("llm-rosetta").warning(

--- a/tests/converters/google_genai/test_content_ops.py
+++ b/tests/converters/google_genai/test_content_ops.py
@@ -78,13 +78,16 @@ class TestGoogleGenAIContentOps:
 
         ir_image = ImagePart(type="image", image_url="https://example.com/img.jpg")
         mock_resp = MagicMock()
-        mock_resp.content = b"\x89PNG\r\n"
-        mock_resp.headers = {"content-type": "image/png"}
-        mock_resp.raise_for_status = MagicMock()
+        mock_resp.read.return_value = b"\x89PNG\r\n"
+        mock_resp.headers = MagicMock()
+        mock_resp.headers.get.return_value = "image/png"
+
+        mock_opener = MagicMock()
+        mock_opener.open.return_value = mock_resp
 
         with patch(
-            "llm_rosetta.converters.google_genai.content_ops.httpx.get",
-            return_value=mock_resp,
+            "llm_rosetta.converters.google_genai.content_ops.urllib.request.build_opener",
+            return_value=mock_opener,
         ):
             result = GoogleGenAIContentOps.ir_image_to_p(ir_image)
 
@@ -100,7 +103,7 @@ class TestGoogleGenAIContentOps:
 
         ir_image = ImagePart(type="image", image_url="https://example.com/img.jpg")
         with patch(
-            "llm_rosetta.converters.google_genai.content_ops.httpx.get",
+            "llm_rosetta.converters.google_genai.content_ops.urllib.request.build_opener",
             side_effect=Exception("timeout"),
         ):
             result = GoogleGenAIContentOps.ir_image_to_p(ir_image)


### PR DESCRIPTION
## Summary

- Replace top-level `import httpx` with `import urllib.request` in `google_genai/content_ops.py`
- `httpx` is only an optional dependency (`gateway` extra), but was imported unconditionally, causing `ModuleNotFoundError` for users installing without the gateway extra
- Update tests to mock `urllib.request.build_opener` instead of `httpx.get`

Closes #163
Reported via Oaklight/argo-proxy#117

## Test plan

- [x] All 35 google_genai content_ops tests pass
- [x] `ruff check` and `ruff format` clean
- [ ] Verify `pip install llm-rosetta` (without `[gateway]`) no longer errors on import