### PR TITLE
feat: handle reasoning_content in OpenAI Chat converter

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/content_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/content_ops.py
@@ -6,7 +6,6 @@ Handles bidirectional conversion of text, image, and other content parts.
 """
 
 import re
-import warnings
 from typing import Any
 
 from ...types.ir import (
@@ -175,33 +174,39 @@ class OpenAIChatContentOps(BaseContentOps):
     # ==================== Reasoning ====================
 
     @staticmethod
-    def ir_reasoning_to_p(ir_reasoning: ReasoningPart, **kwargs: Any) -> dict | None:
-        """IR ReasoningPart → OpenAI reasoning content.
+    def ir_reasoning_to_p(ir_reasoning: ReasoningPart, **kwargs: Any) -> dict:
+        """IR ReasoningPart → OpenAI Chat reasoning_content field value.
 
-        OpenAI Chat Completions does not support reasoning content in requests.
-        Returns None and emits a warning.
+        Returns the reasoning text string. The caller (message_ops) is responsible
+        for placing it in the ``reasoning_content`` field of the assistant message.
 
         Args:
             ir_reasoning: IR reasoning part.
 
         Returns:
-            None (reasoning is dropped with a warning).
+            Dict with ``reasoning_content`` key.
         """
-        warnings.warn(
-            "Reasoning content not supported in OpenAI Chat Completions, ignored",
-            stacklevel=2,
-        )
-        return None
+        return {"reasoning_content": ir_reasoning.get("reasoning", "")}
 
     @staticmethod
     def p_reasoning_to_ir(provider_reasoning: Any, **kwargs: Any) -> ReasoningPart:
-        """OpenAI reasoning content → IR ReasoningPart.
+        """OpenAI Chat reasoning_content → IR ReasoningPart.
 
-        Raises:
-            NotImplementedError: OpenAI Chat Completions does not produce reasoning parts.
+        Handles the ``reasoning_content`` field used by DeepSeek and other
+        OpenAI Chat-compatible providers that extend the standard with
+        reasoning content at the message level.
+
+        Args:
+            provider_reasoning: Reasoning content string from the provider.
+
+        Returns:
+            IR ReasoningPart.
         """
-        raise NotImplementedError(
-            "OpenAI Chat Completions does not produce reasoning content parts."
+        if isinstance(provider_reasoning, str):
+            return ReasoningPart(type="reasoning", reasoning=provider_reasoning)
+        return ReasoningPart(
+            type="reasoning",
+            reasoning=str(provider_reasoning) if provider_reasoning else "",
         )
 
     # ==================== Refusal ====================

--- a/src/llm_rosetta/converters/openai_chat/message_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/message_ops.py
@@ -295,6 +295,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
         text_parts: list[str] = []
         tool_calls: list[dict[str, Any]] = []
         refusal_text = None
+        reasoning_text: str | None = None
 
         for part in content:
             if is_text_part(part):
@@ -302,9 +303,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
             elif is_tool_call_part(part):
                 tool_calls.append(self.tool_ops.ir_tool_call_to_p(part))
             elif is_reasoning_part(part):
-                warnings.append(
-                    "Reasoning content not supported in OpenAI Chat Completions, ignored"
-                )
+                reasoning_text = part.get("reasoning", "")
             elif is_refusal_part(part):
                 refusal_text = part.get("refusal", "")
             elif is_citation_part(part):
@@ -316,6 +315,10 @@ class OpenAIChatMessageOps(BaseMessageOps):
                 )
 
         openai_message: dict[str, Any] = {"role": "assistant"}
+
+        # Set reasoning content (DeepSeek / extended OpenAI Chat providers)
+        if reasoning_text is not None:
+            openai_message["reasoning_content"] = reasoning_text
 
         # Set text content
         if text_parts:
@@ -603,6 +606,12 @@ class OpenAIChatMessageOps(BaseMessageOps):
     def _p_assistant_to_ir(self, msg: dict[str, Any]) -> dict[str, Any]:
         """OpenAI assistant message → IR AssistantMessage."""
         ir_content: list[ContentPart] = []
+
+        # Handle reasoning_content (DeepSeek / extended OpenAI Chat providers)
+        # Prepend before text content to match convention (reasoning first)
+        reasoning_content = msg.get("reasoning_content")
+        if reasoning_content:
+            ir_content.append(self.content_ops.p_reasoning_to_ir(reasoning_content))
 
         # Handle text content
         content = msg.get("content")

--- a/tests/converters/openai_chat/test_content_ops.py
+++ b/tests/converters/openai_chat/test_content_ops.py
@@ -142,13 +142,29 @@ class TestOpenAIChatContentOps:
 
     # ==================== Reasoning ====================
 
-    def test_ir_reasoning_to_p_returns_none(self):
-        """Test ir_reasoning_to_p returns None with warning."""
-        with pytest.warns(UserWarning, match="Reasoning content not supported"):
-            result = OpenAIChatContentOps.ir_reasoning_to_p(
-                {"type": "reasoning", "reasoning": "thinking..."}
-            )
-        assert result is None
+    def test_ir_reasoning_to_p(self):
+        """Test IR ReasoningPart → reasoning_content dict."""
+        result = OpenAIChatContentOps.ir_reasoning_to_p(
+            {"type": "reasoning", "reasoning": "thinking..."}
+        )
+        assert result == {"reasoning_content": "thinking..."}
+
+    def test_ir_reasoning_to_p_empty(self):
+        """Test IR ReasoningPart with no reasoning field → empty string."""
+        result = OpenAIChatContentOps.ir_reasoning_to_p({"type": "reasoning"})
+        assert result == {"reasoning_content": ""}
+
+    def test_p_reasoning_to_ir(self):
+        """Test reasoning_content string → IR ReasoningPart."""
+        result = OpenAIChatContentOps.p_reasoning_to_ir("Let me think step by step...")
+        assert result["type"] == "reasoning"
+        assert result["reasoning"] == "Let me think step by step..."
+
+    def test_p_reasoning_to_ir_empty(self):
+        """Test empty reasoning_content string → IR ReasoningPart with empty reasoning."""
+        result = OpenAIChatContentOps.p_reasoning_to_ir("")
+        assert result["type"] == "reasoning"
+        assert result["reasoning"] == ""
 
     # ==================== Refusal ====================
 

--- a/tests/converters/openai_chat/test_message_ops.py
+++ b/tests/converters/openai_chat/test_message_ops.py
@@ -321,7 +321,7 @@ class TestOpenAIChatMessageOps:
                 "content": "The answer is 42",
             }
         ]
-        result = self.message_ops.p_messages_to_ir(messages)
+        result = cast(list[Any], self.message_ops.p_messages_to_ir(messages))
         assistant_msg = result[0]
         assert assistant_msg["role"] == "assistant"
         parts = assistant_msg["content"]
@@ -334,7 +334,7 @@ class TestOpenAIChatMessageOps:
     def test_reasoning_content_p_to_ir_no_reasoning(self):
         """Test standard assistant message without reasoning_content."""
         messages = [{"role": "assistant", "content": "Hello"}]
-        result = self.message_ops.p_messages_to_ir(messages)
+        result = cast(list[Any], self.message_ops.p_messages_to_ir(messages))
         parts = result[0]["content"]
         assert len(parts) == 1
         assert parts[0]["type"] == "text"
@@ -377,7 +377,7 @@ class TestOpenAIChatMessageOps:
                 ],
             }
         ]
-        result = self.message_ops.p_messages_to_ir(messages)
+        result = cast(list[Any], self.message_ops.p_messages_to_ir(messages))
         parts = result[0]["content"]
         # reasoning first, then tool call (no text since content is empty)
         assert parts[0]["type"] == "reasoning"

--- a/tests/converters/openai_chat/test_message_ops.py
+++ b/tests/converters/openai_chat/test_message_ops.py
@@ -276,8 +276,28 @@ class TestOpenAIChatMessageOps:
         assert len(warnings) == 1
         assert "File content not supported" in warnings[0]
 
-    def test_reasoning_content_warning(self):
-        """Test reasoning content produces warning."""
+    def test_reasoning_content_ir_to_p(self):
+        """Test IR ReasoningPart → reasoning_content field in assistant message."""
+        messages = cast(
+            list[Message],
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "reasoning", "reasoning": "thinking step by step"},
+                        {"type": "text", "text": "The answer is 42"},
+                    ],
+                }
+            ],
+        )
+        result, warnings = self.message_ops.ir_messages_to_p(messages)
+        assert len(warnings) == 0
+        assert result[0]["role"] == "assistant"
+        assert result[0]["reasoning_content"] == "thinking step by step"
+        assert result[0]["content"] == "The answer is 42"
+
+    def test_reasoning_content_ir_to_p_only_reasoning(self):
+        """Test IR assistant message with only ReasoningPart."""
         messages = cast(
             list[Message],
             [
@@ -288,8 +308,81 @@ class TestOpenAIChatMessageOps:
             ],
         )
         result, warnings = self.message_ops.ir_messages_to_p(messages)
-        assert len(warnings) == 1
-        assert "Reasoning content not supported" in warnings[0]
+        assert len(warnings) == 0
+        assert result[0]["reasoning_content"] == "thinking"
+        assert result[0]["content"] == ""
+
+    def test_reasoning_content_p_to_ir(self):
+        """Test reasoning_content field in provider message → IR ReasoningPart."""
+        messages = [
+            {
+                "role": "assistant",
+                "reasoning_content": "Let me think...",
+                "content": "The answer is 42",
+            }
+        ]
+        result = self.message_ops.p_messages_to_ir(messages)
+        assistant_msg = result[0]
+        assert assistant_msg["role"] == "assistant"
+        parts = assistant_msg["content"]
+        assert len(parts) == 2
+        assert parts[0]["type"] == "reasoning"
+        assert parts[0]["reasoning"] == "Let me think..."
+        assert parts[1]["type"] == "text"
+        assert parts[1]["text"] == "The answer is 42"
+
+    def test_reasoning_content_p_to_ir_no_reasoning(self):
+        """Test standard assistant message without reasoning_content."""
+        messages = [{"role": "assistant", "content": "Hello"}]
+        result = self.message_ops.p_messages_to_ir(messages)
+        parts = result[0]["content"]
+        assert len(parts) == 1
+        assert parts[0]["type"] == "text"
+
+    def test_reasoning_content_round_trip(self):
+        """Test round-trip: DeepSeek-style response → IR → back preserves reasoning_content."""
+        provider_messages = [
+            {
+                "role": "assistant",
+                "reasoning_content": "Step 1: analyze\nStep 2: conclude",
+                "content": "The answer is 42",
+            }
+        ]
+        # Provider → IR
+        ir_messages = self.message_ops.p_messages_to_ir(provider_messages)
+        # IR → Provider
+        restored, warnings = self.message_ops.ir_messages_to_p(
+            cast(list[Message], ir_messages)
+        )
+        assert len(warnings) == 0
+        assert restored[0]["reasoning_content"] == "Step 1: analyze\nStep 2: conclude"
+        assert restored[0]["content"] == "The answer is 42"
+
+    def test_reasoning_content_with_tool_calls(self):
+        """Test reasoning_content + content + tool_calls together."""
+        messages = [
+            {
+                "role": "assistant",
+                "reasoning_content": "I need to call a tool",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "NYC"}',
+                        },
+                    }
+                ],
+            }
+        ]
+        result = self.message_ops.p_messages_to_ir(messages)
+        parts = result[0]["content"]
+        # reasoning first, then tool call (no text since content is empty)
+        assert parts[0]["type"] == "reasoning"
+        assert parts[0]["reasoning"] == "I need to call a tool"
+        assert parts[1]["type"] == "tool_call"
 
     # ==================== Tool message reordering ====================
 


### PR DESCRIPTION
## Summary

- Enable bidirectional conversion of `reasoning_content` field in the OpenAI Chat converter, used by DeepSeek and other OpenAI Chat-compatible providers
- **P→IR**: parse `reasoning_content` from assistant messages into `ReasoningPart` (was `NotImplementedError`)
- **IR→P**: output `ReasoningPart` as `reasoning_content` field on assistant messages (was dropped with warning)
- Streaming was already supported, no changes needed there

## Changes

| File | Change |
|------|--------|
| `content_ops.py` | `ir_reasoning_to_p` returns `{"reasoning_content": text}` instead of `None`; `p_reasoning_to_ir` parses string into `ReasoningPart` instead of raising |
| `message_ops.py` | `_p_assistant_to_ir` extracts `reasoning_content` → `ReasoningPart` (prepended); `_ir_assistant_to_p` outputs `ReasoningPart` → `reasoning_content` field |
| `test_content_ops.py` | 4 new tests replacing 1 old "returns None" test |
| `test_message_ops.py` | 6 new tests replacing 1 old "warning" test (round-trip, tool_calls combo, edge cases) |

## Test plan

- [x] `pytest tests/converters/openai_chat/` — 211 passed
- [x] `ruff check` + `ruff format` clean

Closes #169