### PR TITLE
feat: restore SOCKS5 proxy support

### DIFF
--- a/src/llm_rosetta/_vendor/httpclient.py
+++ b/src/llm_rosetta/_vendor/httpclient.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.3.1"
+# version = "0.4.0"
 # deps = []
 # tier = "subsystem"
 # category = "network"
@@ -44,7 +44,9 @@ import http.client
 import json as _json
 import logging
 import os
+import socket
 import ssl
+import struct
 import threading
 import time
 import warnings
@@ -66,6 +68,7 @@ __all__ = [
     "TooManyRedirects",
     "HttpConnectionError",
     "HttpTimeoutError",
+    "Socks5Error",
     # Response classes
     "Response",
     "StreamingResponse",
@@ -166,6 +169,10 @@ class HttpTimeoutError(HttpClientError):
 # Backward-compatible aliases (deprecated: prefer HttpConnectionError/HttpTimeoutError)
 ConnectionError = HttpConnectionError  # noqa: A001
 TimeoutError = HttpTimeoutError  # noqa: A001
+
+
+class Socks5Error(HttpConnectionError):
+    """Raised on SOCKS5 proxy handshake failures."""
 
 
 # ── Data Models (Response) ──
@@ -1013,7 +1020,9 @@ def _parse_proxy(proxy: str) -> tuple[str, int, str | None, str | None]:
     """
     parsed = urlparse(proxy)
     hostname = parsed.hostname or ""
-    port = parsed.port or 8080
+    scheme = (parsed.scheme or "").lower()
+    default_port = 1080 if scheme.startswith("socks") else 8080
+    port = parsed.port or default_port
     username = parsed.username or None
     password = parsed.password or None
     return hostname, port, username, password
@@ -1031,6 +1040,205 @@ def _proxy_auth_header(username: str, password: str) -> str:
     """
     credentials = f"{username}:{password}".encode()
     return "Basic " + base64.b64encode(credentials).decode()
+
+
+# -- SOCKS5 helpers --
+
+_SOCKS5_VER = 0x05
+_SOCKS5_AUTH_VER = 0x01
+_SOCKS5_CMD_CONNECT = 0x01
+_SOCKS5_ATYPE_IPV4 = 0x01
+_SOCKS5_ATYPE_DOMAIN = 0x03
+_SOCKS5_ATYPE_IPV6 = 0x04
+_SOCKS5_METHOD_NO_AUTH = 0x00
+_SOCKS5_METHOD_USERPASS = 0x02
+_SOCKS5_METHOD_NO_ACCEPTABLE = 0xFF
+
+_SOCKS5_ERRORS: dict[int, str] = {
+    0x01: "general SOCKS server failure",
+    0x02: "connection not allowed by ruleset",
+    0x03: "network unreachable",
+    0x04: "host unreachable",
+    0x05: "connection refused by destination",
+    0x06: "TTL expired",
+    0x07: "command not supported",
+    0x08: "address type not supported",
+}
+
+
+def _is_socks_proxy(proxy: str | None) -> bool:
+    """Return True if proxy URL uses the socks5:// scheme."""
+    return proxy is not None and proxy.lower().startswith("socks5://")
+
+
+def _socks5_recv_exact(sock: socket.socket, n: int) -> bytes:
+    """Read exactly *n* bytes from *sock*, raising on premature close."""
+    data = b""
+    while len(data) < n:
+        chunk = sock.recv(n - len(data))
+        if not chunk:
+            raise Socks5Error("SOCKS5 proxy closed connection unexpectedly")
+        data += chunk
+    return data
+
+
+def _socks5_handshake_sync(
+    sock: socket.socket,
+    host: str,
+    port: int,
+    username: str | None = None,
+    password: str | None = None,
+) -> None:
+    """Perform the SOCKS5 handshake (RFC 1928 + RFC 1929) over *sock*."""
+    # Phase 1: method negotiation
+    if username and password:
+        sock.sendall(
+            struct.pack("BBB", _SOCKS5_VER, 2, _SOCKS5_METHOD_NO_AUTH)
+            + struct.pack("B", _SOCKS5_METHOD_USERPASS)
+        )
+    else:
+        sock.sendall(struct.pack("BBB", _SOCKS5_VER, 1, _SOCKS5_METHOD_NO_AUTH))
+
+    ver, method = struct.unpack("BB", _socks5_recv_exact(sock, 2))
+    if ver != _SOCKS5_VER:
+        raise Socks5Error(f"Unexpected SOCKS version: {ver}")
+    if method == _SOCKS5_METHOD_NO_ACCEPTABLE:
+        raise Socks5Error("SOCKS5 proxy: no acceptable authentication method")
+
+    # Phase 2: username/password auth (RFC 1929)
+    if method == _SOCKS5_METHOD_USERPASS:
+        if not username or not password:
+            raise Socks5Error(
+                "SOCKS5 proxy requires authentication but no credentials provided"
+            )
+        uname = username.encode()
+        passwd = password.encode()
+        sock.sendall(
+            struct.pack("BB", _SOCKS5_AUTH_VER, len(uname))
+            + uname
+            + struct.pack("B", len(passwd))
+            + passwd
+        )
+        auth_ver, status = struct.unpack("BB", _socks5_recv_exact(sock, 2))
+        if status != 0x00:
+            raise Socks5Error("SOCKS5 authentication failed")
+
+    # Phase 3: connect request
+    host_bytes = host.encode()
+    if len(host_bytes) > 255:
+        raise Socks5Error(f"SOCKS5 target hostname too long: {len(host_bytes)} bytes")
+    sock.sendall(
+        struct.pack(
+            "BBBB", _SOCKS5_VER, _SOCKS5_CMD_CONNECT, 0x00, _SOCKS5_ATYPE_DOMAIN
+        )
+        + struct.pack("B", len(host_bytes))
+        + host_bytes
+        + struct.pack("!H", port)
+    )
+
+    # Parse reply
+    ver, reply, _rsv, atype = struct.unpack("BBBB", _socks5_recv_exact(sock, 4))
+    if reply != 0x00:
+        msg = _SOCKS5_ERRORS.get(reply, f"unknown error 0x{reply:02x}")
+        raise Socks5Error(f"SOCKS5 connect failed: {msg}")
+
+    # Consume bind address
+    if atype == _SOCKS5_ATYPE_IPV4:
+        _socks5_recv_exact(sock, 4)
+    elif atype == _SOCKS5_ATYPE_IPV6:
+        _socks5_recv_exact(sock, 16)
+    elif atype == _SOCKS5_ATYPE_DOMAIN:
+        addr_len = struct.unpack("B", _socks5_recv_exact(sock, 1))[0]
+        _socks5_recv_exact(sock, addr_len)
+    # Consume bind port
+    _socks5_recv_exact(sock, 2)
+
+
+async def _socks5_handshake_async(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    host: str,
+    port: int,
+    timeout: float,
+    username: str | None = None,
+    password: str | None = None,
+) -> None:
+    """Perform the SOCKS5 handshake (RFC 1928 + RFC 1929) asynchronously."""
+    try:
+        # Phase 1: method negotiation
+        if username and password:
+            writer.write(
+                struct.pack("BBB", _SOCKS5_VER, 2, _SOCKS5_METHOD_NO_AUTH)
+                + struct.pack("B", _SOCKS5_METHOD_USERPASS)
+            )
+        else:
+            writer.write(struct.pack("BBB", _SOCKS5_VER, 1, _SOCKS5_METHOD_NO_AUTH))
+        await asyncio.wait_for(writer.drain(), timeout=timeout)
+
+        data = await asyncio.wait_for(reader.readexactly(2), timeout=timeout)
+        ver, method = struct.unpack("BB", data)
+        if ver != _SOCKS5_VER:
+            raise Socks5Error(f"Unexpected SOCKS version: {ver}")
+        if method == _SOCKS5_METHOD_NO_ACCEPTABLE:
+            raise Socks5Error("SOCKS5 proxy: no acceptable authentication method")
+
+        # Phase 2: username/password auth (RFC 1929)
+        if method == _SOCKS5_METHOD_USERPASS:
+            if not username or not password:
+                raise Socks5Error(
+                    "SOCKS5 proxy requires authentication but no credentials provided"
+                )
+            uname = username.encode()
+            passwd = password.encode()
+            writer.write(
+                struct.pack("BB", _SOCKS5_AUTH_VER, len(uname))
+                + uname
+                + struct.pack("B", len(passwd))
+                + passwd
+            )
+            await asyncio.wait_for(writer.drain(), timeout=timeout)
+            data = await asyncio.wait_for(reader.readexactly(2), timeout=timeout)
+            _auth_ver, status = struct.unpack("BB", data)
+            if status != 0x00:
+                raise Socks5Error("SOCKS5 authentication failed")
+
+        # Phase 3: connect request
+        host_bytes = host.encode()
+        if len(host_bytes) > 255:
+            raise Socks5Error(
+                f"SOCKS5 target hostname too long: {len(host_bytes)} bytes"
+            )
+        writer.write(
+            struct.pack(
+                "BBBB", _SOCKS5_VER, _SOCKS5_CMD_CONNECT, 0x00, _SOCKS5_ATYPE_DOMAIN
+            )
+            + struct.pack("B", len(host_bytes))
+            + host_bytes
+            + struct.pack("!H", port)
+        )
+        await asyncio.wait_for(writer.drain(), timeout=timeout)
+
+        # Parse reply
+        data = await asyncio.wait_for(reader.readexactly(4), timeout=timeout)
+        ver, reply, _rsv, atype = struct.unpack("BBBB", data)
+        if reply != 0x00:
+            msg = _SOCKS5_ERRORS.get(reply, f"unknown error 0x{reply:02x}")
+            raise Socks5Error(f"SOCKS5 connect failed: {msg}")
+
+        # Consume bind address
+        if atype == _SOCKS5_ATYPE_IPV4:
+            await asyncio.wait_for(reader.readexactly(4), timeout=timeout)
+        elif atype == _SOCKS5_ATYPE_IPV6:
+            await asyncio.wait_for(reader.readexactly(16), timeout=timeout)
+        elif atype == _SOCKS5_ATYPE_DOMAIN:
+            data = await asyncio.wait_for(reader.readexactly(1), timeout=timeout)
+            addr_len = struct.unpack("B", data)[0]
+            await asyncio.wait_for(reader.readexactly(addr_len), timeout=timeout)
+        # Consume bind port
+        await asyncio.wait_for(reader.readexactly(2), timeout=timeout)
+
+    except asyncio.IncompleteReadError as exc:
+        raise Socks5Error("SOCKS5 proxy closed connection unexpectedly") from exc
 
 
 # -- URL helpers --
@@ -1222,6 +1430,40 @@ def _sync_connect_via_proxy(
     return conn, path
 
 
+def _sync_connect_via_socks5(
+    host: str,
+    port: int,
+    path: str,
+    is_https: bool,
+    timeout: float,
+    verify: bool,
+    proxy: str,
+) -> tuple[http.client.HTTPConnection, str]:
+    """Establish a sync connection through a SOCKS5 proxy.
+
+    Creates a SOCKS5 tunnel to the target, optionally wrapping with TLS.
+
+    Returns:
+        (connection, request_path).
+    """
+    proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
+    sock = socket.create_connection((proxy_host, proxy_port), timeout=timeout)
+    try:
+        _socks5_handshake_sync(sock, host, port, proxy_user, proxy_pass)
+    except Exception:
+        sock.close()
+        raise
+
+    if is_https:
+        ctx = _make_ssl_context(verify)
+        sock = ctx.wrap_socket(sock, server_hostname=host)
+        conn = http.client.HTTPSConnection(host, port, timeout=timeout, context=ctx)
+    else:
+        conn = http.client.HTTPConnection(host, port, timeout=timeout)
+    conn.sock = sock
+    return conn, path
+
+
 def _sync_acquire_connection(
     host: str,
     port: int,
@@ -1240,6 +1482,10 @@ def _sync_acquire_connection(
         (connection, request_path).
     """
     if proxy:
+        if _is_socks_proxy(proxy):
+            return _sync_connect_via_socks5(
+                host, port, path, is_https, timeout, verify, proxy
+            )
         return _sync_connect_via_proxy(
             host, port, path, is_https, timeout, verify, proxy, req_headers, url
         )
@@ -1624,6 +1870,48 @@ async def _async_connect_via_proxy_tunnel(
     return proxy_reader, proxy_writer
 
 
+async def _async_connect_via_socks5(
+    host: str,
+    port: int,
+    timeout: float,
+    verify: bool,
+    is_https: bool,
+    proxy: str,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Open a SOCKS5 tunnel and optionally upgrade to TLS.
+
+    Returns:
+        (reader, writer) with TLS already established if target is HTTPS.
+    """
+    proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
+    reader, writer = await asyncio.wait_for(
+        asyncio.open_connection(proxy_host, proxy_port),
+        timeout=timeout,
+    )
+    try:
+        await _socks5_handshake_async(
+            reader, writer, host, port, timeout, proxy_user, proxy_pass
+        )
+    except Exception:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+        raise
+
+    if is_https:
+        ctx = _make_ssl_context(verify)
+        loop = asyncio.get_event_loop()
+        transport = writer.transport
+        new_transport = await loop.start_tls(
+            transport, transport.get_protocol(), ctx, server_hostname=host
+        )
+        writer._transport = new_transport  # type: ignore[attr-defined]
+
+    return reader, writer
+
+
 async def _async_acquire_connection(
     host: str,
     port: int,
@@ -1645,6 +1933,11 @@ async def _async_acquire_connection(
     """
     try:
         if proxy:
+            if _is_socks_proxy(proxy):
+                reader, writer = await _async_connect_via_socks5(
+                    host, port, timeout, verify, is_https, proxy
+                )
+                return reader, writer, path
             if not is_https:
                 proxy_host, proxy_port, proxy_user, proxy_pass = _parse_proxy(proxy)
                 reader, writer = await asyncio.wait_for(

--- a/src/llm_rosetta/_vendor/validate.py
+++ b/src/llm_rosetta/_vendor/validate.py
@@ -1,8 +1,8 @@
 # /// zerodep
-# version = "0.4.2"
+# version = "0.4.3"
 # deps = []
 # tier = "medium"
-# category = "data"
+# category = "validation"
 # note = "Install/update via `zerodep add validate`"
 # ///
 
@@ -36,6 +36,33 @@ Annotated constraints::
     class Item(TypedDict):
         name: Annotated[str, MinLen(1)]
         price: Annotated[float, Gt(0)]
+
+Field validators (transform + validate)::
+
+    from validate import FieldValidator
+
+    def strip_lower(v: str) -> str:
+        v = v.strip().lower()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
+    class User(TypedDict):
+        name: Annotated[str, FieldValidator(strip_lower)]
+
+Model validators (cross-field validation)::
+
+    from validate import model_validator
+
+    class RegisterForm(TypedDict):
+        password: str
+        confirm: str
+
+    @model_validator(RegisterForm)
+    def passwords_match(data: dict) -> dict:
+        if data["password"] != data["confirm"]:
+            raise ValueError("passwords do not match")
+        return data
 """
 
 from __future__ import annotations
@@ -57,12 +84,14 @@ __all__ = [
     "MaxLen",
     "Match",
     "Predicate",
+    "FieldValidator",
     # Error types
     "ErrorDetail",
     "ValidationError",
     # Public API
     "validate",
     "json_schema",
+    "model_validator",
 ]
 
 # ── Constraint Annotations ──
@@ -210,8 +239,72 @@ class Predicate:
         return self.description
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
+class FieldValidator:
+    """Custom validator that can transform the field value.
+
+    Unlike ``Predicate`` (which returns bool), the function receives the
+    validated value and returns a (possibly transformed) value.  Raise
+    ``ValueError`` or ``AssertionError`` to signal failure.
+
+    Args:
+        fn: A callable ``(value) -> value``.  Raise on failure.
+        description: Human-readable description for error messages.
+    """
+
+    fn: Callable[[Any], Any]
+    description: str = "custom validator"
+
+    def validate(self, value: Any) -> Any:
+        return self.fn(value)
+
+    def schema_kw(self) -> dict[str, Any]:
+        return {}
+
+    def __str__(self) -> str:
+        return self.description
+
+
 # Constraint base types for isinstance checks
-_CONSTRAINT_TYPES = (Gt, Ge, Lt, Le, MinLen, MaxLen, Match, Predicate)
+_CONSTRAINT_TYPES = (Gt, Ge, Lt, Le, MinLen, MaxLen, Match, Predicate, FieldValidator)
+
+
+# ── Model Validator Registry ──
+
+_MODEL_VALIDATORS: dict[type, list[Callable]] = {}
+
+
+def model_validator(tp: type) -> Callable[[Callable], Callable]:
+    """Register a model-level validator for a TypedDict or dataclass type.
+
+    The validator receives the full data dict after all field validation
+    passes.  It should return the (possibly modified) dict, or raise
+    ``ValueError`` / ``AssertionError`` on failure.
+
+    Args:
+        tp: The TypedDict or dataclass type to attach the validator to.
+
+    Returns:
+        A decorator that registers the function and returns it unchanged.
+
+    Example::
+
+        class RegisterForm(TypedDict):
+            password: str
+            confirm: str
+
+        @model_validator(RegisterForm)
+        def passwords_match(data: dict) -> dict:
+            if data["password"] != data["confirm"]:
+                raise ValueError("passwords do not match")
+            return data
+    """
+
+    def decorator(fn: Callable) -> Callable:
+        _MODEL_VALIDATORS.setdefault(tp, []).append(fn)
+        return fn
+
+    return decorator
 
 
 # ── Error Types ──
@@ -485,7 +578,19 @@ def _validate_annotated(
     value = _validate(value, base, path, errors, coerce)
     if len(errors) == err_count_before:
         for c in constraints:
-            if not c.check(value):
+            if isinstance(c, FieldValidator):
+                try:
+                    value = c.validate(value)
+                except (ValueError, AssertionError) as e:
+                    errors.append(
+                        ErrorDetail(
+                            path=path or "$",
+                            expected=str(c),
+                            actual=repr(value),
+                            message=f"Validator '{c}' failed for value {value!r} at '{path or '$'}': {e}",
+                        )
+                    )
+            elif not c.check(value):
                 errors.append(
                     ErrorDetail(
                         path=path or "$",
@@ -613,6 +718,8 @@ def _validate_struct_fields(
         )
         return value
 
+    err_before = len(errors)
+
     for name, (field_tp, required) in fields.items():
         if required and name not in value:
             errors.append(
@@ -628,6 +735,24 @@ def _validate_struct_fields(
         if name in fields:
             field_tp, _ = fields[name]
             _validate(val, field_tp, _join_path(path, name), errors, coerce)
+
+    # Run model validators only if no field-level errors were added
+    validators = _MODEL_VALIDATORS.get(tp)
+    if validators and len(errors) == err_before:
+        for validator in validators:
+            try:
+                result = validator(value)
+                if result is not None:
+                    value = result
+            except (ValueError, AssertionError) as e:
+                errors.append(
+                    ErrorDetail(
+                        path=path or "$",
+                        expected=f"{tp.__name__} model validation",
+                        actual=str(e),
+                        message=f"Model validator failed for {tp.__name__} at '{path or '$'}': {e}",
+                    )
+                )
 
     return value
 

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -1,0 +1,269 @@
+"""Shared fixtures for gateway tests.
+
+Provides a minimal httpbin-compatible HTTP server, a SOCKS5 proxy server
+(with optional auth), and related fixtures for integration testing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import select
+import socket
+import socketserver
+import struct
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal httpbin-compatible handler
+# ---------------------------------------------------------------------------
+
+
+class _HttpBinHandler(BaseHTTPRequestHandler):
+    """Lightweight httpbin server for proxy integration tests."""
+
+    def log_message(self, format, *args):  # noqa: A002
+        pass
+
+    def _send_json(self, data, status=200):
+        body = json.dumps(data, ensure_ascii=False).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _headers_dict(self):
+        return {k: v for k, v in self.headers.items()}
+
+    def _request_url(self):
+        return f"http://{self.headers['Host']}{self.path}"
+
+    def _read_body(self):
+        length = int(self.headers.get("Content-Length", 0))
+        return self.rfile.read(length) if length else b""
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/")
+
+        if path == "/get":
+            args = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+            self._send_json(
+                {
+                    "args": args,
+                    "headers": self._headers_dict(),
+                    "url": self._request_url(),
+                }
+            )
+        elif path.startswith("/stream-bytes/"):
+            n = int(path.rsplit("/", 1)[1])
+            data = os.urandom(n)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(n))
+            self.end_headers()
+            self.wfile.write(data)
+        else:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/")
+
+        if path == "/post":
+            raw = self._read_body()
+            ct = self.headers.get("Content-Type", "")
+            json_data = None
+            if "application/json" in ct and raw:
+                json_data = json.loads(raw)
+            self._send_json(
+                {
+                    "args": {k: v[0] for k, v in parse_qs(parsed.query).items()},
+                    "headers": self._headers_dict(),
+                    "url": self._request_url(),
+                    "json": json_data,
+                }
+            )
+        else:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+
+# ---------------------------------------------------------------------------
+# SOCKS5 proxy server (RFC 1928 / 1929)
+# ---------------------------------------------------------------------------
+
+
+class _Socks5Server(socketserver.ThreadingTCPServer):
+    """Minimal SOCKS5 server that optionally requires username/password auth."""
+
+    allow_reuse_address = True
+
+    def __init__(self, addr, handler_class, auth=None):
+        super().__init__(addr, handler_class)
+        self.socks5_auth = auth  # (username, password) or None
+
+
+class _Socks5Handler(socketserver.StreamRequestHandler):
+    """Minimal SOCKS5 proxy handler (RFC 1928 / 1929) for testing."""
+
+    def handle(self):
+        try:
+            self._do_handshake()
+        except Exception:
+            return
+
+    def _do_handshake(self):  # noqa: C901
+        # Phase 1: method negotiation
+        header = self.rfile.read(2)
+        if len(header) < 2:
+            return
+        ver, nmethods = struct.unpack("BB", header)
+        if ver != 0x05:
+            return
+        methods = self.rfile.read(nmethods)
+        if len(methods) < nmethods:
+            return
+
+        require_auth = self.server.socks5_auth is not None  # type: ignore
+
+        if require_auth:
+            if 0x02 not in methods:
+                self.wfile.write(struct.pack("BB", 0x05, 0xFF))
+                return
+            self.wfile.write(struct.pack("BB", 0x05, 0x02))
+            # Phase 2: username/password auth (RFC 1929)
+            auth_header = self.rfile.read(2)
+            if len(auth_header) < 2:
+                return
+            _auth_ver, ulen = struct.unpack("BB", auth_header)
+            uname = self.rfile.read(ulen)
+            plen_byte = self.rfile.read(1)
+            if not plen_byte:
+                return
+            plen = struct.unpack("B", plen_byte)[0]
+            passwd = self.rfile.read(plen)
+
+            expected_user, expected_pass = self.server.socks5_auth  # type: ignore
+            if uname.decode() != expected_user or passwd.decode() != expected_pass:
+                self.wfile.write(struct.pack("BB", 0x01, 0x01))  # auth failure
+                return
+            self.wfile.write(struct.pack("BB", 0x01, 0x00))  # auth success
+        else:
+            self.wfile.write(struct.pack("BB", 0x05, 0x00))  # no auth
+
+        # Phase 3: connect request
+        req_header = self.rfile.read(4)
+        if len(req_header) < 4:
+            return
+        ver, cmd, _rsv, atype = struct.unpack("BBBB", req_header)
+        if cmd != 0x01:  # only CONNECT supported
+            self._send_reply(0x07)
+            return
+
+        # Parse target address
+        if atype == 0x01:  # IPv4
+            addr_bytes = self.rfile.read(4)
+            target_host = socket.inet_ntoa(addr_bytes)
+        elif atype == 0x03:  # domain
+            addr_len = struct.unpack("B", self.rfile.read(1))[0]
+            target_host = self.rfile.read(addr_len).decode()
+        elif atype == 0x04:  # IPv6
+            addr_bytes = self.rfile.read(16)
+            target_host = socket.inet_ntop(socket.AF_INET6, addr_bytes)
+        else:
+            self._send_reply(0x08)
+            return
+
+        target_port = struct.unpack("!H", self.rfile.read(2))[0]
+
+        # Connect to target
+        try:
+            target = socket.create_connection((target_host, target_port), timeout=10)
+        except Exception:
+            self._send_reply(0x05)  # connection refused
+            return
+
+        # Success reply
+        self._send_reply(0x00)
+
+        # Bidirectional relay
+        client_sock = self.connection
+        client_sock.setblocking(False)
+        target.setblocking(False)
+        try:
+            while True:
+                readable, _, _ = select.select([client_sock, target], [], [], 1.0)
+                if not readable:
+                    continue
+                for sock in readable:
+                    try:
+                        data = sock.recv(8192)
+                    except (BlockingIOError, ConnectionResetError):
+                        data = b""
+                    if not data:
+                        return
+                    if sock is client_sock:
+                        target.sendall(data)
+                    else:
+                        client_sock.sendall(data)
+        except Exception:
+            pass
+        finally:
+            target.close()
+
+    def _send_reply(self, reply_code):
+        """Send a SOCKS5 reply with the given status code."""
+        self.wfile.write(
+            struct.pack("BBBB", 0x05, reply_code, 0x00, 0x01)
+            + b"\x00\x00\x00\x00"  # bind addr (0.0.0.0)
+            + struct.pack("!H", 0)  # bind port
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def httpbin_url():
+    """Start a local httpbin-compatible server and yield its base URL."""
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _HttpBinHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}"
+    server.shutdown()
+
+
+@pytest.fixture(scope="session")
+def socks5_url():
+    """Start a local SOCKS5 proxy (no auth) and yield its URL."""
+    server = _Socks5Server(("127.0.0.1", 0), _Socks5Handler, auth=None)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"socks5://127.0.0.1:{port}"
+    server.shutdown()
+
+
+@pytest.fixture(scope="session")
+def socks5_auth_url():
+    """Start a local SOCKS5 proxy with username/password auth."""
+    server = _Socks5Server(
+        ("127.0.0.1", 0), _Socks5Handler, auth=("testuser", "testpass")
+    )
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"socks5://testuser:testpass@127.0.0.1:{port}"
+    server.shutdown()

--- a/tests/gateway/test_socks5_proxy.py
+++ b/tests/gateway/test_socks5_proxy.py
@@ -1,0 +1,94 @@
+"""SOCKS5 proxy integration tests for the vendored httpclient.
+
+Verifies that the gateway's proxy code path (AsyncClient with proxy=)
+works correctly with SOCKS5 proxies, mirroring how proxy.py:get_client()
+creates clients for upstream requests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from llm_rosetta._vendor.httpclient import (
+    AsyncClient,
+    HttpConnectionError,
+    Response as HttpResponse,
+    Socks5Error,
+    StreamingResponse as HttpStreamingResponse,
+)
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestAsyncSocks5:
+    """Async SOCKS5 proxy tests — mirrors gateway's AsyncClient usage."""
+
+    def test_get_through_socks5(self, httpbin_url, socks5_url):
+        async def _t():
+            async with AsyncClient(proxy=socks5_url) as client:
+                r = await client.get(f"{httpbin_url}/get")
+                assert isinstance(r, HttpResponse)
+                assert r.status_code == 200
+                assert "url" in r.json()
+
+        _run(_t())
+
+    def test_post_json_through_socks5(self, httpbin_url, socks5_url):
+        async def _t():
+            async with AsyncClient(proxy=socks5_url) as client:
+                r = await client.post(f"{httpbin_url}/post", json={"key": "value"})
+                assert isinstance(r, HttpResponse)
+                assert r.status_code == 200
+                assert r.json()["json"] == {"key": "value"}
+
+        _run(_t())
+
+    def test_streaming_through_socks5(self, httpbin_url, socks5_url):
+        async def _t():
+            async with AsyncClient(proxy=socks5_url) as client:
+                r = await client.get(f"{httpbin_url}/stream-bytes/1024", stream=True)
+                assert isinstance(r, HttpStreamingResponse)
+                assert r.status_code == 200
+                data = b""
+                async for chunk in r.aiter_bytes():
+                    data += chunk
+                assert len(data) == 1024
+
+        _run(_t())
+
+    def test_socks5_with_auth(self, httpbin_url, socks5_auth_url):
+        async def _t():
+            async with AsyncClient(proxy=socks5_auth_url) as client:
+                r = await client.get(f"{httpbin_url}/get")
+                assert r.status_code == 200
+
+        _run(_t())
+
+    def test_socks5_auth_missing(self, httpbin_url, socks5_auth_url):
+        """SOCKS5 server requires auth but client provides none."""
+        no_auth_url = socks5_auth_url.split("@")[-1]
+        no_auth_url = f"socks5://{no_auth_url}"
+
+        async def _t():
+            async with AsyncClient(proxy=no_auth_url) as client:
+                await client.get(f"{httpbin_url}/get")
+
+        with pytest.raises((Socks5Error, HttpConnectionError)):
+            _run(_t())
+
+    def test_socks5_wrong_credentials(self, httpbin_url, socks5_auth_url):
+        """SOCKS5 server requires auth but client provides wrong credentials."""
+        parts = socks5_auth_url.split("@")
+        wrong_url = f"socks5://wrong:creds@{parts[-1]}"
+
+        async def _t():
+            async with AsyncClient(proxy=wrong_url) as client:
+                await client.get(f"{httpbin_url}/get")
+
+        with pytest.raises((Socks5Error, HttpConnectionError)):
+            _run(_t())


### PR DESCRIPTION
## Summary

- Update vendored `httpclient` from zerodep v0.3.1 to v0.4.0, restoring full SOCKS5 proxy support (RFC 1928/1929, username/password auth)
- Update vendored `validate` from v0.4.2 to v0.4.3 (minor internal refactor)
- Add 6 SOCKS5 integration tests with local proxy server fixtures

No gateway application code changes were needed — `proxy.py:get_client()` already passes proxy URLs through to `AsyncClient`, which now auto-detects `socks5://` scheme.

Closes the SOCKS5 unavailability noted in the zerodep gateway migration (#178, tracked: zerodep#72).

## Test plan

- [x] All 6 SOCKS5 proxy tests pass (GET, POST, streaming, auth, error cases)
- [x] Full test suite: 1609 passed, 4 skipped
- [x] ty check: clean
- [x] ruff check + format: clean
- [ ] CI green