### PR TITLE
feat: Argo shims, model alias, and admin UI fixes

### DIFF
--- a/src/llm_rosetta/_vendor/httpclient.py
+++ b/src/llm_rosetta/_vendor/httpclient.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.4.0"
+# version = "0.4.1"
 # deps = []
 # tier = "subsystem"
 # category = "network"
@@ -2437,7 +2437,8 @@ async def async_options(url: str, **kwargs: Any) -> Response | StreamingResponse
 class Client:
     """Synchronous HTTP client session with connection pooling.
 
-    Thread-safe: uses a threading.Lock internally.
+    Thread-safe: the underlying connection pool uses its own
+    ``threading.Lock`` to protect shared state.
 
     Usage::
 
@@ -2463,7 +2464,6 @@ class Client:
         self._auth = auth
         self._proxy = proxy
         self._pool = _SyncConnectionPool(pool_size)
-        self._lock = threading.Lock()
 
     def request(
         self,
@@ -2479,10 +2479,7 @@ class Client:
         kwargs.setdefault("proxy", self._proxy)
         kwargs["_pool"] = self._pool
         kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
-        if kwargs.get("stream"):
-            return _sync_request(method, url, **kwargs)
-        with self._lock:
-            return _sync_request(method, url, **kwargs)
+        return _sync_request(method, url, **kwargs)
 
     def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
         return self.request("GET", url, **kwargs)
@@ -2519,8 +2516,8 @@ class Client:
 class AsyncClient:
     """Asynchronous HTTP client session with connection pooling.
 
-    Safe to use from a single asyncio task; for concurrent requests
-    from the same client, use asyncio.Lock internally.
+    Safe for concurrent use from multiple asyncio tasks.  The underlying
+    connection pool uses its own ``asyncio.Lock`` to protect shared state.
 
     Usage::
 
@@ -2546,7 +2543,6 @@ class AsyncClient:
         self._auth = auth
         self._proxy = proxy
         self._pool = _AsyncConnectionPool(pool_size)
-        self._lock = asyncio.Lock()
 
     async def request(
         self,
@@ -2562,10 +2558,7 @@ class AsyncClient:
         kwargs.setdefault("proxy", self._proxy)
         kwargs["_pool"] = self._pool
         kwargs["headers"] = _merge_headers(self._base_headers, kwargs.get("headers"))
-        if kwargs.get("stream"):
-            return await _async_request(method, url, **kwargs)
-        async with self._lock:
-            return await _async_request(method, url, **kwargs)
+        return await _async_request(method, url, **kwargs)
 
     async def get(self, url: str, **kwargs: Any) -> Response | StreamingResponse:
         return await self.request("GET", url, **kwargs)

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -607,9 +607,8 @@ th.sortable.desc::after { content:'\25BC';opacity:.8; }
       <div class="fetch-models-list" id="fetchModelsList"></div>
       <div class="prefix-group">
         <label data-i18n="label.modelPrefix">Prefix:</label>
-        <input id="fetchPrefix" placeholder="e.g. myprefix/" oninput="updatePrefixPreview()">
+        <input id="fetchPrefix" placeholder="e.g. myprefix/">
       </div>
-      <div class="prefix-preview" id="prefixPreview"></div>
     </div>
     <div id="fetchModelsLoading" style="display:none;text-align:center;padding:20px;color:var(--text-dim)">
       Loading models...
@@ -1606,7 +1605,6 @@ function openFetchModelsModal() {
   document.getElementById('fetchModelsError').style.display = 'none';
   document.getElementById('fetchPrefix').value = '';
   document.getElementById('fetchModelSearch').value = '';
-  document.getElementById('prefixPreview').textContent = '';
   document.getElementById('fetchAddBtn').disabled = true;
   document.getElementById('fetchModelsModal').classList.add('open');
 }
@@ -1688,35 +1686,6 @@ function updateFetchCount() {
 }
 
 function updatePrefixPreview() {
-  const prefix = document.getElementById('fetchPrefix').value || '';
-  const checked = document.querySelectorAll('#fetchModelsList input[type="checkbox"]:checked');
-  const el = document.getElementById('prefixPreview');
-  if (checked.length === 0 || !prefix) {
-    el.textContent = '';
-    return;
-  }
-  // Show first 3 as preview
-  const names = [...checked].slice(0, 3).map(cb => prefix + cb.value);
-  el.textContent = names.join(', ') + (checked.length > 3 ? ', ...' : '');
-
-  // Update "exists" labels in-place without re-rendering (preserves check state)
-  const existingModels = configData.models || {};
-  document.querySelectorAll('#fetchModelsList input[type="checkbox"]').forEach(cb => {
-    const displayName = prefix ? prefix + cb.value : cb.value;
-    const exists = displayName in existingModels;
-    const label = cb.closest('label');
-    const existsSpan = label.querySelector('.exists-tag');
-    if (exists) {
-      label.style.opacity = '0.6';
-      cb.dataset.exists = 'true';
-      if (!cb.checked) cb.checked = true;
-      if (!existsSpan) label.insertAdjacentHTML('beforeend', ' <span class="exists-tag" style="font-size:11px;color:var(--text-dim)">(exists)</span>');
-    } else {
-      label.style.opacity = '';
-      delete cb.dataset.exists;
-      if (existsSpan) existsSpan.remove();
-    }
-  });
   updateFetchCount();
 }
 

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -2158,19 +2158,35 @@ function truncatePayloadForDisplay(payload) {
   return str.replace(/(data:[^;]+;base64,)([A-Za-z0-9+/=]{80})[A-Za-z0-9+/=]+/g, '$1$2...[truncated]');
 }
 
-// --- Test request lifecycle (AbortController + timeout) ---
-const _TEST_TIMEOUT_MS = 120_000; // 2 minutes
-let _testAbortCtrl = null;
+// --- Test request lifecycle ---
+// Async task-based testing for non-stream requests.  The browser
+// POSTs to /admin/api/test which returns immediately with a task_id;
+// we then poll /admin/api/test/<id> until done.  This completely
+// avoids the browser connection-pool exhaustion problem because the
+// long-running upstream call lives in the gateway's httpx pool, not
+// in the browser's 6-connection HTTP/1.1 limit.
+const _TEST_TIMEOUT_MS = 120_000;
+let _testAbortCtrl = null;   // AbortController for stream tests
+let _testTaskId = null;       // server-side task id for async tests
+let _testPollTimer = null;    // setInterval id for polling
 
 function _abortPendingTest() {
+  // Cancel browser-side stream fetch
   if (_testAbortCtrl) { _testAbortCtrl.abort(); _testAbortCtrl = null; }
+  // Cancel server-side async task
+  if (_testTaskId) {
+    api.del('/admin/api/test/' + _testTaskId).catch(() => {});
+    _testTaskId = null;
+  }
+  // Stop polling
+  if (_testPollTimer) { clearInterval(_testPollTimer); _testPollTimer = null; }
 }
 
 function _newTestSignal() {
-  _abortPendingTest();                      // cancel previous if any
+  _abortPendingTest();
   _testAbortCtrl = new AbortController();
   const ctrl = _testAbortCtrl;
-  setTimeout(() => ctrl.abort(), _TEST_TIMEOUT_MS);  // auto-timeout
+  setTimeout(() => ctrl.abort(), _TEST_TIMEOUT_MS);
   return ctrl.signal;
 }
 
@@ -2209,133 +2225,160 @@ async function runTest(model, type) {
   reqBody.textContent = truncatePayloadForDisplay(payload);
 
   const t0 = performance.now();
-  const signal = _newTestSignal();
+  _abortPendingTest();  // cancel any previous test
 
-  // Shared headers — Connection: close prevents keep-alive so abort()
-  // immediately frees the TCP slot instead of leaving it lingering.
-  const testHeaders = {'Content-Type':'application/json', 'Connection':'close'};
-  if (internalToken) testHeaders['Authorization'] = `Bearer ${internalToken}`;
-
-  if (type === 'embedding') {
-    // Embedding test — POST to /v1/embeddings
+  if (type === 'embedding' || (type !== 'stream')) {
+    // --- Async task path (embedding + all non-streaming tests) ---
+    // Browser never holds a long connection; the gateway's httpx pool
+    // handles the upstream call.
+    const endpoint = type === 'embedding' ? '/v1/embeddings' : '/v1/chat/completions';
     output.innerHTML = `<span class="test-spinner"></span>${t('test.sending')}`;
     try {
-      const res = await fetch('/v1/embeddings', {
-        method:'POST', headers:testHeaders, body:JSON.stringify(payload), signal
-      });
-      const elapsed = ((performance.now() - t0)/1000).toFixed(2);
-      const body = await res.json();
-      resDetails.style.display = '';
-      resBody.textContent = JSON.stringify(body, null, 2);
-      if (!res.ok) {
-        output.textContent = `Error ${res.status}: ${body.error?.message || JSON.stringify(body.error || body)}`;
-        meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${elapsed}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--red)">${res.status}</span></div>`;
-        return;
-      }
-      meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${elapsed}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--green)">200 OK</span></div>`;
-      if (body.usage) {
-        meta.innerHTML += `<div class="meta-item"><strong>Tokens:</strong> ${body.usage.prompt_tokens || '?'} in</div>`;
-      }
-      const dim = body.data?.[0]?.embedding?.length;
-      output.textContent = dim ? `Embedding OK — ${dim} dimensions` : t('test.emptyResponse');
-    } catch(e) {
-      output.textContent = e.name === 'AbortError' ? 'Request aborted (timeout or cancelled)' : `Network error: ${e.message}`;
-    }
-  } else if (type === 'stream') {
-    output.classList.add('streaming');
-    output.innerHTML = `<span class="test-spinner"></span>${t('test.connecting')}`;
-    try {
-      const res = await fetch('/v1/chat/completions', {
-        method:'POST', headers:testHeaders, body:JSON.stringify(payload), signal
-      });
-      if (!res.ok) {
-        const errText = await res.text();
-        output.className = 'test-output';
-        output.textContent = `Error ${res.status}: ${errText}`;
-        meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${((performance.now()-t0)/1000).toFixed(2)}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--red)">${res.status}</span></div>`;
-        resDetails.style.display = '';
-        resBody.textContent = errText;
-        return;
-      }
-      output.textContent = '';
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let fullText = '';
-      let buffer = '';
-      let rawChunks = [];
-      while(true) {
-        const {done, value} = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, {stream:true});
-        const lines = buffer.split('\n');
-        buffer = lines.pop();
-        for (const line of lines) {
-          if (!line.startsWith('data: ')) continue;
-          const data = line.slice(6);
-          if (data === '[DONE]') { rawChunks.push('[DONE]'); continue; }
-          rawChunks.push(data);
+      const startResp = await api.post('/admin/api/test', {endpoint, payload});
+      const taskId = startResp.task_id;
+      _testTaskId = taskId;
+
+      // Poll for result
+      await new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          clearInterval(_testPollTimer);
+          _testPollTimer = null;
+          reject(new DOMException('Test timed out', 'AbortError'));
+        }, _TEST_TIMEOUT_MS);
+
+        _testPollTimer = setInterval(async () => {
           try {
-            const chunk = JSON.parse(data);
-            const delta = chunk.choices?.[0]?.delta?.content || '';
-            fullText += delta;
-            output.textContent = fullText;
-            output.scrollTop = output.scrollHeight;
-          } catch(e) {}
-        }
-      }
-      output.className = 'test-output';
-      if (!fullText) output.textContent = t('test.emptyResponse');
-      const elapsed = ((performance.now() - t0)/1000).toFixed(2);
-      meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${elapsed}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--green)">OK (stream)</span></div>`;
-      // Show raw SSE chunks in response details
-      resDetails.style.display = '';
-      resBody.textContent = rawChunks.map(c => c === '[DONE]' ? c : JSON.stringify(JSON.parse(c), null, 2)).join('\n---\n');
-    } catch(e) {
-      output.className = 'test-output';
-      output.textContent = e.name === 'AbortError' ? 'Request aborted (timeout or cancelled)' : `Network error: ${e.message}`;
-    }
-  } else {
-    // Non-streaming
-    output.innerHTML = `<span class="test-spinner"></span>${t('test.sending')}`;
-    try {
-      const res = await fetch('/v1/chat/completions', {
-        method:'POST', headers:testHeaders, body:JSON.stringify(payload), signal
+            const r = await api.get('/admin/api/test/' + taskId);
+            if (r.status === 'pending') return; // keep polling
+            clearInterval(_testPollTimer);
+            _testPollTimer = null;
+            clearTimeout(timeout);
+            _testTaskId = null;
+
+            if (r.status === 'cancelled') {
+              reject(new DOMException('Request cancelled', 'AbortError'));
+              return;
+            }
+            if (r.status === 'error') {
+              reject(new Error(r.error || 'Unknown error'));
+              return;
+            }
+
+            // --- done ---
+            const elapsed = ((performance.now() - t0)/1000).toFixed(2);
+            const body = r.body;
+            const statusCode = r.status_code || 200;
+
+            resDetails.style.display = '';
+            resBody.textContent = typeof body === 'string' ? body : JSON.stringify(body, null, 2);
+
+            if (statusCode >= 400) {
+              const errMsg = body?.error?.message || JSON.stringify(body?.error || body);
+              output.textContent = `Error ${statusCode}: ${errMsg}`;
+              meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${elapsed}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--red)">${statusCode}</span></div>`;
+              resolve();
+              return;
+            }
+
+            meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${elapsed}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--green)">200 OK</span></div>`;
+
+            if (type === 'embedding') {
+              if (body?.usage) {
+                meta.innerHTML += `<div class="meta-item"><strong>Tokens:</strong> ${body.usage.prompt_tokens || '?'} in</div>`;
+              }
+              const dim = body?.data?.[0]?.embedding?.length;
+              output.textContent = dim ? `Embedding OK — ${dim} dimensions` : t('test.emptyResponse');
+            } else {
+              // Chat completion result
+              if (body?.usage) {
+                meta.innerHTML += `<div class="meta-item"><strong>Tokens:</strong> ${body.usage.prompt_tokens || '?'} in / ${body.usage.completion_tokens || '?'} out</div>`;
+              }
+              const choice = body?.choices?.[0];
+              if (type === 'tools' && choice?.message?.tool_calls) {
+                const tc = choice.message.tool_calls[0];
+                output.textContent = `Tool call: ${tc.function?.name || tc.name || '?'}(${tc.function?.arguments || JSON.stringify(tc.arguments) || '{}'})`;
+                if (choice.message.content) output.textContent += '\n\nContent: ' + choice.message.content;
+              } else {
+                const content = choice?.message?.content;
+                output.textContent = (content != null && content !== '') ? content : t('test.emptyResponse');
+              }
+            }
+            resolve();
+          } catch(pollErr) {
+            // Network error during poll — stop polling
+            clearInterval(_testPollTimer);
+            _testPollTimer = null;
+            clearTimeout(timeout);
+            reject(pollErr);
+          }
+        }, 500);
       });
-      const elapsed = ((performance.now() - t0)/1000).toFixed(2);
-      const body = await res.json();
-
-      // Always show raw response
-      resDetails.style.display = '';
-      resBody.textContent = JSON.stringify(body, null, 2);
-
-      if (!res.ok) {
-        output.textContent = `Error ${res.status}: ${body.error?.message || JSON.stringify(body.error || body)}`;
-        meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${elapsed}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--red)">${res.status}</span></div>`;
-        return;
-      }
-
-      meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${elapsed}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--green)">200 OK</span></div>`;
-
-      // Extract usage if present
-      if (body.usage) {
-        meta.innerHTML += `<div class="meta-item"><strong>Tokens:</strong> ${body.usage.prompt_tokens || '?'} in / ${body.usage.completion_tokens || '?'} out</div>`;
-      }
-
-      // Display extracted model reply in main output
-      const choice = body.choices?.[0];
-      if (type === 'tools' && choice?.message?.tool_calls) {
-        const tc = choice.message.tool_calls[0];
-        output.textContent = `Tool call: ${tc.function?.name || tc.name || '?'}(${tc.function?.arguments || JSON.stringify(tc.arguments) || '{}'})`;
-        if (choice.message.content) {
-          output.textContent += '\n\nContent: ' + choice.message.content;
-        }
-      } else {
-        const content = choice?.message?.content;
-        output.textContent = (content != null && content !== '') ? content : t('test.emptyResponse');
-      }
     } catch(e) {
-      output.textContent = e.name === 'AbortError' ? 'Request aborted (timeout or cancelled)' : `Network error: ${e.message}`;
+      if (e.name === 'AbortError') {
+        output.textContent = 'Request aborted (timeout or cancelled)';
+      } else {
+        output.textContent = `Error: ${e.message}`;
+      }
     }
+    return;
+  }
+
+  // --- Stream test: direct browser fetch (SSE needs live connection) ---
+  // type === 'stream' is the only path that reaches here (others return above)
+  const signal = _newTestSignal();
+  const streamHeaders = {'Content-Type':'application/json', 'Connection':'close'};
+  if (internalToken) streamHeaders['Authorization'] = `Bearer ${internalToken}`;
+
+  output.classList.add('streaming');
+  output.innerHTML = `<span class="test-spinner"></span>${t('test.connecting')}`;
+  try {
+    const res = await fetch('/v1/chat/completions', {
+      method:'POST', headers:streamHeaders, body:JSON.stringify(payload), signal
+    });
+    if (!res.ok) {
+      const errText = await res.text();
+      output.className = 'test-output';
+      output.textContent = `Error ${res.status}: ${errText}`;
+      meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${((performance.now()-t0)/1000).toFixed(2)}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--red)">${res.status}</span></div>`;
+      resDetails.style.display = '';
+      resBody.textContent = errText;
+      return;
+    }
+    output.textContent = '';
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let fullText = '';
+    let buffer = '';
+    let rawChunks = [];
+    while(true) {
+      const {done, value} = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, {stream:true});
+      const lines = buffer.split('\n');
+      buffer = lines.pop();
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        const data = line.slice(6);
+        if (data === '[DONE]') { rawChunks.push('[DONE]'); continue; }
+        rawChunks.push(data);
+        try {
+          const chunk = JSON.parse(data);
+          const delta = chunk.choices?.[0]?.delta?.content || '';
+          fullText += delta;
+          output.textContent = fullText;
+          output.scrollTop = output.scrollHeight;
+        } catch(e) {}
+      }
+    }
+    output.className = 'test-output';
+    if (!fullText) output.textContent = t('test.emptyResponse');
+    const elapsed = ((performance.now() - t0)/1000).toFixed(2);
+    meta.innerHTML += `<div class="meta-item"><strong>Time:</strong> ${elapsed}s</div><div class="meta-item"><strong>Status:</strong> <span style="color:var(--green)">OK (stream)</span></div>`;
+    resDetails.style.display = '';
+    resBody.textContent = rawChunks.map(c => c === '[DONE]' ? c : JSON.stringify(JSON.parse(c), null, 2)).join('\n---\n');
+  } catch(e) {
+    output.className = 'test-output';
+    output.textContent = e.name === 'AbortError' ? 'Request aborted (timeout or cancelled)' : `Network error: ${e.message}`;
   }
 }
 

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -2103,7 +2103,7 @@ const TEST_IMAGE_URL = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDA
 function getTestLabel(type) { return t('test.' + type); }
 
 function buildTestPayload(model, type) {
-  const base = {model, max_tokens: 256};
+  const base = {model, max_tokens: 4096};
   switch(type) {
     case 'text':
       return {...base, messages:[{role:'user', content:'Say "Hello! The gateway test is working." and nothing else.'}]};

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -2083,9 +2083,16 @@ document.getElementById('filterModel').addEventListener('change', () => { logOff
 document.getElementById('filterProvider').addEventListener('change', () => { logOffset = 0; expandedLogRows.clear(); loadLogs(); });
 document.getElementById('filterStatus').addEventListener('change', () => { logOffset = 0; expandedLogRows.clear(); loadLogs(); });
 
-// Close modal on overlay click
+// Close modal on overlay click (delegates to closeModal so abort hooks fire)
 document.querySelectorAll('.modal-overlay').forEach(m => {
-  m.addEventListener('click', e => { if (e.target === m) m.classList.remove('open'); });
+  m.addEventListener('click', e => { if (e.target === m) closeModal(m.id); });
+});
+// Close test modal on Escape key
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') {
+    const testModal = document.getElementById('testModal');
+    if (testModal && testModal.classList.contains('open')) closeModal('testModal');
+  }
 });
 
 // ===================== Helpers =====================
@@ -2204,12 +2211,15 @@ async function runTest(model, type) {
   const t0 = performance.now();
   const signal = _newTestSignal();
 
+  // Shared headers — Connection: close prevents keep-alive so abort()
+  // immediately frees the TCP slot instead of leaving it lingering.
+  const testHeaders = {'Content-Type':'application/json', 'Connection':'close'};
+  if (internalToken) testHeaders['Authorization'] = `Bearer ${internalToken}`;
+
   if (type === 'embedding') {
     // Embedding test — POST to /v1/embeddings
     output.innerHTML = `<span class="test-spinner"></span>${t('test.sending')}`;
     try {
-      const testHeaders = {'Content-Type':'application/json'};
-      if (internalToken) testHeaders['Authorization'] = `Bearer ${internalToken}`;
       const res = await fetch('/v1/embeddings', {
         method:'POST', headers:testHeaders, body:JSON.stringify(payload), signal
       });
@@ -2235,8 +2245,6 @@ async function runTest(model, type) {
     output.classList.add('streaming');
     output.innerHTML = `<span class="test-spinner"></span>${t('test.connecting')}`;
     try {
-      const testHeaders = {'Content-Type':'application/json'};
-      if (internalToken) testHeaders['Authorization'] = `Bearer ${internalToken}`;
       const res = await fetch('/v1/chat/completions', {
         method:'POST', headers:testHeaders, body:JSON.stringify(payload), signal
       });
@@ -2290,8 +2298,6 @@ async function runTest(model, type) {
     // Non-streaming
     output.innerHTML = `<span class="test-spinner"></span>${t('test.sending')}`;
     try {
-      const testHeaders = {'Content-Type':'application/json'};
-      if (internalToken) testHeaders['Authorization'] = `Bearer ${internalToken}`;
       const res = await fetch('/v1/chat/completions', {
         method:'POST', headers:testHeaders, body:JSON.stringify(payload), signal
       });

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -1114,7 +1114,10 @@ function showToast(msg, type='success') {
 }
 
 // ===================== Modal =====================
-function closeModal(id) { document.getElementById(id).classList.remove('open'); }
+function closeModal(id) {
+  document.getElementById(id).classList.remove('open');
+  if (id === 'testModal') _abortPendingTest();
+}
 
 let _editingProviderName = null; // original name when editing (for rename)
 
@@ -2148,6 +2151,22 @@ function truncatePayloadForDisplay(payload) {
   return str.replace(/(data:[^;]+;base64,)([A-Za-z0-9+/=]{80})[A-Za-z0-9+/=]+/g, '$1$2...[truncated]');
 }
 
+// --- Test request lifecycle (AbortController + timeout) ---
+const _TEST_TIMEOUT_MS = 120_000; // 2 minutes
+let _testAbortCtrl = null;
+
+function _abortPendingTest() {
+  if (_testAbortCtrl) { _testAbortCtrl.abort(); _testAbortCtrl = null; }
+}
+
+function _newTestSignal() {
+  _abortPendingTest();                      // cancel previous if any
+  _testAbortCtrl = new AbortController();
+  const ctrl = _testAbortCtrl;
+  setTimeout(() => ctrl.abort(), _TEST_TIMEOUT_MS);  // auto-timeout
+  return ctrl.signal;
+}
+
 async function runTest(model, type) {
   // Close any open dropdown
   document.querySelectorAll('.test-menu.open').forEach(m => m.classList.remove('open'));
@@ -2183,6 +2202,7 @@ async function runTest(model, type) {
   reqBody.textContent = truncatePayloadForDisplay(payload);
 
   const t0 = performance.now();
+  const signal = _newTestSignal();
 
   if (type === 'embedding') {
     // Embedding test — POST to /v1/embeddings
@@ -2191,7 +2211,7 @@ async function runTest(model, type) {
       const testHeaders = {'Content-Type':'application/json'};
       if (internalToken) testHeaders['Authorization'] = `Bearer ${internalToken}`;
       const res = await fetch('/v1/embeddings', {
-        method:'POST', headers:testHeaders, body:JSON.stringify(payload)
+        method:'POST', headers:testHeaders, body:JSON.stringify(payload), signal
       });
       const elapsed = ((performance.now() - t0)/1000).toFixed(2);
       const body = await res.json();
@@ -2209,7 +2229,7 @@ async function runTest(model, type) {
       const dim = body.data?.[0]?.embedding?.length;
       output.textContent = dim ? `Embedding OK — ${dim} dimensions` : t('test.emptyResponse');
     } catch(e) {
-      output.textContent = `Network error: ${e.message}`;
+      output.textContent = e.name === 'AbortError' ? 'Request aborted (timeout or cancelled)' : `Network error: ${e.message}`;
     }
   } else if (type === 'stream') {
     output.classList.add('streaming');
@@ -2218,7 +2238,7 @@ async function runTest(model, type) {
       const testHeaders = {'Content-Type':'application/json'};
       if (internalToken) testHeaders['Authorization'] = `Bearer ${internalToken}`;
       const res = await fetch('/v1/chat/completions', {
-        method:'POST', headers:testHeaders, body:JSON.stringify(payload)
+        method:'POST', headers:testHeaders, body:JSON.stringify(payload), signal
       });
       if (!res.ok) {
         const errText = await res.text();
@@ -2264,7 +2284,7 @@ async function runTest(model, type) {
       resBody.textContent = rawChunks.map(c => c === '[DONE]' ? c : JSON.stringify(JSON.parse(c), null, 2)).join('\n---\n');
     } catch(e) {
       output.className = 'test-output';
-      output.textContent = `Network error: ${e.message}`;
+      output.textContent = e.name === 'AbortError' ? 'Request aborted (timeout or cancelled)' : `Network error: ${e.message}`;
     }
   } else {
     // Non-streaming
@@ -2273,7 +2293,7 @@ async function runTest(model, type) {
       const testHeaders = {'Content-Type':'application/json'};
       if (internalToken) testHeaders['Authorization'] = `Bearer ${internalToken}`;
       const res = await fetch('/v1/chat/completions', {
-        method:'POST', headers:testHeaders, body:JSON.stringify(payload)
+        method:'POST', headers:testHeaders, body:JSON.stringify(payload), signal
       });
       const elapsed = ((performance.now() - t0)/1000).toFixed(2);
       const body = await res.json();
@@ -2308,7 +2328,7 @@ async function runTest(model, type) {
         output.textContent = (content != null && content !== '') ? content : t('test.emptyResponse');
       }
     } catch(e) {
-      output.textContent = `Network error: ${e.message}`;
+      output.textContent = e.name === 'AbortError' ? 'Request aborted (timeout or cancelled)' : `Network error: ${e.message}`;
     }
   }
 }

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -1684,11 +1684,6 @@ function updateFetchCount() {
   const btn = document.getElementById('fetchAddBtn');
   btn.disabled = !hasChanges;
   btn.textContent = t('btn.applyChanges');
-  updatePrefixPreview();
-}
-
-function updatePrefixPreview() {
-  updateFetchCount();
 }
 
 async function bulkAddFetchedModels() {

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -569,6 +569,10 @@ th.sortable.desc::after { content:'\25BC';opacity:.8; }
       <select id="modelProvider"></select>
     </div>
     <div class="form-group">
+      <label data-i18n="label.upstreamModel">Upstream Model <span style="font-weight:normal;color:var(--text-dim)">(optional)</span></label>
+      <input id="modelUpstream" placeholder="e.g. claudeopus45 (leave blank if same as model name)">
+    </div>
+    <div class="form-group">
       <label data-i18n="label.capabilities">Capabilities</label>
       <div class="checkbox-group">
         <label><input type="checkbox" id="capText" checked onchange="onCapChange()"> text</label>
@@ -775,7 +779,7 @@ const I18N = {
     'label.baseUrl':'Base URL',
     'label.apiKey':'API Key (or ${ENV_VAR} placeholder)',
     'label.proxyUrl':'Proxy URL (optional, overrides global)',
-    'label.modelName':'Model Name', 'label.provider':'Provider', 'label.capabilities':'Capabilities',
+    'label.modelName':'Model Name', 'label.provider':'Provider', 'label.upstreamModel':'Upstream Model', 'label.capabilities':'Capabilities',
     'modal.addProvider':'Add Provider', 'modal.editProvider':'Edit Provider',
     'modal.addModel':'Add Model', 'modal.editModel':'Edit Model',
     'col.model':'Model', 'col.provider':'Provider', 'col.time':'Time',
@@ -864,7 +868,7 @@ const I18N = {
     'label.baseUrl':'Base URL',
     'label.apiKey':'API Key\uff08\u6216 ${ENV_VAR} \u5360\u4f4d\u7b26\uff09',
     'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09',
-    'label.modelName':'\u6a21\u578b\u540d\u79f0', 'label.provider':'\u670d\u52a1\u5546', 'label.capabilities':'\u80fd\u529b',
+    'label.modelName':'\u6a21\u578b\u540d\u79f0', 'label.provider':'\u670d\u52a1\u5546', 'label.upstreamModel':'\u4e0a\u6e38\u6a21\u578b', 'label.capabilities':'\u80fd\u529b',
     'modal.addProvider':'\u6dfb\u52a0\u670d\u52a1\u5546', 'modal.editProvider':'\u7f16\u8f91\u670d\u52a1\u5546',
     'modal.addModel':'\u6dfb\u52a0\u6a21\u578b', 'modal.editModel':'\u7f16\u8f91\u6a21\u578b',
     'col.model':'\u6a21\u578b', 'col.provider':'\u670d\u52a1\u5546', 'col.time':'\u65f6\u95f4',
@@ -1184,10 +1188,11 @@ function openProviderModal(name, baseUrl, apiKey, proxy, provType) {
   }
 }
 
-function openModelModal(model, provider, capabilities) {
+function openModelModal(model, provider, capabilities, upstreamModel) {
   document.getElementById('modelModalTitle').textContent = model ? t('modal.editModel') : t('modal.addModel');
   document.getElementById('modelName').value = model || '';
   document.getElementById('modelName').dataset.originalName = model || '';
+  document.getElementById('modelUpstream').value = upstreamModel || '';
   // Populate provider dropdown from config
   const sel = document.getElementById('modelProvider');
   sel.innerHTML = '';
@@ -1399,8 +1404,10 @@ function renderModels() {
     const hasTools = caps.includes('tools');
     const hasReasoning = caps.includes('reasoning');
     const isEmbedding = caps.includes('embedding');
+    const upstream = (typeof info === 'object' && info.upstream_model) ? info.upstream_model : '';
+    const upstreamTag = upstream ? ` <span style="font-size:11px;color:var(--text-dim)" title="Upstream: ${esc(upstream)}">→ ${esc(upstream)}</span>` : '';
     return `<tr${provDisabled ? ' style="opacity:0.4"' : ''}>
-      <td><code class="copyable" title="Click to copy" onclick="copyText('${esc(name)}')">${esc(name)}</code> ${capBadges}</td>
+      <td><code class="copyable" title="Click to copy" onclick="copyText('${esc(name)}')">${esc(name)}</code>${upstreamTag} ${capBadges}</td>
       <td>${esc(prov)}${provDisabled ? ` <span style="color:var(--text-dim);font-size:11px">(${t('provider.disabled')})</span>` : ''}</td>
       <td style="text-align:right; white-space:nowrap">
         ${isEmbedding ? `<button class="btn btn-sm btn-test" style="border-radius:var(--radius);color:var(--orange);font-weight:600" onclick="runTest('${esc(name)}','embedding')">${t('btn.test')}</button>` : `<div class="test-group">
@@ -1552,6 +1559,8 @@ async function saveModel() {
   if (document.getElementById('capEmbedding').checked) capabilities.push('embedding');
   if (document.getElementById('capReasoning').checked) capabilities.push('reasoning');
   const body = {provider, capabilities};
+  const upstreamModel = document.getElementById('modelUpstream').value.trim();
+  if (upstreamModel) body.upstream_model = upstreamModel;
   const originalName = document.getElementById('modelName').dataset.originalName;
   if (originalName && originalName !== name) {
     body.rename_from = originalName;
@@ -1571,7 +1580,8 @@ async function deleteModel(name) {
 function editModel(name, provider) {
   const info = configData.models[name];
   const caps = (typeof info === 'object' && info.capabilities) ? info.capabilities : ['text'];
-  openModelModal(name, provider, caps);
+  const upstream = (typeof info === 'object' && info.upstream_model) ? info.upstream_model : '';
+  openModelModal(name, provider, caps, upstream);
 }
 
 // ===================== Fetch Models from Provider =====================

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -776,7 +776,7 @@ const I18N = {
     'label.providerName':'Provider Name', 'label.providerType':'Provider Type',
     'label.selectOne':'— select —',
     'label.baseUrl':'Base URL',
-    'label.apiKey':'API Key (or ${ENV_VAR} placeholder)',
+    'label.apiKey':'API Key (or ${ENV_VAR} placeholder)', 'label.keyUnchangedHint':'Leave blank to keep current key',
     'label.proxyUrl':'Proxy URL (optional, overrides global)',
     'label.modelName':'Model Name', 'label.provider':'Provider', 'label.upstreamModel':'Upstream Model', 'label.capabilities':'Capabilities',
     'modal.addProvider':'Add Provider', 'modal.editProvider':'Edit Provider',
@@ -865,7 +865,7 @@ const I18N = {
     'label.providerName':'\u670d\u52a1\u5546\u540d\u79f0', 'label.providerType':'\u670d\u52a1\u5546\u7c7b\u578b',
     'label.selectOne':'\u2014 \u8bf7\u9009\u62e9 \u2014',
     'label.baseUrl':'Base URL',
-    'label.apiKey':'API Key\uff08\u6216 ${ENV_VAR} \u5360\u4f4d\u7b26\uff09',
+    'label.apiKey':'API Key\uff08\u6216 ${ENV_VAR} \u5360\u4f4d\u7b26\uff09', 'label.keyUnchangedHint':'\u7559\u7a7a\u4ee5\u4fdd\u7559\u5f53\u524d\u5bc6\u94a5',
     'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09',
     'label.modelName':'\u6a21\u578b\u540d\u79f0', 'label.provider':'\u670d\u52a1\u5546', 'label.upstreamModel':'\u4e0a\u6e38\u6a21\u578b', 'label.capabilities':'\u80fd\u529b',
     'modal.addProvider':'\u6dfb\u52a0\u670d\u52a1\u5546', 'modal.editProvider':'\u7f16\u8f91\u670d\u52a1\u5546',
@@ -1165,17 +1165,18 @@ function openProviderModal(name, baseUrl, apiKey, proxy, provType) {
 
   document.getElementById('provBaseUrl').value = baseUrl || '';
   const keyInput = document.getElementById('provApiKey');
-  keyInput.value = apiKey || '';
   keyInput.type = 'password';
+  keyInput.readOnly = false;
   // Hide eye/copy buttons when credential visibility is off
   document.getElementById('provKeyToggleBtn').style.display = _credentialVisible ? '' : 'none';
   document.getElementById('provKeyCopyBtn').style.display = _credentialVisible ? '' : 'none';
   if (!_credentialVisible) {
-    keyInput.placeholder = '••••••••';
-    keyInput.readOnly = !!name; // read-only when editing, writable when creating
+    // Don't reveal even masked key; leave empty so user can type a new one
+    keyInput.value = '';
+    keyInput.placeholder = name ? t('label.keyUnchangedHint', 'Leave blank to keep current key') : '${OPENAI_API_KEY}';
   } else {
+    keyInput.value = apiKey || '';
     keyInput.placeholder = '${OPENAI_API_KEY}';
-    keyInput.readOnly = false;
   }
   document.getElementById('provProxy').value = proxy || '';
   document.getElementById('providerModal').classList.add('open');
@@ -1438,8 +1439,9 @@ async function saveProvider() {
   const apiKey = document.getElementById('provApiKey').value.trim();
   const proxy = document.getElementById('provProxy').value.trim();
   if (!name || !provType) { showToast(t('error.fieldsRequired'), 'error'); return; }
-  if (!baseUrl && !apiKey) { /* allow empty for shim defaults */ }
-  const body = {type: provType, api_key: apiKey, base_url: baseUrl, proxy};
+  const body = {type: provType, base_url: baseUrl, proxy};
+  // When api_key is empty and we're editing, omit it so backend keeps the original
+  if (apiKey) body.api_key = apiKey;
   // If editing and name changed, include rename_from so backend updates model references
   if (_editingProviderName && _editingProviderName !== name) {
     body.rename_from = _editingProviderName;

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import secrets
+import time
 import uuid
 from datetime import datetime, timezone
 from typing import Any, overload
@@ -1009,6 +1011,165 @@ async def get_internal_token(request: Any) -> Response:
 
 
 # ---------------------------------------------------------------------------
+# Async model test tasks
+# ---------------------------------------------------------------------------
+
+# In-memory store: task_id → {status, result, asyncio_task, started, ...}
+_test_tasks: dict[str, dict[str, Any]] = {}
+_MAX_TASK_AGE = 300  # seconds — auto-cleanup threshold
+
+
+def _cleanup_stale_tasks() -> None:
+    """Remove tasks older than _MAX_TASK_AGE."""
+    now = time.monotonic()
+    expired = [
+        tid
+        for tid, t in _test_tasks.items()
+        if now - t.get("started", 0) > _MAX_TASK_AGE
+    ]
+    for tid in expired:
+        task = _test_tasks.pop(tid, None)
+        if task and not task.get("_task_obj", asyncio.Future()).done():
+            task["_task_obj"].cancel()
+
+
+async def _run_test_task(
+    task_id: str,
+    endpoint: str,
+    payload: dict[str, Any],
+    internal_token: str,
+    proxy_url: str | None,
+) -> None:
+    """Execute the upstream test request using the gateway's httpx client pool.
+
+    Results are stored in ``_test_tasks[task_id]``.  This runs as an
+    ``asyncio.Task`` so the admin API handler can return immediately.
+    """
+    from ..proxy import get_client
+
+    try:
+        client = get_client(proxy_url)
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {internal_token}",
+        }
+
+        # Determine target URL — route to ourselves on localhost.
+        # The app object is not accessible here, so we build the URL from
+        # the well-known gateway bind address stored when the task was
+        # created.
+        base_url = _test_tasks[task_id].get("_base_url", "http://127.0.0.1:28765")
+        url = f"{base_url}{endpoint}"
+
+        resp = await client.post(url, json=payload, headers=headers)
+        assert isinstance(resp, HttpResponse)
+
+        # Try to parse JSON body
+        try:
+            body = resp.json()
+        except Exception:
+            body = resp.text
+
+        _test_tasks[task_id].update(
+            {
+                "status": "done",
+                "status_code": resp.status_code,
+                "body": body,
+            }
+        )
+    except asyncio.CancelledError:
+        _test_tasks[task_id]["status"] = "cancelled"
+    except Exception as exc:
+        _test_tasks[task_id].update(
+            {
+                "status": "error",
+                "error": str(exc),
+            }
+        )
+
+
+async def start_test(request: Any) -> Response:
+    """Start an async model test.  Returns a task_id immediately.
+
+    POST /admin/api/test
+    Body: {endpoint: "/v1/...", payload: {...}}
+    """
+    _cleanup_stale_tasks()
+
+    try:
+        body = request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON"}, status_code=400)
+
+    endpoint = body.get("endpoint")
+    payload = body.get("payload")
+    if not endpoint or not isinstance(payload, dict):
+        return JSONResponse({"error": "Missing endpoint or payload"}, status_code=400)
+
+    internal_token = getattr(request.app, "internal_token", "")
+    if not internal_token:
+        return JSONResponse({"error": "No internal token available"}, status_code=500)
+
+    # Determine the base URL the gateway is listening on so the test
+    # task can POST back to ourselves.
+    host = getattr(request.app, "_bind_host", "127.0.0.1")
+    port = getattr(request.app, "_bind_port", 28765)
+    # Always use 127.0.0.1 for self-calls — even if bound to 0.0.0.0
+    if host in ("0.0.0.0", "::"):
+        host = "127.0.0.1"
+    base_url = f"http://{host}:{port}"
+
+    task_id = uuid.uuid4().hex[:12]
+    _test_tasks[task_id] = {
+        "status": "pending",
+        "started": time.monotonic(),
+        "_base_url": base_url,
+    }
+
+    # Determine proxy from gateway config
+    gw_config = _get_gateway_config(request)
+    proxy_url = gw_config.proxy if gw_config else None
+
+    asyncio_task = asyncio.create_task(
+        _run_test_task(task_id, endpoint, payload, internal_token, proxy_url)
+    )
+    _test_tasks[task_id]["_task_obj"] = asyncio_task
+
+    return JSONResponse({"task_id": task_id})
+
+
+async def get_test_result(request: Any, task_id: str = "") -> Response:
+    """Poll for a test task result.
+
+    GET /admin/api/test/<task_id>
+    """
+    task = _test_tasks.get(task_id)
+    if not task:
+        return JSONResponse({"error": "Task not found"}, status_code=404)
+
+    # Return only serialisable fields (skip _task_obj, _base_url)
+    result: dict[str, Any] = {k: v for k, v in task.items() if not k.startswith("_")}
+    return JSONResponse(result)
+
+
+async def cancel_test(request: Any, task_id: str = "") -> Response:
+    """Cancel a running test task.
+
+    DELETE /admin/api/test/<task_id>
+    """
+    task = _test_tasks.get(task_id)
+    if not task:
+        return JSONResponse({"error": "Task not found"}, status_code=404)
+
+    task_obj = task.get("_task_obj")
+    if task_obj and not task_obj.done():
+        task_obj.cancel()
+        task["status"] = "cancelled"
+
+    return JSONResponse({"ok": True})
+
+
+# ---------------------------------------------------------------------------
 # Fetch upstream models
 # ---------------------------------------------------------------------------
 
@@ -1251,3 +1412,7 @@ def register_admin_routes(app: Any) -> None:
     app.route("/admin/api/keys/<key_id>", methods=["DELETE"])(delete_api_key)
     app.route("/admin/api/keys/<key_id>/reveal", methods=["GET"])(reveal_api_key)
     app.route("/admin/api/internal-token", methods=["GET"])(get_internal_token)
+    # Async model test
+    app.route("/admin/api/test", methods=["POST"])(start_test)
+    app.route("/admin/api/test/<task_id>", methods=["GET"])(get_test_result)
+    app.route("/admin/api/test/<task_id>", methods=["DELETE"])(cancel_test)

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -220,10 +220,13 @@ async def get_config(request: Any) -> Response:
         if isinstance(value, str):
             models_normalized[name] = {"provider": value, "capabilities": ["text"]}
         elif isinstance(value, dict):
-            models_normalized[name] = {
+            entry = {
                 "provider": value.get("provider", ""),
                 "capabilities": value.get("capabilities", ["text"]),
             }
+            if value.get("upstream_model"):
+                entry["upstream_model"] = value["upstream_model"]
+            models_normalized[name] = entry
 
     # Mask api_keys in server section for the response
     server = dict(raw.get("server", {}))
@@ -494,10 +497,14 @@ async def put_model(request: Any, **kwargs: Any) -> Response:
             )
         del models[rename_from]
 
-    data.setdefault("models", {})[name] = {
+    model_entry: dict[str, Any] = {
         "provider": provider,
         "capabilities": capabilities,
     }
+    upstream_model = body.get("upstream_model")
+    if upstream_model:
+        model_entry["upstream_model"] = upstream_model
+    data.setdefault("models", {})[name] = model_entry
 
     try:
         write_config(config_path, data)
@@ -1067,6 +1074,13 @@ async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
             status_code=502,
         )
 
+    # Resolve model_id_field from shim (e.g. Argo uses "internal_id")
+    from llm_rosetta.shims import get_shim
+
+    shim_name = config.provider_shim_names.get(provider_name)
+    shim = get_shim(shim_name) if shim_name else None
+    id_field = shim.model_id_field if shim and shim.model_id_field else None
+
     # Normalize response — different providers return different formats
     model_ids: list[str] = []
     if ptype == "google":
@@ -1075,17 +1089,21 @@ async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
             name = m.get("name", "")
             if name.startswith("models/"):
                 name = name[len("models/") :]
+            if id_field:
+                name = m.get(id_field, name)
             model_ids.append(name)
     elif ptype == "anthropic":
         # Anthropic: {"data": [{"id": "claude-...", ...}]}
         for m in body.get("data", []):
-            model_ids.append(m.get("id", ""))
+            model_ids.append(
+                m.get(id_field, m.get("id", "")) if id_field else m.get("id", "")
+            )
     else:
         # OpenAI-compatible: {"data": [{"id": "gpt-...", ...}]}
-        # Prefer internal_id over id when available (e.g. Argo uses
-        # display names in id but the actual model identifier in internal_id)
         for m in body.get("data", []):
-            model_ids.append(m.get("internal_id") or m.get("id", ""))
+            model_ids.append(
+                m.get(id_field, m.get("id", "")) if id_field else m.get("id", "")
+            )
 
     model_ids = [m for m in model_ids if m]
     model_ids.sort()
@@ -1141,10 +1159,16 @@ async def bulk_add_models(request: Any) -> Response:
         if display_name in models_section:
             skipped.append(display_name)
             continue
-        models_section[display_name] = {
+        entry: dict[str, Any] = {
             "provider": provider,
             "capabilities": capabilities,
         }
+        # When a prefix is used, the gateway name differs from the
+        # upstream model id — store the original as upstream_model so the
+        # proxy handler can substitute it before forwarding.
+        if prefix:
+            entry["upstream_model"] = model_id
+        models_section[display_name] = entry
         added.append(display_name)
 
     if not added:

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -274,12 +274,8 @@ async def put_provider(request: Any, **kwargs: Any) -> Response:
     except Exception:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
-    api_key = body.get("api_key")
-    base_url = body.get("base_url")
-    if not api_key or not base_url:
-        return JSONResponse(
-            {"error": "Both 'api_key' and 'base_url' are required"}, status_code=400
-        )
+    api_key = body.get("api_key", "")
+    base_url = body.get("base_url", "")
 
     try:
         data = load_config_raw(config_path)
@@ -288,6 +284,16 @@ async def put_provider(request: Any, **kwargs: Any) -> Response:
 
     existing_providers = data.get("providers", {})
     resolve_name = body.get("rename_from", name) or name
+
+    # When api_key is omitted/empty and we're editing, keep the existing key
+    if not api_key and resolve_name in existing_providers:
+        api_key = existing_providers[resolve_name].get("api_key", "")
+
+    if not api_key or not base_url:
+        return JSONResponse(
+            {"error": "Both 'api_key' and 'base_url' are required"}, status_code=400
+        )
+
     provider_entry = _build_provider_entry(
         body, api_key, base_url, existing_providers, resolve_name
     )

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -1038,45 +1038,50 @@ async def _run_test_task(
     endpoint: str,
     payload: dict[str, Any],
     internal_token: str,
-    proxy_url: str | None,
+    proxy_url: str | None,  # noqa: ARG001 — reserved for future use
 ) -> None:
-    """Execute the upstream test request using the gateway's httpx client pool.
+    """Execute an upstream test request via a self-call to the gateway.
 
     Results are stored in ``_test_tasks[task_id]``.  This runs as an
     ``asyncio.Task`` so the admin API handler can return immediately.
+
+    Important: we create a **dedicated** ``AsyncClient`` per task instead
+    of reusing the shared pool from ``proxy.get_client()``.  The shared
+    client serialises non-streaming requests with an ``asyncio.Lock``,
+    which would deadlock when the self-call triggers the proxy handler
+    that itself needs the same lock to call the upstream provider.
     """
-    from ..proxy import get_client
-
     try:
-        client = get_client(proxy_url)
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {internal_token}",
-        }
-
-        # Determine target URL — route to ourselves on localhost.
-        # The app object is not accessible here, so we build the URL from
-        # the well-known gateway bind address stored when the task was
-        # created.
-        base_url = _test_tasks[task_id].get("_base_url", "http://127.0.0.1:28765")
-        url = f"{base_url}{endpoint}"
-
-        resp = await client.post(url, json=payload, headers=headers)
-        assert isinstance(resp, HttpResponse)
-
-        # Try to parse JSON body
+        # Use a per-task client to avoid lock contention / deadlock
+        # with the shared proxy client.
+        client = AsyncClient(timeout=300.0)
         try:
-            body = resp.json()
-        except Exception:
-            body = resp.text
-
-        _test_tasks[task_id].update(
-            {
-                "status": "done",
-                "status_code": resp.status_code,
-                "body": body,
+            headers = {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {internal_token}",
             }
-        )
+
+            base_url = _test_tasks[task_id].get("_base_url", "http://127.0.0.1:28765")
+            url = f"{base_url}{endpoint}"
+
+            resp = await client.post(url, json=payload, headers=headers)
+            assert isinstance(resp, HttpResponse)
+
+            # Try to parse JSON body
+            try:
+                body = resp.json()
+            except Exception:
+                body = resp.text
+
+            _test_tasks[task_id].update(
+                {
+                    "status": "done",
+                    "status_code": resp.status_code,
+                    "body": body,
+                }
+            )
+        finally:
+            await client.aclose()
     except asyncio.CancelledError:
         _test_tasks[task_id]["status"] = "cancelled"
     except Exception as exc:

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -405,6 +405,9 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
 
 async def run_gateway(app: App, host: str, port: int) -> None:
     """Start the gateway with lifecycle management."""
+    # Expose bind address so admin test tasks can self-call.
+    app._bind_host = host  # type: ignore[attr-defined]
+    app._bind_port = port  # type: ignore[attr-defined]
     flush_task = asyncio.create_task(_periodic_flush(app))
     try:
         await app._serve(host, port)

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -65,8 +65,8 @@ async def _proxy_handler(
 
     # Resolve target provider
     try:
-        target_provider_str, provider_info, target_shim_name = _config.resolve_model(
-            model
+        target_provider_str, provider_info, target_shim_name, upstream_model = (
+            _config.resolve_model(model)
         )
         target_provider = cast(ProviderType, target_provider_str)
     except KeyError:
@@ -77,14 +77,21 @@ async def _proxy_handler(
             f"Unknown model: '{model}'. Configured models: {configured}",
         )
 
+    # Model alias: replace the model name in the request body with the
+    # actual upstream identifier so the converter and upstream provider
+    # both see the correct name.
+    if upstream_model:
+        body["model"] = upstream_model
+
     # Determine streaming
     is_stream = force_stream or detect_stream_request(source_provider, body)
 
+    model_label = f"{model} (upstream={upstream_model})" if upstream_model else model
     logger.info(
         "%s -> %s | model=%s stream=%s",
         source_provider,
         target_provider,
-        model,
+        model_label,
         is_stream,
     )
 

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -406,8 +406,8 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
 async def run_gateway(app: App, host: str, port: int) -> None:
     """Start the gateway with lifecycle management."""
     # Expose bind address so admin test tasks can self-call.
-    app._bind_host = host  # type: ignore[attr-defined]
-    app._bind_port = port  # type: ignore[attr-defined]
+    setattr(app, "_bind_host", host)
+    setattr(app, "_bind_port", port)
     flush_task = asyncio.create_task(_periodic_flush(app))
     try:
         await app._serve(host, port)

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -150,10 +150,12 @@ class GatewayConfig:
         # Parse models — supports both string and dict formats:
         #   "model": "provider"                     (legacy)
         #   "model": {"provider": "p", "capabilities": ["text", "vision"]}
+        #   "model": {"provider": "p", "upstream_model": "actual_model_name"}
         # Models referencing disabled providers are silently skipped.
         raw_models = raw.get("models", {})
         self.models: dict[str, ProviderType] = {}
         self.model_capabilities: dict[str, list[str]] = {}
+        self.model_upstream_names: dict[str, str] = {}
         for name, value in raw_models.items():
             if isinstance(value, str):
                 provider_name = value
@@ -174,6 +176,9 @@ class GatewayConfig:
                 self.model_capabilities[name] = value.get(
                     "capabilities", list(self.DEFAULT_CAPABILITIES)
                 )
+                upstream = value.get("upstream_model")
+                if upstream:
+                    self.model_upstream_names[name] = upstream
 
         _server = raw.get("server", {})
         self.host: str = _server.get("host", "0.0.0.0")
@@ -243,8 +248,10 @@ class GatewayConfig:
         """First configured key (for backward-compat middleware init)."""
         return self.api_keys[0]["key"] if self.api_keys else None
 
-    def resolve_model(self, model: str) -> tuple[str, ProviderInfo, str | None]:
-        """Return (provider_type, provider_info, shim_name) for a model name.
+    def resolve_model(
+        self, model: str
+    ) -> tuple[str, ProviderInfo, str | None, str | None]:
+        """Return (provider_type, provider_info, shim_name, upstream_model).
 
         ``provider_type`` is the API standard (e.g. ``"openai_chat"``),
         resolved from the provider's ``type`` field or its name as fallback.
@@ -252,9 +259,15 @@ class GatewayConfig:
         ``shim_name`` is the original shim/type identifier before base
         resolution (e.g. ``"volcengine"``), used for transform lookup.
 
+        ``upstream_model`` is the actual model identifier to send to the
+        upstream provider, or ``None`` when the gateway model name is used
+        as-is.  This enables model aliasing — e.g. gateway name
+        ``"argo:claude-opus-4.5"`` mapping to upstream ``"claudeopus45"``.
+
         Raises KeyError if the model is not in the routing table.
         """
         provider_name = self.models[model]
         provider_type = self.provider_types[provider_name]
         shim_name = self.provider_shim_names.get(provider_name)
-        return provider_type, self.providers[provider_name], shim_name
+        upstream_model = self.model_upstream_names.get(model)
+        return provider_type, self.providers[provider_name], shim_name, upstream_model

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -65,7 +65,7 @@ async def handle_embeddings(
 
     # --- Resolve provider ---
     try:
-        _, provider_info, _ = config.resolve_model(model)
+        _, provider_info, _, _ = config.resolve_model(model)
     except KeyError:
         configured = ", ".join(sorted(config.models.keys()))
         return JSONResponse(

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -31,6 +31,10 @@ class ProviderShim:
         default_api_key_env: Default environment variable name for the
             API key (e.g. ``"DEEPSEEK_API_KEY"``).
         logo: URL to the provider's logo image (SVG preferred).
+        model_id_field: JSON field name to use as model identifier when
+            fetching the upstream model list.  Defaults to ``"id"``
+            when ``None``.  Useful for providers like Argo that place
+            the actual model identifier in a non-standard field.
         from_transforms: Transforms applied when data comes FROM this
             provider (normalise dialect → standard).
         to_transforms: Transforms applied when data goes TO this
@@ -42,6 +46,7 @@ class ProviderShim:
     default_base_url: str | None = None
     default_api_key_env: str | None = None
     logo: str | None = None
+    model_id_field: str | None = None
     from_transforms: tuple[Transform, ...] = ()
     to_transforms: tuple[Transform, ...] = ()
 

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -63,6 +63,7 @@ def load_providers() -> list[ProviderShim]:
             default_base_url=cfg.get("default_base_url"),
             default_api_key_env=cfg.get("default_api_key_env"),
             logo=cfg.get("logo"),
+            model_id_field=cfg.get("model_id_field"),
             from_transforms=from_t,
             to_transforms=to_t,
         )

--- a/src/llm_rosetta/shims/providers/argo_anthropic/provider.yaml
+++ b/src/llm_rosetta/shims/providers/argo_anthropic/provider.yaml
@@ -1,0 +1,4 @@
+name: argo_anthropic
+base: anthropic
+default_base_url: https://apps.inside.anl.gov/argoapi/
+model_id_field: internal_id

--- a/src/llm_rosetta/shims/providers/argo_anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo_anthropic/transforms.py
@@ -1,0 +1,39 @@
+"""Argo Anthropic schema transforms.
+
+Argo does not support ``thinking.type = "adaptive"`` — only
+``"enabled"`` (with ``budget_tokens``) and ``"disabled"`` are accepted.
+Convert ``"adaptive"`` to ``"enabled"`` with budget_tokens derived from
+max_tokens so the constraint ``max_tokens > budget_tokens`` is always met.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta.shims.transforms import _NamedTransform
+
+# Fraction of max_tokens to allocate as budget_tokens when converting
+# "adaptive" → "enabled".  80% leaves 20% for the actual response.
+_BUDGET_RATIO = 0.8
+
+
+def _normalize_thinking(body: dict[str, Any]) -> dict[str, Any]:
+    """Normalize thinking block for Argo compatibility.
+
+    - ``"adaptive"`` → ``"enabled"`` with budget_tokens = 80% of
+      max_tokens (Argo only accepts ``"enabled"`` or ``"disabled"``,
+      and requires ``max_tokens > budget_tokens``)
+    """
+    thinking = body.get("thinking")
+    if not isinstance(thinking, dict):
+        return body
+    if thinking.get("type") == "adaptive":
+        thinking["type"] = "enabled"
+        if "budget_tokens" not in thinking:
+            max_tokens = body.get("max_tokens", 16384)
+            thinking["budget_tokens"] = int(max_tokens * _BUDGET_RATIO)
+    return body
+
+
+to_transforms = (_NamedTransform(_normalize_thinking, "normalize_thinking()"),)
+from_transforms = ()

--- a/src/llm_rosetta/shims/providers/argo_anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo_anthropic/transforms.py
@@ -31,7 +31,11 @@ def _normalize_thinking(body: dict[str, Any]) -> dict[str, Any]:
         thinking["type"] = "enabled"
         if "budget_tokens" not in thinking:
             max_tokens = body.get("max_tokens", 16384)
-            thinking["budget_tokens"] = int(max_tokens * _BUDGET_RATIO)
+            budget = max(1024, int(max_tokens * _BUDGET_RATIO))
+            # Ensure budget < max_tokens; bump max_tokens if needed
+            if budget >= max_tokens:
+                body["max_tokens"] = budget + 1024
+            thinking["budget_tokens"] = budget
     return body
 
 

--- a/src/llm_rosetta/shims/providers/argo_openai_chat/provider.yaml
+++ b/src/llm_rosetta/shims/providers/argo_openai_chat/provider.yaml
@@ -1,0 +1,4 @@
+name: argo_openai_chat
+base: openai_chat
+default_base_url: https://apps.inside.anl.gov/argoapi/
+model_id_field: internal_id

--- a/tests/test_shim_loader.py
+++ b/tests/test_shim_loader.py
@@ -83,10 +83,12 @@ class TestLoadProviders:
         return d
 
     def test_loads_from_builtin_directory(self):
-        """Verify the real providers/ directory loads all 12 built-in shims."""
+        """Verify the real providers/ directory loads all 14 built-in shims."""
         shims = load_providers()
         names = {s.name for s in shims}
         assert names == {
+            "argo_anthropic",
+            "argo_openai_chat",
             "openai",
             "openai_responses",
             "openrouter",
@@ -266,10 +268,15 @@ class TestLoadProviders:
                 f"{name}: expected base={base!r}, got {shim.base!r}"
             )
 
+    # Shims that intentionally have no public logo
+    _LOGO_EXEMPT = {"argo_anthropic", "argo_openai_chat"}
+
     def test_all_shims_have_logos(self):
-        """Every built-in shim should have a logo URL set."""
+        """Every built-in shim (except exempted ones) should have a logo URL."""
         shims = load_providers()
         for shim in shims:
+            if shim.name in self._LOGO_EXEMPT:
+                continue
             assert shim.logo is not None, f"Shim {shim.name!r} missing logo"
             assert shim.logo.startswith("https://"), (
                 f"Shim {shim.name!r} logo should be an HTTPS URL"


### PR DESCRIPTION
## Summary

- **Argo shims**: Add `argo_anthropic` and `argo_openai_chat` provider shims with `model_id_field: internal_id` for correct model ID extraction from Argo's `/v1/models` endpoint
- **Model alias (`upstream_model`)**: Gateway model name can differ from upstream name — e.g. `argo:claude-opus-4.7` maps to upstream `claudeopus47`. Prefix in "Fetch from Provider" auto-sets the alias
- **Argo thinking transform**: Convert Anthropic converter's `thinking.type: "adaptive"` to `"enabled"` with proportional `budget_tokens` (Argo only accepts `"enabled"` / `"disabled"`)
- **Admin UI fixes**: input lag on prefix field, API key editing with `credential_visible: false`, infinite recursion in fetch count handler, AbortController timeout (120s) on test requests to prevent browser connection pool exhaustion

## Changed files

| File | Change |
|------|--------|
| `shims/providers/argo_anthropic/` | New shim + thinking transform |
| `shims/providers/argo_openai_chat/` | New shim |
| `shims/provider_shim.py` | Add `model_id_field` |
| `gateway/config.py` | Parse `upstream_model`, 4-tuple `resolve_model()` |
| `gateway/app.py` | Substitute `body["model"]` with upstream name |
| `gateway/admin/routes.py` | Fetch uses shim `model_id_field`, bulk_add sets alias |
| `gateway/admin/admin.html` | UI: upstream_model display/edit, AbortController, fixes |
| `tests/test_shim_loader.py` | Expect 14 shims, logo exemption for Argo |

## Test plan

- [x] `make test` — 1637 passed
- [x] All 29 Argo models tested on lambda5 (7 Claude + 22 OpenAI) — all 200 OK
- [x] 9/21 ALCF-sophia models responded (rest need >120s cold start, not a bug)
- [x] Embedding model (Salesforce/SFR-Embedding-Mistral) — OK
- [x] Thinking transform verified: `argo:claude-haiku-4.5` reasoning test passes