### PR TITLE
feat: provider shim layer + transform mechanism

### DIFF
--- a/src/llm_rosetta/__init__.py
+++ b/src/llm_rosetta/__init__.py
@@ -24,10 +24,17 @@ from .converters.base.context import ConversionContext, StreamContext
 from .shims import (
     ModelShim,
     ProviderShim,
+    Transform,
+    Transformable,
+    apply_transforms,
     get_shim,
     list_shims,
     register_shim,
+    rename_field,
     resolve_base,
+    resolve_transforms,
+    set_defaults,
+    strip_fields,
     unregister_shim,
 )
 
@@ -59,4 +66,12 @@ __all__ = [
     "get_shim",
     "list_shims",
     "resolve_base",
+    # Transforms
+    "Transform",
+    "Transformable",
+    "apply_transforms",
+    "resolve_transforms",
+    "strip_fields",
+    "rename_field",
+    "set_defaults",
 ]

--- a/src/llm_rosetta/__init__.py
+++ b/src/llm_rosetta/__init__.py
@@ -21,25 +21,42 @@ from .converters import (
 )
 from . import tool_ops
 from .converters.base.context import ConversionContext, StreamContext
+from .shims import (
+    ModelShim,
+    ProviderShim,
+    get_shim,
+    list_shims,
+    register_shim,
+    resolve_base,
+    unregister_shim,
+)
 
 __version__ = "0.5.2"
 
 __all__ = [
-    # 转换器 Converters
+    # Converters
     "BaseConverter",
     "OpenAIChatConverter",
     "AnthropicConverter",
     "GoogleGenAIConverter",
     "GoogleConverter",
     "OpenAIResponsesConverter",
-    # 转换上下文 Conversion context
+    # Conversion context
     "ConversionContext",
     "StreamContext",
-    # 工具定义便利 API Tool definition convenience API
+    # Tool definition convenience API
     "tool_ops",
-    # 自动检测和转换 Auto-detection and conversion
+    # Auto-detection and conversion
     "detect_provider",
     "get_converter_for_provider",
     "convert",
     "ProviderType",
+    # Provider shim layer
+    "ProviderShim",
+    "ModelShim",
+    "register_shim",
+    "unregister_shim",
+    "get_shim",
+    "list_shims",
+    "resolve_base",
 ]

--- a/src/llm_rosetta/auto_detect.py
+++ b/src/llm_rosetta/auto_detect.py
@@ -173,9 +173,10 @@ def get_converter_for_provider(provider: str):
 
 def convert(
     source_body: dict[str, Any],
-    target_provider: ProviderType,
-    source_provider: ProviderType | None = None,
+    target_provider: ProviderType | str,
+    source_provider: ProviderType | str | None = None,
     *,
+    model: str | None = None,
     force_conversion: bool = False,
 ) -> dict[str, Any]:
     """Auto-detect source provider and convert to target provider format.
@@ -183,11 +184,18 @@ def convert(
     This is a convenience function that auto-detects the source format and
     performs conversion through the IR (Intermediate Representation).
 
+    When *source_provider* or *target_provider* is a registered shim name
+    (e.g. ``"deepseek"``), the shim's transforms are applied around the
+    base converter.  If *model* is also provided, model-level transforms
+    are merged with the provider-level ones via
+    :func:`~llm_rosetta.shims.resolve_transforms`.
+
     Args:
         source_body: Source provider request body.
-        target_provider: Target provider type.
-        source_provider: Optional source provider type.  Auto-detected from
-            *source_body* when not provided.
+        target_provider: Target provider type or registered shim name.
+        source_provider: Optional source provider type or shim name.
+            Auto-detected from *source_body* when not provided.
+        model: Optional model name for model-level transform lookup.
         force_conversion: When ``True``, always run the full conversion
             pipeline (source -> IR -> target) even when source and target
             providers are the same.  This normalises parameter names (e.g.
@@ -207,10 +215,16 @@ def convert(
         >>> anthropic_body = {"messages": [...]}
         >>> openai_body = convert(anthropic_body, "openai_chat", source_provider="anthropic")
 
+        >>> # With shim transforms
+        >>> body = convert(req, "anthropic", source_provider="deepseek", model="deepseek-r1")
+
         >>> # Force normalisation even for same-provider passthrough
         >>> body = {"messages": [...], "max_tokens": 256}
         >>> normalised = convert(body, "openai_chat", force_conversion=True)
     """
+    from .shims import get_shim
+    from .shims.transforms import apply_transforms, resolve_transforms
+
     # Detect source provider
     if source_provider is None:
         source_provider = detect_provider(source_body)
@@ -223,19 +237,39 @@ def convert(
     if source_provider == target_provider and not force_conversion:
         return source_body
 
-    # 获取转换器 Get converter
+    # --- Resolve shims and transforms ---
+    source_shim = get_shim(source_provider)
+    target_shim = get_shim(target_provider)
+
+    source_model_shim = (
+        source_shim.get_model_shim(model) if source_shim and model else None
+    )
+    target_model_shim = (
+        target_shim.get_model_shim(model) if target_shim and model else None
+    )
+
+    # Merge provider + model transforms (provider first, model after)
+    if source_shim:
+        source_from_t, _ = resolve_transforms(source_shim, source_model_shim)
+    else:
+        source_from_t = ()
+
+    if target_shim:
+        _, target_to_t = resolve_transforms(target_shim, target_model_shim)
+    else:
+        target_to_t = ()
+
+    # --- Apply source from_transforms ---
+    body = apply_transforms(source_from_t, source_body)
+
+    # --- Core conversion: source → IR → target ---
     source_converter = get_converter_for_provider(source_provider)
     target_converter = get_converter_for_provider(target_provider)
 
-    # 执行转换: source -> IR -> target Perform conversion: source -> IR -> target
-    ir_request = source_converter.request_from_provider(source_body)
+    ir_request = source_converter.request_from_provider(body)
+    target_body, _warnings = target_converter.request_to_provider(ir_request)
 
-    # 转换到目标格式 Convert to target format
-    target_body, warnings = target_converter.request_to_provider(ir_request)
-
-    # 如果有警告，可以选择记录或返回 If there are warnings, can choose to log or return
-    if warnings:
-        # 可以添加到结果中或记录日志
-        pass
+    # --- Apply target to_transforms ---
+    target_body = apply_transforms(target_to_t, target_body)
 
     return target_body

--- a/src/llm_rosetta/auto_detect.py
+++ b/src/llm_rosetta/auto_detect.py
@@ -129,23 +129,27 @@ def detect_provider(body: dict[str, Any]) -> ProviderType | None:
     return "openai_chat"
 
 
-def get_converter_for_provider(provider: ProviderType):
-    """根据 provider 类型获取对应的转换器
-    Get the corresponding converter according to provider type
+def get_converter_for_provider(provider: str):
+    """Get the corresponding converter for a provider type or shim name.
+
+    Accepts both base converter types (e.g. ``"openai_chat"``) and
+    registered shim names (e.g. ``"deepseek"``).  Shim names are
+    resolved to their base converter type via the shim registry.
 
     Args:
-        provider: Provider 类型 Provider type
+        provider: Provider type string or registered shim name.
 
     Returns:
-        对应的转换器实例 Corresponding converter instance
+        Corresponding converter instance.
 
     Raises:
-        ValueError: 如果 provider 类型不支持 If provider type is not supported
+        ValueError: If the provider is not a known type or shim name.
     """
     from .converters.anthropic import AnthropicConverter
     from .converters.google_genai import GoogleConverter
     from .converters.openai_chat import OpenAIChatConverter
     from .converters.openai_responses import OpenAIResponsesConverter
+    from .shims import resolve_base
 
     converter_map = {
         "openai_chat": OpenAIChatConverter,
@@ -155,10 +159,16 @@ def get_converter_for_provider(provider: ProviderType):
         "google": GoogleConverter,
     }
 
-    if provider not in converter_map:
-        raise ValueError(f"Unsupported provider: {provider}")
+    # Direct match against base converter types
+    if provider in converter_map:
+        return converter_map[provider]()
 
-    return converter_map[provider]()
+    # Resolve through shim registry
+    base = resolve_base(provider)
+    if base in converter_map:
+        return converter_map[base]()
+
+    raise ValueError(f"Unsupported provider: {provider}")
 
 
 def convert(

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -128,11 +128,20 @@ class GatewayConfig:
         }
 
         # Map provider name → API standard type.
-        # If the provider config has a "type" field, use it; otherwise the
-        # provider name itself is treated as the type (backward compatible).
-        self.provider_types: dict[str, ProviderType] = {  # ty: ignore[invalid-assignment]
-            name: cfg.get("type", name) for name, cfg in self._raw_providers.items()
-        }
+        # Resolution order:
+        #   1. "shim" field → resolve via shim registry to base type
+        #   2. "type" field → use directly
+        #   3. provider name itself (backward compatible fallback)
+        from llm_rosetta.shims import resolve_base
+
+        self.provider_types: dict[str, str] = {}
+        for name, cfg in self._raw_providers.items():
+            if "shim" in cfg:
+                self.provider_types[name] = resolve_base(cfg["shim"])
+            elif "type" in cfg:
+                self.provider_types[name] = cfg["type"]
+            else:
+                self.provider_types[name] = name
 
         # Parse models — supports both string and dict formats:
         #   "model": "provider"                     (legacy)
@@ -228,7 +237,7 @@ class GatewayConfig:
         """First configured key (for backward-compat middleware init)."""
         return self.api_keys[0]["key"] if self.api_keys else None
 
-    def resolve_model(self, model: str) -> tuple[ProviderType, ProviderInfo]:
+    def resolve_model(self, model: str) -> tuple[str, ProviderInfo]:
         """Return (provider_type, provider_info) for a model name.
 
         ``provider_type`` is the API standard (e.g. ``"openai_chat"``),

--- a/src/llm_rosetta/gateway/providers.py
+++ b/src/llm_rosetta/gateway/providers.py
@@ -180,6 +180,11 @@ def build_provider_info(
 ) -> ProviderInfo:
     """Create a :class:`ProviderInfo` from a provider config dict.
 
+    *provider_type* may be a base converter type (e.g. ``"openai_chat"``)
+    or a registered shim name (e.g. ``"deepseek"``).  When a shim is
+    found, its ``default_base_url`` and ``default_api_key_env`` are used
+    as fallbacks when the config does not specify them.
+
     *cfg* is the dict from the JSONC config, e.g.
     ``{"api_key": "sk-...", "base_url": "https://..."}``
 
@@ -190,7 +195,25 @@ def build_provider_info(
     registry.  Unknown types fall back to Bearer-token auth and a simple
     ``{base_url}/`` URL template.
     """
-    reg = _PROVIDER_REGISTRY.get(provider_type)
+    import os
+
+    from llm_rosetta.shims import get_shim
+
+    # Resolve through shim registry for defaults
+    shim = get_shim(provider_type)
+    if shim is not None:
+        base_type = shim.base
+        # Apply shim defaults where config is missing
+        if "base_url" not in cfg and shim.default_base_url:
+            cfg = {**cfg, "base_url": shim.default_base_url}
+        if "api_key" not in cfg and shim.default_api_key_env:
+            env_val = os.environ.get(shim.default_api_key_env, "")
+            if env_val:
+                cfg = {**cfg, "api_key": env_val}
+    else:
+        base_type = provider_type
+
+    reg = _PROVIDER_REGISTRY.get(base_type)
 
     if reg:
         auth_fn = reg["auth_header_fn"]
@@ -203,8 +226,19 @@ def build_provider_info(
         stream_tpl = None
         logger.warning(
             "Unknown provider type '%s'; using Bearer auth and generic URL template",
-            provider_type,
+            base_type,
         )
+
+    # Fall back to base-type defaults if still missing
+    if "base_url" not in cfg:
+        default_url = get_default_base_url(base_type)
+        if default_url:
+            cfg = {**cfg, "base_url": default_url}
+    if "api_key" not in cfg:
+        default_env = get_default_api_key_env(base_type)
+        env_val = os.environ.get(default_env, "")
+        if env_val:
+            cfg = {**cfg, "api_key": env_val}
 
     # Per-provider proxy overrides global proxy
     proxy_url = cfg.get("proxy") or global_proxy or None

--- a/src/llm_rosetta/shims/__init__.py
+++ b/src/llm_rosetta/shims/__init__.py
@@ -13,6 +13,15 @@ from .provider_shim import (
     resolve_base,
     unregister_shim,
 )
+from .transforms import (
+    Transform,
+    Transformable,
+    apply_transforms,
+    rename_field,
+    resolve_transforms,
+    set_defaults,
+    strip_fields,
+)
 
 # Importing builtins triggers auto-registration of built-in shims.
 from . import builtins as _builtins  # noqa: F401
@@ -20,9 +29,16 @@ from . import builtins as _builtins  # noqa: F401
 __all__ = [
     "ModelShim",
     "ProviderShim",
-    "register_shim",
-    "unregister_shim",
+    "Transform",
+    "Transformable",
+    "apply_transforms",
     "get_shim",
     "list_shims",
+    "register_shim",
+    "rename_field",
     "resolve_base",
+    "resolve_transforms",
+    "set_defaults",
+    "strip_fields",
+    "unregister_shim",
 ]

--- a/src/llm_rosetta/shims/__init__.py
+++ b/src/llm_rosetta/shims/__init__.py
@@ -1,0 +1,28 @@
+"""Provider shim layer — identity cards for LLM providers and models.
+
+Importing this package automatically registers the built-in shims
+(OpenAI, Anthropic, Google, DeepSeek, Volcengine, etc.).
+"""
+
+from .provider_shim import (
+    ModelShim,
+    ProviderShim,
+    get_shim,
+    list_shims,
+    register_shim,
+    resolve_base,
+    unregister_shim,
+)
+
+# Importing builtins triggers auto-registration of built-in shims.
+from . import builtins as _builtins  # noqa: F401
+
+__all__ = [
+    "ModelShim",
+    "ProviderShim",
+    "register_shim",
+    "unregister_shim",
+    "get_shim",
+    "list_shims",
+    "resolve_base",
+]

--- a/src/llm_rosetta/shims/builtins.py
+++ b/src/llm_rosetta/shims/builtins.py
@@ -7,6 +7,7 @@ provider shims into the global registry.
 from __future__ import annotations
 
 from .provider_shim import ModelShim, ProviderShim, register_shim
+from .transforms import strip_fields
 
 # ---------------------------------------------------------------------------
 # Reusable model shim tuples
@@ -75,6 +76,7 @@ VOLCENGINE = ProviderShim(
     base="openai_chat",
     default_base_url=None,
     default_api_key_env="VOLCENGINE_API_KEY",
+    to_transforms=(strip_fields("logprobs", "top_logprobs"),),
 )
 
 # ---------------------------------------------------------------------------

--- a/src/llm_rosetta/shims/builtins.py
+++ b/src/llm_rosetta/shims/builtins.py
@@ -1,0 +1,100 @@
+"""Built-in provider shim definitions.
+
+Importing this module registers the official and well-known third-party
+provider shims into the global registry.
+"""
+
+from __future__ import annotations
+
+from .provider_shim import ModelShim, ProviderShim, register_shim
+
+# ---------------------------------------------------------------------------
+# Reusable model shim tuples
+# ---------------------------------------------------------------------------
+
+_OPENAI_MODELS: tuple[ModelShim, ...] = (
+    ModelShim("o1-*", frozenset({"reasoning", "tools", "vision"})),
+    ModelShim("o3-*", frozenset({"reasoning", "tools", "vision"})),
+    ModelShim("o4-*", frozenset({"reasoning", "tools", "vision"})),
+    ModelShim("gpt-*", frozenset({"tools", "vision"})),
+)
+
+# ---------------------------------------------------------------------------
+# Official provider shims
+# ---------------------------------------------------------------------------
+
+OPENAI = ProviderShim(
+    name="openai",
+    base="openai_chat",
+    default_base_url="https://api.openai.com/v1",
+    default_api_key_env="OPENAI_API_KEY",
+    models=_OPENAI_MODELS,
+)
+
+OPENAI_RESPONSES = ProviderShim(
+    name="openai_responses",
+    base="openai_responses",
+    default_base_url="https://api.openai.com/v1",
+    default_api_key_env="OPENAI_API_KEY",
+    models=_OPENAI_MODELS,
+)
+
+ANTHROPIC = ProviderShim(
+    name="anthropic",
+    base="anthropic",
+    default_base_url="https://api.anthropic.com",
+    default_api_key_env="ANTHROPIC_API_KEY",
+    models=(ModelShim("claude-*", frozenset({"reasoning", "tools", "vision"})),),
+)
+
+GOOGLE = ProviderShim(
+    name="google",
+    base="google",
+    default_base_url="https://generativelanguage.googleapis.com",
+    default_api_key_env="GOOGLE_API_KEY",
+    models=(
+        ModelShim("gemini-2.5-*", frozenset({"reasoning", "tools", "vision"})),
+        ModelShim("gemini-*", frozenset({"tools", "vision"})),
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Third-party provider shims
+# ---------------------------------------------------------------------------
+
+DEEPSEEK = ProviderShim(
+    name="deepseek",
+    base="openai_chat",
+    default_base_url="https://api.deepseek.com",
+    default_api_key_env="DEEPSEEK_API_KEY",
+    models=(ModelShim("deepseek-*", frozenset({"reasoning", "tools"})),),
+)
+
+VOLCENGINE = ProviderShim(
+    name="volcengine",
+    base="openai_chat",
+    default_base_url=None,
+    default_api_key_env="VOLCENGINE_API_KEY",
+)
+
+# ---------------------------------------------------------------------------
+# Auto-register all built-in shims
+# ---------------------------------------------------------------------------
+
+_BUILTIN_SHIMS: tuple[ProviderShim, ...] = (
+    OPENAI,
+    OPENAI_RESPONSES,
+    ANTHROPIC,
+    GOOGLE,
+    DEEPSEEK,
+    VOLCENGINE,
+)
+
+
+def _register_builtins() -> None:
+    """Register all built-in shims into the global registry."""
+    for shim in _BUILTIN_SHIMS:
+        register_shim(shim)
+
+
+_register_builtins()

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -1,0 +1,126 @@
+"""Provider and model shim definitions with a global registry.
+
+A **ProviderShim** is a lightweight identity card that declares which API
+standard (converter) a provider uses, along with connection defaults.
+
+A **ModelShim** describes model-level capabilities and constraints.  It is
+always nested within a ``ProviderShim`` — a model inherently belongs to a
+provider.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from fnmatch import fnmatch
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ModelShim:
+    """Model-level capabilities and constraints.
+
+    Nested within a :class:`ProviderShim` to express that every model
+    belongs to exactly one provider.
+
+    Attributes:
+        pattern: Glob pattern to match model names (e.g. ``"o3-*"``).
+        capabilities: Set of capability tags this model supports
+            (e.g. ``{"reasoning", "tools", "vision"}``).
+    """
+
+    pattern: str
+    capabilities: frozenset[str] = field(default_factory=frozenset)
+    # hooks: reserved for #173 (declarative transform mechanism)
+
+
+@dataclass(frozen=True)
+class ProviderShim:
+    """Provider identity card with optional nested model overrides.
+
+    Attributes:
+        name: Canonical provider identifier (e.g. ``"deepseek"``).
+        base: API standard this provider follows.  Must be one of the
+            converter type strings (``"openai_chat"``, ``"anthropic"``,
+            ``"google"``, ``"openai_responses"``).
+        default_base_url: Default upstream base URL.  Used by the gateway
+            when the provider config does not specify ``base_url``.
+        default_api_key_env: Default environment variable name for the
+            API key (e.g. ``"DEEPSEEK_API_KEY"``).
+        models: Tuple of :class:`ModelShim` entries that provide
+            model-specific capability metadata.
+    """
+
+    name: str
+    base: str
+    default_base_url: str | None = None
+    default_api_key_env: str | None = None
+    models: tuple[ModelShim, ...] = ()
+    # hooks: reserved for #173
+
+    def get_model_shim(self, model: str) -> ModelShim | None:
+        """Return the first :class:`ModelShim` whose pattern matches *model*.
+
+        Uses :func:`fnmatch.fnmatch` for glob-style matching.  Returns
+        ``None`` if no nested model shim matches.
+        """
+        for m in self.models:
+            if fnmatch(model, m.pattern):
+                return m
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_SHIM_REGISTRY: dict[str, ProviderShim] = {}
+
+# Base converter types — used by resolve_base() for pass-through detection
+_BASE_TYPES: frozenset[str] = frozenset(
+    {"openai_chat", "openai_responses", "open_responses", "anthropic", "google"}
+)
+
+
+def register_shim(shim: ProviderShim) -> None:
+    """Register (or replace) a :class:`ProviderShim` in the global registry."""
+    _SHIM_REGISTRY[shim.name] = shim
+
+
+def unregister_shim(name: str) -> ProviderShim | None:
+    """Remove and return a shim by name.  Returns ``None`` if not found."""
+    return _SHIM_REGISTRY.pop(name, None)
+
+
+def get_shim(name: str) -> ProviderShim | None:
+    """Look up a registered :class:`ProviderShim` by *name*."""
+    return _SHIM_REGISTRY.get(name)
+
+
+def list_shims() -> list[ProviderShim]:
+    """Return all registered provider shims."""
+    return list(_SHIM_REGISTRY.values())
+
+
+def resolve_base(name: str) -> str:
+    """Resolve a provider/shim *name* to its base converter type.
+
+    If *name* is already a known base type (e.g. ``"openai_chat"``),
+    it is returned unchanged.  Otherwise the shim registry is consulted.
+    If the name is not found in either, it is returned as-is (caller
+    decides how to handle unknown names).
+    """
+    if name in _BASE_TYPES:
+        return name
+    shim = _SHIM_REGISTRY.get(name)
+    if shim is not None:
+        return shim.base
+    return name
+
+
+def _reset_registry() -> None:
+    """Clear the registry.  Intended for testing only."""
+    _SHIM_REGISTRY.clear()

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
 
+from .transforms import Transform
+
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -26,15 +28,24 @@ class ModelShim:
     Nested within a :class:`ProviderShim` to express that every model
     belongs to exactly one provider.
 
+    Transforms on a ``ModelShim`` are merged with the parent
+    ``ProviderShim``'s transforms via :func:`~.transforms.resolve_transforms`
+    (provider first, model after).
+
     Attributes:
         pattern: Glob pattern to match model names (e.g. ``"o3-*"``).
         capabilities: Set of capability tags this model supports
             (e.g. ``{"reasoning", "tools", "vision"}``).
+        from_transforms: Transforms applied when data comes FROM this
+            model's provider (normalise dialect → standard).
+        to_transforms: Transforms applied when data goes TO this
+            model's provider (standard → dialect).
     """
 
     pattern: str
     capabilities: frozenset[str] = field(default_factory=frozenset)
-    # hooks: reserved for #173 (declarative transform mechanism)
+    from_transforms: tuple[Transform, ...] = ()
+    to_transforms: tuple[Transform, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -52,6 +63,10 @@ class ProviderShim:
             API key (e.g. ``"DEEPSEEK_API_KEY"``).
         models: Tuple of :class:`ModelShim` entries that provide
             model-specific capability metadata.
+        from_transforms: Transforms applied when data comes FROM this
+            provider (normalise dialect → standard).
+        to_transforms: Transforms applied when data goes TO this
+            provider (standard → dialect).
     """
 
     name: str
@@ -59,7 +74,8 @@ class ProviderShim:
     default_base_url: str | None = None
     default_api_key_env: str | None = None
     models: tuple[ModelShim, ...] = ()
-    # hooks: reserved for #173
+    from_transforms: tuple[Transform, ...] = ()
+    to_transforms: tuple[Transform, ...] = ()
 
     def get_model_shim(self, model: str) -> ModelShim | None:
         """Return the first :class:`ModelShim` whose pattern matches *model*.

--- a/src/llm_rosetta/shims/transforms.py
+++ b/src/llm_rosetta/shims/transforms.py
@@ -1,0 +1,145 @@
+"""Transform primitives for the provider/model shim layer.
+
+A **Transform** is a pure data transformation: ``dict → dict``.  Transforms
+bridge the gap between a real provider's API dialect and the "ideal" standard
+that the corresponding base converter expects.
+
+Transforms are NOT a replacement for converter functionality — they handle
+provider/model-specific field-level quirks (rename, strip, inject defaults),
+while converters handle semantic API-standard translation.
+
+Design principles:
+
+* **Idempotent**: applying the same transform twice should be harmless.
+* **Non-overlapping**: provider-level and model-level transforms should
+  operate on different fields by convention.
+* **Merge by concatenation**: ``resolve_transforms`` merges provider + model
+  transforms.  Provider transforms run first (broad dialect normalisation),
+  model transforms run after (model-specific adjustments).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+from collections.abc import Callable
+
+# ---------------------------------------------------------------------------
+# Core type
+# ---------------------------------------------------------------------------
+
+Transform = Callable[[dict[str, Any]], dict[str, Any]]
+"""A pure data transformation: receives a provider body dict and returns
+a (possibly mutated) body dict."""
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class Transformable(Protocol):
+    """Shared interface satisfied by both ``ProviderShim`` and ``ModelShim``."""
+
+    from_transforms: tuple[Transform, ...]
+    to_transforms: tuple[Transform, ...]
+
+
+# ---------------------------------------------------------------------------
+# Factory functions
+# ---------------------------------------------------------------------------
+
+
+class _NamedTransform:
+    """Thin wrapper that gives a factory-produced callable a readable repr."""
+
+    __slots__ = ("_fn", "_repr")
+
+    def __init__(self, fn: Transform, repr_str: str) -> None:
+        self._fn = fn
+        self._repr = repr_str
+
+    def __call__(self, body: dict[str, Any]) -> dict[str, Any]:
+        return self._fn(body)
+
+    def __repr__(self) -> str:
+        return self._repr
+
+
+def strip_fields(*keys: str) -> Transform:
+    """Return a transform that removes *keys* from the body.
+
+    No-op for keys that do not exist (idempotent).
+    """
+
+    def _strip(body: dict[str, Any]) -> dict[str, Any]:
+        for k in keys:
+            body.pop(k, None)
+        return body
+
+    return _NamedTransform(_strip, f"strip_fields({', '.join(repr(k) for k in keys)})")
+
+
+def rename_field(old: str, new: str) -> Transform:
+    """Return a transform that renames a top-level field.
+
+    No-op if *old* does not exist (idempotent).
+    """
+
+    def _rename(body: dict[str, Any]) -> dict[str, Any]:
+        if old in body:
+            body[new] = body.pop(old)
+        return body
+
+    return _NamedTransform(_rename, f"rename_field({old!r}, {new!r})")
+
+
+def set_defaults(**defaults: Any) -> Transform:
+    """Return a transform that sets fields only when they are absent.
+
+    Idempotent: existing values are never overwritten.
+    """
+
+    def _defaults(body: dict[str, Any]) -> dict[str, Any]:
+        for k, v in defaults.items():
+            body.setdefault(k, v)
+        return body
+
+    return _NamedTransform(
+        _defaults,
+        f"set_defaults({', '.join(f'{k}={v!r}' for k, v in defaults.items())})",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def apply_transforms(
+    transforms: tuple[Transform, ...], body: dict[str, Any]
+) -> dict[str, Any]:
+    """Apply *transforms* sequentially to *body*, returning the result."""
+    for t in transforms:
+        body = t(body)
+    return body
+
+
+def resolve_transforms(
+    provider: Transformable,
+    model: Transformable | None,
+) -> tuple[tuple[Transform, ...], tuple[Transform, ...]]:
+    """Merge provider and model transforms by concatenation.
+
+    Provider transforms run first (broad dialect normalisation), model
+    transforms run after (model-specific adjustments).
+
+    Returns:
+        ``(from_transforms, to_transforms)`` ready for ``apply_transforms``.
+    """
+    if model is None:
+        return provider.from_transforms, provider.to_transforms
+    return (
+        provider.from_transforms + model.from_transforms,
+        provider.to_transforms + model.to_transforms,
+    )

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -40,8 +40,16 @@ EXPECTED_EXPORTS: dict[str, _ModuleSpec] = {
             "get_converter_for_provider",
             "convert",
             "ProviderType",
+            # Provider shim layer
+            "ProviderShim",
+            "ModelShim",
+            "register_shim",
+            "unregister_shim",
+            "get_shim",
+            "list_shims",
+            "resolve_base",
         ],
-        "max_count": 16,
+        "max_count": 23,
     },
     "llm_rosetta.types.ir": {
         "items": None,  # too many to enumerate; just check count

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -48,8 +48,16 @@ EXPECTED_EXPORTS: dict[str, _ModuleSpec] = {
             "get_shim",
             "list_shims",
             "resolve_base",
+            # Transforms
+            "Transform",
+            "Transformable",
+            "apply_transforms",
+            "resolve_transforms",
+            "strip_fields",
+            "rename_field",
+            "set_defaults",
         ],
-        "max_count": 23,
+        "max_count": 30,
     },
     "llm_rosetta.types.ir": {
         "items": None,  # too many to enumerate; just check count

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -1,0 +1,315 @@
+"""Tests for the provider shim layer."""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_rosetta.shims.provider_shim import (
+    ModelShim,
+    ProviderShim,
+    _reset_registry,
+    get_shim,
+    list_shims,
+    register_shim,
+    resolve_base,
+    unregister_shim,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Reset the shim registry before and after each test."""
+    _reset_registry()
+    yield
+    _reset_registry()
+
+
+# ---------------------------------------------------------------------------
+# ModelShim
+# ---------------------------------------------------------------------------
+
+
+class TestModelShim:
+    def test_creation_defaults(self):
+        m = ModelShim("gpt-*")
+        assert m.pattern == "gpt-*"
+        assert m.capabilities == frozenset()
+
+    def test_creation_with_capabilities(self):
+        m = ModelShim("o3-*", frozenset({"reasoning", "tools"}))
+        assert m.capabilities == {"reasoning", "tools"}
+
+    def test_frozen(self):
+        m = ModelShim("gpt-*")
+        with pytest.raises(AttributeError):
+            m.pattern = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# ProviderShim
+# ---------------------------------------------------------------------------
+
+
+class TestProviderShim:
+    def test_creation_minimal(self):
+        s = ProviderShim(name="test", base="openai_chat")
+        assert s.name == "test"
+        assert s.base == "openai_chat"
+        assert s.default_base_url is None
+        assert s.default_api_key_env is None
+        assert s.models == ()
+
+    def test_creation_full(self):
+        models = (
+            ModelShim("o3-*", frozenset({"reasoning"})),
+            ModelShim("gpt-*", frozenset({"tools"})),
+        )
+        s = ProviderShim(
+            name="openai",
+            base="openai_chat",
+            default_base_url="https://api.openai.com/v1",
+            default_api_key_env="OPENAI_API_KEY",
+            models=models,
+        )
+        assert s.default_base_url == "https://api.openai.com/v1"
+        assert len(s.models) == 2
+
+    def test_frozen(self):
+        s = ProviderShim(name="test", base="openai_chat")
+        with pytest.raises(AttributeError):
+            s.name = "other"  # type: ignore[misc]
+
+    def test_get_model_shim_match(self):
+        s = ProviderShim(
+            name="openai",
+            base="openai_chat",
+            models=(
+                ModelShim("o3-*", frozenset({"reasoning", "tools"})),
+                ModelShim("gpt-*", frozenset({"tools"})),
+            ),
+        )
+        m = s.get_model_shim("o3-mini")
+        assert m is not None
+        assert "reasoning" in m.capabilities
+
+        m2 = s.get_model_shim("gpt-4o")
+        assert m2 is not None
+        assert m2.capabilities == {"tools"}
+
+    def test_get_model_shim_no_match(self):
+        s = ProviderShim(
+            name="openai",
+            base="openai_chat",
+            models=(ModelShim("gpt-*", frozenset({"tools"})),),
+        )
+        assert s.get_model_shim("claude-3") is None
+
+    def test_get_model_shim_first_match_wins(self):
+        s = ProviderShim(
+            name="test",
+            base="openai_chat",
+            models=(
+                ModelShim("o3-*", frozenset({"reasoning"})),
+                ModelShim("o3-mini*", frozenset({"tools"})),
+            ),
+        )
+        m = s.get_model_shim("o3-mini")
+        assert m is not None
+        assert m.capabilities == {"reasoning"}  # first match
+
+    def test_get_model_shim_empty_models(self):
+        s = ProviderShim(name="test", base="openai_chat")
+        assert s.get_model_shim("anything") is None
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_register_and_get(self):
+        s = ProviderShim(name="test-provider", base="openai_chat")
+        register_shim(s)
+        assert get_shim("test-provider") is s
+
+    def test_get_nonexistent(self):
+        assert get_shim("nonexistent") is None
+
+    def test_register_replaces(self):
+        s1 = ProviderShim(name="test", base="openai_chat")
+        s2 = ProviderShim(name="test", base="anthropic")
+        register_shim(s1)
+        register_shim(s2)
+        result = get_shim("test")
+        assert result is not None
+        assert result.base == "anthropic"
+
+    def test_unregister(self):
+        s = ProviderShim(name="test", base="openai_chat")
+        register_shim(s)
+        removed = unregister_shim("test")
+        assert removed is s
+        assert get_shim("test") is None
+
+    def test_unregister_nonexistent(self):
+        assert unregister_shim("nonexistent") is None
+
+    def test_list_shims(self):
+        s1 = ProviderShim(name="a", base="openai_chat")
+        s2 = ProviderShim(name="b", base="anthropic")
+        register_shim(s1)
+        register_shim(s2)
+        shims = list_shims()
+        assert len(shims) == 2
+        names = {s.name for s in shims}
+        assert names == {"a", "b"}
+
+    def test_list_shims_empty(self):
+        assert list_shims() == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_base
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBase:
+    def test_base_type_passthrough(self):
+        assert resolve_base("openai_chat") == "openai_chat"
+        assert resolve_base("anthropic") == "anthropic"
+        assert resolve_base("google") == "google"
+        assert resolve_base("openai_responses") == "openai_responses"
+        assert resolve_base("open_responses") == "open_responses"
+
+    def test_shim_name_resolves(self):
+        register_shim(ProviderShim(name="deepseek", base="openai_chat"))
+        assert resolve_base("deepseek") == "openai_chat"
+
+    def test_unknown_name_passthrough(self):
+        assert resolve_base("unknown") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Built-in shims
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinShims:
+    @pytest.fixture(autouse=True)
+    def _load_builtins(self):
+        """Re-register builtins for this test class."""
+        from llm_rosetta.shims.builtins import _register_builtins
+
+        _register_builtins()
+
+    def test_official_providers_registered(self):
+        for name in ("openai", "openai_responses", "anthropic", "google"):
+            shim = get_shim(name)
+            assert shim is not None, f"Built-in shim '{name}' not registered"
+
+    def test_third_party_providers_registered(self):
+        for name in ("deepseek", "volcengine"):
+            shim = get_shim(name)
+            assert shim is not None, f"Built-in shim '{name}' not registered"
+
+    def test_openai_base_type(self):
+        shim = get_shim("openai")
+        assert shim is not None
+        assert shim.base == "openai_chat"
+
+    def test_deepseek_base_type(self):
+        shim = get_shim("deepseek")
+        assert shim is not None
+        assert shim.base == "openai_chat"
+
+    def test_anthropic_base_type(self):
+        shim = get_shim("anthropic")
+        assert shim is not None
+        assert shim.base == "anthropic"
+
+    def test_google_base_type(self):
+        shim = get_shim("google")
+        assert shim is not None
+        assert shim.base == "google"
+
+    def test_openai_has_nested_models(self):
+        shim = get_shim("openai")
+        assert shim is not None
+        assert len(shim.models) > 0
+        # o3 should have reasoning capability
+        m = shim.get_model_shim("o3-mini")
+        assert m is not None
+        assert "reasoning" in m.capabilities
+
+    def test_deepseek_has_nested_models(self):
+        shim = get_shim("deepseek")
+        assert shim is not None
+        m = shim.get_model_shim("deepseek-v4-flash")
+        assert m is not None
+        assert "reasoning" in m.capabilities
+        assert "tools" in m.capabilities
+
+    def test_google_model_capabilities(self):
+        shim = get_shim("google")
+        assert shim is not None
+        # gemini-2.5-pro should have reasoning
+        m = shim.get_model_shim("gemini-2.5-pro")
+        assert m is not None
+        assert "reasoning" in m.capabilities
+        # gemini-2.0-flash should NOT have reasoning
+        m2 = shim.get_model_shim("gemini-2.0-flash")
+        assert m2 is not None
+        assert "reasoning" not in m2.capabilities
+
+
+# ---------------------------------------------------------------------------
+# Integration: shim → converter
+# ---------------------------------------------------------------------------
+
+
+class TestShimConverterIntegration:
+    @pytest.fixture(autouse=True)
+    def _load_builtins(self):
+        from llm_rosetta.shims.builtins import _register_builtins
+
+        _register_builtins()
+
+    def test_deepseek_resolves_to_openai_chat_converter(self):
+        from llm_rosetta.auto_detect import get_converter_for_provider
+        from llm_rosetta.converters import OpenAIChatConverter
+
+        converter = get_converter_for_provider("deepseek")
+        assert isinstance(converter, OpenAIChatConverter)
+
+    def test_volcengine_resolves_to_openai_chat_converter(self):
+        from llm_rosetta.auto_detect import get_converter_for_provider
+        from llm_rosetta.converters import OpenAIChatConverter
+
+        converter = get_converter_for_provider("volcengine")
+        assert isinstance(converter, OpenAIChatConverter)
+
+    def test_base_types_still_work(self):
+        from llm_rosetta.auto_detect import get_converter_for_provider
+        from llm_rosetta.converters import (
+            AnthropicConverter,
+            GoogleConverter,
+            OpenAIChatConverter,
+        )
+
+        assert isinstance(
+            get_converter_for_provider("openai_chat"), OpenAIChatConverter
+        )
+        assert isinstance(get_converter_for_provider("anthropic"), AnthropicConverter)
+        assert isinstance(get_converter_for_provider("google"), GoogleConverter)
+
+    def test_unknown_provider_raises(self):
+        from llm_rosetta.auto_detect import get_converter_for_provider
+
+        with pytest.raises(ValueError, match="Unsupported provider"):
+            get_converter_for_provider("totally_unknown")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,428 @@
+"""Tests for the shim transform layer."""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_rosetta.shims.provider_shim import (
+    ModelShim,
+    ProviderShim,
+    _reset_registry,
+    get_shim,
+    register_shim,
+)
+from llm_rosetta.shims.transforms import (
+    Transformable,
+    apply_transforms,
+    rename_field,
+    resolve_transforms,
+    set_defaults,
+    strip_fields,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Reset the shim registry before and after each test."""
+    _reset_registry()
+    yield
+    _reset_registry()
+
+
+# ---------------------------------------------------------------------------
+# Factory functions
+# ---------------------------------------------------------------------------
+
+
+class TestStripFields:
+    def test_removes_existing_fields(self):
+        t = strip_fields("a", "b")
+        result = t({"a": 1, "b": 2, "c": 3})
+        assert result == {"c": 3}
+
+    def test_noop_for_missing_fields(self):
+        t = strip_fields("x", "y")
+        body = {"a": 1}
+        result = t(body)
+        assert result == {"a": 1}
+
+    def test_idempotent(self):
+        t = strip_fields("a")
+        body = {"a": 1, "b": 2}
+        result1 = t(body)
+        result2 = t(result1)
+        assert result1 == result2 == {"b": 2}
+
+    def test_empty_keys(self):
+        t = strip_fields()
+        body = {"a": 1}
+        assert t(body) == {"a": 1}
+
+
+class TestRenameField:
+    def test_renames_existing_field(self):
+        t = rename_field("old", "new")
+        result = t({"old": 42, "other": 1})
+        assert result == {"new": 42, "other": 1}
+
+    def test_noop_for_missing_field(self):
+        t = rename_field("old", "new")
+        body = {"other": 1}
+        result = t(body)
+        assert result == {"other": 1}
+
+    def test_idempotent(self):
+        t = rename_field("a", "b")
+        body = {"a": 1}
+        result1 = t(body)
+        result2 = t(result1)
+        assert result1 == result2 == {"b": 1}
+
+
+class TestSetDefaults:
+    def test_sets_missing_fields(self):
+        t = set_defaults(x=10, y=20)
+        result = t({"z": 30})
+        assert result == {"z": 30, "x": 10, "y": 20}
+
+    def test_does_not_overwrite_existing(self):
+        t = set_defaults(x=10)
+        body = {"x": 99}
+        result = t(body)
+        assert result == {"x": 99}
+
+    def test_idempotent(self):
+        t = set_defaults(x=10)
+        body = {}
+        result1 = t(body)
+        result2 = t(result1)
+        assert result1 == result2 == {"x": 10}
+
+    def test_empty_defaults(self):
+        t = set_defaults()
+        body = {"a": 1}
+        assert t(body) == {"a": 1}
+
+
+# ---------------------------------------------------------------------------
+# Inspectability (repr)
+# ---------------------------------------------------------------------------
+
+
+class TestInspectability:
+    def test_strip_fields_repr(self):
+        t = strip_fields("a", "b")
+        assert repr(t) == "strip_fields('a', 'b')"
+
+    def test_rename_field_repr(self):
+        t = rename_field("old", "new")
+        assert repr(t) == "rename_field('old', 'new')"
+
+    def test_set_defaults_repr(self):
+        t = set_defaults(x=10, y="hello")
+        assert repr(t) == "set_defaults(x=10, y='hello')"
+
+
+# ---------------------------------------------------------------------------
+# apply_transforms
+# ---------------------------------------------------------------------------
+
+
+class TestApplyTransforms:
+    def test_empty_transforms(self):
+        body = {"a": 1}
+        assert apply_transforms((), body) == {"a": 1}
+
+    def test_single_transform(self):
+        result = apply_transforms((strip_fields("a"),), {"a": 1, "b": 2})
+        assert result == {"b": 2}
+
+    def test_ordered_composition(self):
+        transforms = (
+            rename_field("x", "y"),
+            strip_fields("y"),
+        )
+        result = apply_transforms(transforms, {"x": 1, "z": 2})
+        # rename x→y first, then strip y
+        assert result == {"z": 2}
+
+    def test_reverse_order_different_result(self):
+        transforms = (
+            strip_fields("x"),
+            rename_field("x", "y"),
+        )
+        result = apply_transforms(transforms, {"x": 1, "z": 2})
+        # strip x first (removes it), then rename x→y (noop)
+        assert result == {"z": 2}
+
+    def test_custom_callable(self):
+        def double_value(body: dict) -> dict:
+            if "n" in body:
+                body["n"] *= 2
+            return body
+
+        result = apply_transforms((double_value,), {"n": 5})
+        assert result == {"n": 10}
+
+
+# ---------------------------------------------------------------------------
+# resolve_transforms
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTransforms:
+    def test_provider_only(self):
+        t1 = strip_fields("a")
+        t2 = strip_fields("b")
+        provider = ProviderShim(
+            name="test",
+            base="openai_chat",
+            from_transforms=(t1,),
+            to_transforms=(t2,),
+        )
+        from_t, to_t = resolve_transforms(provider, None)
+        assert from_t == (t1,)
+        assert to_t == (t2,)
+
+    def test_merge_provider_and_model(self):
+        pt = strip_fields("a")
+        mt = strip_fields("b")
+        provider = ProviderShim(name="test", base="openai_chat", from_transforms=(pt,))
+        model = ModelShim("test-*", from_transforms=(mt,))
+        from_t, to_t = resolve_transforms(provider, model)
+        # provider first, model after
+        assert from_t == (pt, mt)
+        assert to_t == ()
+
+    def test_merge_both_directions(self):
+        p_from = strip_fields("a")
+        p_to = strip_fields("b")
+        m_from = rename_field("x", "y")
+        m_to = set_defaults(z=1)
+        provider = ProviderShim(
+            name="test",
+            base="openai_chat",
+            from_transforms=(p_from,),
+            to_transforms=(p_to,),
+        )
+        model = ModelShim(
+            "test-*",
+            from_transforms=(m_from,),
+            to_transforms=(m_to,),
+        )
+        from_t, to_t = resolve_transforms(provider, model)
+        assert from_t == (p_from, m_from)
+        assert to_t == (p_to, m_to)
+
+    def test_model_empty_transforms(self):
+        pt = strip_fields("a")
+        provider = ProviderShim(name="test", base="openai_chat", from_transforms=(pt,))
+        model = ModelShim("test-*")  # no transforms
+        from_t, to_t = resolve_transforms(provider, model)
+        assert from_t == (pt,)
+        assert to_t == ()
+
+    def test_provider_empty_transforms(self):
+        mt = strip_fields("b")
+        provider = ProviderShim(name="test", base="openai_chat")
+        model = ModelShim("test-*", from_transforms=(mt,))
+        from_t, _ = resolve_transforms(provider, model)
+        assert from_t == (mt,)
+
+
+# ---------------------------------------------------------------------------
+# Transformable protocol
+# ---------------------------------------------------------------------------
+
+
+class TestTransformable:
+    def test_provider_shim_is_transformable(self):
+        s = ProviderShim(name="test", base="openai_chat")
+        assert isinstance(s, Transformable)
+
+    def test_model_shim_is_transformable(self):
+        m = ModelShim("test-*")
+        assert isinstance(m, Transformable)
+
+
+# ---------------------------------------------------------------------------
+# ProviderShim / ModelShim with transforms
+# ---------------------------------------------------------------------------
+
+
+class TestShimWithTransforms:
+    def test_provider_shim_stores_transforms(self):
+        t1 = strip_fields("a")
+        t2 = rename_field("b", "c")
+        s = ProviderShim(
+            name="test",
+            base="openai_chat",
+            from_transforms=(t1,),
+            to_transforms=(t2,),
+        )
+        assert s.from_transforms == (t1,)
+        assert s.to_transforms == (t2,)
+
+    def test_model_shim_stores_transforms(self):
+        t = set_defaults(x=1)
+        m = ModelShim("test-*", from_transforms=(t,))
+        assert m.from_transforms == (t,)
+        assert m.to_transforms == ()
+
+    def test_provider_shim_default_empty(self):
+        s = ProviderShim(name="test", base="openai_chat")
+        assert s.from_transforms == ()
+        assert s.to_transforms == ()
+
+    def test_model_shim_default_empty(self):
+        m = ModelShim("test-*")
+        assert m.from_transforms == ()
+        assert m.to_transforms == ()
+
+
+# ---------------------------------------------------------------------------
+# Built-in shim transforms
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinTransforms:
+    @pytest.fixture(autouse=True)
+    def _load_builtins(self):
+        from llm_rosetta.shims.builtins import _register_builtins
+
+        _register_builtins()
+
+    def test_volcengine_has_to_transforms(self):
+        shim = get_shim("volcengine")
+        assert shim is not None
+        assert len(shim.to_transforms) > 0
+
+    def test_volcengine_strips_logprobs(self):
+        shim = get_shim("volcengine")
+        assert shim is not None
+        body = {"model": "test", "logprobs": True, "top_logprobs": 5, "messages": []}
+        result = apply_transforms(shim.to_transforms, body)
+        assert "logprobs" not in result
+        assert "top_logprobs" not in result
+        assert result["model"] == "test"
+
+
+# ---------------------------------------------------------------------------
+# Integration: convert() with transforms
+# ---------------------------------------------------------------------------
+
+
+class TestConvertWithTransforms:
+    @pytest.fixture(autouse=True)
+    def _load_builtins(self):
+        from llm_rosetta.shims.builtins import _register_builtins
+
+        _register_builtins()
+
+    def test_convert_applies_source_from_transforms(self):
+        """Source shim's from_transforms should normalise before conversion."""
+        # Register a custom shim with a from_transform
+        custom = ProviderShim(
+            name="custom-oai",
+            base="openai_chat",
+            from_transforms=(rename_field("custom_field", "model"),),
+        )
+        register_shim(custom)
+
+        from llm_rosetta import convert
+
+        body = {
+            "custom_field": "gpt-4",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        # Convert to anthropic — the rename should happen before converter reads it
+        result = convert(body, "anthropic", source_provider="custom-oai")
+        assert "model" in result
+
+    def test_convert_applies_target_to_transforms(self):
+        """Target shim's to_transforms should adapt after conversion."""
+        # Register a custom target shim that strips a field
+        custom = ProviderShim(
+            name="custom-target",
+            base="openai_chat",
+            to_transforms=(strip_fields("logprobs"),),
+        )
+        register_shim(custom)
+
+        from llm_rosetta import convert
+
+        body = {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        result = convert(body, "custom-target", source_provider="openai_chat")
+        assert "logprobs" not in result
+
+    def test_convert_with_model_transforms(self):
+        """Model-level transforms should be merged with provider transforms."""
+        model_t = set_defaults(extra="added_by_model")
+        custom = ProviderShim(
+            name="custom-model-test",
+            base="openai_chat",
+            to_transforms=(strip_fields("logprobs"),),
+            models=(ModelShim("test-model-*", to_transforms=(model_t,)),),
+        )
+        register_shim(custom)
+
+        from llm_rosetta import convert
+
+        body = {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        result = convert(
+            body,
+            "custom-model-test",
+            source_provider="openai_chat",
+            model="test-model-1",
+        )
+        # Provider transform strips logprobs, model transform adds extra
+        assert "logprobs" not in result
+        assert result.get("extra") == "added_by_model"
+
+    def test_convert_without_shim_still_works(self):
+        """Base type conversion without shim should work as before."""
+        from llm_rosetta import convert
+
+        body = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        result = convert(body, "anthropic", source_provider="openai_chat")
+        assert "messages" in result
+
+    def test_convert_idempotent_transforms(self):
+        """Duplicate transforms between provider and model should be harmless."""
+        t = strip_fields("logprobs")
+        custom = ProviderShim(
+            name="idem-test",
+            base="openai_chat",
+            to_transforms=(t,),
+            models=(ModelShim("test-*", to_transforms=(t,)),),
+        )
+        register_shim(custom)
+
+        from llm_rosetta import convert
+
+        body = {
+            "model": "test",
+            "logprobs": True,
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        result = convert(
+            body,
+            "idem-test",
+            source_provider="openai_chat",
+            model="test-model",
+        )
+        assert "logprobs" not in result


### PR DESCRIPTION
## Summary

- **Provider shim layer** (`ProviderShim` + `ModelShim`): lightweight identity cards declaring which API standard a provider uses, with model-level capability metadata via glob pattern matching
- **Transform mechanism**: pure data transformations (`dict → dict`) that bridge the gap between real provider APIs and the "ideal" standard our converters define
- **Pipeline integration**: `convert()` now applies shim transforms around the base converter — `source.from_transforms → converter → target.to_transforms`

### Shim framework (Part 2-3 of #145)
- `ProviderShim`: name, base converter type, default URL/key, nested models
- `ModelShim`: glob pattern matching + capability tags (reasoning, tools, vision)
- Built-in shims: openai, anthropic, google, deepseek, volcengine
- Registry: `register_shim` / `get_shim` / `list_shims` / `resolve_base`
- `auto_detect`: `get_converter_for_provider()` resolves shim names
- Gateway config supports `shim` field

### Transform layer (#173)
- `Transform = Callable[[dict, ...], dict]` — no DSL, just callables
- `Transformable` protocol shared by both `ProviderShim` and `ModelShim`
- `from_transforms`: normalize data coming FROM this provider (dialect → standard)
- `to_transforms`: adapt data going TO this provider (standard → dialect)
- Merge by concatenation: `resolve_transforms(provider, model)` = provider first, model after
- Factory functions with inspectable `__repr__`: `strip_fields()`, `rename_field()`, `set_defaults()`
- `convert()` gains optional `model` parameter for model-level transform lookup
- Example: volcengine strips `logprobs`/`top_logprobs` via `to_transforms`

### Design principles
- Transforms fill the gap between real API and converter standard, NOT a replacement for converter functionality
- Idempotent by convention — duplicates between provider and model are harmless
- Provider and model transforms should operate on different fields (non-overlapping)
- Callable-based for full flexibility; factory functions serve as future bridge for admin panel JSON config

## Test plan

- [x] All 33 existing shim tests pass (registry, model matching, builtins, converter integration)
- [x] 37 new transform tests: factory functions, apply_transforms, resolve_transforms, Transformable protocol, shim integration, convert() with model param, idempotency
- [x] Public API export tests updated
- [x] Full test suite: 1603 passed, 0 failed
- [x] ruff check + ruff format clean
- [x] ty type check passes

Closes #173
Ref #145