### PR TITLE
refactor(gateway): replace starlette/uvicorn/httpx with zerodep modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,9 +77,11 @@ python-version = "3.10"
 
 [tool.ty.src]
 include = ["src", "tests"]
+exclude = ["src/llm_rosetta/_vendor"]
 
 [tool.ruff]
 target-version = "py310"
+exclude = ["src/llm_rosetta/_vendor"]
 
 [tool.ruff.lint]
 select = ["E", "F", "UP", "C901"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = ['typing_extensions>=4.0.0; python_version < "3.11"']
 openai = ["openai"]
 anthropic = ["anthropic"]
 google = ["google-genai"]
-gateway = ["starlette>=0.27.0", "uvicorn>=0.24.0", "httpx[socks]>=0.25.0"]
+gateway = ["httpx[socks]>=0.25.0"]
 dev = [
     "python-dotenv",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = ['typing_extensions>=4.0.0; python_version < "3.11"']
 openai = ["openai"]
 anthropic = ["anthropic"]
 google = ["google-genai"]
-gateway = ["httpx[socks]>=0.25.0"]
+gateway = []
 dev = [
     "python-dotenv",
     "pytest",

--- a/src/llm_rosetta/_vendor/httpclient.py
+++ b/src/llm_rosetta/_vendor/httpclient.py
@@ -1,0 +1,2306 @@
+# /// zerodep
+# version = "0.3.1"
+# deps = []
+# tier = "subsystem"
+# category = "network"
+# note = "Install/update via `zerodep add httpclient`"
+# ///
+
+"""Zero-dependency sync + async HTTP REST client.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Sync (http.client) and async (asyncio streams) HTTP/1.1 client
+for REST API consumption. Thread-safe by design.
+
+Sync usage::
+
+    response = get("https://httpbin.org/get")
+    response.json()
+
+Async usage::
+
+    response = await async_get("https://httpbin.org/get")
+    response.json()
+
+Session usage::
+
+    with Client() as client:
+        r = client.get("https://httpbin.org/get")
+
+    async with AsyncClient() as client:
+        r = await client.get("https://httpbin.org/get")
+"""
+
+# ── Imports ──
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import http.client
+import json as _json
+import logging
+import os
+import ssl
+import threading
+import time
+import warnings
+import zlib
+from collections.abc import AsyncIterator, Iterator
+from typing import IO, Any
+from urllib.parse import quote, urlencode, urlparse
+
+__all__ = [
+    # Constants
+    "DEFAULT_TIMEOUT",
+    "DEFAULT_MAX_REDIRECTS",
+    "DEFAULT_USER_AGENT",
+    "DEFAULT_POOL_SIZE",
+    "DEFAULT_POOL_IDLE_TIMEOUT",
+    # Exceptions
+    "HttpClientError",
+    "HTTPError",
+    "TooManyRedirects",
+    "HttpConnectionError",
+    "HttpTimeoutError",
+    # Response classes
+    "Response",
+    "StreamingResponse",
+    # Auth
+    "Auth",
+    "BasicAuth",
+    "DigestAuth",
+    # Sync convenience functions
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "head",
+    "options",
+    # Async convenience functions
+    "async_get",
+    "async_post",
+    "async_put",
+    "async_patch",
+    "async_delete",
+    "async_head",
+    "async_options",
+    # Client classes
+    "Client",
+    "AsyncClient",
+]
+
+# ── Constants / Defaults ──
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_MAX_REDIRECTS = 10
+DEFAULT_USER_AGENT = "zerodep-http/0.1"
+DEFAULT_POOL_SIZE = 10
+DEFAULT_POOL_IDLE_TIMEOUT = 60.0
+
+
+# ── Exceptions ──
+
+
+class HttpClientError(Exception):
+    """Base exception for all httpclient operations."""
+
+
+class HTTPError(HttpClientError):
+    """Raised on non-2xx status when raise_for_status() is called."""
+
+    def __init__(self, status_code: int, body: str, url: str) -> None:
+        self.status_code = status_code
+        self.body = body
+        self.url = url
+        super().__init__(f"HTTP {status_code} for {url}")
+
+
+class TooManyRedirects(HTTPError):
+    """Raised when redirect limit is exceeded."""
+
+    def __init__(self, url: str, max_redirects: int) -> None:
+        super().__init__(0, "", url)
+        self.max_redirects = max_redirects
+        Exception.__init__(self, f"Too many redirects (>{max_redirects}) for {url}")
+
+
+class HttpConnectionError(HttpClientError):
+    """Raised on connection failures.
+
+    Attributes:
+        host: Remote hostname that the connection targeted.
+        port: Remote port number.
+        message: Human-readable error description.
+    """
+
+    def __init__(self, message: str, *, host: str = "", port: int = 0) -> None:
+        self.host = host
+        self.port = port
+        self.message = message
+        super().__init__(message)
+
+
+class HttpTimeoutError(HttpClientError):
+    """Raised on request timeout.
+
+    Attributes:
+        url: The URL that timed out.
+        timeout: The timeout value in seconds that was exceeded.
+        message: Human-readable error description.
+    """
+
+    def __init__(self, message: str, *, url: str = "", timeout: float = 0.0) -> None:
+        self.url = url
+        self.timeout = timeout
+        self.message = message
+        super().__init__(message)
+
+
+# Backward-compatible aliases (deprecated: prefer HttpConnectionError/HttpTimeoutError)
+ConnectionError = HttpConnectionError  # noqa: A001
+TimeoutError = HttpTimeoutError  # noqa: A001
+
+
+# ── Data Models (Response) ──
+
+
+class Response:
+    """HTTP response object.
+
+    Attributes:
+        status_code: HTTP status code.
+        headers: Response headers as dict (last value wins for duplicates).
+        content: Raw response body as bytes.
+        url: Final URL after redirects.
+    """
+
+    __slots__ = ("status_code", "headers", "content", "url", "_text", "_json")
+
+    def __init__(
+        self,
+        status_code: int,
+        headers: dict[str, str],
+        content: bytes,
+        url: str,
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers
+        self.content = content
+        self.url = url
+        self._text: str | None = None
+        self._json: Any = None
+
+    @property
+    def text(self) -> str:
+        """Decode response body as text."""
+        if self._text is None:
+            encoding = self._guess_encoding()
+            self._text = self.content.decode(encoding, errors="replace")
+        return self._text
+
+    def json(self) -> Any:
+        """Parse response body as JSON."""
+        if self._json is None:
+            self._json = _json.loads(self.content)
+        return self._json
+
+    @property
+    def ok(self) -> bool:
+        """True if status_code is 2xx."""
+        return 200 <= self.status_code < 300
+
+    def raise_for_status(self) -> None:
+        """Raise HTTPError if status is not 2xx."""
+        if not self.ok:
+            raise HTTPError(self.status_code, self.text, self.url)
+
+    def _guess_encoding(self) -> str:
+        return _guess_encoding_from_headers(self.headers)
+
+    # ── Context managers (no-op, body is already fully read) ──
+
+    def __enter__(self) -> Response:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    async def __aenter__(self) -> Response:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """No-op close for a fully-read response."""
+
+    async def aclose(self) -> None:
+        """No-op async close for a fully-read response."""
+
+    def __repr__(self) -> str:
+        return f"<Response [{self.status_code}]>"
+
+
+def _guess_encoding_from_headers(headers: dict[str, str]) -> str:
+    """Extract charset from Content-Type header, default utf-8."""
+    ct = headers.get("content-type", "")
+    for part in ct.split(";"):
+        part = part.strip()
+        if part.startswith("charset="):
+            return part[8:].strip().strip('"')
+    return "utf-8"
+
+
+# ── Auth (BasicAuth, DigestAuth) ──
+
+
+class Auth:
+    """Base class for HTTP authentication."""
+
+    def auth_headers(self, method: str, url: str) -> dict[str, str]:
+        """Return authorization headers.
+
+        Args:
+            method: HTTP method.
+            url: Request URL.
+
+        Returns:
+            Dict of headers to add to the request.
+        """
+        raise NotImplementedError
+
+
+class BasicAuth(Auth):
+    """HTTP Basic authentication."""
+
+    def __init__(self, username: str, password: str) -> None:
+        self._username = username
+        self._password = password
+
+    def auth_headers(self, method: str, url: str) -> dict[str, str]:
+        """Return Basic Authorization header."""
+        credentials = f"{self._username}:{self._password}".encode()
+        return {"Authorization": "Basic " + base64.b64encode(credentials).decode()}
+
+
+class DigestAuth(Auth):
+    """HTTP Digest authentication."""
+
+    def __init__(self, username: str, password: str) -> None:
+        self._username = username
+        self._password = password
+        self._nc = 0
+
+    def auth_headers(self, method: str, url: str) -> dict[str, str]:
+        """Not usable without a server challenge."""
+        raise NotImplementedError("DigestAuth requires a server challenge")
+
+    def auth_headers_from_challenge(
+        self, method: str, path: str, challenge: str
+    ) -> dict[str, str]:
+        """Compute Digest auth headers from a WWW-Authenticate challenge.
+
+        Args:
+            method: HTTP method.
+            path: Request path (URI).
+            challenge: The WWW-Authenticate header value.
+
+        Returns:
+            Dict with the Authorization header.
+        """
+        params = _parse_digest_challenge(challenge)
+        realm = params.get("realm", "")
+        nonce = params.get("nonce", "")
+        qop = params.get("qop", "")
+        opaque = params.get("opaque", "")
+        algorithm = params.get("algorithm", "MD5").upper()
+
+        self._nc += 1
+        nc_hex = f"{self._nc:08x}"
+        cnonce = os.urandom(16).hex()
+
+        if algorithm == "SHA-256":
+            hash_fn = hashlib.sha256
+        else:
+            hash_fn = hashlib.md5
+
+        ha1 = hash_fn(f"{self._username}:{realm}:{self._password}".encode()).hexdigest()
+        ha2 = hash_fn(f"{method}:{path}".encode()).hexdigest()
+
+        if qop == "auth":
+            response = hash_fn(
+                f"{ha1}:{nonce}:{nc_hex}:{cnonce}:{qop}:{ha2}".encode()
+            ).hexdigest()
+        else:
+            response = hash_fn(f"{ha1}:{nonce}:{ha2}".encode()).hexdigest()
+
+        header = (
+            f'Digest username="{self._username}", realm="{realm}", '
+            f'nonce="{nonce}", uri="{path}", response="{response}"'
+        )
+        if qop:
+            header += f', qop={qop}, nc={nc_hex}, cnonce="{cnonce}"'
+        if opaque:
+            header += f', opaque="{opaque}"'
+        header += f", algorithm={algorithm}"
+
+        return {"Authorization": header}
+
+
+def _normalize_auth(
+    auth: tuple[str, str] | Auth | None,
+) -> Auth | None:
+    """Convert auth parameter to an Auth instance.
+
+    Args:
+        auth: A (username, password) tuple, an Auth subclass, or None.
+
+    Returns:
+        An Auth instance or None.
+    """
+    if auth is None:
+        return None
+    if isinstance(auth, tuple):
+        return BasicAuth(str(auth[0]), str(auth[1]))
+    return auth
+
+
+def _parse_digest_challenge(header_value: str) -> dict[str, str]:
+    """Parse a Digest WWW-Authenticate challenge into a dict.
+
+    Args:
+        header_value: The full WWW-Authenticate header value.
+
+    Returns:
+        Dict of challenge parameters.
+    """
+    if header_value.lower().startswith("digest "):
+        header_value = header_value[7:]
+    result: dict[str, str] = {}
+    import re
+
+    for match in re.finditer(r'(\w+)=(?:"([^"]*)"|([\w\-]+))', header_value):
+        key = match.group(1)
+        value = match.group(2) if match.group(2) is not None else match.group(3)
+        result[key] = value
+    return result
+
+
+# ── Compression / Encoding helpers ──
+
+
+def _decompress_body(body: bytes, encoding: str) -> bytes:
+    """Decompress a response body based on Content-Encoding.
+
+    Args:
+        body: The raw response body bytes.
+        encoding: The Content-Encoding value.
+
+    Returns:
+        Decompressed bytes, or original body if encoding is unsupported.
+    """
+    if encoding in ("gzip", "x-gzip"):
+        return zlib.decompress(body, 16 + zlib.MAX_WBITS)
+    if encoding == "deflate":
+        try:
+            return zlib.decompress(body, -zlib.MAX_WBITS)
+        except zlib.error:
+            return zlib.decompress(body)
+    return body
+
+
+def _make_decompressor(encoding: str) -> zlib._Decompress | None:
+    """Create a streaming decompressor for the given encoding.
+
+    Args:
+        encoding: The Content-Encoding value.
+
+    Returns:
+        A zlib.decompressobj or None if encoding is unsupported.
+    """
+    if encoding in ("gzip", "x-gzip"):
+        return zlib.decompressobj(16 + zlib.MAX_WBITS)
+    if encoding == "deflate":
+        return zlib.decompressobj(-zlib.MAX_WBITS)
+    return None
+
+
+# ── Streaming Response (state machine) ──
+
+
+class StreamingResponse:
+    """HTTP streaming response -- holds the connection open.
+
+    Use as a context manager to ensure cleanup::
+
+        with get(url, stream=True) as r:
+            for chunk in r.iter_bytes():
+                process(chunk)
+
+        async with await async_get(url, stream=True) as r:
+            async for line in r.aiter_lines():
+                handle(line)
+    """
+
+    __slots__ = (
+        "status_code",
+        "headers",
+        "url",
+        "_encoding",
+        "_decompressor",
+        "_sync_resp",
+        "_sync_conn",
+        "_async_reader",
+        "_async_writer",
+        "_async_timeout",
+        "_is_chunked",
+        "_content_length",
+        "_bytes_remaining",
+        "_closed",
+    )
+
+    status_code: int
+    headers: dict[str, str]
+    url: str
+    _encoding: str
+    _decompressor: zlib._Decompress | None
+    _sync_resp: http.client.HTTPResponse | None
+    _sync_conn: http.client.HTTPConnection | None
+    _async_reader: asyncio.StreamReader | None
+    _async_writer: asyncio.StreamWriter | None
+    _async_timeout: float | None
+    _is_chunked: bool
+    _content_length: int | None
+    _bytes_remaining: int | None
+    _closed: bool
+
+    def __init__(self) -> None:
+        raise TypeError("Use _from_sync() or _from_async()")
+
+    @classmethod
+    def _from_sync(
+        cls,
+        status_code: int,
+        headers: dict[str, str],
+        url: str,
+        resp: http.client.HTTPResponse,
+        conn: http.client.HTTPConnection,
+        content_encoding: str = "",
+    ) -> "StreamingResponse":
+        obj = object.__new__(cls)
+        obj.status_code = status_code
+        obj.headers = headers
+        obj.url = url
+        obj._encoding = _guess_encoding_from_headers(headers)
+        obj._decompressor = (
+            _make_decompressor(content_encoding) if content_encoding else None
+        )
+        obj._sync_resp = resp
+        obj._sync_conn = conn
+        obj._async_reader = None
+        obj._async_writer = None
+        obj._async_timeout = None
+        obj._is_chunked = False
+        obj._content_length = None
+        obj._bytes_remaining = None
+        obj._closed = False
+        return obj
+
+    @classmethod
+    def _from_async(
+        cls,
+        status_code: int,
+        headers: dict[str, str],
+        url: str,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        is_chunked: bool,
+        content_length: int | None,
+        timeout: float,
+        content_encoding: str = "",
+    ) -> "StreamingResponse":
+        obj = object.__new__(cls)
+        obj.status_code = status_code
+        obj.headers = headers
+        obj.url = url
+        obj._encoding = _guess_encoding_from_headers(headers)
+        obj._decompressor = (
+            _make_decompressor(content_encoding) if content_encoding else None
+        )
+        obj._sync_resp = None
+        obj._sync_conn = None
+        obj._async_reader = reader
+        obj._async_writer = writer
+        obj._async_timeout = timeout
+        obj._is_chunked = is_chunked
+        obj._content_length = content_length
+        obj._bytes_remaining = content_length
+        obj._closed = False
+        return obj
+
+    @property
+    def ok(self) -> bool:
+        """True if status_code is 2xx."""
+        return 200 <= self.status_code < 300
+
+    def raise_for_status(self) -> None:
+        """Raise HTTPError if status is not 2xx."""
+        if not self.ok:
+            raise HTTPError(self.status_code, "", self.url)
+
+    # ── Sync iteration ──
+
+    def iter_bytes(self, chunk_size: int = 4096) -> Iterator[bytes]:
+        """Yield response body in chunks."""
+        if self._sync_resp is None:
+            raise RuntimeError("iter_bytes() on async response")
+        try:
+            while True:
+                chunk = self._sync_resp.read(chunk_size)
+                if not chunk:
+                    break
+                if self._decompressor:
+                    chunk = self._decompressor.decompress(chunk)
+                yield chunk
+            if self._decompressor:
+                remaining = self._decompressor.flush()
+                if remaining:
+                    yield remaining
+        except (OSError, http.client.HTTPException) as exc:
+            raise HttpConnectionError(str(exc)) from exc
+
+    def iter_lines(self) -> Iterator[str]:
+        """Yield response body line by line (decoded)."""
+        if self._sync_resp is None:
+            raise RuntimeError("iter_lines() on async response")
+        try:
+            while True:
+                line = self._sync_resp.readline()
+                if not line:
+                    break
+                yield line.decode(self._encoding, errors="replace").rstrip("\r\n")
+        except (OSError, http.client.HTTPException) as exc:
+            raise HttpConnectionError(str(exc)) from exc
+
+    def read(self) -> bytes:
+        """Consume entire stream into bytes."""
+        return b"".join(self.iter_bytes())
+
+    # ── Async iteration ──
+
+    async def aiter_bytes(self, chunk_size: int = 4096) -> AsyncIterator[bytes]:
+        """Async yield response body in chunks."""
+        if self._async_reader is None:
+            raise RuntimeError("aiter_bytes() on sync response")
+        try:
+            raw_iter = self._select_raw_iterator(chunk_size)
+            async for chunk in raw_iter:
+                if self._decompressor:
+                    chunk = self._decompressor.decompress(chunk)
+                yield chunk
+            if self._decompressor:
+                remaining = self._decompressor.flush()
+                if remaining:
+                    yield remaining
+        except asyncio.TimeoutError:
+            raise HttpTimeoutError(
+                f"Streaming read timed out for {self.url}",
+                url=self.url,
+                timeout=self._async_timeout or 0.0,
+            )
+        except OSError as exc:
+            raise HttpConnectionError(str(exc)) from exc
+
+    async def _select_raw_iterator(self, chunk_size: int) -> AsyncIterator[bytes]:
+        """Select and yield from the appropriate raw byte iterator."""
+        if self._is_chunked:
+            async for chunk in self._aiter_chunked():
+                yield chunk
+        elif self._bytes_remaining is not None:
+            async for chunk in self._aiter_fixed_length(chunk_size):
+                yield chunk
+        else:
+            async for chunk in self._aiter_until_eof(chunk_size):
+                yield chunk
+
+    async def _aiter_fixed_length(self, chunk_size: int) -> AsyncIterator[bytes]:
+        """Read a known-length response body in chunks."""
+        assert self._async_reader is not None
+        while self._bytes_remaining is not None and self._bytes_remaining > 0:
+            to_read = min(chunk_size, self._bytes_remaining)
+            data = await asyncio.wait_for(
+                self._async_reader.read(to_read),
+                timeout=self._async_timeout,
+            )
+            if not data:
+                break
+            self._bytes_remaining -= len(data)
+            yield data
+
+    async def _aiter_until_eof(self, chunk_size: int) -> AsyncIterator[bytes]:
+        """Read response body until EOF in chunks."""
+        assert self._async_reader is not None
+        while True:
+            data = await asyncio.wait_for(
+                self._async_reader.read(chunk_size),
+                timeout=self._async_timeout,
+            )
+            if not data:
+                break
+            yield data
+
+    async def _aiter_chunked(self) -> AsyncIterator[bytes]:
+        """Decode chunked transfer encoding from async reader."""
+        assert self._async_reader is not None  # guaranteed by aiter_bytes guard
+        reader = self._async_reader
+        timeout = self._async_timeout
+        while True:
+            size_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+            size_str = size_line.decode("latin-1").split(";")[0].strip()
+            if not size_str:
+                break
+            chunk_size = int(size_str, 16)
+            if chunk_size == 0:
+                await asyncio.wait_for(
+                    reader.readline(), timeout=timeout
+                )  # trailing \r\n
+                break
+            data = await asyncio.wait_for(
+                reader.readexactly(chunk_size), timeout=timeout
+            )
+            await asyncio.wait_for(reader.readline(), timeout=timeout)  # trailing \r\n
+            yield data
+
+    async def aiter_lines(self) -> AsyncIterator[str]:
+        """Async yield response body line by line (decoded)."""
+        buf = ""
+        async for chunk in self.aiter_bytes():
+            buf += chunk.decode(self._encoding, errors="replace")
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                yield line.rstrip("\r")
+        if buf:
+            yield buf.rstrip("\r")
+
+    async def aread(self) -> bytes:
+        """Async consume entire stream into bytes."""
+        parts = []
+        async for chunk in self.aiter_bytes():
+            parts.append(chunk)
+        return b"".join(parts)
+
+    # ── Context managers ──
+
+    def __enter__(self) -> "StreamingResponse":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "StreamingResponse":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.aclose()
+
+    def close(self) -> None:
+        """Close the underlying sync connection."""
+        if self._closed:
+            return
+        self._closed = True
+        # Tier 2: best-effort observable -- active streaming resource
+        if self._sync_resp is not None:
+            try:
+                self._sync_resp.close()
+            except Exception:
+                logger.debug(
+                    "failed to close sync response for %s",
+                    self.url,
+                    exc_info=True,
+                )
+        if self._sync_conn is not None:
+            try:
+                self._sync_conn.close()
+            except Exception:
+                logger.debug(
+                    "failed to close sync connection for %s",
+                    self.url,
+                    exc_info=True,
+                )
+
+    async def aclose(self) -> None:
+        """Close the underlying async connection."""
+        if self._closed:
+            return
+        self._closed = True
+        # Tier 2: best-effort observable -- active streaming resource
+        if self._async_writer is not None:
+            try:
+                self._async_writer.close()
+                await self._async_writer.wait_closed()
+            except Exception:
+                logger.debug(
+                    "failed to close async writer for %s",
+                    self.url,
+                    exc_info=True,
+                )
+
+    def __del__(self) -> None:
+        if not self._closed:
+            warnings.warn(
+                f"Unclosed StreamingResponse for {self.url}",
+                ResourceWarning,
+                stacklevel=2,
+            )
+            self.close()
+
+    def __repr__(self) -> str:
+        return f"<StreamingResponse [{self.status_code}]>"
+
+
+# ── Connection Pools (Sync + Async) ──
+
+
+class _SyncConnectionPool:
+    """Thread-safe connection pool for sync HTTP connections.
+
+    Pool lifecycle rules:
+        - A connection CAN be returned to the pool when a non-streaming
+          request completes successfully AND the server did not send a
+          ``Connection: close`` header.
+        - A connection MUST be discarded (not returned) when:
+          (a) an error occurred during the request/response cycle,
+          (b) the server sent ``Connection: close``,
+          (c) the request used a proxy (proxy connections are not pooled),
+          (d) streaming mode is active (the connection is owned by
+              StreamingResponse until it is closed/consumed).
+        - Streaming responses bypass the pool entirely: the connection is
+          handed to StreamingResponse, which closes it on ``close()`` or
+          ``__del__``.  The connection is never returned to the pool.
+    """
+
+    def __init__(self, pool_size: int = DEFAULT_POOL_SIZE) -> None:
+        self._pool: dict[
+            tuple[str, int, bool],
+            list[tuple[http.client.HTTPConnection, float]],
+        ] = {}
+        self._pool_size = pool_size
+        self._lock = threading.Lock()
+
+    def acquire(
+        self,
+        host: str,
+        port: int,
+        is_https: bool,
+        timeout: float,
+        verify: bool,
+    ) -> http.client.HTTPConnection | None:
+        """Acquire a connection from the pool if available.
+
+        Args:
+            host: Target hostname.
+            port: Target port.
+            is_https: Whether the connection uses TLS.
+            timeout: Connection timeout.
+            verify: Whether to verify TLS certificates.
+
+        Returns:
+            A reusable connection or None.
+        """
+        key = (host, port, is_https)
+        now = time.monotonic()
+        with self._lock:
+            conns = self._pool.get(key, [])
+            while conns:
+                conn, timestamp = conns.pop()
+                if now - timestamp > DEFAULT_POOL_IDLE_TIMEOUT:
+                    # Tier 3: best-effort silent -- stale connection eviction
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+                    continue
+                if conn.sock is not None and conn.sock.fileno() != -1:
+                    return conn
+                # Tier 3: best-effort silent -- dead connection eviction
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+        return None
+
+    def release(
+        self,
+        host: str,
+        port: int,
+        is_https: bool,
+        conn: http.client.HTTPConnection,
+    ) -> None:
+        """Return a connection to the pool.
+
+        Args:
+            host: Target hostname.
+            port: Target port.
+            is_https: Whether the connection uses TLS.
+            conn: The connection to return.
+        """
+        key = (host, port, is_https)
+        with self._lock:
+            conns = self._pool.setdefault(key, [])
+            if len(conns) < self._pool_size:
+                conns.append((conn, time.monotonic()))
+            else:
+                # Tier 3: best-effort silent -- pool overflow discard
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+
+    def close_all(self) -> None:
+        """Close all pooled connections."""
+        with self._lock:
+            for conns in self._pool.values():
+                for conn, _ in conns:
+                    # Tier 3: best-effort silent -- bulk shutdown
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+            self._pool.clear()
+
+
+class _AsyncConnectionPool:
+    """Async connection pool for async HTTP connections.
+
+    Pool lifecycle rules:
+        - A connection CAN be returned to the pool when a non-streaming
+          request completes successfully AND the server did not send a
+          ``Connection: close`` header.
+        - A connection MUST be discarded (not returned) when:
+          (a) an error occurred during the request/response cycle,
+          (b) the server sent ``Connection: close``,
+          (c) the request used a proxy (proxy connections are not pooled),
+          (d) streaming mode is active (the connection is owned by
+              StreamingResponse until it is closed/consumed).
+        - Streaming responses bypass the pool entirely: the reader/writer
+          pair is handed to StreamingResponse, which closes it on
+          ``aclose()`` or ``__del__``.  The pair is never returned to
+          the pool.
+    """
+
+    def __init__(self, pool_size: int = DEFAULT_POOL_SIZE) -> None:
+        self._pool: dict[
+            tuple[str, int, bool],
+            list[
+                tuple[
+                    asyncio.StreamReader,
+                    asyncio.StreamWriter,
+                    float,
+                ]
+            ],
+        ] = {}
+        self._pool_size = pool_size
+        self._lock = asyncio.Lock()
+
+    async def acquire(
+        self,
+        host: str,
+        port: int,
+        is_https: bool,
+        timeout: float,
+        verify: bool,
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter] | None:
+        """Acquire a connection from the pool if available.
+
+        Args:
+            host: Target hostname.
+            port: Target port.
+            is_https: Whether the connection uses TLS.
+            timeout: Connection timeout.
+            verify: Whether to verify TLS certificates.
+
+        Returns:
+            A (reader, writer) tuple or None.
+        """
+        key = (host, port, is_https)
+        now = time.monotonic()
+        async with self._lock:
+            conns = self._pool.get(key, [])
+            while conns:
+                reader, writer, timestamp = conns.pop()
+                if now - timestamp > DEFAULT_POOL_IDLE_TIMEOUT:
+                    # Tier 3: best-effort silent -- stale connection eviction
+                    try:
+                        writer.close()
+                        await writer.wait_closed()
+                    except Exception:
+                        pass
+                    continue
+                if not reader.at_eof():
+                    return reader, writer
+                # Tier 3: best-effort silent -- dead connection eviction
+                try:
+                    writer.close()
+                    await writer.wait_closed()
+                except Exception:
+                    pass
+        return None
+
+    async def release(
+        self,
+        host: str,
+        port: int,
+        is_https: bool,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """Return a connection to the pool.
+
+        Args:
+            host: Target hostname.
+            port: Target port.
+            is_https: Whether the connection uses TLS.
+            reader: The stream reader.
+            writer: The stream writer.
+        """
+        key = (host, port, is_https)
+        async with self._lock:
+            conns = self._pool.setdefault(key, [])
+            if len(conns) < self._pool_size:
+                conns.append((reader, writer, time.monotonic()))
+            else:
+                # Tier 3: best-effort silent -- pool overflow discard
+                try:
+                    writer.close()
+                    await writer.wait_closed()
+                except Exception:
+                    pass
+
+    async def close_all(self) -> None:
+        """Close all pooled connections."""
+        async with self._lock:
+            for conns in self._pool.values():
+                for _, writer, _ in conns:
+                    # Tier 3: best-effort silent -- bulk shutdown
+                    try:
+                        writer.close()
+                        await writer.wait_closed()
+                    except Exception:
+                        pass
+            self._pool.clear()
+
+
+# ── Transport (request execution) ──
+
+# -- Proxy helpers --
+
+
+def _parse_proxy(proxy: str) -> tuple[str, int, str | None, str | None]:
+    """Parse a proxy URL into components.
+
+    Args:
+        proxy: Proxy URL (e.g. "http://user:pass@host:port").
+
+    Returns:
+        Tuple of (hostname, port, username_or_None, password_or_None).
+    """
+    parsed = urlparse(proxy)
+    hostname = parsed.hostname or ""
+    port = parsed.port or 8080
+    username = parsed.username or None
+    password = parsed.password or None
+    return hostname, port, username, password
+
+
+def _proxy_auth_header(username: str, password: str) -> str:
+    """Build a Proxy-Authorization Basic header value.
+
+    Args:
+        username: Proxy username.
+        password: Proxy password.
+
+    Returns:
+        The header value string.
+    """
+    credentials = f"{username}:{password}".encode()
+    return "Basic " + base64.b64encode(credentials).decode()
+
+
+# -- URL helpers --
+
+
+def _build_url(url: str, params: dict[str, Any] | None = None) -> str:
+    """Append query parameters to URL."""
+    if not params:
+        return url
+    sep = "&" if "?" in url else "?"
+    encoded = urlencode(
+        {k: v for k, v in params.items() if v is not None}, quote_via=quote
+    )
+    return f"{url}{sep}{encoded}"
+
+
+def _parse_url(url: str) -> tuple[str, str, int, str, bool]:
+    """Parse URL into (scheme, host, port, path, is_https)."""
+    parsed = urlparse(url)
+    is_https = parsed.scheme == "https"
+    host = parsed.hostname or ""
+    port = parsed.port or (443 if is_https else 80)
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    return parsed.scheme, host, port, path, is_https
+
+
+# -- Shared request preparation helpers --
+
+
+def _prepare_request(
+    method: str,
+    url: str,
+    headers: dict[str, str] | None,
+    data: bytes | str | dict[str, str] | None,
+    json_data: Any,
+    files: dict[str, Any] | list[tuple[str, Any]] | None,
+    params: dict[str, Any] | None,
+    auth: tuple[str, str] | Auth | None,
+) -> tuple[str, bytes | None, dict[str, str], Auth | None]:
+    """Build URL, encode body, assemble headers, and normalize auth.
+
+    Shared by _sync_request and _async_request (Phases 1-3).
+
+    Returns:
+        (final_url, body_bytes, request_headers, auth_object).
+    """
+    url = _build_url(url, params)
+    body, content_type = _prepare_body(data, json_data, files)
+
+    req_headers: dict[str, str] = {
+        "User-Agent": DEFAULT_USER_AGENT,
+        "Accept-Encoding": "gzip, deflate",
+    }
+    if content_type:
+        req_headers["Content-Type"] = content_type
+    if body is not None:
+        req_headers["Content-Length"] = str(len(body))
+    req_headers.update(headers or {})
+
+    auth_obj = _normalize_auth(auth)
+    if isinstance(auth_obj, BasicAuth):
+        req_headers.update(auth_obj.auth_headers(method, url))
+
+    return url, body, req_headers, auth_obj
+
+
+def _compute_redirect(
+    status: int,
+    method: str,
+    body: bytes | None,
+    req_headers: dict[str, str],
+    resp_headers: dict[str, str],
+    scheme: str,
+    host: str,
+    port: int,
+    url: str,
+    redirects: int,
+    max_redirects: int,
+) -> tuple[str, str, bytes | None]:
+    """Compute redirect target and adjust method/body.
+
+    Raises:
+        TooManyRedirects: If redirect limit exceeded.
+
+    Returns:
+        (new_url, new_method, new_body).
+    """
+    redirects_now = redirects + 1
+    if redirects_now > max_redirects:
+        raise TooManyRedirects(url, max_redirects)
+    location = resp_headers["location"]
+    if location.startswith("/"):
+        new_url = f"{scheme}://{host}:{port}{location}"
+    else:
+        new_url = location
+    new_method = method
+    new_body = body
+    if status == 303 or (status in (301, 302) and method == "POST"):
+        new_method = "GET"
+        new_body = None
+        req_headers.pop("Content-Type", None)
+        req_headers.pop("Content-Length", None)
+    return new_url, new_method, new_body
+
+
+def _is_redirect(status: int, resp_headers: dict[str, str]) -> bool:
+    """Check whether the response is a redirect with a location header."""
+    return status in (301, 302, 303, 307, 308) and "location" in resp_headers
+
+
+def _should_attempt_digest(
+    auth_obj: Auth | None,
+    status: int,
+    resp_headers: dict[str, str],
+    digest_attempted: bool,
+) -> bool:
+    """Return True if a Digest auth retry should be attempted."""
+    return (
+        isinstance(auth_obj, DigestAuth)
+        and status == 401
+        and not digest_attempted
+        and resp_headers.get("www-authenticate", "").lower().startswith("digest")
+    )
+
+
+def _make_ssl_context(verify: bool) -> ssl.SSLContext:
+    """Create an SSL context based on verification setting."""
+    if verify:
+        return ssl.create_default_context()
+    return ssl._create_unverified_context()
+
+
+# -- Sync transport helpers --
+
+
+def _sync_connect_via_proxy(
+    host: str,
+    port: int,
+    path: str,
+    is_https: bool,
+    timeout: float,
+    verify: bool,
+    proxy: str,
+    req_headers: dict[str, str],
+    url: str,
+) -> tuple[http.client.HTTPConnection, str]:
+    """Establish a sync connection through an HTTP proxy.
+
+    For plain HTTP, connects to the proxy directly.
+    For HTTPS, opens a CONNECT tunnel and wraps with TLS.
+
+    Returns:
+        (connection, request_path).
+    """
+    proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
+    if not is_https:
+        conn = http.client.HTTPConnection(proxy_host, proxy_port, timeout=timeout)
+        if proxy_user and proxy_pass:
+            req_headers["Proxy-Authorization"] = _proxy_auth_header(
+                proxy_user, proxy_pass
+            )
+        # For HTTP proxies, the full URL is used as the request path
+        return conn, url
+
+    # CONNECT tunnel for HTTPS through proxy
+    tunnel_conn = http.client.HTTPConnection(proxy_host, proxy_port, timeout=timeout)
+    connect_headers: dict[str, str] = {"Host": f"{host}:{port}"}
+    if proxy_user and proxy_pass:
+        connect_headers["Proxy-Authorization"] = _proxy_auth_header(
+            proxy_user, proxy_pass
+        )
+    tunnel_conn.request("CONNECT", f"{host}:{port}", headers=connect_headers)
+    tunnel_resp = tunnel_conn.getresponse()
+    if tunnel_resp.status != 200:
+        tunnel_conn.close()
+        raise HttpConnectionError(
+            f"CONNECT tunnel failed: {tunnel_resp.status}",
+            host=host,
+            port=port,
+        )
+    tunnel_resp.read()
+    sock = tunnel_conn.sock
+    ctx = _make_ssl_context(verify)
+    wrapped = ctx.wrap_socket(sock, server_hostname=host)
+    conn = http.client.HTTPSConnection(host, port, timeout=timeout, context=ctx)
+    conn.sock = wrapped
+    return conn, path
+
+
+def _sync_acquire_connection(
+    host: str,
+    port: int,
+    path: str,
+    is_https: bool,
+    timeout: float,
+    verify: bool,
+    proxy: str | None,
+    _pool: _SyncConnectionPool | None,
+    req_headers: dict[str, str],
+    url: str,
+) -> tuple[http.client.HTTPConnection, str]:
+    """Acquire a sync HTTP connection via proxy, pool, or direct creation.
+
+    Returns:
+        (connection, request_path).
+    """
+    if proxy:
+        return _sync_connect_via_proxy(
+            host, port, path, is_https, timeout, verify, proxy, req_headers, url
+        )
+
+    if _pool:
+        pooled_conn = _pool.acquire(host, port, is_https, timeout, verify)
+        if pooled_conn is not None:
+            req_headers["Connection"] = "keep-alive"
+            return pooled_conn, path
+
+    # Direct connection
+    if is_https:
+        ctx = _make_ssl_context(verify)
+        conn = http.client.HTTPSConnection(host, port, timeout=timeout, context=ctx)
+    else:
+        conn = http.client.HTTPConnection(host, port, timeout=timeout)
+    return conn, path
+
+
+def _sync_release_or_close(
+    close_conn: bool,
+    _pool: _SyncConnectionPool | None,
+    proxy: str | None,
+    stream: bool,
+    resp_headers: dict[str, str],
+    host: str,
+    port: int,
+    is_https: bool,
+    conn: http.client.HTTPConnection,
+) -> None:
+    """Release a sync connection back to the pool or close it.
+
+    Pool reuse decision: a connection is returned to the pool
+    only when ALL of the following hold:
+      - close_conn is True (not handed off to streaming)
+      - a pool is active (_pool is not None)
+      - the request did not use a proxy
+      - the request is not streaming
+      - the server did not send "Connection: close"
+    Otherwise the connection is closed immediately.
+    """
+    if not close_conn:
+        return
+    if (
+        _pool
+        and not proxy
+        and not stream
+        and resp_headers.get("connection", "").lower() != "close"
+    ):
+        _pool.release(host, port, is_https, conn)
+    else:
+        conn.close()
+
+
+def _build_sync_response(
+    status: int,
+    resp_headers: dict[str, str],
+    url: str,
+    resp: http.client.HTTPResponse,
+    conn: http.client.HTTPConnection,
+    stream: bool,
+) -> tuple[Response | StreamingResponse, bool]:
+    """Build a final sync response (streaming or buffered).
+
+    Returns:
+        (response, close_conn) -- close_conn is False when streaming.
+    """
+    content_encoding = resp_headers.get("content-encoding", "")
+    if stream:
+        return StreamingResponse._from_sync(
+            status,
+            resp_headers,
+            url,
+            resp,
+            conn,
+            content_encoding=content_encoding,
+        ), False
+
+    resp_body = resp.read()
+    if content_encoding:
+        resp_body = _decompress_body(resp_body, content_encoding)
+    return Response(status, resp_headers, resp_body, url), True
+
+
+def _wrap_sync_errors(
+    exc: Exception,
+    host: str,
+    port: int,
+    url: str,
+    timeout: float,
+) -> HttpClientError:
+    """Translate low-level sync exceptions into httpclient exceptions."""
+    if isinstance(exc, (HttpTimeoutError, HttpConnectionError, TooManyRedirects)):
+        return exc
+    if isinstance(exc, (OSError, http.client.HTTPException)):
+        return HttpConnectionError(
+            f"Connection to {host}:{port} failed: {exc}",
+            host=host,
+            port=port,
+        )
+    if "timed out" in str(exc).lower():
+        msg = f"Request to {url} timed out after {timeout}s"
+        return HttpTimeoutError(msg, url=url, timeout=timeout)
+    return exc  # type: ignore[return-value]
+
+
+# -- Sync transport --
+
+
+def _sync_request(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    data: bytes | str | dict[str, str] | None = None,
+    json: Any = None,
+    files: dict[str, Any] | list[tuple[str, Any]] | None = None,
+    params: dict[str, Any] | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    max_redirects: int = DEFAULT_MAX_REDIRECTS,
+    verify: bool = True,
+    stream: bool = False,
+    auth: tuple[str, str] | Auth | None = None,
+    proxy: str | None = None,
+    _pool: _SyncConnectionPool | None = None,
+) -> Response | StreamingResponse:
+    """Perform a synchronous HTTP request.
+
+    Phase structure (mirrors _async_request):
+        1-3. Request preparation (URL, body, headers, auth)
+        4. Redirect loop:
+           a. URL parsing + connection acquisition
+           b. Send request + read response
+           c. Handle redirects / digest auth / response construction
+           d. Connection lifecycle (pool release or close)
+    """
+    url, body, req_headers, auth_obj = _prepare_request(
+        method, url, headers, data, json, files, params, auth
+    )
+
+    redirects = 0
+    _digest_attempted = False
+    while True:
+        scheme, host, port, path, is_https = _parse_url(url)
+        close_conn = True
+        resp_headers: dict[str, str] = {}
+        try:
+            conn, request_path = _sync_acquire_connection(
+                host,
+                port,
+                path,
+                is_https,
+                timeout,
+                verify,
+                proxy,
+                _pool,
+                req_headers,
+                url,
+            )
+            if _pool and not proxy:
+                req_headers.setdefault("Connection", "keep-alive")
+
+            try:
+                conn.request(method, request_path, body=body, headers=req_headers)
+                resp = conn.getresponse()
+                resp_headers = {k.lower(): v for k, v in resp.getheaders()}
+                status = resp.status
+
+                if _is_redirect(status, resp_headers):
+                    resp.read()
+                    url, method, body = _compute_redirect(
+                        status,
+                        method,
+                        body,
+                        req_headers,
+                        resp_headers,
+                        scheme,
+                        host,
+                        port,
+                        url,
+                        redirects,
+                        max_redirects,
+                    )
+                    redirects += 1
+                    continue
+
+                if _should_attempt_digest(
+                    auth_obj, status, resp_headers, _digest_attempted
+                ):
+                    resp.read()
+                    www_auth = resp_headers["www-authenticate"]
+                    req_headers.update(
+                        auth_obj.auth_headers_from_challenge(method, path, www_auth)
+                    )
+                    _digest_attempted = True
+                    conn.close()
+                    continue
+
+                result, close_conn = _build_sync_response(
+                    status,
+                    resp_headers,
+                    url,
+                    resp,
+                    conn,
+                    stream,
+                )
+                return result
+            finally:
+                _sync_release_or_close(
+                    close_conn,
+                    _pool,
+                    proxy,
+                    stream,
+                    resp_headers,
+                    host,
+                    port,
+                    is_https,
+                    conn,
+                )
+        except Exception as exc:
+            wrapped = _wrap_sync_errors(exc, host, port, url, timeout)
+            if wrapped is exc:
+                raise
+            raise wrapped from exc
+
+
+# -- Async transport helpers --
+
+
+async def _async_read_response_headers(
+    reader: asyncio.StreamReader,
+    timeout: float,
+) -> tuple[int, dict[str, str]]:
+    """Read HTTP status line and headers from an asyncio StreamReader.
+
+    Does NOT consume the body -- the reader is left positioned at the
+    start of the response body.
+
+    Returns:
+        (status_code, headers_dict).
+    """
+    # Status line: "HTTP/1.1 200 OK\r\n"
+    status_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+    status_str = status_line.decode("latin-1").rstrip("\r\n")
+    parts = status_str.split(" ", 2)
+    if len(parts) < 2:
+        raise HttpConnectionError(f"Malformed status line: {status_str}")
+    status_code = int(parts[1])
+
+    # Headers until empty line
+    headers: dict[str, str] = {}
+    while True:
+        line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+        decoded = line.decode("latin-1").rstrip("\r\n")
+        if not decoded:
+            break
+        if ":" in decoded:
+            k, v = decoded.split(":", 1)
+            headers[k.strip().lower()] = v.strip()
+
+    return status_code, headers
+
+
+async def _async_read_chunked_body(
+    reader: asyncio.StreamReader,
+    timeout: float,
+) -> bytes:
+    """Read a chunked transfer-encoded body from an asyncio StreamReader."""
+    parts: list[bytes] = []
+    while True:
+        size_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+        size_str = size_line.decode("latin-1").split(";")[0].strip()
+        if not size_str:
+            break
+        chunk_size = int(size_str, 16)
+        if chunk_size == 0:
+            await asyncio.wait_for(reader.readline(), timeout=timeout)  # trailing \r\n
+            break
+        data = await asyncio.wait_for(reader.readexactly(chunk_size), timeout=timeout)
+        await asyncio.wait_for(reader.readline(), timeout=timeout)  # trailing \r\n
+        parts.append(data)
+    return b"".join(parts)
+
+
+async def _async_read_body(
+    reader: asyncio.StreamReader,
+    headers: dict[str, str],
+    timeout: float,
+) -> bytes:
+    """Read the response body based on Content-Length or Transfer-Encoding.
+
+    Falls back to reading until EOF when neither header is present.
+    """
+    te = headers.get("transfer-encoding", "")
+    if te.lower() == "chunked":
+        return await _async_read_chunked_body(reader, timeout)
+
+    cl = headers.get("content-length")
+    if cl is not None:
+        length = int(cl)
+        if length == 0:
+            return b""
+        return await asyncio.wait_for(reader.readexactly(length), timeout=timeout)
+
+    # No Content-Length, no chunked -- read until EOF
+    return await asyncio.wait_for(reader.read(), timeout=timeout)
+
+
+# -- Async connection helpers --
+
+
+async def _async_connect_via_proxy_plain(
+    host: str,
+    port: int,
+    timeout: float,
+    proxy: str,
+    req_headers: dict[str, str],
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, str]:
+    """Connect to a plain HTTP target through a proxy.
+
+    Returns:
+        (reader, writer, request_path) where request_path is the full URL.
+    """
+    proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
+    reader, writer = await asyncio.wait_for(
+        asyncio.open_connection(proxy_host, proxy_port),
+        timeout=timeout,
+    )
+    request_path = f"http://{host}:{port}/"  # will be overridden by caller
+    if proxy_user and proxy_pass:
+        req_headers["Proxy-Authorization"] = _proxy_auth_header(proxy_user, proxy_pass)
+    return reader, writer, request_path
+
+
+async def _async_connect_via_proxy_tunnel(
+    host: str,
+    port: int,
+    timeout: float,
+    verify: bool,
+    proxy: str,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Open a CONNECT tunnel through a proxy and upgrade to TLS.
+
+    Returns:
+        (reader, writer) with TLS already established.
+    """
+    proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
+    proxy_reader, proxy_writer = await asyncio.wait_for(
+        asyncio.open_connection(proxy_host, proxy_port),
+        timeout=timeout,
+    )
+    connect_line = f"CONNECT {host}:{port} HTTP/1.1\r\n"
+    connect_headers = f"Host: {host}:{port}\r\n"
+    if proxy_user and proxy_pass:
+        connect_headers += (
+            f"Proxy-Authorization: {_proxy_auth_header(proxy_user, proxy_pass)}\r\n"
+        )
+    connect_headers += "\r\n"
+    proxy_writer.write((connect_line + connect_headers).encode("latin-1"))
+    await asyncio.wait_for(proxy_writer.drain(), timeout=timeout)
+    tunnel_status, _ = await _async_read_response_headers(proxy_reader, timeout)
+    if tunnel_status != 200:
+        proxy_writer.close()
+        # Tier 3: best-effort silent -- proxy tunnel teardown
+        try:
+            await proxy_writer.wait_closed()
+        except Exception:
+            pass
+        raise HttpConnectionError(
+            f"CONNECT tunnel failed: {tunnel_status}",
+            host=host,
+            port=port,
+        )
+    # Upgrade to TLS over the tunnel
+    ctx = _make_ssl_context(verify)
+    loop = asyncio.get_event_loop()
+    transport = proxy_writer.transport
+    new_transport = await loop.start_tls(
+        transport, transport.get_protocol(), ctx, server_hostname=host
+    )
+    proxy_writer._transport = new_transport  # type: ignore[attr-defined]
+    return proxy_reader, proxy_writer
+
+
+async def _async_acquire_connection(
+    host: str,
+    port: int,
+    path: str,
+    is_https: bool,
+    timeout: float,
+    verify: bool,
+    proxy: str | None,
+    _pool: _AsyncConnectionPool | None,
+    req_headers: dict[str, str],
+    url: str,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, str]:
+    """Acquire an async connection via proxy, pool, or direct creation.
+
+    Wraps connection errors into HttpConnectionError / HttpTimeoutError.
+
+    Returns:
+        (reader, writer, request_path).
+    """
+    try:
+        if proxy:
+            if not is_https:
+                proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
+                reader, writer = await asyncio.wait_for(
+                    asyncio.open_connection(proxy_host, proxy_port),
+                    timeout=timeout,
+                )
+                if proxy_user and proxy_pass:
+                    req_headers["Proxy-Authorization"] = _proxy_auth_header(
+                        proxy_user, proxy_pass
+                    )
+                return reader, writer, url
+            reader, writer = await _async_connect_via_proxy_tunnel(
+                host, port, timeout, verify, proxy
+            )
+            return reader, writer, path
+
+        if _pool:
+            result = await _pool.acquire(host, port, is_https, timeout, verify)
+            if result is not None:
+                reader, writer = result
+                req_headers["Connection"] = "keep-alive"
+                return reader, writer, path
+
+        # Direct connection
+        ctx = _make_ssl_context(verify) if is_https else None
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port, ssl=ctx),
+            timeout=timeout,
+        )
+        return reader, writer, path
+    except asyncio.TimeoutError:
+        msg = f"Connection to {host}:{port} timed out after {timeout}s"
+        raise HttpTimeoutError(msg, url=url, timeout=timeout)
+    except OSError as exc:
+        raise HttpConnectionError(
+            f"Connection to {host}:{port} failed: {exc}",
+            host=host,
+            port=port,
+        ) from exc
+
+
+def _build_raw_http_request(
+    method: str,
+    request_path: str,
+    host: str,
+    req_headers: dict[str, str],
+    use_pool: bool,
+    use_proxy: bool,
+) -> bytes:
+    """Construct raw HTTP/1.1 request bytes for async transport.
+
+    Args:
+        method: HTTP method.
+        request_path: The request path or full URL (for proxy).
+        host: Target hostname.
+        req_headers: Request headers dict.
+        use_pool: Whether connection pooling is active.
+        use_proxy: Whether a proxy is being used.
+
+    Returns:
+        Encoded HTTP/1.1 request bytes (without body).
+    """
+    request_line = f"{method} {request_path} HTTP/1.1\r\n"
+    header_lines = f"Host: {host}\r\n"
+    for k, v in req_headers.items():
+        header_lines += f"{k}: {v}\r\n"
+    if not use_pool or use_proxy:
+        header_lines += "Connection: close\r\n"
+    header_lines += "\r\n"
+    return (request_line + header_lines).encode("latin-1")
+
+
+async def _async_release_or_close(
+    close_writer: bool,
+    _pool: _AsyncConnectionPool | None,
+    proxy: str | None,
+    stream: bool,
+    resp_headers: dict[str, str],
+    host: str,
+    port: int,
+    is_https: bool,
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    """Release an async connection back to the pool or close it.
+
+    Pool reuse decision: a connection is returned to the pool
+    only when ALL of the following hold:
+      - close_writer is True (not handed off to streaming)
+      - a pool is active (_pool is not None)
+      - the request did not use a proxy
+      - the request is not streaming
+      - the server did not send "Connection: close"
+    Otherwise the connection is closed immediately.
+    """
+    if not close_writer:
+        return
+    if (
+        _pool
+        and not proxy
+        and not stream
+        and resp_headers.get("connection", "").lower() != "close"
+    ):
+        await _pool.release(host, port, is_https, reader, writer)
+    else:
+        writer.close()
+        # Tier 3: best-effort silent -- wait_closed on direct close
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+
+async def _async_close_writer_silent(writer: asyncio.StreamWriter) -> None:
+    """Close an async writer, ignoring errors on wait_closed."""
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except Exception:
+        pass
+
+
+def _build_async_streaming_response(
+    status: int,
+    resp_headers: dict[str, str],
+    url: str,
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    timeout: float,
+) -> StreamingResponse:
+    """Build an async StreamingResponse from response metadata."""
+    content_encoding = resp_headers.get("content-encoding", "")
+    te = resp_headers.get("transfer-encoding", "")
+    is_chunked = te.lower() == "chunked"
+    cl = resp_headers.get("content-length")
+    content_length = int(cl) if cl else None
+    return StreamingResponse._from_async(
+        status,
+        resp_headers,
+        url,
+        reader,
+        writer,
+        is_chunked,
+        content_length,
+        timeout,
+        content_encoding=content_encoding,
+    )
+
+
+# -- Async transport --
+
+
+async def _async_request(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    data: bytes | str | dict[str, str] | None = None,
+    json: Any = None,
+    files: dict[str, Any] | list[tuple[str, Any]] | None = None,
+    params: dict[str, Any] | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    max_redirects: int = DEFAULT_MAX_REDIRECTS,
+    verify: bool = True,
+    stream: bool = False,
+    auth: tuple[str, str] | Auth | None = None,
+    proxy: str | None = None,
+    _pool: _AsyncConnectionPool | None = None,
+) -> Response | StreamingResponse:
+    """Perform an asynchronous HTTP request using asyncio streams.
+
+    Phase structure (mirrors _sync_request):
+        1-3. Request preparation (URL, body, headers, auth)
+        4. Redirect loop:
+           a. URL parsing + connection acquisition
+           b. Send raw HTTP/1.1 request + read response headers
+           c. Handle redirects / digest auth / response construction
+           d. Connection lifecycle (pool release or close)
+    """
+    url, body, req_headers, auth_obj = _prepare_request(
+        method, url, headers, data, json, files, params, auth
+    )
+
+    redirects = 0
+    _digest_attempted = False
+    while True:
+        scheme, host, port, path, is_https = _parse_url(url)
+
+        reader, writer, request_path = await _async_acquire_connection(
+            host, port, path, is_https, timeout, verify, proxy, _pool, req_headers, url
+        )
+        if _pool and not proxy:
+            req_headers.setdefault("Connection", "keep-alive")
+
+        close_writer = True
+        resp_headers: dict[str, str] = {}
+        try:
+            raw_request = _build_raw_http_request(
+                method,
+                request_path,
+                host,
+                req_headers,
+                use_pool=bool(_pool),
+                use_proxy=bool(proxy),
+            )
+            writer.write(raw_request)
+            if body:
+                writer.write(body)
+            await asyncio.wait_for(writer.drain(), timeout=timeout)
+
+            status, resp_headers = await _async_read_response_headers(reader, timeout)
+
+            if _is_redirect(status, resp_headers):
+                await _async_read_body(reader, resp_headers, timeout)
+                url, method, body = _compute_redirect(
+                    status,
+                    method,
+                    body,
+                    req_headers,
+                    resp_headers,
+                    scheme,
+                    host,
+                    port,
+                    url,
+                    redirects,
+                    max_redirects,
+                )
+                redirects += 1
+                continue
+
+            if _should_attempt_digest(
+                auth_obj, status, resp_headers, _digest_attempted
+            ):
+                await _async_read_body(reader, resp_headers, timeout)
+                www_auth = resp_headers["www-authenticate"]
+                req_headers.update(
+                    auth_obj.auth_headers_from_challenge(method, path, www_auth)
+                )
+                _digest_attempted = True
+                await _async_close_writer_silent(writer)
+                close_writer = False
+                continue
+
+            if stream:
+                close_writer = False
+                return _build_async_streaming_response(
+                    status,
+                    resp_headers,
+                    url,
+                    reader,
+                    writer,
+                    timeout,
+                )
+
+            content_encoding = resp_headers.get("content-encoding", "")
+            resp_body = await _async_read_body(reader, resp_headers, timeout)
+            if content_encoding:
+                resp_body = _decompress_body(resp_body, content_encoding)
+            return Response(status, resp_headers, resp_body, url)
+        except asyncio.TimeoutError:
+            raise HttpTimeoutError(
+                f"Request to {url} timed out after {timeout}s",
+                url=url,
+                timeout=timeout,
+            )
+        finally:
+            await _async_release_or_close(
+                close_writer,
+                _pool,
+                proxy,
+                stream,
+                resp_headers,
+                host,
+                port,
+                is_https,
+                reader,
+                writer,
+            )
+
+
+# ── Request Building helpers (multipart, headers) ──
+
+
+def _prepare_body(
+    data: bytes | str | dict[str, str] | None = None,
+    json: Any = None,
+    files: dict[str, Any] | list[tuple[str, Any]] | None = None,
+) -> tuple[bytes | None, str | None]:
+    """Prepare request body and content-type header.
+
+    Priority: json > files > data.
+    When files is provided and data is a dict, data fields are included
+    as text parts in the multipart body.
+
+    Returns:
+        (body_bytes, content_type) tuple.
+    """
+    if json is not None:
+        return _json.dumps(json, ensure_ascii=False).encode("utf-8"), "application/json"
+    if files is not None:
+        form_data = data if isinstance(data, dict) else None
+        return _encode_multipart(form_data, files)
+    if isinstance(data, str):
+        return data.encode("utf-8"), "application/x-www-form-urlencoded"
+    if isinstance(data, bytes):
+        return data, "application/octet-stream"
+    return None, None
+
+
+def _read_file_content(value: bytes | IO[bytes]) -> bytes:
+    """Read bytes from a file object or return bytes as-is."""
+    if isinstance(value, bytes):
+        return value
+    return value.read()
+
+
+def _get_filename(value: bytes | IO[bytes]) -> str:
+    """Extract filename from a file object, or return a default."""
+    if isinstance(value, bytes):
+        return "upload"
+    name = getattr(value, "name", None)
+    if name:
+        return os.path.basename(name)
+    return "upload"
+
+
+def _normalize_file_value(
+    value: Any,
+) -> tuple[str, bytes, str]:
+    """Normalize a files parameter value to (filename, content, content_type).
+
+    Accepted formats:
+        bytes / file object      -> ("upload"/basename, content, octet-stream)
+        (filename, content)      -> (filename, content, octet-stream)
+        (filename, content, ct)  -> (filename, content, ct)
+    """
+    if isinstance(value, (bytes, IO)) or hasattr(value, "read"):
+        fn = _get_filename(value)
+        ct = "application/octet-stream"
+        return fn, _read_file_content(value), ct
+    if isinstance(value, (tuple, list)):
+        if len(value) == 2:
+            fname, content = value
+            return fname, _read_file_content(content), "application/octet-stream"
+        if len(value) == 3:
+            fname, content, ct = value
+            return fname, _read_file_content(content), ct
+    raise ValueError(f"Invalid file value format: {type(value)}")
+
+
+def _encode_multipart(
+    data: dict[str, str] | None,
+    files: dict[str, Any] | list[tuple[str, Any]],
+) -> tuple[bytes, str]:
+    """Encode multipart/form-data body.
+
+    Args:
+        data: Optional form fields to include as text parts.
+        files: File fields as dict or list of (name, value) tuples.
+
+    Returns:
+        (body_bytes, content_type_with_boundary).
+    """
+    boundary = os.urandom(16).hex()
+    parts: list[bytes] = []
+
+    # Encode form data fields
+    if data:
+        for name, value in data.items():
+            part = (
+                f"--{boundary}\r\n"
+                f'Content-Disposition: form-data; name="{name}"\r\n'
+                f"\r\n"
+                f"{value}\r\n"
+            )
+            parts.append(part.encode("utf-8"))
+
+    # Encode file fields
+    items: list[tuple[str, Any]]
+    if isinstance(files, dict):
+        items = list(files.items())
+    else:
+        items = list(files)
+
+    for name, value in items:
+        filename, content, content_type = _normalize_file_value(value)
+        header = (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'
+            f"Content-Type: {content_type}\r\n"
+            f"\r\n"
+        )
+        parts.append(header.encode("utf-8") + content + b"\r\n")
+
+    # Final boundary
+    parts.append(f"--{boundary}--\r\n".encode("utf-8"))
+
+    body = b"".join(parts)
+    content_type = f"multipart/form-data; boundary={boundary}"
+    return body, content_type
+
+
+def _merge_headers(
+    base: dict[str, str] | None,
+    extra: dict[str, str] | None,
+) -> dict[str, str]:
+    """Merge header dicts (case-insensitive merge, last wins)."""
+    merged: dict[str, str] = {}
+    for h in (base, extra):
+        if h:
+            for k, v in h.items():
+                merged[k] = v
+    return merged
+
+
+# ── Public API functions (get, post, put, etc.) ──
+
+# -- Sync convenience functions --
+
+
+def get(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send a GET request."""
+    return _sync_request("GET", url, **kwargs)
+
+
+def post(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send a POST request."""
+    return _sync_request("POST", url, **kwargs)
+
+
+def put(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send a PUT request."""
+    return _sync_request("PUT", url, **kwargs)
+
+
+def patch(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send a PATCH request."""
+    return _sync_request("PATCH", url, **kwargs)
+
+
+def delete(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send a DELETE request."""
+    return _sync_request("DELETE", url, **kwargs)
+
+
+def head(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send a HEAD request."""
+    return _sync_request("HEAD", url, **kwargs)
+
+
+def options(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an OPTIONS request."""
+    return _sync_request("OPTIONS", url, **kwargs)
+
+
+# -- Async convenience functions --
+
+
+async def async_get(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async GET request."""
+    return await _async_request("GET", url, **kwargs)
+
+
+async def async_post(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async POST request."""
+    return await _async_request("POST", url, **kwargs)
+
+
+async def async_put(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async PUT request."""
+    return await _async_request("PUT", url, **kwargs)
+
+
+async def async_patch(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async PATCH request."""
+    return await _async_request("PATCH", url, **kwargs)
+
+
+async def async_delete(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async DELETE request."""
+    return await _async_request("DELETE", url, **kwargs)
+
+
+async def async_head(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async HEAD request."""
+    return await _async_request("HEAD", url, **kwargs)
+
+
+async def async_options(url: str, **kwargs: Any) -> Response | StreamingResponse:
+    """Send an async OPTIONS request."""
+    return await _async_request("OPTIONS", url, **kwargs)
+
+
+# ── Client classes (Client, AsyncClient) ──
+
+
+class Client:
+    """Synchronous HTTP client session with connection pooling.
+
+    Thread-safe: uses a threading.Lock internally.
+
+    Usage::
+
+        with Client(headers={"Authorization": "Bearer token"}) as c:
+            r = c.get("https://api.example.com/data")
+    """
+
+    def __init__(
+        self,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        max_redirects: int = DEFAULT_MAX_REDIRECTS,
+        verify: bool = True,
+        auth: tuple[str, str] | Auth | None = None,
+        proxy: str | None = None,
+        pool_size: int = DEFAULT_POOL_SIZE,
+    ) -> None:
+        self._base_headers = headers or {}
+        self._timeout = timeout
+        self._max_redirects = max_redirects
+        self._verify = verify
+        self._auth = auth
+        self._proxy = proxy
+        self._pool = _SyncConnectionPool(pool_size)
+        self._lock = threading.Lock()
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> Response | StreamingResponse:
+        """Send an HTTP request."""
+        kwargs.setdefault("timeout", self._timeout)
+        kwargs.setdefault("max_redirects", self._max_redirects)
+        kwargs.setdefault("verify", self._verify)
+        kwargs.setdefault("auth", self._auth)
+        kwargs.setdefault("proxy", self._proxy)
+        kwargs["_pool"] = self._pool
+        kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
+        if kwargs.get("stream"):
+            return _sync_request(method, url, **kwargs)
+        with self._lock:
+            return _sync_request(method, url, **kwargs)
+
+    def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("POST", url, **kwargs)
+
+    def put(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("PUT", url, **kwargs)
+
+    def patch(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("PATCH", url, **kwargs)
+
+    def delete(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("DELETE", url, **kwargs)
+
+    def head(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("HEAD", url, **kwargs)
+
+    def options(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return self.request("OPTIONS", url, **kwargs)
+
+    def close(self) -> None:
+        """Close all pooled connections."""
+        self._pool.close_all()
+
+    def __enter__(self) -> Client:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self._pool.close_all()
+
+
+class AsyncClient:
+    """Asynchronous HTTP client session with connection pooling.
+
+    Safe to use from a single asyncio task; for concurrent requests
+    from the same client, use asyncio.Lock internally.
+
+    Usage::
+
+        async with AsyncClient(headers={"Authorization": "Bearer token"}) as c:
+            r = await c.get("https://api.example.com/data")
+    """
+
+    def __init__(
+        self,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        max_redirects: int = DEFAULT_MAX_REDIRECTS,
+        verify: bool = True,
+        auth: tuple[str, str] | Auth | None = None,
+        proxy: str | None = None,
+        pool_size: int = DEFAULT_POOL_SIZE,
+    ) -> None:
+        self._base_headers = headers or {}
+        self._timeout = timeout
+        self._max_redirects = max_redirects
+        self._verify = verify
+        self._auth = auth
+        self._proxy = proxy
+        self._pool = _AsyncConnectionPool(pool_size)
+        self._lock = asyncio.Lock()
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> Response | StreamingResponse:
+        """Send an async HTTP request."""
+        kwargs.setdefault("timeout", self._timeout)
+        kwargs.setdefault("max_redirects", self._max_redirects)
+        kwargs.setdefault("verify", self._verify)
+        kwargs.setdefault("auth", self._auth)
+        kwargs.setdefault("proxy", self._proxy)
+        kwargs["_pool"] = self._pool
+        kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
+        if kwargs.get("stream"):
+            return await _async_request(method, url, **kwargs)
+        async with self._lock:
+            return await _async_request(method, url, **kwargs)
+
+    async def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("GET", url, **kwargs)
+
+    async def post(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("POST", url, **kwargs)
+
+    async def put(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("PUT", url, **kwargs)
+
+    async def patch(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("PATCH", url, **kwargs)
+
+    async def delete(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("DELETE", url, **kwargs)
+
+    async def head(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("HEAD", url, **kwargs)
+
+    async def options(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
+        return await self.request("OPTIONS", url, **kwargs)
+
+    async def aclose(self) -> None:
+        """Close all pooled connections."""
+        await self._pool.close_all()
+
+    async def __aenter__(self) -> AsyncClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self._pool.close_all()

--- a/src/llm_rosetta/_vendor/httpserver.py
+++ b/src/llm_rosetta/_vendor/httpserver.py
@@ -1,0 +1,1007 @@
+# /// zerodep
+# version = "0.1.0"
+# deps = []
+# tier = "subsystem"
+# category = "network"
+# note = "Install/update via `zerodep add httpserver`"
+# ///
+
+"""Zero-dependency async HTTP server with decorator-based routing.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Async HTTP/1.1 server built on ``asyncio.start_server()``.  Supports
+decorator-based routing, JSON request/response, static file serving,
+streaming responses (SSE), and graceful shutdown.
+
+Usage::
+
+    from httpserver import App, JSONResponse
+
+    app = App()
+
+    @app.route("/status")
+    async def status(request):
+        return JSONResponse({"state": "idle"})
+
+    @app.route("/echo", methods=["POST"])
+    def echo(request):
+        return JSONResponse(request.json())
+
+    app.run(host="127.0.0.1", port=8000)
+"""
+
+# ── Imports ──────────────────────────────────────────────────────────────────
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import inspect
+import json as _json
+import logging
+import mimetypes
+import os
+import re
+import signal
+import sys
+from collections.abc import AsyncIterator, Callable
+from email.utils import formatdate
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
+
+__all__ = [
+    # Application
+    "App",
+    # Request / Response
+    "Request",
+    "Response",
+    "JSONResponse",
+    "StreamingResponse",
+    "FileResponse",
+    # Exceptions
+    "HTTPException",
+    # Utilities
+    "abort",
+]
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+DEFAULT_MAX_BODY_SIZE = 1_048_576  # 1 MB
+DEFAULT_READ_TIMEOUT = 30.0  # seconds
+
+_STATUS_REASONS: dict[int, str] = {
+    100: "Continue",
+    101: "Switching Protocols",
+    200: "OK",
+    201: "Created",
+    202: "Accepted",
+    204: "No Content",
+    301: "Moved Permanently",
+    302: "Found",
+    303: "See Other",
+    304: "Not Modified",
+    307: "Temporary Redirect",
+    308: "Permanent Redirect",
+    400: "Bad Request",
+    401: "Unauthorized",
+    403: "Forbidden",
+    404: "Not Found",
+    405: "Method Not Allowed",
+    406: "Not Acceptable",
+    408: "Request Timeout",
+    409: "Conflict",
+    413: "Content Too Large",
+    415: "Unsupported Media Type",
+    422: "Unprocessable Entity",
+    429: "Too Many Requests",
+    500: "Internal Server Error",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    504: "Gateway Timeout",
+}
+
+# Type converters for path parameters
+_PARAM_CONVERTERS: dict[str, tuple[str, Callable[[str], Any]]] = {
+    "str": (r"([^/]+)", str),
+    "int": (r"(-?\d+)", int),
+    "float": (r"(-?[0-9]+(?:\.[0-9]+)?)", float),
+    "path": (r"(.+)", str),
+}
+
+# Regex to find <type:name> or <name> segments in route patterns
+_PARAM_RE = re.compile(r"<(?:(\w+):)?(\w+)>")
+
+_SENTINEL = object()
+
+
+# ── Exceptions ───────────────────────────────────────────────────────────────
+
+
+class HTTPException(Exception):
+    """HTTP error that maps to a specific status code.
+
+    Raise directly or via :func:`abort` to short-circuit request handling.
+
+    Args:
+        status_code: HTTP status code (e.g. 404, 500).
+        message: Optional human-readable error message.
+    """
+
+    __slots__ = ("status_code", "message")
+
+    def __init__(self, status_code: int, message: str | None = None):
+        self.status_code = status_code
+        self.message = message or _STATUS_REASONS.get(status_code, "Error")
+        super().__init__(self.message)
+
+
+class _BadRequest(Exception):
+    """Internal: malformed HTTP request from client."""
+
+
+def abort(status_code: int, message: str | None = None) -> None:
+    """Raise an :class:`HTTPException` with the given status code.
+
+    Args:
+        status_code: HTTP status code.
+        message: Optional error message.
+    """
+    raise HTTPException(status_code, message)
+
+
+# ── Request ──────────────────────────────────────────────────────────────────
+
+
+class Request:
+    """Parsed HTTP request.
+
+    Attributes:
+        method: Uppercase HTTP method (GET, POST, ...).
+        path: URL path, percent-decoded.
+        query_string: Raw query string (without leading ``?``).
+        query_params: Parsed query string as ``{key: [values]}``.
+        headers: Case-insensitive header dict (keys stored lowercase).
+        body: Raw request body bytes.
+        path_params: Parameters extracted from the route pattern.
+        client_addr: Client ``(host, port)`` tuple.
+        app: Reference to the :class:`App` instance handling this request.
+    """
+
+    __slots__ = (
+        "method",
+        "path",
+        "query_string",
+        "query_params",
+        "headers",
+        "body",
+        "path_params",
+        "client_addr",
+        "app",
+        "_json",
+    )
+
+    def __init__(
+        self,
+        method: str,
+        path: str,
+        query_string: str,
+        headers: dict[str, str],
+        body: bytes,
+        client_addr: tuple[str, int],
+        app: App | None = None,
+    ):
+        self.method = method
+        self.path = path
+        self.query_string = query_string
+        self.query_params: dict[str, list[str]] = parse_qs(query_string)
+        self.headers = headers
+        self.body = body
+        self.path_params: dict[str, Any] = {}
+        self.client_addr = client_addr
+        self.app = app
+        self._json: Any = _SENTINEL
+
+    def json(self) -> Any:
+        """Parse body as JSON (cached)."""
+        if self._json is _SENTINEL:
+            self._json = _json.loads(self.body)
+        return self._json
+
+    def text(self) -> str:
+        """Decode body as UTF-8."""
+        return self.body.decode("utf-8")
+
+    def form(self) -> dict[str, list[str]]:
+        """Parse URL-encoded form body."""
+        return parse_qs(self.body.decode("utf-8"))
+
+
+# ── Response Classes ─────────────────────────────────────────────────────────
+
+
+class Response:
+    """HTTP response with a fixed body.
+
+    Args:
+        body: Response body (bytes or str).
+        status_code: HTTP status code.
+        headers: Extra response headers.
+        content_type: Shorthand for ``Content-Type`` header.
+    """
+
+    __slots__ = ("status_code", "headers", "body")
+
+    def __init__(
+        self,
+        body: bytes | str = b"",
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        content_type: str | None = None,
+    ):
+        self.status_code = status_code
+        self.headers: dict[str, str] = headers.copy() if headers else {}
+        if isinstance(body, str):
+            self.body = body.encode("utf-8")
+        else:
+            self.body = body
+        if content_type is not None:
+            self.headers["Content-Type"] = content_type
+
+    async def _write(self, writer: asyncio.StreamWriter) -> None:
+        """Serialize and write the full HTTP response."""
+        reason = _STATUS_REASONS.get(self.status_code, "Unknown")
+        self.headers.setdefault("Content-Length", str(len(self.body)))
+        self.headers.setdefault("Content-Type", "text/plain; charset=utf-8")
+        self.headers.setdefault("Date", _http_date())
+        self.headers.setdefault("Connection", "close")
+
+        buf = bytearray()
+        buf.extend(f"HTTP/1.1 {self.status_code} {reason}\r\n".encode("latin-1"))
+        for k, v in self.headers.items():
+            buf.extend(f"{k}: {v}\r\n".encode("latin-1"))
+        buf.extend(b"\r\n")
+        buf.extend(self.body)
+        writer.write(bytes(buf))
+        await writer.drain()
+
+
+class JSONResponse(Response):
+    """Response serialized as JSON.
+
+    Args:
+        data: Python object to serialize.
+        status_code: HTTP status code.
+        headers: Extra response headers.
+    """
+
+    def __init__(
+        self,
+        data: Any,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+    ):
+        body = _json.dumps(data, ensure_ascii=False).encode("utf-8")
+        super().__init__(
+            body=body,
+            status_code=status_code,
+            headers=headers,
+            content_type="application/json; charset=utf-8",
+        )
+
+
+class StreamingResponse:
+    """HTTP response streamed from an async generator.
+
+    Writes chunks using ``Transfer-Encoding: chunked`` unless
+    ``content_type`` is ``text/event-stream`` (SSE), in which case raw
+    bytes are flushed directly for maximum compatibility with SSE clients.
+
+    Args:
+        generator: Async iterator yielding ``bytes`` or ``str`` chunks.
+        status_code: HTTP status code.
+        headers: Extra response headers.
+        content_type: MIME type (default ``application/octet-stream``).
+    """
+
+    __slots__ = ("_generator", "status_code", "headers", "content_type")
+
+    def __init__(
+        self,
+        generator: AsyncIterator[bytes | str],
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        content_type: str = "application/octet-stream",
+    ):
+        self._generator = generator
+        self.status_code = status_code
+        self.headers: dict[str, str] = headers.copy() if headers else {}
+        self.content_type = content_type
+
+    async def _write(self, writer: asyncio.StreamWriter) -> None:
+        """Write status line, headers, then stream the body."""
+        reason = _STATUS_REASONS.get(self.status_code, "Unknown")
+        is_sse = self.content_type.startswith("text/event-stream")
+
+        self.headers["Content-Type"] = self.content_type
+        if not is_sse:
+            self.headers.setdefault("Transfer-Encoding", "chunked")
+        else:
+            self.headers.setdefault("Cache-Control", "no-cache")
+        self.headers.setdefault("Date", _http_date())
+        self.headers.setdefault("Connection", "close")
+
+        buf = bytearray()
+        buf.extend(f"HTTP/1.1 {self.status_code} {reason}\r\n".encode("latin-1"))
+        for k, v in self.headers.items():
+            buf.extend(f"{k}: {v}\r\n".encode("latin-1"))
+        buf.extend(b"\r\n")
+        writer.write(bytes(buf))
+        await writer.drain()
+
+        try:
+            async for chunk in self._generator:
+                if isinstance(chunk, str):
+                    chunk = chunk.encode("utf-8")
+                if is_sse:
+                    writer.write(chunk)
+                else:
+                    writer.write(f"{len(chunk):x}\r\n".encode("latin-1"))
+                    writer.write(chunk)
+                    writer.write(b"\r\n")
+                await writer.drain()
+            if not is_sse:
+                writer.write(b"0\r\n\r\n")
+                await writer.drain()
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+            logger.debug("Client disconnected during streaming")
+        finally:
+            aclose = getattr(self._generator, "aclose", None)
+            if aclose is not None:
+                await aclose()
+
+
+class FileResponse(Response):
+    """Response serving a file from disk.
+
+    Args:
+        path: Path to the file.
+        content_type: MIME type (auto-detected from extension if ``None``).
+        status_code: HTTP status code.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        content_type: str | None = None,
+        status_code: int = 200,
+    ):
+        file_path = Path(path)
+        body = file_path.read_bytes()
+        if content_type is None:
+            guessed, _ = mimetypes.guess_type(str(file_path))
+            content_type = guessed or "application/octet-stream"
+        headers = {
+            "Last-Modified": _http_date(os.path.getmtime(file_path)),
+        }
+        super().__init__(
+            body=body,
+            status_code=status_code,
+            headers=headers,
+            content_type=content_type,
+        )
+
+
+# ── Routing ──────────────────────────────────────────────────────────────────
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _Route:
+    """Internal route entry."""
+
+    methods: list[str]  # uppercase, e.g. ["GET", "POST"], or ["*"]
+    pattern: re.Pattern[str]
+    handler: Callable[..., Any]
+    is_async: bool
+    param_names: list[str]
+    param_converters: list[Callable[[str], Any]]
+
+
+def _compile_route(
+    path: str,
+) -> tuple[re.Pattern[str], list[str], list[Callable[[str], Any]]]:
+    """Compile a path pattern into a regex and parameter metadata.
+
+    Supports ``<name>``, ``<int:name>``, ``<float:name>``, ``<path:name>``.
+
+    Args:
+        path: URL path pattern (e.g. ``/users/<int:id>``).
+
+    Returns:
+        Tuple of (compiled regex, param names, param converters).
+    """
+    param_names: list[str] = []
+    param_converters: list[Callable[[str], Any]] = []
+    regex_parts: list[str] = []
+    last_end = 0
+
+    for m in _PARAM_RE.finditer(path):
+        regex_parts.append(re.escape(path[last_end : m.start()]))
+        type_name = m.group(1) or "str"
+        name = m.group(2)
+        if type_name not in _PARAM_CONVERTERS:
+            raise ValueError(f"Unknown path parameter type: {type_name!r}")
+        regex_fragment, converter = _PARAM_CONVERTERS[type_name]
+        regex_parts.append(regex_fragment)
+        param_names.append(name)
+        param_converters.append(converter)
+        last_end = m.end()
+
+    regex_parts.append(re.escape(path[last_end:]))
+    full_regex = "^" + "".join(regex_parts) + "$"
+    return re.compile(full_regex), param_names, param_converters
+
+
+# ── HTTP Parsing ─────────────────────────────────────────────────────────────
+
+
+async def _read_request(
+    reader: asyncio.StreamReader,
+    timeout: float,
+    max_body_size: int,
+) -> tuple[str, str, str, dict[str, str], bytes]:
+    """Read and parse an HTTP request from a stream.
+
+    Returns:
+        Tuple of (method, path, query_string, headers, body).
+
+    Raises:
+        _BadRequest: If the request is malformed.
+        asyncio.TimeoutError: If reading times out.
+    """
+    # -- Request line --
+    raw_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+    if not raw_line:
+        raise _BadRequest("Empty request")
+    request_line = raw_line.decode("latin-1").rstrip("\r\n")
+    parts = request_line.split(" ", 2)
+    if len(parts) != 3:
+        raise _BadRequest(f"Malformed request line: {request_line!r}")
+    method, raw_url, _version = parts
+
+    # -- URL --
+    parsed = urlparse(raw_url)
+    path = unquote(parsed.path)
+    query_string = parsed.query
+
+    # -- Headers --
+    headers: dict[str, str] = {}
+    while True:
+        line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+        decoded = line.decode("latin-1").rstrip("\r\n")
+        if not decoded:
+            break
+        if ":" in decoded:
+            k, v = decoded.split(":", 1)
+            headers[k.strip().lower()] = v.strip()
+
+    # -- Body --
+    body = b""
+    cl = headers.get("content-length")
+    if cl is not None:
+        length = int(cl)
+        if length > max_body_size:
+            raise HTTPException(413, f"Request body too large ({length} bytes)")
+        if length > 0:
+            body = await asyncio.wait_for(reader.readexactly(length), timeout=timeout)
+    elif headers.get("transfer-encoding", "").lower() == "chunked":
+        body = await _read_chunked_body(reader, timeout, max_body_size)
+
+    return method.upper(), path, query_string, headers, body
+
+
+async def _read_chunked_body(
+    reader: asyncio.StreamReader,
+    timeout: float,
+    max_body_size: int,
+) -> bytes:
+    """Read a chunked transfer-encoded body."""
+    parts: list[bytes] = []
+    total = 0
+    while True:
+        size_line = await asyncio.wait_for(reader.readline(), timeout=timeout)
+        size_str = size_line.decode("latin-1").split(";")[0].strip()
+        if not size_str:
+            break
+        chunk_size = int(size_str, 16)
+        if chunk_size == 0:
+            await asyncio.wait_for(reader.readline(), timeout=timeout)
+            break
+        total += chunk_size
+        if total > max_body_size:
+            raise HTTPException(413, "Request body too large")
+        data = await asyncio.wait_for(reader.readexactly(chunk_size), timeout=timeout)
+        await asyncio.wait_for(reader.readline(), timeout=timeout)
+        parts.append(data)
+    return b"".join(parts)
+
+
+# ── Utilities ────────────────────────────────────────────────────────────────
+
+
+def _http_date(timestamp: float | None = None) -> str:
+    """Format a timestamp as an HTTP-date (RFC 7231)."""
+    return formatdate(timeval=timestamp, localtime=False, usegmt=True)
+
+
+def _coerce_response(result: Any) -> Response | StreamingResponse:
+    """Convert a handler return value into a Response object."""
+    if isinstance(result, (Response, StreamingResponse)):
+        return result
+
+    if result is None:
+        return Response(status_code=204)
+
+    if isinstance(result, dict):
+        return JSONResponse(result)
+
+    if isinstance(result, tuple):
+        if len(result) == 2:
+            body, status = result
+            resp = _coerce_response(body)
+            resp.status_code = status
+            return resp
+        if len(result) == 3:
+            body, status, extra_headers = result
+            resp = _coerce_response(body)
+            resp.status_code = status
+            resp.headers.update(extra_headers)
+            return resp
+        raise ValueError(f"Unsupported tuple length: {len(result)}")
+
+    if isinstance(result, bytes):
+        return Response(body=result, content_type="application/octet-stream")
+
+    if isinstance(result, str):
+        return Response(body=result, content_type="text/plain; charset=utf-8")
+
+    raise TypeError(
+        f"Cannot coerce handler return type {type(result).__name__} to Response"
+    )
+
+
+# ── Static File Resolution ───────────────────────────────────────────────────
+
+
+def _resolve_static_file(
+    request_path: str,
+    url_prefix: str,
+    directory: str,
+) -> FileResponse | None:
+    """Try to resolve a static file request.
+
+    Returns a FileResponse if the file exists and the path is safe,
+    otherwise None.
+    """
+    if not request_path.startswith(url_prefix):
+        return None
+
+    relative = request_path[len(url_prefix) :].lstrip("/")
+    if not relative:
+        return None
+
+    base = Path(directory).resolve()
+    target = (base / relative).resolve()
+
+    # Prevent directory traversal
+    if not str(target).startswith(str(base)):
+        return None
+
+    if not target.is_file():
+        return None
+
+    return FileResponse(target)
+
+
+# ── App ──────────────────────────────────────────────────────────────────────
+
+
+class App:
+    """Async HTTP server application.
+
+    Args:
+        max_body_size: Maximum request body size in bytes.
+        read_timeout: Timeout for reading a single request (seconds).
+
+    Example::
+
+        app = App()
+
+        @app.get("/hello")
+        async def hello(request):
+            return {"message": "Hello, world!"}
+
+        app.run()
+    """
+
+    def __init__(
+        self,
+        *,
+        max_body_size: int = DEFAULT_MAX_BODY_SIZE,
+        read_timeout: float = DEFAULT_READ_TIMEOUT,
+    ):
+        self._routes: list[_Route] = []
+        self._static_routes: list[tuple[str, str]] = []
+        self._before_request_handlers: list[Callable[..., Any]] = []
+        self._after_request_handlers: list[Callable[..., Any]] = []
+        self._error_handlers: dict[int | type, Callable[..., Any]] = {}
+        self._server: asyncio.Server | None = None
+        self._shutdown_event: asyncio.Event | None = None
+        self.max_body_size = max_body_size
+        self.read_timeout = read_timeout
+        self.port: int | None = None
+        self.host: str | None = None
+
+    # ── Route Registration ───────────────────────────────────────────────
+
+    def route(
+        self, url_pattern: str, methods: list[str] | None = None
+    ) -> Callable[..., Any]:
+        """Register a route handler.
+
+        Args:
+            url_pattern: URL pattern with optional parameters.
+            methods: HTTP methods to handle (e.g. ``["GET", "POST"]``).
+                Defaults to ``["GET"]``.
+
+        Example::
+
+            @app.route("/users/<int:id>", methods=["GET", "POST"])
+            async def user(request, id):
+                return {"id": id}
+        """
+        if methods is None:
+            methods = ["GET"]
+
+        def decorator(handler: Callable[..., Any]) -> Callable[..., Any]:
+            pattern, param_names, converters = _compile_route(url_pattern)
+            is_async = inspect.iscoroutinefunction(handler)
+            self._routes.append(
+                _Route(
+                    methods=[m.upper() for m in methods],
+                    pattern=pattern,
+                    handler=handler,
+                    is_async=is_async,
+                    param_names=param_names,
+                    param_converters=converters,
+                )
+            )
+            return handler
+
+        return decorator
+
+    def get(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route(path, methods=["GET"])``."""
+        return self.route(path, methods=["GET"])
+
+    def post(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route(path, methods=["POST"])``."""
+        return self.route(path, methods=["POST"])
+
+    def put(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route(path, methods=["PUT"])``."""
+        return self.route(path, methods=["PUT"])
+
+    def delete(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route(path, methods=["DELETE"])``."""
+        return self.route(path, methods=["DELETE"])
+
+    def patch(self, path: str) -> Callable[..., Any]:
+        """Shorthand for ``@app.route(path, methods=["PATCH"])``."""
+        return self.route(path, methods=["PATCH"])
+
+    def static(self, url_prefix: str, directory: str) -> None:
+        """Register a directory for static file serving.
+
+        Args:
+            url_prefix: URL prefix (e.g. ``"/static"``).
+            directory: Filesystem path to the directory.
+
+        Example::
+
+            app.static("/assets", "./public")
+        """
+        url_prefix = url_prefix.rstrip("/")
+        abs_dir = os.path.abspath(directory)
+        self._static_routes.append((url_prefix, abs_dir))
+
+    # ── Middleware ────────────────────────────────────────────────────────
+
+    def before_request(self, handler: Callable[..., Any]) -> Callable[..., Any]:
+        """Register a before-request hook.
+
+        The hook receives ``(request)`` and may return a ``Response`` to
+        short-circuit the route handler.
+        """
+        self._before_request_handlers.append(handler)
+        return handler
+
+    def after_request(self, handler: Callable[..., Any]) -> Callable[..., Any]:
+        """Register an after-request hook.
+
+        The hook receives ``(request, response)`` and may return a new
+        or modified ``Response``.
+        """
+        self._after_request_handlers.append(handler)
+        return handler
+
+    def errorhandler(self, code_or_exc: int | type) -> Callable[..., Any]:
+        """Register an error handler.
+
+        Args:
+            code_or_exc: HTTP status code (int) or exception class.
+
+        The handler receives ``(request, exception)`` and must return a
+        ``Response``.
+        """
+
+        def decorator(handler: Callable[..., Any]) -> Callable[..., Any]:
+            self._error_handlers[code_or_exc] = handler
+            return handler
+
+        return decorator
+
+    # ── Request Dispatch ─────────────────────────────────────────────────
+
+    def _match_route(
+        self, request: Request
+    ) -> tuple[_Route | None, re.Match[str] | None, bool]:
+        """Find the first route matching the request path and method.
+
+        Returns:
+            (matched_route, regex_match, path_existed).  *path_existed* is
+            True when a route matched the path but not the HTTP method.
+        """
+        path_existed = False
+        for route in self._routes:
+            m = route.pattern.match(request.path)
+            if m is None:
+                continue
+            path_existed = True
+            if "*" not in route.methods and request.method not in route.methods:
+                continue
+            return route, m, True
+        return None, None, path_existed
+
+    async def _invoke_route(
+        self, route: _Route, match: re.Match[str], request: Request
+    ) -> Response | StreamingResponse:
+        """Extract path params, call the handler, return a response."""
+        for name, converter, value in zip(
+            route.param_names, route.param_converters, match.groups()
+        ):
+            request.path_params[name] = converter(value)
+
+        try:
+            result = await _invoke(route.handler, request, **request.path_params)
+            return _coerce_response(result)
+        except HTTPException as exc:
+            return await self._handle_error(request, exc)
+        except Exception as exc:
+            logger.exception(
+                "Unhandled exception in handler %s",
+                getattr(route.handler, "__name__", repr(route.handler)),
+            )
+            return await self._handle_error(request, exc)
+
+    async def _run_after_hooks(
+        self, request: Request, response: Response | StreamingResponse
+    ) -> Response | StreamingResponse:
+        """Run after-request hooks, allowing them to replace the response."""
+        for hook in self._after_request_handlers:
+            hook_result = await _invoke(hook, request, response)
+            if hook_result is not None:
+                response = _coerce_response(hook_result)
+        return response
+
+    async def _dispatch(self, request: Request) -> Response | StreamingResponse:
+        """Match a request to a route and invoke the handler."""
+        # -- before_request hooks --
+        for hook in self._before_request_handlers:
+            result = await _invoke(hook, request)
+            if result is not None:
+                return _coerce_response(result)
+
+        # -- Static file check --
+        for prefix, directory in self._static_routes:
+            file_resp = _resolve_static_file(request.path, prefix, directory)
+            if file_resp is not None:
+                return file_resp
+
+        # -- Route matching --
+        route, match, path_existed = self._match_route(request)
+
+        if route is not None and match is not None:
+            response = await self._invoke_route(route, match, request)
+            return await self._run_after_hooks(request, response)
+
+        # -- No route matched --
+        if path_existed:
+            allowed = sorted(
+                {
+                    m
+                    for r in self._routes
+                    if r.pattern.match(request.path)
+                    for m in r.methods
+                    if m != "*"
+                }
+            )
+            exc = HTTPException(405, "Method Not Allowed")
+            response = await self._handle_error(request, exc)
+            if isinstance(response, Response):
+                response.headers["Allow"] = ", ".join(allowed)
+            return response
+
+        exc = HTTPException(404, "Not Found")
+        return await self._handle_error(request, exc)
+
+    async def _handle_error(
+        self, request: Request, exc: Exception
+    ) -> Response | StreamingResponse:
+        """Resolve an error into a response, consulting registered handlers."""
+        if isinstance(exc, HTTPException):
+            handler = self._error_handlers.get(exc.status_code)
+            if handler is not None:
+                result = await _invoke(handler, request, exc)
+                return _coerce_response(result)
+
+        for exc_cls, handler in self._error_handlers.items():
+            if isinstance(exc_cls, type) and isinstance(exc, exc_cls):
+                result = await _invoke(handler, request, exc)
+                return _coerce_response(result)
+
+        if isinstance(exc, HTTPException):
+            return JSONResponse(
+                {"error": exc.message},
+                status_code=exc.status_code,
+            )
+        return JSONResponse(
+            {"error": "Internal Server Error"},
+            status_code=500,
+        )
+
+    # ── Connection Handling ───────────────────────────────────────────────
+
+    async def _handle_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """Handle a single client connection."""
+        peer = writer.get_extra_info("peername")
+        client_addr = (peer[0], peer[1]) if peer else ("unknown", 0)
+
+        try:
+            method, path, qs, headers, body = await _read_request(
+                reader, self.read_timeout, self.max_body_size
+            )
+        except _BadRequest as exc:
+            logger.debug("Bad request from %s: %s", client_addr, exc)
+            response = Response(
+                body=str(exc),
+                status_code=400,
+                content_type="text/plain; charset=utf-8",
+            )
+            try:
+                await response._write(writer)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            writer.close()
+            return
+        except HTTPException as exc:
+            response = JSONResponse({"error": exc.message}, status_code=exc.status_code)
+            try:
+                await response._write(writer)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            writer.close()
+            return
+        except (asyncio.TimeoutError, asyncio.IncompleteReadError):
+            writer.close()
+            return
+        except Exception:
+            writer.close()
+            return
+
+        request = Request(
+            method=method,
+            path=path,
+            query_string=qs,
+            headers=headers,
+            body=body,
+            client_addr=client_addr,
+            app=self,
+        )
+
+        logger.debug("%s %s from %s", method, path, client_addr)
+
+        try:
+            response = await self._dispatch(request)
+            await response._write(writer)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+            logger.debug("Connection reset by %s during response", client_addr)
+        except Exception:
+            logger.exception("Error writing response to %s", client_addr)
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    # ── Server Lifecycle ─────────────────────────────────────────────────
+
+    def run(
+        self,
+        host: str = DEFAULT_HOST,
+        port: int = DEFAULT_PORT,
+    ) -> None:
+        """Start the server (blocking).
+
+        Args:
+            host: Bind address.
+            port: Bind port. Use ``0`` for OS-assigned port.
+        """
+        try:
+            asyncio.run(self._serve(host, port))
+        except KeyboardInterrupt:
+            pass
+
+    async def _serve(self, host: str, port: int) -> None:
+        """Internal async server loop."""
+        self._shutdown_event = asyncio.Event()
+
+        server = await asyncio.start_server(
+            self._handle_connection,
+            host,
+            port,
+        )
+
+        self._server = server
+        addrs = server.sockets[0].getsockname() if server.sockets else (host, port)
+        self.host = addrs[0]
+        self.port = addrs[1]
+        logger.info("Serving on %s:%d", self.host, self.port)
+
+        loop = asyncio.get_running_loop()
+        if sys.platform != "win32":
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                loop.add_signal_handler(sig, self._shutdown_event.set)
+
+        async with server:
+            await self._shutdown_event.wait()
+            logger.info("Shutting down server")
+
+    def shutdown(self) -> None:
+        """Request a graceful server shutdown.
+
+        Safe to call from a request handler.
+        """
+        if self._shutdown_event is not None:
+            self._shutdown_event.set()
+
+
+# ── Handler Invocation ───────────────────────────────────────────────────────
+
+
+async def _invoke(handler: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Invoke a handler, wrapping sync functions with ``asyncio.to_thread``."""
+    if inspect.iscoroutinefunction(handler):
+        return await handler(*args, **kwargs)
+    return await asyncio.to_thread(handler, *args, **kwargs)

--- a/src/llm_rosetta/gateway/__init__.py
+++ b/src/llm_rosetta/gateway/__init__.py
@@ -1,9 +1,5 @@
 """llm-rosetta Gateway — HTTP proxy/translator between LLM provider formats.
 
-Requires the ``gateway`` extra to be installed::
-
-    pip install "llm-rosetta[gateway]"
-
 Usage::
 
     # CLI entry point (after pip install)
@@ -19,25 +15,12 @@ Usage::
     app = create_app(GatewayConfig(raw))
 """
 
-_INSTALL_MSG = (
-    "llm-rosetta gateway requires extra dependencies.\n"
-    "Install them with:  pip install 'llm-rosetta[gateway]'"
-)
+# httpserver and httpclient are vendored in _vendor/ — no external deps needed.
 
-_missing: list[str] = []
-for _pkg in ("httpx",):
-    try:
-        __import__(_pkg)
-    except ImportError:
-        _missing.append(_pkg)
-
-if _missing:
-    raise ImportError(f"{_INSTALL_MSG}\nMissing packages: {', '.join(_missing)}")
-
-from .app import create_app  # noqa: E402
-from .cli import main  # noqa: E402
-from .config import GatewayConfig, discover_config, load_config  # noqa: E402
-from .proxy import ProviderMetadataStore  # noqa: E402
+from .app import create_app
+from .cli import main
+from .config import GatewayConfig, discover_config, load_config
+from .proxy import ProviderMetadataStore
 
 __all__ = [
     "ProviderMetadataStore",

--- a/src/llm_rosetta/gateway/__init__.py
+++ b/src/llm_rosetta/gateway/__init__.py
@@ -25,7 +25,7 @@ _INSTALL_MSG = (
 )
 
 _missing: list[str] = []
-for _pkg in ("starlette", "uvicorn", "httpx"):
+for _pkg in ("httpx",):
     try:
         __import__(_pkg)
     except ImportError:

--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -4,15 +4,13 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .metrics import MetricsCollector
 from .persistence import PersistenceManager
 from .request_log import RequestLog
 
 if TYPE_CHECKING:
-    from starlette.applications import Starlette
-
     from ..config import GatewayConfig
 
 __all__ = ["setup_admin", "MetricsCollector", "RequestLog", "PersistenceManager"]
@@ -21,14 +19,14 @@ logger = logging.getLogger("llm-rosetta-gateway")
 
 
 def setup_admin(
-    app: Starlette,
+    app: Any,
     config: GatewayConfig,
     config_path: str | None,
 ) -> None:
     """Initialize admin panel state on the app.
 
-    Routes are added separately in ``create_app`` *before* the Starlette
-    instance is constructed so that its Router compiles them properly.
+    Routes are registered separately via ``register_admin_routes`` before
+    calling this function.
     """
     metrics = MetricsCollector()
 
@@ -50,8 +48,8 @@ def setup_admin(
     # Request log delegates to persistence when available
     request_log = RequestLog(persistence=persistence)
 
-    app.state.metrics = metrics
-    app.state.request_log = request_log
-    app.state.persistence = persistence
-    app.state.gateway_config = config
-    app.state.config_path = config_path
+    app.metrics = metrics
+    app.request_log = request_log
+    app.persistence = persistence
+    app.gateway_config = config
+    app.config_path = config_path

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -1,4 +1,4 @@
-"""Starlette route handlers for the admin panel API."""
+"""Route handlers for the admin panel API."""
 
 from __future__ import annotations
 
@@ -8,9 +8,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse, Response
-from starlette.routing import Route
+from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
 from ..config import GatewayConfig, load_config, load_config_raw, write_config
 from ..providers import known_provider_types
@@ -27,6 +25,14 @@ _ENV_VAR_RE = re.compile(r"^\$\{.+\}$")
 # ---------------------------------------------------------------------------
 
 
+def _qp(request: Any, key: str, default: str | None = None) -> str | None:
+    """Extract a single query param value (Starlette-compatible convenience)."""
+    vals = request.query_params.get(key)
+    if vals:
+        return vals[0]
+    return default
+
+
 def _mask_api_key(value: str) -> str:
     """Mask a literal API key, leaving env-var placeholders intact."""
     if _ENV_VAR_RE.match(value):
@@ -36,23 +42,18 @@ def _mask_api_key(value: str) -> str:
     return value[:4] + "***" + value[-4:]
 
 
-def _get_config_path(request: Request) -> str | None:
-    return getattr(request.app.state, "config_path", None)
+def _get_config_path(request: Any) -> str | None:
+    return getattr(request.app, "config_path", None)
 
 
-def _reload_gateway_config(request: Request, config_path: str) -> GatewayConfig:
-    """Re-read config from disk, rebuild GatewayConfig, swap into app state.
-
-    Also refreshes the auth middleware's key set so new/deleted keys take
-    effect immediately.  The import of ``app._config`` is deferred to
-    avoid circular imports.
-    """
+def _reload_gateway_config(request: Any, config_path: str) -> GatewayConfig:
+    """Re-read config from disk, rebuild GatewayConfig, swap into app state."""
     import llm_rosetta.gateway.app as _app_mod
 
     raw = load_config(config_path)
     new_config = GatewayConfig(raw)
     _app_mod._config = new_config
-    request.app.state.gateway_config = new_config
+    request.app.gateway_config = new_config
 
     _sync_auth_middleware(request.app, new_config)
 
@@ -60,16 +61,11 @@ def _reload_gateway_config(request: Request, config_path: str) -> GatewayConfig:
 
 
 def _sync_auth_middleware(app: Any, config: GatewayConfig) -> None:
-    """Walk the ASGI middleware chain and update the auth middleware keys."""
-    from ..auth import GatewayAuthMiddleware
-
-    layer: Any = app.middleware_stack
-    while layer is not None:
-        if isinstance(layer, GatewayAuthMiddleware):
-            layer._key_set = config.api_key_set
-            layer._labels = dict(config.api_key_labels)
-            break
-        layer = getattr(layer, "app", None)
+    """Update the auth hook's state for hot-reload."""
+    auth_state = getattr(app, "auth_state", None)
+    if auth_state is not None:
+        auth_state.key_set = config.api_key_set
+        auth_state.labels = dict(config.api_key_labels)
 
 
 def _build_provider_entry(
@@ -105,10 +101,7 @@ def _build_provider_entry(
 def _handle_provider_rename(
     data: dict[str, Any], rename_from: str, name: str
 ) -> Response | None:
-    """Handle provider rename: remove old entry, update model refs.
-
-    Returns a JSONResponse on error, or None on success.
-    """
+    """Handle provider rename: remove old entry, update model refs."""
     providers = data.get("providers", {})
     if rename_from not in providers:
         return JSONResponse(
@@ -135,13 +128,15 @@ def _handle_provider_rename(
 # ---------------------------------------------------------------------------
 
 
-async def serve_admin_html(request: Request) -> Response:
+async def serve_admin_html(request: Any) -> Response:
     """Serve the admin panel SPA."""
     global _admin_html
     if _admin_html is None:
         _admin_html = load_admin_html()
-    return HTMLResponse(
-        _admin_html,
+    return Response(
+        body=_admin_html,
+        status_code=200,
+        content_type="text/html; charset=utf-8",
         headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
     )
 
@@ -151,7 +146,7 @@ async def serve_admin_html(request: Request) -> Response:
 # ---------------------------------------------------------------------------
 
 
-async def get_config(request: Request) -> Response:
+async def get_config(request: Any) -> Response:
     """Return the current (raw) gateway configuration."""
     config_path = _get_config_path(request)
     if not config_path:
@@ -207,7 +202,7 @@ async def get_config(request: Request) -> Response:
     )
 
 
-async def put_provider(request: Request) -> Response:
+async def put_provider(request: Any) -> Response:
     """Add or update a provider entry."""
     config_path = _get_config_path(request)
     if not config_path:
@@ -216,7 +211,7 @@ async def put_provider(request: Request) -> Response:
     name = request.path_params["name"]
 
     try:
-        body = await request.json()
+        body = request.json()
     except Exception:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
@@ -275,7 +270,7 @@ async def put_provider(request: Request) -> Response:
     )
 
 
-async def delete_provider(request: Request) -> Response:
+async def delete_provider(request: Any) -> Response:
     """Remove a provider entry."""
     config_path = _get_config_path(request)
     if not config_path:
@@ -337,7 +332,7 @@ async def delete_provider(request: Request) -> Response:
     )
 
 
-async def toggle_provider(request: Request) -> Response:
+async def toggle_provider(request: Any) -> Response:
     """Toggle a provider's enabled/disabled state."""
     config_path = _get_config_path(request)
     if not config_path:
@@ -386,7 +381,7 @@ async def toggle_provider(request: Request) -> Response:
     return JSONResponse({"ok": True, "provider": name, "enabled": new_enabled})
 
 
-async def put_model(request: Request) -> Response:
+async def put_model(request: Any) -> Response:
     """Add or update a model routing entry."""
     config_path = _get_config_path(request)
     if not config_path:
@@ -395,7 +390,7 @@ async def put_model(request: Request) -> Response:
     name = request.path_params["name"]
 
     try:
-        body = await request.json()
+        body = request.json()
     except Exception:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
@@ -468,7 +463,7 @@ async def put_model(request: Request) -> Response:
     )
 
 
-async def delete_model(request: Request) -> Response:
+async def delete_model(request: Any) -> Response:
     """Remove a model routing entry."""
     config_path = _get_config_path(request)
     if not config_path:
@@ -515,14 +510,14 @@ async def delete_model(request: Request) -> Response:
     )
 
 
-async def put_server_settings(request: Request) -> Response:
+async def put_server_settings(request: Any) -> Response:
     """Update server settings (e.g. global proxy)."""
     config_path = _get_config_path(request)
     if not config_path:
         return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     try:
-        body = await request.json()
+        body = request.json()
     except Exception:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
@@ -563,7 +558,7 @@ async def put_server_settings(request: Request) -> Response:
     return JSONResponse({"ok": True, "server": data.get("server", {})})
 
 
-async def reload_config(request: Request) -> Response:
+async def reload_config(request: Any) -> Response:
     """Force hot-reload of the config from disk."""
     config_path = _get_config_path(request)
     if not config_path:
@@ -588,10 +583,10 @@ async def reload_config(request: Request) -> Response:
 # ---------------------------------------------------------------------------
 
 
-async def get_metrics(request: Request) -> Response:
+async def get_metrics(request: Any) -> Response:
     """Return a full metrics snapshot."""
-    metrics = request.app.state.metrics
-    seconds = int(request.query_params.get("seconds", "60"))
+    metrics = request.app.metrics
+    seconds = int(_qp(request, "seconds", "60"))
     seconds = max(1, min(seconds, 300))
     return JSONResponse(metrics.snapshot(series_seconds=seconds))
 
@@ -601,14 +596,14 @@ async def get_metrics(request: Request) -> Response:
 # ---------------------------------------------------------------------------
 
 
-async def get_requests(request: Request) -> Response:
+async def get_requests(request: Any) -> Response:
     """Return paginated, filtered request log entries."""
-    log = request.app.state.request_log
-    limit = int(request.query_params.get("limit", "50"))
-    offset = int(request.query_params.get("offset", "0"))
-    model = request.query_params.get("model")
-    provider = request.query_params.get("provider")
-    status = request.query_params.get("status")
+    log = request.app.request_log
+    limit = int(_qp(request, "limit", "50"))
+    offset = int(_qp(request, "offset", "0"))
+    model = _qp(request, "model")
+    provider = _qp(request, "provider")
+    status = _qp(request, "status")
 
     entries, total = log.get_entries(
         limit=limit, offset=offset, model=model, provider=provider, status=status
@@ -616,14 +611,14 @@ async def get_requests(request: Request) -> Response:
     return JSONResponse({"entries": entries, "total": total})
 
 
-async def clear_requests(request: Request) -> Response:
+async def clear_requests(request: Any) -> Response:
     """Clear the request log."""
-    log = request.app.state.request_log
+    log = request.app.request_log
     log.clear()
     return JSONResponse({"ok": True})
 
 
-async def get_provider_key(request: Request) -> Response:
+async def get_provider_key(request: Any) -> Response:
     """Return the raw (unmasked) API key for a single provider."""
     config_path = _get_config_path(request)
     if not config_path:
@@ -648,7 +643,7 @@ async def get_provider_key(request: Request) -> Response:
 # ---------------------------------------------------------------------------
 
 
-async def network_diagnostics(request: Request) -> Response:
+async def network_diagnostics(request: Any) -> Response:
     """Run basic network diagnostics: IP geolocation and Google connectivity.
 
     Uses the gateway's configured global proxy (if any) so the diagnostics
@@ -657,7 +652,7 @@ async def network_diagnostics(request: Request) -> Response:
     import httpx
 
     # Resolve the global proxy from current gateway config
-    gw_config: GatewayConfig | None = getattr(request.app.state, "gateway_config", None)
+    gw_config: GatewayConfig | None = getattr(request.app, "gateway_config", None)
     proxy_url = gw_config.proxy if gw_config else None
 
     client_kwargs: dict[str, Any] = {"timeout": 15}
@@ -707,7 +702,7 @@ async def network_diagnostics(request: Request) -> Response:
 # ---------------------------------------------------------------------------
 
 
-async def get_api_keys(request: Request) -> Response:
+async def get_api_keys(request: Any) -> Response:
     """List all gateway API keys (values masked)."""
     config_path = _get_config_path(request)
     if not config_path:
@@ -735,14 +730,14 @@ async def get_api_keys(request: Request) -> Response:
     return JSONResponse({"keys": masked})
 
 
-async def create_api_key(request: Request) -> Response:
+async def create_api_key(request: Any) -> Response:
     """Create a new gateway API key."""
     config_path = _get_config_path(request)
     if not config_path:
         return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     try:
-        body = await request.json()
+        body = request.json()
     except Exception:
         body = {}
 
@@ -796,7 +791,7 @@ async def create_api_key(request: Request) -> Response:
     return JSONResponse({"ok": True, "key": entry})
 
 
-async def update_api_key(request: Request) -> Response:
+async def update_api_key(request: Any) -> Response:
     """Update an API key's label."""
     config_path = _get_config_path(request)
     if not config_path:
@@ -805,7 +800,7 @@ async def update_api_key(request: Request) -> Response:
     key_id = request.path_params["key_id"]
 
     try:
-        body = await request.json()
+        body = request.json()
     except Exception:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
@@ -849,7 +844,7 @@ async def update_api_key(request: Request) -> Response:
     return JSONResponse({"ok": True, "id": key_id, "label": target["label"]})
 
 
-async def delete_api_key(request: Request) -> Response:
+async def delete_api_key(request: Any) -> Response:
     """Delete a gateway API key."""
     config_path = _get_config_path(request)
     if not config_path:
@@ -891,7 +886,7 @@ async def delete_api_key(request: Request) -> Response:
     return JSONResponse({"ok": True, "deleted": key_id})
 
 
-async def reveal_api_key(request: Request) -> Response:
+async def reveal_api_key(request: Any) -> Response:
     """Return the raw (unmasked) API key value."""
     config_path = _get_config_path(request)
     if not config_path:
@@ -912,68 +907,49 @@ async def reveal_api_key(request: Request) -> Response:
     return JSONResponse({"error": f"Key '{key_id}' not found"}, status_code=404)
 
 
-async def get_internal_token(request: Request) -> Response:
+async def get_internal_token(request: Any) -> Response:
     """Return the ephemeral internal token for admin panel test requests."""
-    token = getattr(request.app.state, "internal_token", None)
+    token = getattr(request.app, "internal_token", None)
     if not token:
         return JSONResponse({"error": "No internal token available"}, status_code=500)
     return JSONResponse({"token": token})
 
 
 # ---------------------------------------------------------------------------
-# Route table
+# Route registration
 # ---------------------------------------------------------------------------
 
-admin_routes: list[Route] = [
+
+def register_admin_routes(app: Any) -> None:
+    """Register all admin panel routes on the httpserver App."""
     # HTML
-    Route("/admin", serve_admin_html, methods=["GET"]),
-    Route("/admin/", serve_admin_html, methods=["GET"]),
+    app.route("/admin", methods=["GET"])(serve_admin_html)
+    app.route("/admin/", methods=["GET"])(serve_admin_html)
     # Config CRUD
-    Route("/admin/api/config", get_config, methods=["GET"]),
-    Route(
-        "/admin/api/config/providers/{name}",
-        put_provider,
-        methods=["PUT"],
-    ),
-    Route(
-        "/admin/api/config/providers/{name}",
-        delete_provider,
-        methods=["DELETE"],
-    ),
-    Route(
-        "/admin/api/config/providers/{name}/toggle",
-        toggle_provider,
-        methods=["POST"],
-    ),
-    Route(
-        "/admin/api/config/providers/{name}/key",
-        get_provider_key,
-        methods=["GET"],
-    ),
-    Route(
-        "/admin/api/config/models/{name:path}",
-        put_model,
-        methods=["PUT"],
-    ),
-    Route(
-        "/admin/api/config/models/{name:path}",
-        delete_model,
-        methods=["DELETE"],
-    ),
-    Route("/admin/api/config/server", put_server_settings, methods=["PUT"]),
-    Route("/admin/api/config/reload", reload_config, methods=["POST"]),
+    app.route("/admin/api/config", methods=["GET"])(get_config)
+    app.route("/admin/api/config/providers/<name>", methods=["PUT"])(put_provider)
+    app.route("/admin/api/config/providers/<name>", methods=["DELETE"])(delete_provider)
+    app.route("/admin/api/config/providers/<name>/toggle", methods=["POST"])(
+        toggle_provider
+    )
+    app.route("/admin/api/config/providers/<name>/key", methods=["GET"])(
+        get_provider_key
+    )
+    app.route("/admin/api/config/models/<path:name>", methods=["PUT"])(put_model)
+    app.route("/admin/api/config/models/<path:name>", methods=["DELETE"])(delete_model)
+    app.route("/admin/api/config/server", methods=["PUT"])(put_server_settings)
+    app.route("/admin/api/config/reload", methods=["POST"])(reload_config)
     # Metrics
-    Route("/admin/api/metrics", get_metrics, methods=["GET"]),
+    app.route("/admin/api/metrics", methods=["GET"])(get_metrics)
     # Request log
-    Route("/admin/api/requests", get_requests, methods=["GET"]),
-    Route("/admin/api/requests", clear_requests, methods=["DELETE"]),
+    app.route("/admin/api/requests", methods=["GET"])(get_requests)
+    app.route("/admin/api/requests", methods=["DELETE"])(clear_requests)
     # Network diagnostics
-    Route("/admin/api/diagnostics/network", network_diagnostics, methods=["GET"]),
+    app.route("/admin/api/diagnostics/network", methods=["GET"])(network_diagnostics)
     # API key management
-    Route("/admin/api/keys", get_api_keys, methods=["GET"]),
-    Route("/admin/api/keys", create_api_key, methods=["POST"]),
-    Route("/admin/api/keys/{key_id}", update_api_key, methods=["PUT"]),
-    Route("/admin/api/keys/{key_id}", delete_api_key, methods=["DELETE"]),
-    Route("/admin/api/keys/{key_id}/reveal", reveal_api_key, methods=["GET"]),
-    Route("/admin/api/internal-token", get_internal_token, methods=["GET"]),
-]
+    app.route("/admin/api/keys", methods=["GET"])(get_api_keys)
+    app.route("/admin/api/keys", methods=["POST"])(create_api_key)
+    app.route("/admin/api/keys/<key_id>", methods=["PUT"])(update_api_key)
+    app.route("/admin/api/keys/<key_id>", methods=["DELETE"])(delete_api_key)
+    app.route("/admin/api/keys/<key_id>/reveal", methods=["GET"])(reveal_api_key)
+    app.route("/admin/api/internal-token", methods=["GET"])(get_internal_token)

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -649,13 +649,13 @@ async def network_diagnostics(request: Any) -> Response:
     Uses the gateway's configured global proxy (if any) so the diagnostics
     reflect the actual outbound path of API requests.
     """
-    import httpx
+    from llm_rosetta._vendor.httpclient import AsyncClient as HttpClient
 
     # Resolve the global proxy from current gateway config
     gw_config: GatewayConfig | None = getattr(request.app, "gateway_config", None)
     proxy_url = gw_config.proxy if gw_config else None
 
-    client_kwargs: dict[str, Any] = {"timeout": 15}
+    client_kwargs: dict[str, Any] = {"timeout": 15.0}
     if proxy_url:
         client_kwargs["proxy"] = proxy_url
 
@@ -665,7 +665,7 @@ async def network_diagnostics(request: Any) -> Response:
 
     # IP geolocation via ip-api.com (no key required, JSON by default)
     try:
-        async with httpx.AsyncClient(**client_kwargs) as client:
+        async with HttpClient(**client_kwargs) as client:
             resp = await client.get(
                 "http://ip-api.com/json/?fields=query,country,city,isp"
             )
@@ -685,7 +685,7 @@ async def network_diagnostics(request: Any) -> Response:
 
     # Google connectivity
     try:
-        async with httpx.AsyncClient(**client_kwargs) as client:
+        async with HttpClient(**client_kwargs) as client:
             resp = await client.get("https://www.google.com/generate_204")
             results["google"] = {
                 "ok": resp.status_code == 204,

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -1,22 +1,15 @@
-"""llm-rosetta Gateway — ASGI application and route handlers."""
+"""llm-rosetta Gateway — HTTP application and route handlers."""
 
 from __future__ import annotations
 
 import asyncio
 import time
-from contextlib import asynccontextmanager
-from collections.abc import AsyncGenerator
 from typing import Any
 
-from starlette.applications import Starlette
-from starlette.middleware import Middleware
-from starlette.middleware.cors import CORSMiddleware
-from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
-from starlette.routing import Route
-
+from llm_rosetta._vendor.httpserver import App, JSONResponse, Response
 from llm_rosetta.auto_detect import ProviderType
 
+from .auth import AuthState, api_key_label_var, create_auth_hook
 from .config import GatewayConfig
 from .logging import get_logger
 from .proxy import (
@@ -40,7 +33,7 @@ _config: GatewayConfig | None = None
 
 
 async def _proxy_handler(
-    request: Request,
+    request: Any,
     source_provider: ProviderType,
     model_override: str | None = None,
     force_stream: bool = False,
@@ -49,7 +42,7 @@ async def _proxy_handler(
     assert _config is not None
 
     try:
-        body: dict[str, Any] = await request.json()
+        body: dict[str, Any] = request.json()
     except Exception:
         return error_response_for_source(source_provider, 400, "Invalid JSON body")
 
@@ -86,7 +79,7 @@ async def _proxy_handler(
         is_stream,
     )
 
-    store: ProviderMetadataStore = request.app.state.metadata_store
+    store: ProviderMetadataStore = request.app.metadata_store
 
     # Forward OpenResponses-Version header to upstream if present
     extra_headers: dict[str, str] | None = None
@@ -95,8 +88,8 @@ async def _proxy_handler(
         extra_headers = {"OpenResponses-Version": or_version}
 
     # --- Metrics instrumentation ---
-    metrics = getattr(request.app.state, "metrics", None)
-    request_log = getattr(request.app.state, "request_log", None)
+    metrics = getattr(request.app, "metrics", None)
+    request_log = getattr(request.app, "request_log", None)
     t0 = time.monotonic()
     status_code = 500
     error_detail: str | None = None
@@ -149,7 +142,7 @@ async def _proxy_handler(
         if request_log is not None:
             from .admin.request_log import RequestLogEntry
 
-            api_key_label = getattr(request.state, "api_key_label", None)
+            api_key_label = api_key_label_var.get()
             request_log.add(
                 RequestLogEntry.create(
                     model=model,
@@ -167,20 +160,19 @@ async def _proxy_handler(
 # --- Endpoint handlers ---
 
 
-async def handle_openai_chat(request: Request) -> Response:
+async def handle_openai_chat(request: Any) -> Response:
     return await _proxy_handler(request, source_provider="openai_chat")
 
 
-async def handle_anthropic(request: Request) -> Response:
+async def handle_anthropic(request: Any) -> Response:
     return await _proxy_handler(request, source_provider="anthropic")
 
 
-async def handle_openai_responses(request: Request) -> Response:
+async def handle_openai_responses(request: Any) -> Response:
     return await _proxy_handler(request, source_provider="openai_responses")
 
 
-async def handle_google_genai(request: Request) -> Response:
-    model_path = request.path_params["model_path"]
+async def handle_google_genai(request: Any, model_path: str = "") -> Response:
     if model_path.endswith(":streamGenerateContent"):
         model = model_path.removesuffix(":streamGenerateContent")
         return await _proxy_handler(
@@ -196,13 +188,13 @@ async def handle_google_genai(request: Request) -> Response:
         )
     else:
         return Response(
+            body='{"error": "Unknown Google GenAI method"}',
             status_code=404,
-            content='{"error": "Unknown Google GenAI method"}',
-            media_type="application/json",
+            content_type="application/json",
         )
 
 
-async def handle_list_models(request: Request) -> Response:
+async def handle_list_models(request: Any) -> Response:
     """List configured models in a format compatible with OpenAI and Anthropic SDKs."""
     assert _config is not None
     models = sorted(_config.models.keys())
@@ -229,7 +221,7 @@ async def handle_list_models(request: Request) -> Response:
     )
 
 
-async def handle_list_models_google(request: Request) -> Response:
+async def handle_list_models_google(request: Any) -> Response:
     """List configured models in Google GenAI SDK format."""
     assert _config is not None
     models_list = [
@@ -246,7 +238,7 @@ async def handle_list_models_google(request: Request) -> Response:
     return JSONResponse({"models": models_list})
 
 
-async def handle_health(request: Request) -> Response:
+async def handle_health(request: Any) -> Response:
     assert _config is not None
     return JSONResponse(
         {
@@ -264,18 +256,14 @@ async def handle_health(request: Request) -> Response:
 _FLUSH_METRICS_INTERVAL = 30  # seconds
 
 
-async def _periodic_flush(app: Starlette) -> None:
-    """Periodically flush metrics counters to disk.
-
-    Request log entries are written to SQLite immediately by
-    :class:`RequestLog`, so only metrics need periodic flushing.
-    """
+async def _periodic_flush(app: App) -> None:
+    """Periodically flush metrics counters to disk."""
     while True:
         await asyncio.sleep(_FLUSH_METRICS_INTERVAL)
-        persistence = getattr(app.state, "persistence", None)
+        persistence = getattr(app, "persistence", None)
         if persistence is None:
             continue
-        metrics = getattr(app.state, "metrics", None)
+        metrics = getattr(app, "metrics", None)
         if metrics is not None:
             try:
                 persistence.save_metrics(metrics.export_counters())
@@ -283,13 +271,13 @@ async def _periodic_flush(app: Starlette) -> None:
                 logger.warning("Failed to flush metrics: %s", exc)
 
 
-def _flush_now(app: Starlette) -> None:
+def _flush_now(app: App) -> None:
     """Final synchronous flush on shutdown."""
-    persistence = getattr(app.state, "persistence", None)
+    persistence = getattr(app, "persistence", None)
     if persistence is None:
         return
 
-    metrics = getattr(app.state, "metrics", None)
+    metrics = getattr(app, "metrics", None)
     if metrics is not None:
         try:
             persistence.save_metrics(metrics.export_counters())
@@ -305,8 +293,8 @@ def _flush_now(app: Starlette) -> None:
 # ---------------------------------------------------------------------------
 
 
-def create_app(config: GatewayConfig, config_path: str | None = None) -> Starlette:
-    """Create the Starlette ASGI application."""
+def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
+    """Create the httpserver application."""
     global _config
     _config = config
 
@@ -320,64 +308,74 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> Starlet
 
     metadata_store = ProviderMetadataStore()
 
-    routes = [
-        Route("/v1/chat/completions", handle_openai_chat, methods=["POST"]),
-        Route("/v1/messages", handle_anthropic, methods=["POST"]),
-        Route("/v1/responses", handle_openai_responses, methods=["POST"]),
-        Route("/v1/models", handle_list_models, methods=["GET"]),
-        Route("/v1beta/models", handle_list_models_google, methods=["GET"]),
-        Route(
-            "/v1beta/models/{model_path:path}",
-            handle_google_genai,
-            methods=["POST"],
-        ),
-        Route("/health", handle_health, methods=["GET"]),
-    ]
+    app = App(max_body_size=50_000_000, read_timeout=300.0)
 
-    @asynccontextmanager
-    async def lifespan(app: Starlette) -> AsyncGenerator[None, None]:
-        flush_task = asyncio.create_task(_periodic_flush(app))
-        yield
+    # --- Routes ---
+    app.route("/v1/chat/completions", methods=["POST"])(handle_openai_chat)
+    app.route("/v1/messages", methods=["POST"])(handle_anthropic)
+    app.route("/v1/responses", methods=["POST"])(handle_openai_responses)
+    app.route("/v1/models", methods=["GET"])(handle_list_models)
+    app.route("/v1beta/models", methods=["GET"])(handle_list_models_google)
+    app.route("/v1beta/models/<path:model_path>", methods=["POST"])(handle_google_genai)
+    app.route("/health", methods=["GET"])(handle_health)
+
+    # --- Auth ---
+    import secrets
+
+    internal_token = f"rsk-internal-{secrets.token_hex(16)}"
+    auth_state = AuthState(config.api_key_set, config.api_key_labels, internal_token)
+    app.before_request(create_auth_hook(auth_state))
+
+    # --- CORS ---
+    @app.after_request
+    async def add_cors_headers(request: Any, response: Any) -> Any:
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        response.headers["Access-Control-Allow-Methods"] = "*"
+        response.headers["Access-Control-Allow-Headers"] = "*"
+        return response
+
+    @app.route("/<path:_path>", methods=["OPTIONS"])
+    async def cors_preflight(request: Any, _path: str = "") -> Response:
+        return Response(body=b"", status_code=204)
+
+    @app.errorhandler(404)
+    async def handle_404(request: Any, exc: Any) -> Response:
+        resp = JSONResponse({"error": "Not Found"}, status_code=404)
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        return resp
+
+    @app.errorhandler(405)
+    async def handle_405(request: Any, exc: Any) -> Response:
+        resp = JSONResponse({"error": "Method Not Allowed"}, status_code=405)
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        return resp
+
+    # --- Admin routes ---
+    from .admin import setup_admin
+    from .admin.routes import register_admin_routes
+
+    register_admin_routes(app)
+
+    # --- App-level state ---
+    app.metadata_store = metadata_store  # type: ignore[attr-defined]
+    app.internal_token = internal_token  # type: ignore[attr-defined]
+    app.auth_state = auth_state  # type: ignore[attr-defined]
+
+    setup_admin(app, config, config_path)
+
+    return app
+
+
+async def run_gateway(app: App, host: str, port: int) -> None:
+    """Start the gateway with lifecycle management."""
+    flush_task = asyncio.create_task(_periodic_flush(app))
+    try:
+        await app._serve(host, port)
+    finally:
         flush_task.cancel()
         try:
             await flush_task
         except asyncio.CancelledError:
             pass
         _flush_now(app)
-        await close_resources(metadata_store=metadata_store)
-
-    import secrets
-
-    from .auth import GatewayAuthMiddleware
-
-    internal_token = f"rsk-internal-{secrets.token_hex(16)}"
-
-    middleware = [
-        Middleware(
-            CORSMiddleware,  # type: ignore[arg-type]
-            allow_origins=["*"],
-            allow_methods=["*"],
-            allow_headers=["*"],
-        ),
-        Middleware(
-            GatewayAuthMiddleware,  # type: ignore[arg-type]
-            api_key_set=config.api_key_set,
-            api_key_labels=config.api_key_labels,
-            internal_token=internal_token,
-        ),
-    ]
-
-    # Append admin panel routes before constructing the app so that
-    # Starlette's Router compiles them into its lookup structures.
-    from .admin import setup_admin
-    from .admin.routes import admin_routes
-
-    routes.extend(admin_routes)
-
-    app = Starlette(routes=routes, lifespan=lifespan, middleware=middleware)
-    app.state.metadata_store = metadata_store
-    app.state.internal_token = internal_token
-
-    setup_admin(app, config, config_path)
-
-    return app
+        await close_resources(metadata_store=app.metadata_store)  # type: ignore[attr-defined]

--- a/src/llm_rosetta/gateway/auth.py
+++ b/src/llm_rosetta/gateway/auth.py
@@ -1,4 +1,4 @@
-"""Gateway API key authentication middleware.
+"""Gateway API key authentication — before-request hook.
 
 Validates incoming requests against the gateway's configured API keys,
 extracting credentials in the format native to each API standard:
@@ -13,12 +13,15 @@ configured, all requests pass through (backward compatible).
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+import contextvars
+from typing import Any
 
-from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
-from starlette.types import ASGIApp, Receive, Scope, Send
+from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
+# Per-request API key label — set by auth hook, read by proxy handler.
+api_key_label_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "api_key_label", default=None
+)
 
 # Paths that never require authentication
 _PUBLIC_PATHS = frozenset({"/health"})
@@ -32,9 +35,9 @@ _ROUTE_EXTRACTORS: list[tuple[str, str]] = [
 ]
 
 
-def _extract_key(request: Request) -> str | None:
+def _extract_key(request: Any) -> str | None:
     """Extract API key from the request using the appropriate strategy."""
-    path = request.url.path
+    path = request.path
 
     strategy = "openai"  # default fallback
     for prefix, strat in _ROUTE_EXTRACTORS:
@@ -46,7 +49,11 @@ def _extract_key(request: Request) -> str | None:
         return request.headers.get("x-api-key")
     elif strategy == "google":
         # Google uses x-goog-api-key header or ?key= query param
-        return request.headers.get("x-goog-api-key") or request.query_params.get("key")
+        google_key = request.headers.get("x-goog-api-key")
+        if google_key:
+            return google_key
+        vals = request.query_params.get("key")
+        return vals[0] if vals else None
     else:
         # OpenAI-style Bearer token
         auth = request.headers.get("authorization", "")
@@ -95,61 +102,57 @@ def _error_for_path(path: str, status: int, message: str) -> Response:
         )
 
 
-class GatewayAuthMiddleware:
-    """Starlette ASGI middleware for gateway API key authentication."""
+class AuthState:
+    """Mutable state container for auth hook — allows hot-reload from admin."""
 
     def __init__(
         self,
-        app: ASGIApp,
-        *,
-        api_key: str | None = None,
-        api_key_set: Iterable[str] | None = None,
-        api_key_labels: dict[str, str] | None = None,
-        internal_token: str | None = None,
+        key_set: frozenset[str],
+        labels: dict[str, str],
+        internal_token: str | None,
     ) -> None:
-        self.app = app
-        # Accept either multi-key set or legacy single key
-        if api_key_set is not None:
-            self._key_set: frozenset[str] = frozenset(api_key_set)
-        elif api_key:
-            self._key_set = frozenset({api_key})
-        else:
-            self._key_set = frozenset()
-        self._labels: dict[str, str] = dict(api_key_labels or {})
-        self._internal_token: str | None = internal_token
+        self.key_set = key_set
+        self.labels = labels
+        self.internal_token = internal_token
 
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http" or not self._key_set:
-            await self.app(scope, receive, send)
-            return
 
-        request = Request(scope)
-        path = request.url.path
+def create_auth_hook(auth_state: AuthState) -> Any:
+    """Return a before-request hook that validates API keys.
+
+    The hook reads from ``auth_state`` which can be mutated by the admin
+    panel's hot-reload logic.
+    """
+
+    async def auth_hook(request: Any) -> Response | None:
+        # Reset per-request label
+        api_key_label_var.set(None)
+
+        if not auth_state.key_set:
+            return None  # no keys configured → pass through
+
+        path = request.path
 
         # Public paths skip auth
         if path in _PUBLIC_PATHS:
-            await self.app(scope, receive, send)
-            return
+            return None
 
         # Admin panel: no gateway-level auth — delegate to reverse proxy
         if path.startswith("/admin"):
-            await self.app(scope, receive, send)
-            return
+            return None
 
         # API paths: extract key using format-appropriate strategy
         key = _extract_key(request)
 
         # Check internal token first (admin panel test requests)
-        if key and self._internal_token and key == self._internal_token:
-            scope.setdefault("state", {})["api_key_label"] = "internal"
-            await self.app(scope, receive, send)
-            return
+        if key and auth_state.internal_token and key == auth_state.internal_token:
+            api_key_label_var.set("internal")
+            return None
 
-        if key not in self._key_set:
-            response = _error_for_path(path, 401, "Invalid or missing API key")
-            await response(scope, receive, send)
-            return
+        if key not in auth_state.key_set:
+            return _error_for_path(path, 401, "Invalid or missing API key")
 
         # Attach key label for request logging
-        scope.setdefault("state", {})["api_key_label"] = self._labels.get(key, "")
-        await self.app(scope, receive, send)
+        api_key_label_var.set(auth_state.labels.get(key, ""))
+        return None
+
+    return auth_hook

--- a/src/llm_rosetta/gateway/cli.py
+++ b/src/llm_rosetta/gateway/cli.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from typing import Any
 
-import uvicorn
+import asyncio
 
 from llm_rosetta import __version__
 
@@ -357,9 +357,10 @@ def main() -> None:
         logger.info("Request/response body logging enabled")
 
     app = create_app(config, config_path=config_path)
-    uvicorn.run(
-        app,
-        host=host,
-        port=port,
-        log_level="debug" if verbose else args.log_level,
-    )
+
+    from .app import run_gateway
+
+    try:
+        asyncio.run(run_gateway(app, host, port))
+    except KeyboardInterrupt:
+        pass

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -18,7 +18,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any
 
-import httpx
+from llm_rosetta._vendor.httpclient import AsyncClient, HttpClientError
 from llm_rosetta._vendor.httpserver import JSONResponse, Response, StreamingResponse
 
 from llm_rosetta import get_converter_for_provider
@@ -213,14 +213,14 @@ def extract_model(source_provider: ProviderType, body: dict[str, Any]) -> str | 
 # HTTP client pool
 # ---------------------------------------------------------------------------
 
-# Shared httpx clients keyed by proxy URL (None = direct connection)
-_http_clients: dict[str | None, httpx.AsyncClient] = {}
+# Shared HTTP clients keyed by proxy URL (None = direct connection)
+_http_clients: dict[str | None, AsyncClient] = {}
 
 
-def get_client(proxy_url: str | None = None) -> httpx.AsyncClient:
-    """Get or create an ``httpx.AsyncClient`` for the given proxy URL."""
+def get_client(proxy_url: str | None = None) -> AsyncClient:
+    """Get or create an ``AsyncClient`` for the given proxy URL."""
     if proxy_url not in _http_clients:
-        _http_clients[proxy_url] = httpx.AsyncClient(
+        _http_clients[proxy_url] = AsyncClient(
             timeout=300.0,
             proxy=proxy_url,
         )
@@ -407,7 +407,7 @@ async def handle_non_streaming(
     client = get_client(provider_info.proxy_url)
     try:
         upstream_resp = await client.post(url, json=upstream_body, headers=headers)
-    except httpx.HTTPError as exc:
+    except HttpClientError as exc:
         return error_response_for_source(
             source_provider, 502, f"Upstream request failed: {exc}"
         )
@@ -480,8 +480,8 @@ def _parse_sse_data(line: str) -> Any:
 
 async def _format_upstream_error(upstream_resp: Any, endpoint: str) -> str:
     """Read an error response from upstream and format it as an SSE data line."""
-    await upstream_resp.aread()
-    error_text = upstream_resp.text
+    raw = await upstream_resp.aread()
+    error_text = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
     log_upstream_error(
         upstream_resp.status_code,
         error_text,
@@ -525,9 +525,10 @@ async def _stream_event_generator(
     t0 = time.monotonic()
 
     client = get_client(provider_info.proxy_url)
-    async with client.stream(
-        "POST", url, json=upstream_body, headers=headers
-    ) as upstream_resp:
+    upstream_resp = await client.post(
+        url, json=upstream_body, headers=headers, stream=True
+    )
+    async with upstream_resp:
         if upstream_resp.status_code >= 400:
             error_sse = await _format_upstream_error(
                 upstream_resp, str(target_provider)

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -481,7 +481,9 @@ def _parse_sse_data(line: str) -> Any:
 async def _format_upstream_error(upstream_resp: Any, endpoint: str) -> str:
     """Read an error response from upstream and format it as an SSE data line."""
     raw = await upstream_resp.aread()
-    error_text = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
+    error_text = (
+        raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
+    )
     log_upstream_error(
         upstream_resp.status_code,
         error_text,

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
-from starlette.responses import JSONResponse, Response, StreamingResponse
+from llm_rosetta._vendor.httpserver import JSONResponse, Response, StreamingResponse
 
 from llm_rosetta import get_converter_for_provider
 from llm_rosetta.auto_detect import ProviderType
@@ -420,9 +420,9 @@ async def handle_non_streaming(
             endpoint=str(target_provider),
         )
         return Response(
-            content=upstream_resp.content,
+            body=upstream_resp.content,
             status_code=upstream_resp.status_code,
-            media_type="application/json",
+            content_type="application/json",
         )
 
     # 6. Target response -> IR
@@ -650,5 +650,5 @@ async def handle_streaming(
             store=store,
             model=model,
         ),
-        media_type="text/event-stream",
+        content_type="text/event-stream",
     )


### PR DESCRIPTION
## Summary

- Replace Starlette + uvicorn with vendored zerodep `httpserver` module (zero-dependency async HTTP server)
- Replace httpx with vendored zerodep `httpclient` module (zero-dependency async HTTP client)
- Gateway now has **zero external runtime dependencies** — the `[gateway]` optional-dependencies list is empty

## Changes

### Phase 1: httpserver (replaces Starlette + uvicorn)
- Vendor `httpserver` via `zerodep add` CLI
- Rewrite auth from ASGI middleware to `before_request` hook with `contextvars.ContextVar` for per-request state
- Rewrite app factory with httpserver routing, CORS via `after_request` hook, and error handlers
- Migrate admin routes from Starlette `Route` list to `app.route()` decorators
- Replace `uvicorn.run()` with `asyncio.run(run_gateway())`

### Phase 2: httpclient (replaces httpx)
- Vendor `httpclient` via `zerodep add` CLI
- Replace `httpx.AsyncClient` with `httpclient.AsyncClient` in proxy and admin routes
- Adapt streaming pattern (`client.stream()` → `client.post(stream=True)`)
- Adapt response reading (`resp.text` → `(await resp.aread()).decode()`)

### Known limitation
- SOCKS proxy not yet supported by httpclient (tracked: Oaklight/zerodep#72)
- HTTP proxy support works as before

## Test plan
- [ ] Gateway starts with `llm-rosetta-gateway --config config.jsonc`
- [ ] OpenAI chat completions (streaming + non-streaming)
- [ ] Anthropic messages (streaming + non-streaming)
- [ ] Google GenAI generateContent
- [ ] Admin panel accessible and functional
- [ ] Auth middleware (API key validation, hot-reload)
- [ ] CORS headers present on responses