### PR TITLE
fix: fetch models prefix losing selections & prefer internal_id

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -1646,7 +1646,7 @@ function renderFetchedModels() {
     const exists = displayName in existingModels;
     return `<label${exists ? ' style="opacity:0.6"' : ''}>
       <input type="checkbox" value="${esc(m)}" onchange="updateFetchCount()"${exists ? ' checked data-exists="true"' : ''}>
-      <span>${esc(m)}</span>${exists ? ' <span style="font-size:11px;color:var(--text-dim)">(exists)</span>' : ''}
+      <span>${esc(m)}</span>${exists ? ' <span class="exists-tag" style="font-size:11px;color:var(--text-dim)">(exists)</span>' : ''}
     </label>`;
   }).join('');
 
@@ -1689,8 +1689,25 @@ function updatePrefixPreview() {
   const names = [...checked].slice(0, 3).map(cb => prefix + cb.value);
   el.textContent = names.join(', ') + (checked.length > 3 ? ', ...' : '');
 
-  // Re-render to update "exists" state based on new prefix
-  renderFetchedModels();
+  // Update "exists" labels in-place without re-rendering (preserves check state)
+  const existingModels = configData.models || {};
+  document.querySelectorAll('#fetchModelsList input[type="checkbox"]').forEach(cb => {
+    const displayName = prefix ? prefix + cb.value : cb.value;
+    const exists = displayName in existingModels;
+    const label = cb.closest('label');
+    const existsSpan = label.querySelector('.exists-tag');
+    if (exists) {
+      label.style.opacity = '0.6';
+      cb.dataset.exists = 'true';
+      if (!cb.checked) cb.checked = true;
+      if (!existsSpan) label.insertAdjacentHTML('beforeend', ' <span class="exists-tag" style="font-size:11px;color:var(--text-dim)">(exists)</span>');
+    } else {
+      label.style.opacity = '';
+      delete cb.dataset.exists;
+      if (existsSpan) existsSpan.remove();
+    }
+  });
+  updateFetchCount();
 }
 
 async function bulkAddFetchedModels() {

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -1082,8 +1082,10 @@ async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
             model_ids.append(m.get("id", ""))
     else:
         # OpenAI-compatible: {"data": [{"id": "gpt-...", ...}]}
+        # Prefer internal_id over id when available (e.g. Argo uses
+        # display names in id but the actual model identifier in internal_id)
         for m in body.get("data", []):
-            model_ids.append(m.get("id", ""))
+            model_ids.append(m.get("internal_id") or m.get("id", ""))
 
     model_ids = [m for m in model_ids if m]
     model_ids.sort()


### PR DESCRIPTION
## Summary

- **Prefix input losing selections**: Typing in the prefix field called `renderFetchedModels()` which rebuilt the entire checkbox list, losing all user selections. Now updates the "exists" labels in-place without re-rendering.
- **Prefer internal_id for model names**: Some providers (e.g. Argo) use display names in the `id` field but actual model identifiers in `internal_id`. Now prefers `internal_id` when available, falling back to `id`.

## Test plan

- [x] `make test` — 1637 passed
- [x] Prefix input preserves checkbox state
- [x] Argo models fetched with correct identifiers (e.g. `claudeopus45` instead of `Claude Opus 4.5`)