### PR TITLE
security: fix stored XSS and add admin login rate limiting

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -2096,7 +2096,16 @@ document.addEventListener('keydown', e => {
 });
 
 // ===================== Helpers =====================
-function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+// esc() escapes HTML special chars AND single quotes so the result is
+// safe in both HTML text nodes and single-quoted JS-string attributes
+// such as onclick="fn('${esc(name)}')".
+function esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  // innerHTML escapes &, <, > and " but NOT '.  Replace ' last to avoid
+  // double-encoding the & in the &#39; entity.
+  return d.innerHTML.replace(/'/g, '&#39;');
+}
 
 function formatDuration(seconds) {
   if (seconds < 60) return Math.floor(seconds) + 's';

--- a/src/llm_rosetta/gateway/admin/routes.py
+++ b/src/llm_rosetta/gateway/admin/routes.py
@@ -158,8 +158,56 @@ async def serve_admin_html(request: Any) -> Response:
 
 
 # ---------------------------------------------------------------------------
-# Admin authentication
+# Admin authentication — login rate limiter
 # ---------------------------------------------------------------------------
+
+# Per-IP failure tracking: {ip: {"count": int, "locked_until": float}}
+_login_failures: dict[str, dict[str, Any]] = {}
+_LOGIN_MAX_ATTEMPTS = 5  # failures before lockout
+_LOGIN_LOCKOUT_SECONDS = 300  # 5-minute lockout window
+
+
+def _get_client_ip(request: Any) -> str:
+    """Extract client IP, honouring X-Forwarded-For when present."""
+    xff = request.headers.get("x-forwarded-for", "")
+    if xff:
+        return xff.split(",")[0].strip()
+    addr = getattr(request, "client_addr", None)
+    if addr:
+        return str(addr[0])
+    return "unknown"
+
+
+def _check_login_rate_limit(ip: str) -> tuple[bool, float]:
+    """Return (is_blocked, retry_after_seconds).
+
+    An IP is blocked for ``_LOGIN_LOCKOUT_SECONDS`` after
+    ``_LOGIN_MAX_ATTEMPTS`` consecutive failures.
+    """
+    rec = _login_failures.get(ip)
+    if not rec:
+        return False, 0.0
+    locked_until = rec.get("locked_until", 0.0)
+    if locked_until and time.monotonic() < locked_until:
+        return True, locked_until - time.monotonic()
+    return False, 0.0
+
+
+def _record_login_failure(ip: str) -> None:
+    """Increment failure counter; lock out the IP after max attempts."""
+    rec = _login_failures.setdefault(ip, {"count": 0, "locked_until": 0.0})
+    # Reset counter if a previous lockout has expired
+    if rec["locked_until"] and time.monotonic() >= rec["locked_until"]:
+        rec["count"] = 0
+        rec["locked_until"] = 0.0
+    rec["count"] += 1
+    if rec["count"] >= _LOGIN_MAX_ATTEMPTS:
+        rec["locked_until"] = time.monotonic() + _LOGIN_LOCKOUT_SECONDS
+
+
+def _clear_login_failures(ip: str) -> None:
+    """Reset failure counter on successful login."""
+    _login_failures.pop(ip, None)
 
 
 async def admin_login(request: Any) -> Response:
@@ -168,6 +216,16 @@ async def admin_login(request: Any) -> Response:
     if not auth_state.admin_password:
         return JSONResponse({"error": "Admin password not configured"}, status_code=400)
 
+    ip = _get_client_ip(request)
+    blocked, retry_after = _check_login_rate_limit(ip)
+    if blocked:
+        return JSONResponse(
+            {
+                "error": f"Too many failed attempts. Try again in {int(retry_after) + 1}s."
+            },
+            status_code=429,
+        )
+
     try:
         body = request.json()
     except Exception:
@@ -175,8 +233,16 @@ async def admin_login(request: Any) -> Response:
 
     password = body.get("password", "")
     if password != auth_state.admin_password:
-        return JSONResponse({"error": "Invalid password"}, status_code=401)
+        _record_login_failure(ip)
+        blocked, retry_after = _check_login_rate_limit(ip)
+        resp: dict[str, Any] = {"error": "Invalid password"}
+        if blocked:
+            resp["error"] = (
+                f"Too many failed attempts. Locked for {int(retry_after) + 1}s."
+            )
+        return JSONResponse(resp, status_code=401)
 
+    _clear_login_failures(ip)
     return JSONResponse({"ok": True, "token": auth_state.admin_token})
 
 


### PR DESCRIPTION
## Summary

Two security fixes found during a Playwright + API security audit of the admin panel.

- **Stored XSS** (`esc()` missing single-quote escaping): all inline event handlers used single-quoted JS strings like `onclick="editModel('${esc(name)}', ...)"`. Since `esc()` (based on `div.textContent → innerHTML`) escapes `&`, `<`, `>`, `"` but **not** `'`, any model or provider name containing a single quote could inject arbitrary JS that executes on button click. Fixed by appending `.replace(/'/g, '&#39;')`.
- **No login rate limiting**: `/admin/api/login` accepted unlimited password attempts with no delay. Fixed with per-IP failure tracking — 5 consecutive failures trigger a 5-minute lockout, returning HTTP 429. Resets on successful login; respects `X-Forwarded-For`.

## Test plan

- [ ] Verify login overlay appears when `admin_password` is set and sessionStorage is cleared
- [ ] Confirm 5 wrong passwords → 6th attempt returns 429 with lockout message
- [ ] Confirm correct password resets failure counter
- [ ] Confirm model/provider names with `'` (e.g. `test'name`) render as escaped text in the UI and do **not** execute JS when buttons are clicked