### PR TITLE
feat: add /v1/embeddings passthrough endpoint

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -204,6 +204,7 @@ canvas { width: 100%; height: 160px; }
 .badge-cap { background: rgba(139,144,165,0.15); color: var(--text-dim); font-size: 10px; padding: 1px 6px; margin-right: 3px; }
 .badge-cap-vision { background: rgba(245,158,11,0.12); color: var(--orange); }
 .badge-cap-tools { background: rgba(59,130,246,0.12); color: var(--blue); }
+.badge-cap-embed { background: rgba(16,185,129,0.12); color: var(--green); }
 
 /* Checkbox group */
 .checkbox-group { display: flex; gap: 14px; flex-wrap: wrap; }
@@ -537,6 +538,7 @@ th.sortable.desc::after { content:'\25BC';opacity:.8; }
         <label><input type="checkbox" id="capText" checked disabled> text</label>
         <label><input type="checkbox" id="capVision" checked> vision</label>
         <label><input type="checkbox" id="capTools" checked> tools</label>
+        <label><input type="checkbox" id="capEmbedding"> embedding</label>
       </div>
     </div>
     <div class="modal-actions">
@@ -1051,6 +1053,7 @@ function openModelModal(model, provider, capabilities) {
   const caps = capabilities || ['text', 'vision', 'tools'];
   document.getElementById('capVision').checked = caps.includes('vision');
   document.getElementById('capTools').checked = caps.includes('tools');
+  document.getElementById('capEmbedding').checked = caps.includes('embedding');
   document.getElementById('modelModal').classList.add('open');
 }
 
@@ -1211,7 +1214,7 @@ function renderModels() {
     const provDisabled = disabledProviders.has(prov);
     const caps = typeof info === 'string' ? ['text'] : (info.capabilities || ['text']);
     const capBadges = caps.map(c => {
-      const cls = c === 'vision' ? 'badge-cap-vision' : c === 'tools' ? 'badge-cap-tools' : 'badge-cap';
+      const cls = c === 'vision' ? 'badge-cap-vision' : c === 'tools' ? 'badge-cap-tools' : c === 'embedding' ? 'badge-cap-embed' : 'badge-cap';
       return `<span class="badge ${cls}">${esc(c)}</span>`;
     }).join('');
     const hasVision = caps.includes('vision');
@@ -1302,6 +1305,7 @@ async function saveModel() {
   const capabilities = ['text'];
   if (document.getElementById('capVision').checked) capabilities.push('vision');
   if (document.getElementById('capTools').checked) capabilities.push('tools');
+  if (document.getElementById('capEmbedding').checked) capabilities.push('embedding');
   const body = {provider, capabilities};
   const originalName = document.getElementById('modelName').dataset.originalName;
   if (originalName && originalName !== name) {

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -16,6 +16,7 @@ from llm_rosetta.auto_detect import ProviderType
 
 from .auth import AuthState, api_key_label_var, create_auth_hook
 from .config import GatewayConfig
+from .embeddings import handle_embeddings as _handle_embeddings
 from .logging import get_logger
 from .proxy import (
     ProviderMetadataStore,
@@ -174,6 +175,11 @@ async def handle_openai_chat(request: Any) -> Response | StreamingResponse:
     return await _proxy_handler(request, source_provider="openai_chat")
 
 
+async def handle_embeddings(request: Any) -> Response:
+    assert _config is not None
+    return await _handle_embeddings(request, _config)
+
+
 async def handle_anthropic(request: Any) -> Response | StreamingResponse:
     return await _proxy_handler(request, source_provider="anthropic")
 
@@ -330,6 +336,7 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
 
     # --- Routes ---
     app.route("/v1/chat/completions", methods=["POST"])(handle_openai_chat)
+    app.route("/v1/embeddings", methods=["POST"])(handle_embeddings)
     app.route("/v1/messages", methods=["POST"])(handle_anthropic)
     app.route("/v1/responses", methods=["POST"])(handle_openai_responses)
     app.route("/v1/models", methods=["GET"])(handle_list_models)

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -1,0 +1,159 @@
+"""Embeddings passthrough handler.
+
+Proxies ``/v1/embeddings`` requests to the upstream provider without
+format conversion — the OpenAI embeddings API format is universal
+across providers that support it.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from llm_rosetta._vendor.httpclient import HttpClientError, Response as HttpResponse
+from llm_rosetta._vendor.httpserver import JSONResponse, Response
+
+from .auth import api_key_label_var
+from .config import GatewayConfig
+from .logging import get_logger
+from .proxy import get_client
+
+logger = get_logger()
+
+
+async def handle_embeddings(
+    request: Any,
+    config: GatewayConfig,
+) -> Response:
+    """Proxy an embeddings request to the upstream provider.
+
+    This is a thin passthrough — no IR conversion is performed.
+    The request body is forwarded as-is after model resolution.
+
+    Args:
+        request: The incoming HTTP request.
+        config: The live gateway configuration.
+
+    Returns:
+        The upstream response, forwarded to the client.
+    """
+    # --- Parse request ---
+    try:
+        body: dict[str, Any] = request.json()
+    except Exception:
+        return JSONResponse(
+            {
+                "error": {
+                    "message": "Invalid JSON body",
+                    "type": "invalid_request_error",
+                }
+            },
+            status_code=400,
+        )
+
+    model = body.get("model")
+    if not model:
+        return JSONResponse(
+            {
+                "error": {
+                    "message": "Missing 'model' in request body",
+                    "type": "invalid_request_error",
+                }
+            },
+            status_code=400,
+        )
+
+    # --- Resolve provider ---
+    try:
+        _, provider_info, _ = config.resolve_model(model)
+    except KeyError:
+        configured = ", ".join(sorted(config.models.keys()))
+        return JSONResponse(
+            {
+                "error": {
+                    "message": f"Unknown model: '{model}'. Configured models: {configured}",
+                    "type": "model_not_found",
+                }
+            },
+            status_code=404,
+        )
+
+    # --- Build upstream URL ---
+    base_url = provider_info.base_url
+    upstream_url = f"{base_url}/embeddings"
+
+    # --- Forward request ---
+    headers = provider_info.auth_headers()
+    headers["Content-Type"] = "application/json"
+
+    metrics = getattr(request.app, "metrics", None)
+    request_log = getattr(request.app, "request_log", None)
+    t0 = time.monotonic()
+    status_code = 500
+    error_detail: str | None = None
+
+    try:
+        client = get_client(provider_info.proxy_url)
+        upstream_resp = await client.post(upstream_url, json=body, headers=headers)
+        assert isinstance(upstream_resp, HttpResponse)
+
+        status_code = upstream_resp.status_code
+
+        if upstream_resp.status_code >= 400:
+            error_detail = upstream_resp.text
+            return Response(
+                body=upstream_resp.content,
+                status_code=upstream_resp.status_code,
+                content_type="application/json",
+            )
+
+        return Response(
+            body=upstream_resp.content,
+            status_code=200,
+            content_type="application/json",
+        )
+    except HttpClientError as exc:
+        error_detail = str(exc)
+        status_code = 502
+        return JSONResponse(
+            {
+                "error": {
+                    "message": f"Upstream request failed: {exc}",
+                    "type": "upstream_error",
+                }
+            },
+            status_code=502,
+        )
+    except Exception as exc:
+        error_detail = str(exc)
+        raise
+    finally:
+        duration_ms = (time.monotonic() - t0) * 1000
+        provider_type = config.provider_types.get(
+            config.models.get(model, ""), "unknown"
+        )
+        if metrics:
+            metrics.record_request(
+                model=model,
+                source="openai_chat",
+                target=provider_type,
+                status_code=status_code,
+                duration_ms=duration_ms,
+                is_stream=False,
+            )
+        if request_log is not None:
+            from .admin.request_log import RequestLogEntry
+
+            api_key_label = api_key_label_var.get()
+            request_log.add(
+                RequestLogEntry.create(
+                    model=model,
+                    source_provider="openai_chat",
+                    target_provider=provider_type,
+                    is_stream=False,
+                    status_code=status_code,
+                    duration_ms=duration_ms,
+                    error_detail=error_detail,
+                    api_key_label=api_key_label,
+                )
+            )


### PR DESCRIPTION
## Summary

- Add `/v1/embeddings` passthrough endpoint that proxies embedding requests directly to upstream providers without IR conversion
- The OpenAI embeddings API format is universal across compatible providers, so no format conversion needed — just forward request and return response
- Full metrics and request log instrumentation included
- Add `embedding` capability to admin UI model editor (checkbox + badge)

## Changes

| File | Change |
|------|--------|
| `src/llm_rosetta/gateway/embeddings.py` | New passthrough handler |
| `src/llm_rosetta/gateway/app.py` | Register `/v1/embeddings` route |
| `src/llm_rosetta/gateway/admin/admin.html` | Add embedding capability checkbox + badge CSS |

## Test plan

- [x] `make test` passes (1637 passed)
- [ ] Manual curl test against `/v1/embeddings` with configured embedding model
- [ ] Verify admin UI shows embedding capability badge correctly