### PR TITLE
fix: handle custom_tool_call responses and cross-provider degradation

### DIFF
--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -321,6 +321,7 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
     _TOOL_CALL_TYPES = frozenset(
         {
             "function_call",
+            "custom_tool_call",
             "mcp_call",
             "shell_call",
             "computer_call",

--- a/src/llm_rosetta/converters/openai_responses/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/tool_ops.py
@@ -162,31 +162,20 @@ class OpenAIResponsesToolOps(BaseToolOps):
         if passthrough is not None:
             return dict(passthrough)
 
-        if ir_tool.get("type", "function") == "function":
-            parameters = ir_tool.get("parameters", {})
-            if isinstance(parameters, dict):
-                parameters = sanitize_schema(parameters)
-            result: dict[str, Any] = {
-                "type": "function",
-                "name": ir_tool["name"],
-                "description": ir_tool.get("description", ""),
-                "parameters": parameters,
-                "strict": False,
-            }
-            return result
-
-        # Non-function tool types (e.g. Codex apply_patch with type="custom"):
-        # preserve the original name so the client can match tool_call
-        # responses back to the tool definition.
-        raw_schema = ir_tool.get("parameters", {})
-        return {
-            "type": "custom",
+        # After #177, all non-function tools entering IR are coerced to
+        # type="function" and carry _passthrough (handled above).  Only
+        # genuine function tools reach here.
+        parameters = ir_tool.get("parameters", {})
+        if isinstance(parameters, dict):
+            parameters = sanitize_schema(parameters)
+        result: dict[str, Any] = {
+            "type": "function",
             "name": ir_tool["name"],
             "description": ir_tool.get("description", ""),
-            "schema": sanitize_schema(raw_schema)
-            if isinstance(raw_schema, dict)
-            else raw_schema,
+            "parameters": parameters,
+            "strict": False,
         }
+        return result
 
     @staticmethod
     def p_tool_definition_to_ir(provider_tool: Any, **kwargs: Any) -> ToolDefinition:
@@ -229,15 +218,45 @@ class OpenAIResponsesToolOps(BaseToolOps):
             # satisfy validation; ``ir_tool_definition_to_p`` restores the
             # original payload on the outbound leg.
             if tool_type != "function" and tool_type not in _IR_ALLOWED_TYPES:
+                # Synthesize a minimal JSON Schema for cross-provider
+                # degradation so other providers see "a function that
+                # accepts one text input" instead of an empty schema.
+                synth_params: dict[str, Any] = {}
+                if provider_tool.get("name"):
+                    synth_params = {
+                        "type": "object",
+                        "properties": {
+                            "input": {
+                                "type": "string",
+                                "description": "Free-form text input",
+                            }
+                        },
+                        "required": ["input"],
+                    }
+                # Append format constraint info to description so
+                # cross-provider models get a hint about the expected
+                # output shape (best-effort, not enforced).
+                desc = provider_tool.get("description", "")
+                fmt = provider_tool.get("format")
+                if fmt:
+                    fmt_type = fmt.get("type", "unknown")
+                    fmt_syntax = fmt.get("syntax", "")
+                    hint = f"[Output format: {fmt_type}"
+                    if fmt_syntax:
+                        hint += f", syntax: {fmt_syntax}"
+                    hint += "]"
+                    desc = f"{desc}\n\n{hint}" if desc else hint
                 result = {
                     "type": "function",
                     "name": provider_tool.get("name", tool_type),
-                    "description": provider_tool.get("description", ""),
-                    "parameters": {},
+                    "description": desc,
+                    "parameters": synth_params,
                     "_passthrough": dict(provider_tool),
                 }
                 result["metadata"] = {"provider_type": tool_type}
-                result["required_parameters"] = []
+                result["required_parameters"] = (
+                    synth_params.get("required", []) if synth_params else []
+                )
                 return cast(ToolDefinition, result)
 
             # Flat format (Responses API native).
@@ -414,6 +433,24 @@ class OpenAIResponsesToolOps(BaseToolOps):
                 "arguments": arguments,
                 "status": "completed",
             }
+        elif tool_type == "custom":
+            # Custom tool calls use plain text 'input' instead of JSON
+            # 'arguments'.  If tool_input has a single "input" key, unwrap
+            # it to plain text; otherwise JSON-serialize the dict.
+            if isinstance(tool_input, dict) and list(tool_input.keys()) == ["input"]:
+                input_str = str(tool_input["input"])
+            else:
+                input_str = (
+                    json.dumps(tool_input)
+                    if isinstance(tool_input, dict)
+                    else str(tool_input)
+                )
+            return {
+                "type": "custom_tool_call",
+                "call_id": tool_call_id,
+                "name": tool_name,
+                "input": input_str,
+            }
         elif tool_type == "web_search":
             return {
                 "type": "function_web_search",
@@ -530,6 +567,28 @@ class OpenAIResponsesToolOps(BaseToolOps):
                     "tool_input": tool_input,
                     "tool_type": tool_type_map.get(item_type, "function"),
                 },
+            )
+        elif item_type == "custom_tool_call":
+            # custom_tool_call uses plain text 'input' instead of JSON
+            # 'arguments'.  Wrap as {"input": str} for IR compatibility
+            # (tool_input must be dict).  If the input happens to be valid
+            # JSON, parse it so cross-provider converters can inspect fields.
+            input_str = provider_tool_call.get("input", "")
+            try:
+                parsed_input = json.loads(input_str) if input_str else {}
+            except (json.JSONDecodeError, TypeError):
+                parsed_input = {"input": input_str}
+            # Ensure tool_input is always a dict
+            if not isinstance(parsed_input, dict):
+                parsed_input = {"input": parsed_input}
+            return ToolCallPart(
+                type="tool_call",
+                tool_call_id=provider_tool_call.get(
+                    "call_id", provider_tool_call.get("id", "")
+                ),
+                tool_name=provider_tool_call.get("name", ""),
+                tool_input=parsed_input,
+                tool_type="custom",
             )
         else:
             raise ValueError(f"Unsupported OpenAI Responses item type: {item_type}")

--- a/src/llm_rosetta/types/ir/parts.py
+++ b/src/llm_rosetta/types/ir/parts.py
@@ -117,6 +117,7 @@ class ToolCallPart(TypedDict):
         Literal[
             "function",
             "mcp",
+            "custom",
             "web_search",
             "code_interpreter",
             "file_search",

--- a/tests/converters/openai_responses/test_converter.py
+++ b/tests/converters/openai_responses/test_converter.py
@@ -313,6 +313,39 @@ class TestOpenAIResponsesConverter:
         assert tc["tool_name"] == "get_weather"
         assert tc["tool_call_id"] == "call_1"
 
+    def test_response_from_provider_with_custom_tool_call(self):
+        """End-to-end: a ``custom_tool_call`` response item is converted to IR.
+
+        The model returns a ``custom_tool_call`` with plain text ``input``
+        (not JSON ``arguments``).  The converter should produce a valid IR
+        ToolCallPart with ``tool_type="custom"``.
+        """
+        provider_response = {
+            "id": "resp_custom",
+            "object": "response",
+            "created_at": 1700000000,
+            "model": "gpt-5.4",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "custom_tool_call",
+                    "call_id": "call_patch",
+                    "name": "apply_patch",
+                    "input": "--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new",
+                }
+            ],
+        }
+        result = self.converter.response_from_provider(provider_response)
+        choice = result["choices"][0]
+        tc = list(choice["message"]["content"])[0]
+        assert tc["type"] == "tool_call"
+        assert tc["tool_name"] == "apply_patch"
+        assert tc["tool_call_id"] == "call_patch"
+        assert tc["tool_type"] == "custom"
+        assert tc["tool_input"] == {
+            "input": "--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new"
+        }
+
     def test_response_from_provider_with_reasoning(self):
         """Test response with reasoning content."""
         provider_response = {

--- a/tests/converters/openai_responses/test_tool_ops.py
+++ b/tests/converters/openai_responses/test_tool_ops.py
@@ -44,8 +44,15 @@ class TestOpenAIResponsesToolOps:
         assert result["parameters"]["type"] == "object"
         assert result["strict"] is False
 
-    def test_ir_tool_definition_to_p_non_function(self):
-        """Test non-function tool type → custom wrapper."""
+    def test_ir_tool_definition_to_p_non_function_without_passthrough(self):
+        """Non-function IR tools without _passthrough emit as function.
+
+        After #177, all non-function provider tools entering IR carry
+        ``_passthrough`` and are returned as-is.  An IR tool with a
+        non-function type but no ``_passthrough`` is technically impossible
+        (IR validation rejects it), but the converter defensively emits
+        it as ``type: "function"``.
+        """
         ir_tool = cast(
             ToolDefinition,
             {
@@ -58,7 +65,7 @@ class TestOpenAIResponsesToolOps:
             },
         )
         result = OpenAIResponsesToolOps.ir_tool_definition_to_p(ir_tool)
-        assert result["type"] == "custom"
+        assert result["type"] == "function"
         assert result["name"] == "search"
 
     def test_p_tool_definition_to_ir_flat(self):
@@ -122,7 +129,15 @@ class TestOpenAIResponsesToolOps:
         result = OpenAIResponsesToolOps.p_tool_definition_to_ir(provider_tool)
         assert result["type"] == "function"
         assert result["name"] == "apply_patch"
-        assert result["description"] == "Apply a unified-diff style patch."
+        # Description is enriched with format hint for cross-provider.
+        assert "Apply a unified-diff style patch." in result["description"]
+        assert "[Output format: grammar, syntax: lark]" in result["description"]
+        # Synthesized parameters for cross-provider degradation.
+        params = result["parameters"]
+        assert params["type"] == "object"
+        assert "input" in params["properties"]
+        assert params["properties"]["input"]["type"] == "string"
+        assert result["required_parameters"] == ["input"]
         # provider_type is preserved in metadata for diagnostics.
         assert result["metadata"]["provider_type"] == "custom"
         assert cast(Any, result)["_passthrough"] == provider_tool
@@ -395,6 +410,93 @@ class TestOpenAIResponsesToolOps:
         assert restored["tool_call_id"] == original["tool_call_id"]
         assert restored["tool_name"] == original["tool_name"]
         assert restored["tool_input"] == original["tool_input"]
+
+    # ==================== Custom Tool Call ====================
+
+    def test_ir_tool_call_to_p_custom(self):
+        """Test IR ToolCallPart with tool_type="custom" → custom_tool_call."""
+        ir_tc = ToolCallPart(
+            type="tool_call",
+            tool_call_id="call_custom1",
+            tool_name="apply_patch",
+            tool_input={"input": "--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new"},
+            tool_type="custom",
+        )
+        result = OpenAIResponsesToolOps.ir_tool_call_to_p(ir_tc)
+        assert result["type"] == "custom_tool_call"
+        assert result["call_id"] == "call_custom1"
+        assert result["name"] == "apply_patch"
+        # Single "input" key is unwrapped to plain text.
+        assert result["input"] == "--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new"
+
+    def test_ir_tool_call_to_p_custom_multi_keys(self):
+        """Custom tool call with multi-key dict JSON-serializes the full dict."""
+        ir_tc = ToolCallPart(
+            type="tool_call",
+            tool_call_id="call_custom2",
+            tool_name="multi_tool",
+            tool_input={"a": 1, "b": 2},
+            tool_type="custom",
+        )
+        result = OpenAIResponsesToolOps.ir_tool_call_to_p(ir_tc)
+        assert result["type"] == "custom_tool_call"
+        assert json.loads(result["input"]) == {"a": 1, "b": 2}
+
+    def test_p_tool_call_to_ir_custom_tool_call(self):
+        """Test custom_tool_call with plain text input → IR ToolCallPart."""
+        provider_tc = {
+            "type": "custom_tool_call",
+            "call_id": "call_custom3",
+            "name": "apply_patch",
+            "input": "--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new",
+        }
+        result = OpenAIResponsesToolOps.p_tool_call_to_ir(provider_tc)
+        assert result["type"] == "tool_call"
+        assert result["tool_call_id"] == "call_custom3"
+        assert result["tool_name"] == "apply_patch"
+        assert result["tool_type"] == "custom"
+        # Plain text input is wrapped as {"input": str}.
+        assert result["tool_input"] == {
+            "input": "--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new"
+        }
+
+    def test_p_tool_call_to_ir_custom_tool_call_json_input(self):
+        """Custom tool call with valid JSON input parses to dict."""
+        provider_tc = {
+            "type": "custom_tool_call",
+            "call_id": "call_custom4",
+            "name": "json_tool",
+            "input": '{"key": "value", "count": 42}',
+        }
+        result = OpenAIResponsesToolOps.p_tool_call_to_ir(provider_tc)
+        assert result["tool_input"] == {"key": "value", "count": 42}
+        assert result["tool_type"] == "custom"
+
+    def test_p_tool_call_to_ir_custom_tool_call_empty_input(self):
+        """Custom tool call with empty input returns empty dict."""
+        provider_tc = {
+            "type": "custom_tool_call",
+            "call_id": "call_custom5",
+            "name": "empty_tool",
+            "input": "",
+        }
+        result = OpenAIResponsesToolOps.p_tool_call_to_ir(provider_tc)
+        assert result["tool_input"] == {}
+
+    def test_custom_tool_call_round_trip(self):
+        """Test custom_tool_call round-trip: provider → IR → provider."""
+        original = {
+            "type": "custom_tool_call",
+            "call_id": "call_rt_custom",
+            "name": "apply_patch",
+            "input": "--- patch content ---",
+        }
+        ir = OpenAIResponsesToolOps.p_tool_call_to_ir(original)
+        restored = OpenAIResponsesToolOps.ir_tool_call_to_p(ir)
+        assert restored["type"] == "custom_tool_call"
+        assert restored["call_id"] == original["call_id"]
+        assert restored["name"] == original["name"]
+        assert restored["input"] == original["input"]
 
     # ==================== Tool Result ====================
 


### PR DESCRIPTION
## Summary

Companion to #177 — covers the **response side** and **cross-provider degradation** that #177 left out.

- **`custom_tool_call` response handling**: `p_tool_call_to_ir` now recognizes `custom_tool_call` items (plain text `input` → IR `ToolCallPart` with `tool_type="custom"`). Previously this crashed with `ValueError`.
- **`custom` tool call emit**: `ir_tool_call_to_p` emits `custom_tool_call` when `tool_type == "custom"`, unwrapping single `{"input": str}` to plain text.
- **Cross-provider degradation**: Custom tool definitions now get a synthesized single-string-param JSON Schema (`{"input": {"type": "string"}}`) instead of empty `parameters`, and format constraint info is appended to the description. This makes cross-provider targets (Anthropic/Google/Chat) see a usable function signature.
- **Dead code cleanup**: Removed unreachable `type: "custom"` fallback in `ir_tool_definition_to_p` that became dead after #177.
- **IR type update**: Added `"custom"` to `ToolCallPart.tool_type` Literal and `"custom_tool_call"` to message_ops recognition set.

Partially addresses #182.

## Test plan

- [x] `test_ir_tool_call_to_p_custom` — single-key unwrap to plain text
- [x] `test_ir_tool_call_to_p_custom_multi_keys` — multi-key dict serialization
- [x] `test_p_tool_call_to_ir_custom_tool_call` — plain text input → IR
- [x] `test_p_tool_call_to_ir_custom_tool_call_json_input` — JSON-parseable input
- [x] `test_p_tool_call_to_ir_custom_tool_call_empty_input` — empty input edge case
- [x] `test_custom_tool_call_round_trip` — provider → IR → provider lossless
- [x] `test_response_from_provider_with_custom_tool_call` — end-to-end converter test
- [x] Updated `test_p_tool_definition_to_ir_codex_custom_apply_patch` — verifies synthesized params + enriched description
- [x] `make lint` ✅ `make test` ✅ (1646 passed)