### PR TITLE
refactor: replace JSONL/JSON persistence with SQLite

### DIFF
--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -31,19 +31,12 @@ def setup_admin(
     instance is constructed so that its Router compiles them properly.
     """
     metrics = MetricsCollector()
-    request_log = RequestLog()
 
-    # Set up file persistence alongside the config file
+    # Set up SQLite persistence alongside the config file
     persistence: PersistenceManager | None = None
     if config_path:
         data_dir = os.path.join(os.path.dirname(config_path), "data")
         persistence = PersistenceManager(data_dir)
-
-        # Restore persisted request log
-        saved_entries = persistence.load_log_entries(request_log._max_entries)
-        if saved_entries:
-            request_log.load_entries(saved_entries)
-            logger.info("Loaded %d request log entries from disk", len(saved_entries))
 
         # Restore persisted metrics counters
         saved_metrics = persistence.load_metrics()
@@ -53,6 +46,9 @@ def setup_admin(
                 "Loaded metrics from disk (total_requests=%d)",
                 metrics.total_requests,
             )
+
+    # Request log delegates to persistence when available
+    request_log = RequestLog(persistence=persistence)
 
     app.state.metrics = metrics
     app.state.request_log = request_log

--- a/src/llm_rosetta/gateway/admin/persistence.py
+++ b/src/llm_rosetta/gateway/admin/persistence.py
@@ -1,8 +1,8 @@
-"""File-based persistence for metrics and request logs.
+"""SQLite-based persistence for gateway admin data.
 
-Stores request log entries as JSONL and metrics counters as JSON,
-with size-based rotation and gzip compression.  All I/O uses the
-Python standard library for cross-platform compatibility.
+Stores request log entries and metrics counters in a single SQLite
+database (``gateway.db``) using WAL journal mode.  Automatically
+migrates legacy JSONL/JSON files on first startup.
 """
 
 from __future__ import annotations
@@ -10,207 +10,338 @@ from __future__ import annotations
 import gzip
 import json
 import logging
-import os
-import tempfile
+import sqlite3
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger("llm-rosetta-gateway")
 
-_LOG_FILENAME = "request_log.jsonl"
-_METRICS_FILENAME = "metrics.json"
+_DB_FILENAME = "gateway.db"
+
+# Legacy filenames for migration
+_LEGACY_LOG = "request_log.jsonl"
+_LEGACY_METRICS = "metrics.json"
 
 
 class PersistenceManager:
-    """Manages on-disk persistence for gateway admin data.
+    """SQLite-backed persistence for request logs and metrics.
 
     Args:
-        data_dir: Directory for data files (created if missing).
-        max_file_size: Max size in bytes for ``request_log.jsonl``
-            before rotation (default 2 MB).
-        max_backups: Number of rotated ``.jsonl.gz`` files to keep.
+        data_dir: Directory for the database file (created if missing).
+        max_entries: Maximum request log entries to retain.
     """
 
     def __init__(
         self,
         data_dir: str,
-        max_file_size: int = 2 * 1024 * 1024,
-        max_backups: int = 3,
+        max_entries: int = 5000,
     ) -> None:
         self._data_dir = Path(data_dir)
-        self._max_file_size = max_file_size
-        self._max_backups = max_backups
+        self._max_entries = max_entries
+        self._insert_count = 0
         self._data_dir.mkdir(parents=True, exist_ok=True)
 
-    @property
-    def log_path(self) -> Path:
-        return self._data_dir / _LOG_FILENAME
+        self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._init_tables()
+        self._migrate_legacy()
 
     @property
-    def metrics_path(self) -> Path:
-        return self._data_dir / _METRICS_FILENAME
+    def db_path(self) -> Path:
+        return self._data_dir / _DB_FILENAME
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    def _init_tables(self) -> None:
+        self._conn.executescript("""
+            CREATE TABLE IF NOT EXISTS request_log (
+                id              TEXT PRIMARY KEY,
+                timestamp       TEXT NOT NULL,
+                model           TEXT NOT NULL,
+                source_provider TEXT NOT NULL,
+                target_provider TEXT NOT NULL,
+                is_stream       INTEGER NOT NULL,
+                status_code     INTEGER NOT NULL,
+                duration_ms     REAL NOT NULL,
+                error_detail    TEXT,
+                api_key_label   TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_rl_timestamp
+                ON request_log(timestamp DESC);
+            CREATE INDEX IF NOT EXISTS idx_rl_status
+                ON request_log(status_code);
+            CREATE TABLE IF NOT EXISTS metrics (
+                key   TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+        """)
 
     # ------------------------------------------------------------------
     # Request log
     # ------------------------------------------------------------------
 
-    def append_log_entries(self, entries: list[dict]) -> None:
-        """Append *entries* to the JSONL log file, rotating if needed."""
+    _LOG_COLUMNS = [
+        "id",
+        "timestamp",
+        "model",
+        "source_provider",
+        "target_provider",
+        "is_stream",
+        "status_code",
+        "duration_ms",
+        "error_detail",
+        "api_key_label",
+    ]
+
+    def insert_log_entries(self, entries: list[dict[str, Any]]) -> None:
+        """Insert request log entries, pruning oldest if over capacity."""
         if not entries:
             return
-        self._rotate_if_needed()
-        with open(self.log_path, "a", encoding="utf-8") as f:
-            for entry in entries:
-                f.write(json.dumps(entry, ensure_ascii=False))
-                f.write("\n")
+        self._conn.executemany(
+            "INSERT OR IGNORE INTO request_log "
+            "(id, timestamp, model, source_provider, target_provider, "
+            "is_stream, status_code, duration_ms, error_detail, api_key_label) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    e["id"],
+                    e["timestamp"],
+                    e["model"],
+                    e["source_provider"],
+                    e["target_provider"],
+                    int(e["is_stream"]),
+                    e["status_code"],
+                    e["duration_ms"],
+                    e.get("error_detail"),
+                    e.get("api_key_label"),
+                )
+                for e in entries
+            ],
+        )
+        self._conn.commit()
+        self._insert_count += len(entries)
+        if self._insert_count >= 100:
+            self._prune()
+            self._insert_count = 0
+        elif self.count_log_entries() > self._max_entries:
+            self._prune()
 
-    def load_log_entries(self, max_entries: int = 500) -> list[dict]:
-        """Load the most recent *max_entries* from the log file.
+    def query_log_entries(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        model: str | None = None,
+        provider: str | None = None,
+        status: str | None = None,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Query request log with optional filters, newest first.
 
-        Reads the current JSONL first, then compressed backups if more
-        entries are needed.  Returns entries in chronological order
-        (oldest first).
+        Returns:
+            A ``(entries, total)`` tuple.
         """
-        entries: list[dict] = []
+        where_clauses: list[str] = []
+        params: list[Any] = []
 
-        # Read current log file
-        entries.extend(self._read_jsonl(self.log_path))
+        if model:
+            where_clauses.append("model = ?")
+            params.append(model)
+        if provider:
+            where_clauses.append("target_provider = ?")
+            params.append(provider)
+        if status == "ok":
+            where_clauses.append("status_code < 400")
+        elif status == "error":
+            where_clauses.append("status_code >= 400")
 
-        # Read compressed backups (newest backup = .1) if we need more
-        if len(entries) < max_entries:
-            for i in range(1, self._max_backups + 1):
-                gz_path = self._data_dir / f"request_log.{i}.jsonl.gz"
-                if not gz_path.exists():
-                    break
-                backup_entries = self._read_jsonl_gz(gz_path)
-                entries = backup_entries + entries
-                if len(entries) >= max_entries:
-                    break
+        where_sql = ""
+        if where_clauses:
+            where_sql = "WHERE " + " AND ".join(where_clauses)
 
-        # Keep only the newest max_entries
-        if len(entries) > max_entries:
-            entries = entries[-max_entries:]
-        return entries
+        count_row = self._conn.execute(
+            f"SELECT COUNT(*) FROM request_log {where_sql}", params
+        ).fetchone()
+        total = count_row[0] if count_row else 0
+
+        rows = self._conn.execute(
+            f"SELECT * FROM request_log {where_sql} "
+            f"ORDER BY timestamp DESC LIMIT ? OFFSET ?",
+            [*params, limit, offset],
+        ).fetchall()
+
+        entries = [self._row_to_dict(row) for row in rows]
+        return entries, total
+
+    def get_log_entry(self, entry_id: str) -> dict[str, Any] | None:
+        """Return a single log entry by id, or ``None``."""
+        row = self._conn.execute(
+            "SELECT * FROM request_log WHERE id = ?", (entry_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_dict(row)
+
+    def count_log_entries(self) -> int:
+        """Return the total number of log entries."""
+        row = self._conn.execute("SELECT COUNT(*) FROM request_log").fetchone()
+        return row[0] if row else 0
+
+    def clear_log(self) -> None:
+        """Delete all request log entries."""
+        self._conn.execute("DELETE FROM request_log")
+        self._conn.commit()
 
     # ------------------------------------------------------------------
     # Metrics
     # ------------------------------------------------------------------
 
-    def save_metrics(self, data: dict) -> None:
-        """Atomically write metrics counters to ``metrics.json``."""
-        # Write to temp file then rename for crash safety
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(self._data_dir), suffix=".tmp", prefix="metrics_"
+    def save_metrics(self, data: dict[str, Any]) -> None:
+        """Persist metrics counters."""
+        self._conn.execute(
+            "INSERT OR REPLACE INTO metrics (key, value) VALUES (?, ?)",
+            ("counters", json.dumps(data, ensure_ascii=False)),
         )
+        self._conn.commit()
+
+    def load_metrics(self) -> dict[str, Any] | None:
+        """Load metrics counters, or ``None`` if not yet saved."""
+        row = self._conn.execute(
+            "SELECT value FROM metrics WHERE key = ?", ("counters",)
+        ).fetchone()
+        if row is None:
+            return None
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(data, f, ensure_ascii=False)
-                f.write("\n")
-            # os.replace is atomic on all platforms
-            os.replace(tmp_path, str(self.metrics_path))
+            return json.loads(row[0])
+        except (json.JSONDecodeError, TypeError) as exc:
+            logger.warning("Failed to load metrics: %s", exc)
+            return None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Commit and close the database connection."""
+        try:
+            self._conn.commit()
         except Exception:
-            # Clean up temp file on failure
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
-
-    def load_metrics(self) -> dict | None:
-        """Load metrics counters from ``metrics.json``.
-
-        Returns ``None`` if the file is missing or corrupt.
-        """
-        if not self.metrics_path.exists():
-            return None
+            pass
         try:
-            with open(self.metrics_path, encoding="utf-8") as f:
-                return json.load(f)
-        except Exception as exc:
-            logger.warning("Failed to load metrics from %s: %s", self.metrics_path, exc)
-            return None
+            self._conn.close()
+        except Exception:
+            pass
 
     # ------------------------------------------------------------------
-    # Rotation
+    # Internal helpers
     # ------------------------------------------------------------------
 
-    def _rotate_if_needed(self) -> None:
-        """Rotate ``request_log.jsonl`` if it exceeds the size limit."""
-        if not self.log_path.exists():
-            return
-        try:
-            size = self.log_path.stat().st_size
-        except OSError:
-            return
-        if size < self._max_file_size:
-            return
+    def _prune(self) -> None:
+        """Remove oldest entries beyond the retention limit."""
+        self._conn.execute(
+            "DELETE FROM request_log WHERE id NOT IN "
+            "(SELECT id FROM request_log ORDER BY timestamp DESC LIMIT ?)",
+            (self._max_entries,),
+        )
+        self._conn.commit()
 
-        # Shift existing backups: .3 -> delete, .2 -> .3, .1 -> .2
-        for i in range(self._max_backups, 0, -1):
-            src = self._data_dir / f"request_log.{i}.jsonl.gz"
-            if i == self._max_backups:
-                # Delete the oldest backup
-                if src.exists():
-                    src.unlink()
+    @classmethod
+    def _row_to_dict(cls, row: tuple[Any, ...]) -> dict[str, Any]:
+        d: dict[str, Any] = {}
+        for col, val in zip(cls._LOG_COLUMNS, row):
+            if col == "is_stream":
+                d[col] = bool(val)
+            elif col in ("error_detail", "api_key_label") and val is None:
+                continue  # omit None optional fields (match old behavior)
             else:
-                dst = self._data_dir / f"request_log.{i + 1}.jsonl.gz"
-                if src.exists():
-                    src.rename(dst)
-
-        # Compress current log -> .1.jsonl.gz
-        gz_path = self._data_dir / "request_log.1.jsonl.gz"
-        try:
-            with open(self.log_path, "rb") as f_in:
-                with gzip.open(gz_path, "wb") as f_out:
-                    while True:
-                        chunk = f_in.read(65536)
-                        if not chunk:
-                            break
-                        f_out.write(chunk)
-            # Truncate the current log
-            with open(self.log_path, "w", encoding="utf-8"):
-                pass
-            logger.info("Rotated request log (%d bytes) -> %s", size, gz_path)
-        except Exception as exc:
-            logger.warning("Log rotation failed: %s", exc)
+                d[col] = val
+        return d
 
     # ------------------------------------------------------------------
-    # Helpers
+    # Legacy migration
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _read_jsonl(path: Path) -> list[dict]:
-        """Read a JSONL file, skipping malformed lines."""
-        if not path.exists():
-            return []
-        entries: list[dict] = []
-        try:
-            with open(path, encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        entries.append(json.loads(line))
-                    except json.JSONDecodeError:
-                        continue
-        except OSError as exc:
-            logger.warning("Failed to read %s: %s", path, exc)
-        return entries
+    def _migrate_legacy(self) -> None:
+        """Import data from legacy JSONL/JSON files if present."""
+        migrated_anything = False
 
-    @staticmethod
-    def _read_jsonl_gz(path: Path) -> list[dict]:
-        """Read a gzipped JSONL file, skipping malformed lines."""
-        entries: list[dict] = []
-        try:
-            with gzip.open(path, "rt", encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        entries.append(json.loads(line))
-                    except json.JSONDecodeError:
-                        continue
-        except (OSError, gzip.BadGzipFile) as exc:
-            logger.warning("Failed to read %s: %s", path, exc)
-        return entries
+        # Migrate request log
+        log_path = self._data_dir / _LEGACY_LOG
+        if log_path.exists():
+            entries: list[dict[str, Any]] = []
+            # Read compressed backups first (oldest)
+            for i in range(3, 0, -1):
+                gz_path = self._data_dir / f"request_log.{i}.jsonl.gz"
+                if gz_path.exists():
+                    entries.extend(_read_jsonl_gz(gz_path))
+                    gz_path.rename(gz_path.parent / (gz_path.name + ".migrated"))
+            # Then current log
+            entries.extend(_read_jsonl(log_path))
+            if entries:
+                self.insert_log_entries(entries)
+                logger.info(
+                    "Migrated %d request log entries from legacy files",
+                    len(entries),
+                )
+            log_path.rename(log_path.with_suffix(".migrated"))
+            migrated_anything = True
+
+        # Migrate metrics
+        metrics_path = self._data_dir / _LEGACY_METRICS
+        if metrics_path.exists():
+            try:
+                data = json.loads(metrics_path.read_text(encoding="utf-8"))
+                self.save_metrics(data)
+                logger.info("Migrated metrics from legacy JSON file")
+            except Exception as exc:
+                logger.warning("Failed to migrate metrics: %s", exc)
+            metrics_path.rename(metrics_path.with_suffix(".migrated"))
+            migrated_anything = True
+
+        if migrated_anything:
+            logger.info("Legacy file migration complete")
+
+
+# ------------------------------------------------------------------
+# JSONL readers (used for legacy migration only)
+# ------------------------------------------------------------------
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL file, skipping malformed lines."""
+    if not path.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except OSError as exc:
+        logger.warning("Failed to read %s: %s", path, exc)
+    return entries
+
+
+def _read_jsonl_gz(path: Path) -> list[dict[str, Any]]:
+    """Read a gzipped JSONL file, skipping malformed lines."""
+    entries: list[dict[str, Any]] = []
+    try:
+        with gzip.open(path, "rt", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except (OSError, gzip.BadGzipFile) as exc:
+        logger.warning("Failed to read %s: %s", path, exc)
+    return entries

--- a/src/llm_rosetta/gateway/admin/request_log.py
+++ b/src/llm_rosetta/gateway/admin/request_log.py
@@ -1,4 +1,8 @@
-"""Ring-buffer request log for the gateway admin panel."""
+"""Request log for the gateway admin panel.
+
+Delegates to SQLite persistence when available, falls back to an
+in-memory ring buffer otherwise.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +10,10 @@ import uuid
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .persistence import PersistenceManager
 
 
 @dataclass(frozen=True)
@@ -50,9 +58,9 @@ class RequestLogEntry:
             api_key_label=api_key_label,
         )
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable dict."""
-        d: dict = {
+        d: dict[str, Any] = {
             "id": self.id,
             "timestamp": self.timestamp,
             "model": self.model,
@@ -70,21 +78,30 @@ class RequestLogEntry:
 
 
 class RequestLog:
-    """Fixed-size ring buffer of recent proxy requests.
+    """Proxy request log with optional SQLite persistence.
 
-    Uses :class:`collections.deque` with *maxlen* to automatically
-    evict the oldest entries when capacity is exceeded.
+    When *persistence* is provided, all operations delegate to SQLite.
+    Otherwise falls back to an in-memory :class:`collections.deque`
+    ring buffer (used when no config path is available).
     """
 
-    def __init__(self, max_entries: int = 500) -> None:
+    def __init__(
+        self,
+        persistence: PersistenceManager | None = None,
+        max_entries: int = 500,
+    ) -> None:
+        self._persistence = persistence
+        # Fallback in-memory storage (only used when persistence is None)
         self._entries: deque[RequestLogEntry] = deque(maxlen=max_entries)
-        self._max_entries = max_entries
         self._pending: list[RequestLogEntry] = []
 
     def add(self, entry: RequestLogEntry) -> None:
-        """Append *entry* to the log (oldest entry evicted if full)."""
-        self._entries.append(entry)
-        self._pending.append(entry)
+        """Record a proxy request."""
+        if self._persistence is not None:
+            self._persistence.insert_log_entries([entry.to_dict()])
+        else:
+            self._entries.append(entry)
+            self._pending.append(entry)
 
     def get_entries(
         self,
@@ -94,23 +111,19 @@ class RequestLog:
         model: str | None = None,
         provider: str | None = None,
         status: str | None = None,
-    ) -> tuple[list[dict], int]:
-        """Return filtered entries (newest-first) and total count.
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Return filtered entries (newest-first) and total count."""
+        if self._persistence is not None:
+            return self._persistence.query_log_entries(
+                limit=limit,
+                offset=offset,
+                model=model,
+                provider=provider,
+                status=status,
+            )
 
-        Args:
-            limit: Max entries to return.
-            offset: Number of entries to skip.
-            model: Filter by model name.
-            provider: Filter by target provider.
-            status: Filter by status category: ``"ok"`` (2xx/3xx) or
-                ``"error"`` (4xx/5xx).
-
-        Returns:
-            A ``(entries, total)`` tuple where *entries* is a list of
-            dicts and *total* is the filtered count before pagination.
-        """
+        # Fallback: in-memory filtering
         filtered: list[RequestLogEntry] = list(reversed(self._entries))
-
         if model:
             filtered = [e for e in filtered if e.model == model]
         if provider:
@@ -119,40 +132,48 @@ class RequestLog:
             filtered = [e for e in filtered if e.status_code < 400]
         elif status == "error":
             filtered = [e for e in filtered if e.status_code >= 400]
-
         total = len(filtered)
         page = filtered[offset : offset + limit]
         return [e.to_dict() for e in page], total
 
-    def get_entry(self, entry_id: str) -> dict | None:
+    def get_entry(self, entry_id: str) -> dict[str, Any] | None:
         """Return a single entry by id, or ``None``."""
+        if self._persistence is not None:
+            return self._persistence.get_log_entry(entry_id)
         for e in self._entries:
             if e.id == entry_id:
                 return e.to_dict()
         return None
 
-    def load_entries(self, entries: list[dict]) -> None:
-        """Bulk-load entries from persistence (oldest first)."""
+    def load_entries(self, entries: list[dict[str, Any]]) -> None:
+        """Bulk-load entries (in-memory fallback only)."""
         for d in entries:
             try:
                 entry = RequestLogEntry(**d)
                 self._entries.append(entry)
             except (TypeError, KeyError):
-                continue  # skip malformed entries
+                continue
 
-    def pending_entries(self) -> list[dict]:
+    def pending_entries(self) -> list[dict[str, Any]]:
         """Return and clear entries added since last call.
 
-        Used by the persistence flush loop to get new entries
-        without re-writing the entire log.
+        Only meaningful in fallback mode; returns ``[]`` when using
+        SQLite persistence (entries are written immediately).
         """
+        if self._persistence is not None:
+            return []
         entries = [e.to_dict() for e in self._pending]
         self._pending.clear()
         return entries
 
     def clear(self) -> None:
         """Remove all entries."""
-        self._entries.clear()
+        if self._persistence is not None:
+            self._persistence.clear_log()
+        else:
+            self._entries.clear()
 
     def __len__(self) -> int:
+        if self._persistence is not None:
+            return self._persistence.count_log_entries()
         return len(self._entries)

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -257,39 +257,26 @@ async def handle_health(request: Request) -> Response:
 # Persistence flush helpers
 # ---------------------------------------------------------------------------
 
-_FLUSH_LOG_INTERVAL = 10  # seconds
 _FLUSH_METRICS_INTERVAL = 30  # seconds
 
 
 async def _periodic_flush(app: Starlette) -> None:
-    """Periodically flush request log and metrics to disk."""
-    ticks = 0
+    """Periodically flush metrics counters to disk.
+
+    Request log entries are written to SQLite immediately by
+    :class:`RequestLog`, so only metrics need periodic flushing.
+    """
     while True:
-        await asyncio.sleep(_FLUSH_LOG_INTERVAL)
-        ticks += _FLUSH_LOG_INTERVAL
+        await asyncio.sleep(_FLUSH_METRICS_INTERVAL)
         persistence = getattr(app.state, "persistence", None)
         if persistence is None:
             continue
-
-        # Flush pending request log entries every tick
-        request_log = getattr(app.state, "request_log", None)
-        if request_log is not None:
-            entries = request_log.pending_entries()
-            if entries:
-                try:
-                    persistence.append_log_entries(entries)
-                except Exception as exc:
-                    logger.warning("Failed to flush request log: %s", exc)
-
-        # Flush metrics counters less frequently
-        if ticks >= _FLUSH_METRICS_INTERVAL:
-            ticks = 0
-            metrics = getattr(app.state, "metrics", None)
-            if metrics is not None:
-                try:
-                    persistence.save_metrics(metrics.export_counters())
-                except Exception as exc:
-                    logger.warning("Failed to flush metrics: %s", exc)
+        metrics = getattr(app.state, "metrics", None)
+        if metrics is not None:
+            try:
+                persistence.save_metrics(metrics.export_counters())
+            except Exception as exc:
+                logger.warning("Failed to flush metrics: %s", exc)
 
 
 def _flush_now(app: Starlette) -> None:
@@ -298,15 +285,6 @@ def _flush_now(app: Starlette) -> None:
     if persistence is None:
         return
 
-    request_log = getattr(app.state, "request_log", None)
-    if request_log is not None:
-        entries = request_log.pending_entries()
-        if entries:
-            try:
-                persistence.append_log_entries(entries)
-            except Exception as exc:
-                logger.warning("Shutdown: failed to flush request log: %s", exc)
-
     metrics = getattr(app.state, "metrics", None)
     if metrics is not None:
         try:
@@ -314,7 +292,8 @@ def _flush_now(app: Starlette) -> None:
         except Exception as exc:
             logger.warning("Shutdown: failed to flush metrics: %s", exc)
 
-    logger.info("Persistence flushed on shutdown")
+    persistence.close()
+    logger.info("Persistence flushed and closed on shutdown")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_persistence_sqlite.py
+++ b/tests/gateway/test_persistence_sqlite.py
@@ -237,6 +237,7 @@ class TestPersistenceManagerMetrics:
         pm.save_metrics({"total_requests": 20})
 
         loaded = pm.load_metrics()
+        assert loaded is not None
         assert loaded["total_requests"] == 20
         pm.close()
 
@@ -267,6 +268,7 @@ class TestLegacyMigration:
 
         pm = PersistenceManager(str(tmp_path))
         loaded = pm.load_metrics()
+        assert loaded is not None
         assert loaded["total_requests"] == 99
 
         assert not metrics_path.exists()

--- a/tests/gateway/test_persistence_sqlite.py
+++ b/tests/gateway/test_persistence_sqlite.py
@@ -1,0 +1,376 @@
+"""Tests for SQLite-based persistence and request log integration."""
+
+import gzip
+import json
+import time
+
+from llm_rosetta.gateway.admin.persistence import PersistenceManager
+from llm_rosetta.gateway.admin.request_log import RequestLog, RequestLogEntry
+
+
+# -- Helpers --
+
+
+def _make_entry_dict(
+    model: str = "gpt-4o",
+    status: int = 200,
+    provider: str = "openai_chat",
+    error_detail: str | None = None,
+) -> dict:
+    e = RequestLogEntry.create(
+        model=model,
+        source_provider="openai_chat",
+        target_provider=provider,
+        is_stream=False,
+        status_code=status,
+        duration_ms=10.0,
+        error_detail=error_detail,
+    )
+    return e.to_dict()
+
+
+def _make_entry(
+    model: str = "gpt-4o",
+    status: int = 200,
+    provider: str = "openai_chat",
+) -> RequestLogEntry:
+    return RequestLogEntry.create(
+        model=model,
+        source_provider="openai_chat",
+        target_provider=provider,
+        is_stream=False,
+        status_code=status,
+        duration_ms=10.0,
+    )
+
+
+# -- PersistenceManager tests --
+
+
+class TestPersistenceManagerSchema:
+    def test_creates_db_file(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        assert pm.db_path.exists()
+        pm.close()
+
+    def test_wal_mode(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        row = pm._conn.execute("PRAGMA journal_mode").fetchone()
+        assert row[0] == "wal"
+        pm.close()
+
+
+class TestPersistenceManagerRequestLog:
+    def test_insert_and_query(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        entries = [_make_entry_dict(model=f"m-{i}") for i in range(5)]
+        pm.insert_log_entries(entries)
+
+        results, total = pm.query_log_entries(limit=10)
+        assert total == 5
+        assert len(results) == 5
+        pm.close()
+
+    def test_newest_first(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        e1 = _make_entry_dict(model="first")
+        time.sleep(0.01)  # ensure distinct timestamps
+        e2 = _make_entry_dict(model="second")
+        pm.insert_log_entries([e1, e2])
+
+        results, _ = pm.query_log_entries()
+        assert results[0]["model"] == "second"
+        assert results[1]["model"] == "first"
+        pm.close()
+
+    def test_filter_by_model(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        pm.insert_log_entries(
+            [
+                _make_entry_dict(model="gpt-4o"),
+                _make_entry_dict(model="claude"),
+                _make_entry_dict(model="gpt-4o"),
+            ]
+        )
+
+        results, total = pm.query_log_entries(model="gpt-4o")
+        assert total == 2
+        assert all(r["model"] == "gpt-4o" for r in results)
+        pm.close()
+
+    def test_filter_by_provider(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        pm.insert_log_entries(
+            [
+                _make_entry_dict(provider="openai_chat"),
+                _make_entry_dict(provider="anthropic"),
+            ]
+        )
+
+        results, total = pm.query_log_entries(provider="anthropic")
+        assert total == 1
+        assert results[0]["target_provider"] == "anthropic"
+        pm.close()
+
+    def test_filter_by_status(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        pm.insert_log_entries(
+            [
+                _make_entry_dict(status=200),
+                _make_entry_dict(status=500),
+                _make_entry_dict(status=404),
+            ]
+        )
+
+        ok_results, ok_total = pm.query_log_entries(status="ok")
+        assert ok_total == 1
+
+        err_results, err_total = pm.query_log_entries(status="error")
+        assert err_total == 2
+        pm.close()
+
+    def test_pagination(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        entries = [_make_entry_dict(model=f"m-{i}") for i in range(20)]
+        pm.insert_log_entries(entries)
+
+        page1, total = pm.query_log_entries(limit=5, offset=0)
+        assert total == 20
+        assert len(page1) == 5
+
+        page2, _ = pm.query_log_entries(limit=5, offset=5)
+        assert len(page2) == 5
+        assert page1[0]["id"] != page2[0]["id"]
+        pm.close()
+
+    def test_get_log_entry(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        entry = _make_entry_dict()
+        pm.insert_log_entries([entry])
+
+        found = pm.get_log_entry(entry["id"])
+        assert found is not None
+        assert found["id"] == entry["id"]
+        assert found["model"] == entry["model"]
+        pm.close()
+
+    def test_get_log_entry_not_found(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        assert pm.get_log_entry("nonexistent") is None
+        pm.close()
+
+    def test_clear_log(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        pm.insert_log_entries([_make_entry_dict() for _ in range(5)])
+        assert pm.count_log_entries() == 5
+
+        pm.clear_log()
+        assert pm.count_log_entries() == 0
+        pm.close()
+
+    def test_prune(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path), max_entries=10)
+        # Insert 15 entries in batches to trigger prune
+        for batch in range(3):
+            entries = [_make_entry_dict(model=f"m-{batch}-{i}") for i in range(50)]
+            pm.insert_log_entries(entries)
+
+        assert pm.count_log_entries() <= 10
+        pm.close()
+
+    def test_bool_roundtrip(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        e = RequestLogEntry.create(
+            model="test",
+            source_provider="a",
+            target_provider="b",
+            is_stream=True,
+            status_code=200,
+            duration_ms=1.0,
+        )
+        pm.insert_log_entries([e.to_dict()])
+
+        results, _ = pm.query_log_entries()
+        assert results[0]["is_stream"] is True
+        pm.close()
+
+    def test_error_detail_stored(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        pm.insert_log_entries(
+            [
+                _make_entry_dict(error_detail="upstream 500: internal error"),
+            ]
+        )
+
+        results, _ = pm.query_log_entries()
+        assert results[0]["error_detail"] == "upstream 500: internal error"
+        pm.close()
+
+    def test_none_fields_omitted(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        pm.insert_log_entries([_make_entry_dict()])
+
+        results, _ = pm.query_log_entries()
+        assert "error_detail" not in results[0]
+        assert "api_key_label" not in results[0]
+        pm.close()
+
+
+class TestPersistenceManagerMetrics:
+    def test_save_and_load(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        data = {"total_requests": 42, "total_errors": 3}
+        pm.save_metrics(data)
+
+        loaded = pm.load_metrics()
+        assert loaded == data
+        pm.close()
+
+    def test_load_empty(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        assert pm.load_metrics() is None
+        pm.close()
+
+    def test_overwrite(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        pm.save_metrics({"total_requests": 10})
+        pm.save_metrics({"total_requests": 20})
+
+        loaded = pm.load_metrics()
+        assert loaded["total_requests"] == 20
+        pm.close()
+
+
+# -- Legacy migration tests --
+
+
+class TestLegacyMigration:
+    def test_migrate_jsonl(self, tmp_path):
+        # Write legacy JSONL
+        entries = [_make_entry_dict(model=f"legacy-{i}") for i in range(3)]
+        jsonl_path = tmp_path / "request_log.jsonl"
+        with open(jsonl_path, "w") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+
+        pm = PersistenceManager(str(tmp_path))
+        assert pm.count_log_entries() == 3
+
+        # Legacy file renamed
+        assert not jsonl_path.exists()
+        assert (tmp_path / "request_log.migrated").exists()
+        pm.close()
+
+    def test_migrate_metrics_json(self, tmp_path):
+        metrics_path = tmp_path / "metrics.json"
+        metrics_path.write_text(json.dumps({"total_requests": 99}))
+
+        pm = PersistenceManager(str(tmp_path))
+        loaded = pm.load_metrics()
+        assert loaded["total_requests"] == 99
+
+        assert not metrics_path.exists()
+        assert (tmp_path / "metrics.migrated").exists()
+        pm.close()
+
+    def test_migrate_gzip_backups(self, tmp_path):
+        # Write gzipped backup
+        entries = [_make_entry_dict(model=f"gz-{i}") for i in range(5)]
+        gz_path = tmp_path / "request_log.1.jsonl.gz"
+        with gzip.open(gz_path, "wt", encoding="utf-8") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+        # Also need the main file to trigger migration
+        (tmp_path / "request_log.jsonl").write_text("")
+
+        pm = PersistenceManager(str(tmp_path))
+        assert pm.count_log_entries() == 5
+        assert not gz_path.exists()
+        pm.close()
+
+    def test_no_migration_when_clean(self, tmp_path):
+        # No legacy files — should just start clean
+        pm = PersistenceManager(str(tmp_path))
+        assert pm.count_log_entries() == 0
+        assert pm.load_metrics() is None
+        pm.close()
+
+
+# -- RequestLog with persistence integration --
+
+
+class TestRequestLogWithPersistence:
+    def test_add_and_get(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        log = RequestLog(persistence=pm)
+        log.add(_make_entry())
+
+        entries, total = log.get_entries()
+        assert total == 1
+        assert len(entries) == 1
+        pm.close()
+
+    def test_filter_by_model(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        log = RequestLog(persistence=pm)
+        log.add(_make_entry(model="gpt-4o"))
+        log.add(_make_entry(model="claude"))
+        log.add(_make_entry(model="gpt-4o"))
+
+        entries, total = log.get_entries(model="gpt-4o")
+        assert total == 2
+        assert all(e["model"] == "gpt-4o" for e in entries)
+        pm.close()
+
+    def test_filter_by_status(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        log = RequestLog(persistence=pm)
+        log.add(_make_entry(status=200))
+        log.add(_make_entry(status=500))
+        log.add(_make_entry(status=404))
+
+        _, ok_total = log.get_entries(status="ok")
+        assert ok_total == 1
+        _, err_total = log.get_entries(status="error")
+        assert err_total == 2
+        pm.close()
+
+    def test_clear(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        log = RequestLog(persistence=pm)
+        log.add(_make_entry())
+        log.add(_make_entry())
+        assert len(log) == 2
+        log.clear()
+        assert len(log) == 0
+        pm.close()
+
+    def test_get_entry_by_id(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        log = RequestLog(persistence=pm)
+        e = _make_entry()
+        log.add(e)
+
+        found = log.get_entry(e.id)
+        assert found is not None
+        assert found["id"] == e.id
+        pm.close()
+
+    def test_pending_returns_empty(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        log = RequestLog(persistence=pm)
+        log.add(_make_entry())
+        assert log.pending_entries() == []
+        pm.close()
+
+    def test_newest_first(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        log = RequestLog(persistence=pm)
+        log.add(_make_entry(model="first"))
+        time.sleep(0.01)
+        log.add(_make_entry(model="second"))
+
+        entries, _ = log.get_entries()
+        assert entries[0]["model"] == "second"
+        assert entries[1]["model"] == "first"
+        pm.close()


### PR DESCRIPTION
## Summary

- Replace JSONL file rotation + JSON metrics with a single SQLite database (`gateway.db`) using WAL mode
- `PersistenceManager` now manages two tables: `request_log` (time-series with indexes) and `metrics` (key-value)
- `RequestLog` delegates to SQLite when persistence is available, falls back to in-memory deque otherwise
- Automatic legacy migration on first startup: existing JSONL/gz/JSON files are imported and renamed to `.migrated`
- Simplify periodic flush loop — request log writes are immediate, only metrics need periodic flushing

## Test plan

- [x] 29 new tests in `test_persistence_sqlite.py` covering schema, CRUD, filtering, pagination, pruning, migration, and integration
- [x] All 92 gateway tests pass
- [x] ruff check + format clean
- [x] ty check clean