### PR TITLE
fix: resolve 4 pre-existing ty type check errors

### DIFF
--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -6,7 +6,7 @@ import asyncio
 import time
 from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import Any, cast
 
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -66,7 +66,8 @@ async def _proxy_handler(
 
     # Resolve target provider
     try:
-        target_provider, provider_info = _config.resolve_model(model)
+        target_provider_str, provider_info = _config.resolve_model(model)
+        target_provider = cast(ProviderType, target_provider_str)
     except KeyError:
         configured = ", ".join(sorted(_config.models.keys()))
         return error_response_for_source(

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -47,7 +47,7 @@ class TestModelShim:
     def test_frozen(self):
         m = ModelShim("gpt-*")
         with pytest.raises(AttributeError):
-            m.pattern = "other"  # type: ignore[misc]
+            m.pattern = "other"  # type: ignore
 
 
 # ---------------------------------------------------------------------------
@@ -82,7 +82,7 @@ class TestProviderShim:
     def test_frozen(self):
         s = ProviderShim(name="test", base="openai_chat")
         with pytest.raises(AttributeError):
-            s.name = "other"  # type: ignore[misc]
+            s.name = "other"  # type: ignore
 
     def test_get_model_shim_match(self):
         s = ProviderShim(


### PR DESCRIPTION
## Summary

- Cast `resolve_model()` return value to `ProviderType` in `gateway/app.py` (lines 110/120) to satisfy ty's stricter `str` → `Literal` checking
- Switch `# type: ignore[misc]` (mypy-only) to bare `# type: ignore` in `test_shims.py` (lines 50/85) for ty compatibility on frozen dataclass assignment tests

## Test plan

- [x] `ty check` passes with 0 diagnostics
- [x] All 1603 tests pass
- [x] `ruff check` and `ruff format` clean