### PR TITLE
fix: preserve OpenAI Responses custom tools through IR

### DIFF
--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -734,7 +734,7 @@ class GoogleGenAIConverter(BaseConverter):
             return self.request_to_provider(cast(IRRequest, ir_input))
 
         # Handle IRInput (message list)
-        ir_input_list = list(cast("IRInput", ir_input))
+        ir_input_list: list[Message | ExtensionItem] = list(cast(IRInput, ir_input))
         warnings_list: list[str] = []
 
         # Extract system messages

--- a/src/llm_rosetta/converters/openai_responses/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/tool_ops.py
@@ -195,7 +195,12 @@ class OpenAIResponsesToolOps(BaseToolOps):
         Handles both flat format (Responses API native) and nested format
         (with ``function`` key).  Non-function tool types without a ``name``
         field (e.g. ``web_search``) are stored as passthrough so they can be
-        round-tripped without modification.
+        round-tripped without modification.  Named non-function tools (e.g.
+        Codex ``"custom"`` ``apply_patch``) are downgraded to IR
+        ``type: "function"`` so the request passes IR validation; this
+        mirrors the existing downgrade in ``openai_chat/tool_ops.py``.  The
+        original provider type is retained in ``metadata["provider_type"]``
+        for diagnostics.
 
         Args:
             provider_tool: OpenAI Responses tool definition dict.
@@ -203,6 +208,10 @@ class OpenAIResponsesToolOps(BaseToolOps):
         Returns:
             IR ToolDefinition.
         """
+        # IR ToolDefinition.type is restricted to Literal["function", "mcp"];
+        # see types/ir/tools.py.
+        _IR_ALLOWED_TYPES = {"function", "mcp"}
+
         # Handle nested format ({"type": "function", "function": {...}})
         if "function" in provider_tool and isinstance(provider_tool["function"], dict):
             func = provider_tool["function"]
@@ -214,31 +223,39 @@ class OpenAIResponsesToolOps(BaseToolOps):
             }
         else:
             tool_type = provider_tool.get("type", "function")
-            # Non-function tools without a name (e.g. web_search) should be
-            # stored as passthrough to avoid lossy conversion.
-            if tool_type != "function" and "name" not in provider_tool:
+            # Non-function tools outside the IR type set (e.g. web_search or
+            # Codex custom apply_patch) are stored as passthrough to avoid
+            # lossy conversion. IR ``type`` is forced to "function" to
+            # satisfy validation; ``ir_tool_definition_to_p`` restores the
+            # original payload on the outbound leg.
+            if tool_type != "function" and tool_type not in _IR_ALLOWED_TYPES:
                 result = {
-                    "type": tool_type,
-                    "name": tool_type,
-                    "description": "",
+                    "type": "function",
+                    "name": provider_tool.get("name", tool_type),
+                    "description": provider_tool.get("description", ""),
                     "parameters": {},
                     "_passthrough": dict(provider_tool),
                 }
-                result["metadata"] = {}
+                result["metadata"] = {"provider_type": tool_type}
                 result["required_parameters"] = []
                 return cast(ToolDefinition, result)
 
-            # Flat format (Responses API native)
-            # Custom tools use "schema" instead of "parameters"
+            # Flat format (Responses API native).
+            # Custom tools use "schema" instead of "parameters".
             params = provider_tool.get("parameters", {})
             if tool_type != "function" and not params:
                 params = provider_tool.get("schema", {})
+            # Downgrade unknown provider tool types (e.g. Codex "custom") to
+            # IR "function" so the request passes IR validation.
+            ir_type = tool_type if tool_type in _IR_ALLOWED_TYPES else "function"
             result = {
-                "type": tool_type,
+                "type": ir_type,
                 "name": provider_tool.get("name", ""),
                 "description": provider_tool.get("description", ""),
                 "parameters": params,
             }
+            if ir_type != tool_type:
+                result["_downgraded_from"] = tool_type
 
         # Extract required_parameters from JSON Schema if available
         parameters = result.get("parameters", {})
@@ -247,7 +264,10 @@ class OpenAIResponsesToolOps(BaseToolOps):
         else:
             result["required_parameters"] = []
 
-        result["metadata"] = {}
+        downgraded_from = result.pop("_downgraded_from", None)
+        result["metadata"] = (
+            {"provider_type": downgraded_from} if downgraded_from else {}
+        )
         return cast(ToolDefinition, result)
 
     # ==================== Tool Choice ====================

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -65,7 +65,7 @@ async def _proxy_handler(
     # Resolve target provider
     try:
         target_provider_str, provider_info = _config.resolve_model(model)
-        target_provider = cast(ProviderType, target_provider_str)
+        target_provider: ProviderType = cast(ProviderType, target_provider_str)
     except KeyError:
         configured = ", ".join(sorted(_config.models.keys()))
         return error_response_for_source(

--- a/src/llm_rosetta/types/ir/tools.py
+++ b/src/llm_rosetta/types/ir/tools.py
@@ -27,6 +27,18 @@ class ToolDefinition(TypedDict):
     - OpenAI Responses: {"type": "function", "name": "...", ...}
     - Anthropic: {"name": "...", "description": "...", "input_schema": {...}}
     - Google: {"function_declarations": [{"name": "...", ...}]}
+
+    Source converter contract:
+    Provider tool types that fall outside the ``type`` Literal below
+    (e.g. OpenAI Responses' ``"custom"`` hosted tools, or unnamed hosted
+    tools like ``"web_search"``) MUST be coerced to ``"function"`` at the
+    provider→IR boundary so that runtime IR validation
+    (``validate_ir_request``) accepts the result.  Provider-specific
+    information may be retained in ``metadata`` (e.g.
+    ``{"provider_type": "custom"}``) or in the ``_passthrough`` extension
+    for round-tripping.  Target converters' downgrade fallbacks (e.g.
+    ``openai_chat/tool_ops.py``) are defensive only — IR is guaranteed
+    valid by validation.
     """
 
     type: Literal[

--- a/tests/converters/openai_responses/test_converter.py
+++ b/tests/converters/openai_responses/test_converter.py
@@ -191,6 +191,54 @@ class TestOpenAIResponsesConverter:
         result = self.converter.request_from_provider(provider_request)
         assert result["response_format"]["type"] == "json_object"
 
+    def test_request_from_provider_codex_custom_tool_passes_validation(self):
+        """End-to-end: a Codex ``"custom"`` apply_patch tool passes IR validation.
+
+        Regression test for the IR validator added in v0.3.0 (commit 5dc1b94)
+        rejecting ``tools[i].type == "custom"`` because IR's ToolDefinition
+        Literal only allows ``"function"`` and ``"mcp"``.  The source
+        converter must downgrade unknown provider tool types to ``"function"``
+        so the request reaches the target converter.
+        """
+        provider_request = {
+            "model": "gpt-5.4",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "patch this"}],
+                }
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "shell",
+                    "description": "run a shell command",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                {
+                    "type": "custom",
+                    "name": "apply_patch",
+                    "description": "Apply a unified-diff style patch.",
+                    "format": {
+                        "type": "grammar",
+                        "syntax": "lark",
+                        "definition": "start: ...",
+                    },
+                },
+            ],
+        }
+        # Must not raise — pre-fix this raised ValidationError with
+        # "Expected one of ('function', 'mcp') at 'tools[1].type', got 'custom'".
+        result = self.converter.request_from_provider(provider_request)
+        tools = list(result["tools"])
+        assert len(tools) == 2
+        assert tools[0]["type"] == "function"
+        assert tools[0]["name"] == "shell"
+        assert tools[1]["type"] == "function"
+        assert tools[1]["name"] == "apply_patch"
+        assert tools[1]["metadata"]["provider_type"] == "custom"
+
     def test_request_from_provider_malformed_tool_raises_with_context(self):
         """Test that malformed tools raise clear errors with tool type/name context."""
         provider_request = {

--- a/tests/converters/openai_responses/test_tool_ops.py
+++ b/tests/converters/openai_responses/test_tool_ops.py
@@ -100,6 +100,34 @@ class TestOpenAIResponsesToolOps:
         assert result["description"] == "Search"
         assert result["required_parameters"] == ["query"]
 
+    def test_p_tool_definition_to_ir_codex_custom_apply_patch(self):
+        """Codex ``"custom"`` tools (e.g. apply_patch) downgrade to IR function.
+
+        Regression test for the IR validation gap introduced in v0.3.0:
+        the IR ToolDefinition.type Literal only accepts ``"function"`` and
+        ``"mcp"``, so the source converter must coerce provider ``"custom"``
+        tools to ``"function"`` rather than carrying the provider type into
+        IR.  See ``types/ir/tools.py`` for the converter contract.
+        """
+        provider_tool = {
+            "type": "custom",
+            "name": "apply_patch",
+            "description": "Apply a unified-diff style patch.",
+            "format": {
+                "type": "grammar",
+                "syntax": "lark",
+                "definition": "start: ...",
+            },
+        }
+        result = OpenAIResponsesToolOps.p_tool_definition_to_ir(provider_tool)
+        assert result["type"] == "function"
+        assert result["name"] == "apply_patch"
+        assert result["description"] == "Apply a unified-diff style patch."
+        # provider_type is preserved in metadata for diagnostics.
+        assert result["metadata"]["provider_type"] == "custom"
+        assert cast(Any, result)["_passthrough"] == provider_tool
+        assert OpenAIResponsesToolOps.ir_tool_definition_to_p(result) == provider_tool
+
     def test_tool_definition_round_trip(self):
         """Test tool definition round-trip."""
         ir_tool = cast(


### PR DESCRIPTION
## Summary

Codex sends OpenAI Responses requests with hosted `"custom"` tools, notably `apply_patch` carrying a grammar `format`. The `openai_responses` source converter forwarded the provider `type` straight into IR, and since `IRRequest` runtime validation landed in #91 (v0.3.0), any value outside `Literal["function", "mcp"]` is rejected at the end of `request_from_provider`:

```
1 validation error(s): Expected one of ('function', 'mcp')
at 'tools[i].type', got 'custom'
```

This breaks Codex CLI requests before the `openai_chat` target converter's existing downgrade can run. Reported via argo-proxy's Codex integration.

## Fix

`openai_responses/tool_ops.py::p_tool_definition_to_ir` now coerces provider tool types that are outside the IR `ToolDefinition.type` literal to IR `"function"` at the provider-to-IR boundary, so runtime IR validation succeeds.

- Named custom tools such as Codex `apply_patch`: `type` is rewritten to `"function"`, `metadata["provider_type"]` keeps the original provider type for diagnostics, and the full provider payload is preserved in `_passthrough` so `format` and other provider-specific fields round-trip back to OpenAI Responses without loss.
- Unnamed hosted tools such as `web_search`: use the same IR-safe `"function"` type and keep the full original payload in `_passthrough`.
- `ToolDefinition`'s docstring now documents the source-converter contract: source converters must not forward out-of-literal provider tool types directly into IR.

## Repro (pre-fix)

```python
OpenAIResponsesConverter().request_from_provider({
    "model": "gpt-5.4",
    "input": [{"type": "message", "role": "user",
               "content": [{"type": "input_text", "text": "hi"}]}],
    "tools": [{
        "type": "custom", "name": "apply_patch",
        "description": "Apply a unified-diff style patch.",
        "format": {"type": "grammar", "syntax": "lark", "definition": "start: ..."},
    }],
})
# ValidationError: 1 validation error(s): Expected one of ('function', 'mcp')
# at 'tools[0].type', got 'custom'
```

## Test plan

- [x] `pytest -o addopts='' tests/converters/openai_responses/test_tool_ops.py tests/converters/openai_responses/test_converter.py` - 88 passed
- [x] `ty check src/llm_rosetta/converters/openai_responses/tool_ops.py tests/converters/openai_responses/test_tool_ops.py tests/converters/openai_responses/test_converter.py tests/converters/google_genai/test_converter.py tests/converters/openai_chat/test_converter.py tests/test_shims.py` - passed
- [x] New unit test `test_p_tool_definition_to_ir_codex_custom_apply_patch` covers the Codex `apply_patch` shape with grammar `format` and exact passthrough round-trip behavior
- [x] New end-to-end test `test_request_from_provider_codex_custom_tool_passes_validation` exercises `request_from_provider` plus IR validation against the bug-report tool shape

> A second commit unblocks `ty 0.0.32+` checks by adding explicit type annotations where newer ty no longer preserves narrowing through casts. It is orthogonal to the Responses custom-tool fix and kept separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
