### PR TITLE
feat: handle thinking config in OpenAI Chat converter

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/config_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/config_ops.py
@@ -253,8 +253,10 @@ class OpenAIChatConfigOps(BaseConfigOps):
         Mapping:
         - ``effort`` → ``reasoning_effort``
           (``"minimal"`` → ``"low"``, ``"max"`` → ``"high"`` with warning)
-        - ``mode: "disabled"`` → skip ``reasoning_effort`` entirely
-        - ``budget_tokens`` → not supported (warning)
+        - ``mode`` → ``thinking.type`` (DeepSeek/Volcengine extension)
+        - ``budget_tokens`` → ``thinking.budget_tokens``
+        - ``mode: "disabled"`` → skip ``reasoning_effort``, emit
+          ``thinking.type = "disabled"``
 
         Args:
             ir_reasoning: IR reasoning config.
@@ -263,9 +265,19 @@ class OpenAIChatConfigOps(BaseConfigOps):
             Dict of OpenAI request fields to merge.
         """
         result: dict[str, Any] = {}
+        mode = ir_reasoning.get("mode")
+
+        # Build thinking object for mode / budget_tokens
+        thinking: dict[str, Any] = {}
+        if mode:
+            thinking["type"] = mode
+        if "budget_tokens" in ir_reasoning:
+            thinking["budget_tokens"] = ir_reasoning["budget_tokens"]
+        if thinking:
+            result["thinking"] = thinking
 
         # mode: "disabled" → skip reasoning_effort
-        if ir_reasoning.get("mode") == "disabled":
+        if mode == "disabled":
             return result
 
         if "effort" in ir_reasoning:
@@ -285,12 +297,6 @@ class OpenAIChatConfigOps(BaseConfigOps):
                 effort = "high"
             result["reasoning_effort"] = effort
 
-        if "budget_tokens" in ir_reasoning:
-            warnings.warn(
-                "OpenAI Chat does not support reasoning budget_tokens, ignored",
-                stacklevel=2,
-            )
-
         return result
 
     @staticmethod
@@ -299,11 +305,11 @@ class OpenAIChatConfigOps(BaseConfigOps):
     ) -> ReasoningConfig:
         """OpenAI Chat reasoning parameters → IR ReasoningConfig.
 
-        Extracts ``reasoning_effort`` from the provider request.
+        Extracts ``reasoning_effort`` and ``thinking`` config from the
+        provider request.
 
         Args:
-            provider_reasoning: Provider request dict (or subset with
-                ``reasoning_effort``).
+            provider_reasoning: Provider request dict.
 
         Returns:
             IR ReasoningConfig.
@@ -316,6 +322,16 @@ class OpenAIChatConfigOps(BaseConfigOps):
         effort = provider_reasoning.get("reasoning_effort")
         if effort:
             result["effort"] = effort
+
+        # DeepSeek/Volcengine thinking extension
+        thinking = provider_reasoning.get("thinking")
+        if isinstance(thinking, dict):
+            thinking_type = thinking.get("type")
+            if thinking_type:
+                result["mode"] = thinking_type
+            budget = thinking.get("budget_tokens")
+            if budget is not None:
+                result["budget_tokens"] = budget
 
         return cast(ReasoningConfig, result)
 

--- a/tests/converters/openai_chat/test_config_ops.py
+++ b/tests/converters/openai_chat/test_config_ops.py
@@ -170,24 +170,46 @@ class TestOpenAIChatConfigOps:
             result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"effort": "max"})
         assert result["reasoning_effort"] == "high"
 
-    def test_ir_reasoning_config_budget_warning(self):
-        """Test budget_tokens produces warning."""
-        with pytest.warns(UserWarning, match="budget_tokens"):
-            OpenAIChatConfigOps.ir_reasoning_config_to_p({"budget_tokens": 1000})
+    def test_ir_reasoning_config_budget_tokens(self):
+        """Test budget_tokens → thinking.budget_tokens."""
+        result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"budget_tokens": 1000})
+        assert result["thinking"]["budget_tokens"] == 1000
 
     def test_ir_reasoning_config_mode_disabled(self):
-        """Test mode: disabled skips reasoning_effort entirely."""
+        """Test mode: disabled skips reasoning_effort, emits thinking."""
         result = OpenAIChatConfigOps.ir_reasoning_config_to_p(
             {"mode": "disabled", "effort": "high"}
         )
-        assert result == {}
+        assert "reasoning_effort" not in result
+        assert result["thinking"]["type"] == "disabled"
+
+    def test_ir_reasoning_config_mode_enabled(self):
+        """Test mode: enabled → thinking.type = enabled."""
+        result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"mode": "enabled"})
+        assert result["thinking"]["type"] == "enabled"
 
     def test_ir_reasoning_config_mode_auto_with_effort(self):
-        """Test mode: auto still outputs reasoning_effort."""
+        """Test mode: auto outputs both reasoning_effort and thinking."""
         result = OpenAIChatConfigOps.ir_reasoning_config_to_p(
             {"mode": "auto", "effort": "medium"}
         )
         assert result["reasoning_effort"] == "medium"
+        assert result["thinking"]["type"] == "auto"
+
+    def test_ir_reasoning_config_all_fields(self):
+        """Test mode + effort + budget_tokens coexistence."""
+        result = OpenAIChatConfigOps.ir_reasoning_config_to_p(
+            {"mode": "enabled", "effort": "high", "budget_tokens": 4096}
+        )
+        assert result["reasoning_effort"] == "high"
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 4096
+
+    def test_ir_reasoning_config_effort_only_no_thinking(self):
+        """Test effort-only does not produce thinking object."""
+        result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"effort": "high"})
+        assert result["reasoning_effort"] == "high"
+        assert "thinking" not in result
 
     def test_p_reasoning_config_to_ir(self):
         """Test OpenAI reasoning_effort → IR ReasoningConfig."""
@@ -195,6 +217,38 @@ class TestOpenAIChatConfigOps:
             {"reasoning_effort": "medium"}
         )
         assert result["effort"] == "medium"
+
+    def test_p_reasoning_config_thinking_to_ir(self):
+        """Test thinking object → IR mode + budget_tokens."""
+        result = OpenAIChatConfigOps.p_reasoning_config_to_ir(
+            {"thinking": {"type": "enabled", "budget_tokens": 4096}}
+        )
+        assert result["mode"] == "enabled"
+        assert result["budget_tokens"] == 4096
+
+    def test_p_reasoning_config_thinking_and_effort(self):
+        """Test reasoning_effort + thinking coexistence in P→IR."""
+        result = OpenAIChatConfigOps.p_reasoning_config_to_ir(
+            {
+                "reasoning_effort": "high",
+                "thinking": {"type": "enabled", "budget_tokens": 2048},
+            }
+        )
+        assert result["effort"] == "high"
+        assert result["mode"] == "enabled"
+        assert result["budget_tokens"] == 2048
+
+    def test_reasoning_config_roundtrip(self):
+        """Test thinking config round-trip: P → IR → P."""
+        original = {
+            "reasoning_effort": "high",
+            "thinking": {"type": "enabled", "budget_tokens": 4096},
+        }
+        ir = OpenAIChatConfigOps.p_reasoning_config_to_ir(original)
+        result = OpenAIChatConfigOps.ir_reasoning_config_to_p(ir)
+        assert result["reasoning_effort"] == "high"
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 4096
 
     # ==================== Cache Config ====================
 


### PR DESCRIPTION
Closes #170

## Summary

- Support DeepSeek/Volcengine `thinking` config extension in the OpenAI Chat converter's reasoning config handling
- IR→P: `mode` → `thinking.type`, `budget_tokens` → `thinking.budget_tokens`
- P→IR: parse `thinking` object back to IR `mode` and `budget_tokens`
- `thinking` coexists with standard `reasoning_effort` (both emitted when present)
- Effort-only configs (no mode/budget) produce no `thinking` object, preserving backward compatibility

## Test plan

- [x] 31 config_ops tests pass (12 reasoning-specific, including round-trip)
- [x] ruff check/format clean
- [x] ty check clean