### PR TITLE
feat: add copy entry buttons for providers and models in admin

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -133,6 +133,8 @@ tr:hover td { background: var(--bg-hover); }
   color: var(--text-dim); font-size: 13px; line-height: 1; border-radius: 3px;
 }
 .key-btn:hover { color: var(--accent); background: var(--bg-hover); }
+code.copyable { cursor: pointer; transition: background 0.15s; }
+code.copyable:hover { background: var(--bg-hover); }
 
 /* Modal */
 .modal-overlay {
@@ -702,6 +704,7 @@ const I18N = {
     'toast.keyDeleted':'API key deleted',
     'toast.keyLabelUpdated':'Label updated',
     'toast.keyCopied':'Key copied to clipboard',
+    'toast.copied':'Copied to clipboard',
     'confirm.deleteKey':"Delete API key '{label}'?",
     'filter.allKeys':'All Keys',
   },
@@ -770,6 +773,7 @@ const I18N = {
     'toast.keyDeleted':'API \u5bc6\u94a5\u5df2\u5220\u9664',
     'toast.keyLabelUpdated':'\u6807\u7b7e\u5df2\u66f4\u65b0',
     'toast.keyCopied':'\u5bc6\u94a5\u5df2\u590d\u5236\u5230\u526a\u8d34\u677f',
+    'toast.copied':'\u5df2\u590d\u5236\u5230\u526a\u8d34\u677f',
     'confirm.deleteKey':"\u786e\u5b9a\u5220\u9664 API \u5bc6\u94a5 '{label}'\uff1f",
     'filter.allKeys':'\u5168\u90e8\u5bc6\u94a5',
   },
@@ -841,6 +845,31 @@ const api = {
     return r.json();
   }
 };
+
+// ===================== Copy Helper =====================
+async function copyText(text, toastMsg) {
+  try {
+    await navigator.clipboard.writeText(text);
+    showToast(toastMsg || t('toast.copied'));
+  } catch(e) {
+    showToast('Copy failed', 'error');
+  }
+}
+
+function copyProviderEntry(name) {
+  const cfg = configData.providers[name] || {};
+  // Open Add Provider modal pre-filled with non-sensitive fields; API key is intentionally omitted
+  openProviderModal('', cfg.base_url, '', cfg.proxy, cfg.type || name);
+}
+
+function copyModelEntry(name) {
+  const models = configData.models || {};
+  const info = models[name];
+  const provider = typeof info === 'string' ? info : (info.provider || '');
+  const caps = typeof info === 'string' ? ['text'] : (info.capabilities || ['text']);
+  let text = `${name}:\n  provider: ${provider}\n  capabilities: [${caps.join(', ')}]`;
+  copyText(text, t('toast.copied'));
+}
 
 // ===================== Toast =====================
 function showToast(msg, type='success') {
@@ -970,6 +999,7 @@ function renderProviders() {
       <div class="field">API Key: <code>${esc(cfg.api_key || '')}</code></div>
       ${cfg.proxy ? `<div class="field">Proxy: <code>${esc(cfg.proxy)}</code></div>` : ''}
       <div class="actions">
+        <button class="btn btn-sm" onclick="copyProviderEntry('${esc(name)}')">${t('btn.copy')}</button>
         <button class="btn btn-sm" onclick="editProvider('${esc(name)}')">${t('btn.edit')}</button>
         <button class="btn btn-sm btn-danger" onclick="deleteProvider('${esc(name)}')">${t('btn.delete')}</button>
       </div>
@@ -1052,7 +1082,7 @@ function renderModels() {
     const hasVision = caps.includes('vision');
     const hasTools = caps.includes('tools');
     return `<tr${provDisabled ? ' style="opacity:0.4"' : ''}>
-      <td><code>${esc(name)}</code> ${capBadges}</td>
+      <td><code class="copyable" title="Click to copy" onclick="copyText('${esc(name)}')">${esc(name)}</code> ${capBadges}</td>
       <td>${esc(prov)}${provDisabled ? ` <span style="color:var(--text-dim);font-size:11px">(${t('provider.disabled')})</span>` : ''}</td>
       <td style="text-align:right; white-space:nowrap">
         <div class="test-group">
@@ -1065,6 +1095,7 @@ function renderModels() {
             <div class="test-menu-item${hasVision ? '' : ' disabled'}" onclick="${hasVision ? `runTest('${esc(name)}','vision')` : ''}">${t('test.vision')}</div>
           </div>
         </div>
+        <button class="btn btn-sm" onclick="copyModelEntry('${esc(name)}')">${t('btn.copy')}</button>
         <button class="btn btn-sm" onclick="editModel('${esc(name)}','${esc(prov)}')">${t('btn.edit')}</button>
         <button class="btn btn-sm btn-danger" onclick="deleteModel('${esc(name)}')">${t('btn.delete')}</button>
       </td>

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -1210,10 +1210,12 @@ function renderKeys() {
     const created = k.created ? new Date(k.created).toLocaleDateString() : '—';
     return `<tr>
       <td><span class="key-label-text" id="label-${k.id}">${esc(k.label || '—')}</span>
-        <button class="btn btn-sm" style="margin-left:4px;padding:2px 6px" onclick="editKeyLabel('${k.id}','${esc(k.label || '')}')" title="Edit">&#9998;</button></td>
-      <td><code class="key-masked">${esc(k.key)}</code>
-        <button class="btn btn-sm" style="padding:2px 6px" onclick="revealKey('${k.id}',this)" title="Reveal">&#128065;</button>
-        <button class="btn btn-sm" style="padding:2px 6px" onclick="copyKeyById('${k.id}')" title="Copy">&#128203;</button></td>
+        <button class="key-btn" style="margin-left:4px" onclick="editKeyLabel('${k.id}','${esc(k.label || '')}')" title="Edit"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg></button></td>
+      <td><code class="key-masked" data-masked="${esc(k.key)}">${esc(k.key)}</code>
+        <span class="key-actions">
+          <button class="key-btn" onclick="toggleKey('${k.id}',this)" title="Toggle visibility"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
+          <button class="key-btn" onclick="copyKeyById('${k.id}')" title="Copy"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
+        </span></td>
       <td>${created}</td>
       <td><button class="btn btn-sm btn-danger" onclick="deleteKey('${k.id}','${esc(k.label || k.id)}')">${t('btn.delete')}</button></td>
     </tr>`;
@@ -1261,12 +1263,22 @@ async function deleteKey(id, label) {
   else { showToast(res.error || 'Failed', 'error'); }
 }
 
-async function revealKey(id, btn) {
-  const res = await api.get(`/admin/api/keys/${encodeURIComponent(id)}/reveal`);
-  if (res.key) {
-    const code = btn.parentElement.querySelector('code');
-    code.textContent = res.key;
-    btn.style.display = 'none';
+const _eyeOpenSvg = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
+const _eyeClosedSvg = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/><line x1="1" y1="1" x2="23" y2="23"/></svg>';
+
+async function toggleKey(id, btn) {
+  const code = btn.closest('td').querySelector('code');
+  if (code.dataset.revealed === 'true') {
+    code.textContent = code.dataset.masked;
+    code.dataset.revealed = 'false';
+    btn.innerHTML = _eyeOpenSvg;
+  } else {
+    const res = await api.get(`/admin/api/keys/${encodeURIComponent(id)}/reveal`);
+    if (res.key) {
+      code.textContent = res.key;
+      code.dataset.revealed = 'true';
+      btn.innerHTML = _eyeClosedSvg;
+    }
   }
 }
 

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -127,7 +127,9 @@ tr:hover td { background: var(--bg-hover); }
 .toggle .slider::before { content:'';position:absolute;height:14px;width:14px;left:3px;bottom:3px;background:#fff;border-radius:50%;transition:.2s; }
 .toggle input:checked + .slider { background:var(--accent); }
 .toggle input:checked + .slider::before { transform:translateX(16px); }
-.key-actions { display: inline-flex; gap: 2px; margin-left: 4px; vertical-align: middle; }
+.key-cell { display: flex; align-items: center; gap: 4px; }
+.key-cell code { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.key-actions { display: flex; gap: 2px; flex-shrink: 0; }
 .key-btn {
   background: none; border: none; cursor: pointer; padding: 2px 4px;
   color: var(--text-dim); font-size: 13px; line-height: 1; border-radius: 3px;
@@ -1211,11 +1213,11 @@ function renderKeys() {
     return `<tr>
       <td><span class="key-label-text" id="label-${k.id}">${esc(k.label || '—')}</span>
         <button class="key-btn" style="margin-left:4px" onclick="editKeyLabel('${k.id}','${esc(k.label || '')}')" title="Edit"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg></button></td>
-      <td><code class="key-masked" data-masked="${esc(k.key)}">${esc(k.key)}</code>
+      <td style="width:40%"><div class="key-cell"><code class="key-masked" data-masked="${esc(k.key)}">${esc(k.key)}</code>
         <span class="key-actions">
           <button class="key-btn" onclick="toggleKey('${k.id}',this)" title="Toggle visibility"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
           <button class="key-btn" onclick="copyKeyById('${k.id}')" title="Copy"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
-        </span></td>
+        </span></div></td>
       <td>${created}</td>
       <td><button class="btn btn-sm btn-danger" onclick="deleteKey('${k.id}','${esc(k.label || k.id)}')">${t('btn.delete')}</button></td>
     </tr>`;


### PR DESCRIPTION
## Summary
- **Provider card**: "Copy" button opens Add Provider modal pre-filled with type, base_url, and proxy (API key intentionally omitted to prevent sensitive data leakage)
- **Model row**: "Copy" button copies model config as YAML to clipboard
- **Model name**: click-to-copy with hover cursor and toast feedback
- Added `toast.copied` i18n key for en/zh

## Test plan
- [ ] Providers tab: click Copy → verify Add Provider modal opens with correct pre-filled values and empty API key
- [ ] Models tab: click Copy → paste and verify YAML format is correct
- [ ] Models tab: click model name → paste and verify model name is copied
- [ ] Switch to Chinese, verify button text and toast messages