### PR TITLE
feat: streaming support for custom_tool_call events

### DIFF
--- a/src/llm_rosetta/converters/base/context.py
+++ b/src/llm_rosetta/converters/base/context.py
@@ -139,6 +139,7 @@ class StreamContext(ConversionContext):
     # Tool call accumulation for streaming
     _tool_call_args: dict[str, str] = field(default_factory=dict, repr=False)
     _tool_call_order: list[str] = field(default_factory=list, repr=False)
+    _tool_call_types: dict[str, str] = field(default_factory=dict, repr=False)
 
     def next_block_index(self) -> int:
         """Increment and return the next block index.
@@ -149,17 +150,32 @@ class StreamContext(ConversionContext):
         self.current_block_index += 1
         return self.current_block_index
 
-    def register_tool_call(self, tool_call_id: str, tool_name: str) -> None:
+    def register_tool_call(
+        self, tool_call_id: str, tool_name: str, tool_type: str = "function"
+    ) -> None:
         """Register a tool call ID to name mapping.
 
         Args:
             tool_call_id: The unique identifier for the tool call.
             tool_name: The name of the tool being called.
+            tool_type: The type of tool call ("function" or "custom").
         """
         self.tool_call_id_map[tool_call_id] = tool_name
         self._tool_call_args[tool_call_id] = ""
+        self._tool_call_types[tool_call_id] = tool_type
         if tool_call_id not in self._tool_call_order:
             self._tool_call_order.append(tool_call_id)
+
+    def get_tool_type(self, tool_call_id: str) -> str:
+        """Get tool type by tool call ID.
+
+        Args:
+            tool_call_id: The unique identifier for the tool call.
+
+        Returns:
+            The tool type ("function" or "custom"), defaults to "function".
+        """
+        return self._tool_call_types.get(tool_call_id, "function")
 
     def register_tool_call_item(self, tool_call_id: str, item_id: str) -> None:
         """Register the Responses output item ID for a tool call.

--- a/src/llm_rosetta/converters/openai_responses/_constants.py
+++ b/src/llm_rosetta/converters/openai_responses/_constants.py
@@ -24,6 +24,8 @@ class ResponsesEventType:
     REASONING_SUMMARY_TEXT_DELTA = "response.reasoning_summary_text.delta"
     FUNCTION_CALL_ARGS_DELTA = "response.function_call_arguments.delta"
     FUNCTION_CALL_ARGS_DONE = "response.function_call_arguments.done"
+    CUSTOM_TOOL_CALL_INPUT_DELTA = "response.custom_tool_call_input.delta"
+    CUSTOM_TOOL_CALL_INPUT_DONE = "response.custom_tool_call_input.done"
 
 
 # --- Status <-> Reason mappings ---

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -833,19 +833,21 @@ class OpenAIResponsesConverter(BaseConverter):
         if isinstance(item, dict):
             item_type = item.get("type", "")
 
-            if item_type == "function_call":
+            if item_type in ("function_call", "custom_tool_call"):
                 call_id = item.get("call_id", "")
                 item_id = item.get("id", "")
+                tool_type = "custom" if item_type == "custom_tool_call" else "function"
 
                 # Register tool call in context
                 if context is not None:
-                    context.register_tool_call(call_id, item.get("name", ""))
+                    context.register_tool_call(call_id, item.get("name", ""), tool_type)
                     context.register_tool_call_item(call_id, item_id)
 
                 start_event_tc = ToolCallStartEvent(
                     type="tool_call_start",
                     tool_call_id=call_id,
                     tool_name=item.get("name", ""),
+                    tool_type=tool_type,
                 )
                 output_index = chunk.get("output_index")
                 if output_index is not None:
@@ -908,11 +910,19 @@ class OpenAIResponsesConverter(BaseConverter):
         # so it can be included in the response.completed output array.
         # Message-level done is a no-op (content_part.done handles it).
         item = chunk.get("item", {})
-        if isinstance(item, dict) and item.get("type") == "function_call":
+        if not isinstance(item, dict):
+            return
+        item_type = item.get("type", "")
+        if item_type == "function_call":
             if context is not None:
                 call_id = item.get("call_id", "")
                 if call_id:
                     context.set_tool_call_args(call_id, item.get("arguments", ""))
+        elif item_type == "custom_tool_call":
+            if context is not None:
+                call_id = item.get("call_id", "")
+                if call_id:
+                    context.set_tool_call_args(call_id, item.get("input", ""))
 
     def _handle_function_call_args_delta_from_p(
         self,
@@ -948,6 +958,42 @@ class OpenAIResponsesConverter(BaseConverter):
         # Store final arguments in context
         if context is not None and call_id:
             context.set_tool_call_args(call_id, arguments)
+
+    def _handle_custom_tool_call_input_delta_from_p(
+        self,
+        chunk: dict[str, Any],
+        context: StreamContext | None,
+        events: list[IRStreamEvent],
+    ) -> None:
+        """Handle custom_tool_call_input.delta — same as function_call args delta."""
+        delta_text = chunk.get("delta", "")
+        call_id = resolve_call_id(chunk, context)
+        delta_event = ToolCallDeltaEvent(
+            type="tool_call_delta",
+            tool_call_id=call_id,
+            arguments_delta=delta_text,
+        )
+        output_index = chunk.get("output_index")
+        if output_index is not None:
+            delta_event["tool_call_index"] = output_index
+
+        # Accumulate input in context
+        if context is not None and call_id:
+            context.append_tool_call_args(call_id, delta_text)
+
+        events.append(delta_event)
+
+    def _handle_custom_tool_call_input_done_from_p(
+        self,
+        chunk: dict[str, Any],
+        context: StreamContext | None,
+        events: list[IRStreamEvent],
+    ) -> None:
+        """Handle custom_tool_call_input.done — store final input text."""
+        call_id = resolve_call_id(chunk, context)
+        input_text = chunk.get("input", "")
+        if context is not None and call_id:
+            context.set_tool_call_args(call_id, input_text)
 
     def _handle_response_completed_from_p(
         self,
@@ -1034,6 +1080,8 @@ class OpenAIResponsesConverter(BaseConverter):
         ResponsesEventType.OUTPUT_ITEM_DONE: "_handle_output_item_done_from_p",
         ResponsesEventType.FUNCTION_CALL_ARGS_DELTA: "_handle_function_call_args_delta_from_p",
         ResponsesEventType.FUNCTION_CALL_ARGS_DONE: "_handle_function_call_args_done_from_p",
+        ResponsesEventType.CUSTOM_TOOL_CALL_INPUT_DELTA: "_handle_custom_tool_call_input_delta_from_p",
+        ResponsesEventType.CUSTOM_TOOL_CALL_INPUT_DONE: "_handle_custom_tool_call_input_done_from_p",
         ResponsesEventType.RESPONSE_COMPLETED: "_handle_response_completed_from_p",
         ResponsesEventType.RESPONSE_FAILED: "_handle_response_failed_from_p",
     }
@@ -1275,26 +1323,40 @@ class OpenAIResponsesConverter(BaseConverter):
     ) -> dict[str, Any]:
         call_id = event["tool_call_id"]
         tool_name = event["tool_name"]
+        tool_type = event.get("tool_type", "function")
         item_id = call_id
 
         # Register in context for later done events
         if context is not None and call_id:
-            context.register_tool_call(call_id, tool_name)
+            context.register_tool_call(call_id, tool_name, tool_type)
             context.register_tool_call_item(call_id, item_id)
 
         tc_index = event.get("tool_call_index")
         output_index = tc_index if tc_index is not None else 0
-        result: dict[str, Any] = {
-            "type": ResponsesEventType.OUTPUT_ITEM_ADDED,
-            "output_index": output_index,
-            "item": {
+
+        if tool_type == "custom":
+            item: dict[str, Any] = {
+                "id": item_id,
+                "type": "custom_tool_call",
+                "call_id": call_id,
+                "name": tool_name,
+                "input": "",
+                "status": "in_progress",
+            }
+        else:
+            item = {
                 "id": item_id,
                 "type": "function_call",
                 "call_id": call_id,
                 "name": tool_name,
                 "arguments": "",
                 "status": "in_progress",
-            },
+            }
+
+        result: dict[str, Any] = {
+            "type": ResponsesEventType.OUTPUT_ITEM_ADDED,
+            "output_index": output_index,
+            "item": item,
         }
         return result
 
@@ -1326,8 +1388,21 @@ class OpenAIResponsesConverter(BaseConverter):
             item_id = call_id
 
         output_index = tc_index if tc_index is not None else 0
+
+        # Determine event type based on tool type (custom vs function)
+        tool_type = (
+            context.get_tool_type(call_id)
+            if context is not None and call_id
+            else "function"
+        )
+        event_type = (
+            ResponsesEventType.CUSTOM_TOOL_CALL_INPUT_DELTA
+            if tool_type == "custom"
+            else ResponsesEventType.FUNCTION_CALL_ARGS_DELTA
+        )
+
         result: dict[str, Any] = {
-            "type": ResponsesEventType.FUNCTION_CALL_ARGS_DELTA,
+            "type": event_type,
             "item_id": item_id,
             "output_index": output_index,
             "delta": delta,
@@ -1429,16 +1504,30 @@ class OpenAIResponsesConverter(BaseConverter):
             tool_name = context.get_tool_name(call_id)
             arguments = context._tool_call_args.get(call_id, "")
             tc_item_id = context.get_tool_call_item_id(call_id) or call_id
-            output.append(
-                {
-                    "id": tc_item_id,
-                    "type": "function_call",
-                    "call_id": call_id,
-                    "name": tool_name,
-                    "arguments": arguments,
-                    "status": "completed",
-                }
-            )
+            tool_type = context.get_tool_type(call_id)
+
+            if tool_type == "custom":
+                output.append(
+                    {
+                        "id": tc_item_id,
+                        "type": "custom_tool_call",
+                        "call_id": call_id,
+                        "name": tool_name,
+                        "input": arguments,
+                        "status": "completed",
+                    }
+                )
+            else:
+                output.append(
+                    {
+                        "id": tc_item_id,
+                        "type": "function_call",
+                        "call_id": call_id,
+                        "name": tool_name,
+                        "arguments": arguments,
+                        "status": "completed",
+                    }
+                )
         return output
 
     @staticmethod
@@ -1552,32 +1641,60 @@ class OpenAIResponsesConverter(BaseConverter):
             arguments = context._tool_call_args.get(call_id, "")
             item_id = context.get_tool_call_item_id(call_id) or call_id
             output_index = tc_idx + (1 if context.output_item_emitted else 0)
+            tool_type = context.get_tool_type(call_id)
 
-            # response.function_call_arguments.done
-            results.append(
-                {
-                    "type": ResponsesEventType.FUNCTION_CALL_ARGS_DONE,
-                    "item_id": item_id,
-                    "output_index": output_index,
-                    "arguments": arguments,
-                }
-            )
+            if tool_type == "custom":
+                # response.custom_tool_call_input.done
+                results.append(
+                    {
+                        "type": ResponsesEventType.CUSTOM_TOOL_CALL_INPUT_DONE,
+                        "item_id": item_id,
+                        "output_index": output_index,
+                        "input": arguments,
+                    }
+                )
 
-            # response.output_item.done for the function_call
-            results.append(
-                {
-                    "type": ResponsesEventType.OUTPUT_ITEM_DONE,
-                    "output_index": output_index,
-                    "item": {
-                        "id": item_id,
-                        "type": "function_call",
-                        "call_id": call_id,
-                        "name": tool_name,
+                # response.output_item.done for the custom_tool_call
+                results.append(
+                    {
+                        "type": ResponsesEventType.OUTPUT_ITEM_DONE,
+                        "output_index": output_index,
+                        "item": {
+                            "id": item_id,
+                            "type": "custom_tool_call",
+                            "call_id": call_id,
+                            "name": tool_name,
+                            "input": arguments,
+                            "status": "completed",
+                        },
+                    }
+                )
+            else:
+                # response.function_call_arguments.done
+                results.append(
+                    {
+                        "type": ResponsesEventType.FUNCTION_CALL_ARGS_DONE,
+                        "item_id": item_id,
+                        "output_index": output_index,
                         "arguments": arguments,
-                        "status": "completed",
-                    },
-                }
-            )
+                    }
+                )
+
+                # response.output_item.done for the function_call
+                results.append(
+                    {
+                        "type": ResponsesEventType.OUTPUT_ITEM_DONE,
+                        "output_index": output_index,
+                        "item": {
+                            "id": item_id,
+                            "type": "function_call",
+                            "call_id": call_id,
+                            "name": tool_name,
+                            "arguments": arguments,
+                            "status": "completed",
+                        },
+                    }
+                )
 
     def _handle_usage_to_p(
         self,

--- a/src/llm_rosetta/converters/openai_responses/stream_context.py
+++ b/src/llm_rosetta/converters/openai_responses/stream_context.py
@@ -62,6 +62,7 @@ class OpenAIResponsesStreamContext(StreamContext):
         ctx._ended = base._ended
         ctx._tool_call_args = base._tool_call_args
         ctx._tool_call_order = base._tool_call_order
+        ctx._tool_call_types = base._tool_call_types
         return ctx
 
     def register_tool_call_item(self, tool_call_id: str, item_id: str) -> None:

--- a/src/llm_rosetta/types/ir/stream.py
+++ b/src/llm_rosetta/types/ir/stream.py
@@ -128,6 +128,7 @@ class ToolCallStartEvent(TypedDict):
     type: Required[Literal["tool_call_start"]]
     tool_call_id: Required[str]
     tool_name: Required[str]
+    tool_type: NotRequired[str]  # "function" (default), "custom", etc.
     tool_call_index: NotRequired[int]  # Index for multiple parallel tool calls
     choice_index: NotRequired[int]
     provider_metadata: NotRequired[dict[str, Any]]

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -1313,3 +1313,302 @@ class TestStreamResponseToProviderWithContext:
         assert end_result["response"]["usage"]["input_tokens"] == 50
         assert end_result["response"]["usage"]["output_tokens"] == 25
         assert end_result["response"]["usage"]["total_tokens"] == 75
+
+
+class TestCustomToolCallStreaming:
+    """Tests for custom_tool_call streaming events."""
+
+    def setup_method(self):
+        self.converter = OpenAIResponsesConverter()
+
+    # --- From provider ---
+
+    def test_custom_tool_call_output_item_added(self):
+        """response.output_item.added with custom_tool_call produces ToolCallStartEvent."""
+        ctx = OpenAIResponsesStreamContext()
+        event = {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": "ctc_001",
+                "type": "custom_tool_call",
+                "call_id": "call_custom_1",
+                "name": "my_tool",
+                "input": "",
+            },
+        }
+        events = cast(
+            list[Any],
+            self.converter.stream_response_from_provider(event, context=ctx),
+        )
+        assert len(events) == 1
+        assert events[0]["type"] == "tool_call_start"
+        assert events[0]["tool_call_id"] == "call_custom_1"
+        assert events[0]["tool_name"] == "my_tool"
+        assert events[0]["tool_type"] == "custom"
+        assert events[0]["tool_call_index"] == 0
+        # Context should register the custom tool type
+        assert ctx.get_tool_name("call_custom_1") == "my_tool"
+        assert ctx.get_tool_type("call_custom_1") == "custom"
+        assert ctx.get_tool_call_item_id("call_custom_1") == "ctc_001"
+
+    def test_custom_tool_call_input_delta(self):
+        """response.custom_tool_call_input.delta produces ToolCallDeltaEvent."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.register_tool_call("call_custom_1", "my_tool", "custom")
+        event = {
+            "type": "response.custom_tool_call_input.delta",
+            "call_id": "call_custom_1",
+            "delta": "hello ",
+            "output_index": 0,
+        }
+        events = cast(
+            list[Any],
+            self.converter.stream_response_from_provider(event, context=ctx),
+        )
+        assert len(events) == 1
+        assert events[0]["type"] == "tool_call_delta"
+        assert events[0]["tool_call_id"] == "call_custom_1"
+        assert events[0]["arguments_delta"] == "hello "
+        assert ctx.get_tool_call_args("call_custom_1") == "hello "
+
+    def test_custom_tool_call_input_done(self):
+        """response.custom_tool_call_input.done stores final input in context."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.register_tool_call("call_custom_1", "my_tool", "custom")
+        ctx.append_tool_call_args("call_custom_1", "hello ")
+        event = {
+            "type": "response.custom_tool_call_input.done",
+            "call_id": "call_custom_1",
+            "input": "hello world",
+        }
+        events = cast(
+            list[Any],
+            self.converter.stream_response_from_provider(event, context=ctx),
+        )
+        # Done event produces no IR events
+        assert len(events) == 0
+        # But the final input is stored in context
+        assert ctx.get_tool_call_args("call_custom_1") == "hello world"
+
+    def test_custom_tool_call_output_item_done(self):
+        """response.output_item.done with custom_tool_call stores input in context."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.register_tool_call("call_custom_1", "my_tool", "custom")
+        event = {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "custom_tool_call",
+                "call_id": "call_custom_1",
+                "name": "my_tool",
+                "input": "final input text",
+            },
+        }
+        self.converter.stream_response_from_provider(event, context=ctx)
+        assert ctx.get_tool_call_args("call_custom_1") == "final input text"
+
+    # --- To provider ---
+
+    def test_tool_call_start_custom_to_p(self):
+        """ToolCallStartEvent with tool_type='custom' → custom_tool_call item."""
+        ctx = OpenAIResponsesStreamContext()
+        event = cast(
+            ToolCallStartEvent,
+            {
+                "type": "tool_call_start",
+                "tool_call_id": "call_custom_1",
+                "tool_name": "my_tool",
+                "tool_type": "custom",
+                "tool_call_index": 0,
+            },
+        )
+        result = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(event, context=ctx),
+        )
+        assert result["type"] == "response.output_item.added"
+        assert result["item"]["type"] == "custom_tool_call"
+        assert result["item"]["call_id"] == "call_custom_1"
+        assert result["item"]["name"] == "my_tool"
+        assert result["item"]["input"] == ""
+        assert result["item"]["status"] == "in_progress"
+        # Context should have registered the custom type
+        assert ctx.get_tool_type("call_custom_1") == "custom"
+
+    def test_tool_call_delta_custom_to_p(self):
+        """ToolCallDeltaEvent for custom tool → custom_tool_call_input.delta."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.register_tool_call("call_custom_1", "my_tool", "custom")
+        ctx.register_tool_call_item("call_custom_1", "call_custom_1")
+        event = cast(
+            ToolCallDeltaEvent,
+            {
+                "type": "tool_call_delta",
+                "tool_call_id": "call_custom_1",
+                "arguments_delta": "hello ",
+                "tool_call_index": 0,
+            },
+        )
+        result = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(event, context=ctx),
+        )
+        assert result["type"] == "response.custom_tool_call_input.delta"
+        assert result["delta"] == "hello "
+
+    def test_tool_call_delta_function_to_p(self):
+        """ToolCallDeltaEvent for function tool → function_call_arguments.delta."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.register_tool_call("call_fn_1", "get_weather", "function")
+        ctx.register_tool_call_item("call_fn_1", "call_fn_1")
+        event = cast(
+            ToolCallDeltaEvent,
+            {
+                "type": "tool_call_delta",
+                "tool_call_id": "call_fn_1",
+                "arguments_delta": '{"city":',
+            },
+        )
+        result = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(event, context=ctx),
+        )
+        assert result["type"] == "response.function_call_arguments.delta"
+
+    def test_finish_with_custom_tool_call(self):
+        """FinishEvent emits custom_tool_call done events and output items."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.mark_started()
+        ctx.register_tool_call("call_custom_1", "my_tool", "custom")
+        ctx.register_tool_call_item("call_custom_1", "ctc_001")
+        ctx.set_tool_call_args("call_custom_1", "hello world")
+
+        event = cast(
+            FinishEvent,
+            {"type": "finish", "finish_reason": {"reason": "tool_calls"}},
+        )
+        results = cast(
+            list[dict[str, Any]],
+            self.converter.stream_response_to_provider(event, context=ctx),
+        )
+
+        # Should have custom_tool_call_input.done and output_item.done
+        done_events = [
+            r
+            for r in results
+            if r.get("type") == "response.custom_tool_call_input.done"
+        ]
+        assert len(done_events) == 1
+        assert done_events[0]["input"] == "hello world"
+        assert done_events[0]["item_id"] == "ctc_001"
+
+        item_done_events = [
+            r for r in results if r.get("type") == "response.output_item.done"
+        ]
+        assert len(item_done_events) == 1
+        assert item_done_events[0]["item"]["type"] == "custom_tool_call"
+        assert item_done_events[0]["item"]["input"] == "hello world"
+        assert item_done_events[0]["item"]["name"] == "my_tool"
+        assert item_done_events[0]["item"]["status"] == "completed"
+
+        # Deferred response should have custom_tool_call output
+        assert ctx.pending_response is not None
+        output = ctx.pending_response["output"]
+        assert len(output) == 1
+        assert output[0]["type"] == "custom_tool_call"
+        assert output[0]["input"] == "hello world"
+
+    def test_finish_with_mixed_tool_calls(self):
+        """FinishEvent with both function and custom tool calls emits correct types."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.mark_started()
+        ctx.register_tool_call("call_fn_1", "get_weather", "function")
+        ctx.register_tool_call_item("call_fn_1", "fc_001")
+        ctx.set_tool_call_args("call_fn_1", '{"city": "NYC"}')
+        ctx.register_tool_call("call_custom_1", "my_tool", "custom")
+        ctx.register_tool_call_item("call_custom_1", "ctc_001")
+        ctx.set_tool_call_args("call_custom_1", "do something")
+
+        event = cast(
+            FinishEvent,
+            {"type": "finish", "finish_reason": {"reason": "tool_calls"}},
+        )
+        results = cast(
+            list[dict[str, Any]],
+            self.converter.stream_response_to_provider(event, context=ctx),
+        )
+
+        # Function call done events
+        fn_done = [
+            r
+            for r in results
+            if r.get("type") == "response.function_call_arguments.done"
+        ]
+        assert len(fn_done) == 1
+        assert fn_done[0]["arguments"] == '{"city": "NYC"}'
+
+        # Custom tool call done events
+        custom_done = [
+            r
+            for r in results
+            if r.get("type") == "response.custom_tool_call_input.done"
+        ]
+        assert len(custom_done) == 1
+        assert custom_done[0]["input"] == "do something"
+
+        # Output items
+        item_done = [r for r in results if r.get("type") == "response.output_item.done"]
+        assert len(item_done) == 2
+        assert item_done[0]["item"]["type"] == "function_call"
+        assert item_done[1]["item"]["type"] == "custom_tool_call"
+
+    # --- Round-trip ---
+
+    def test_custom_tool_call_stream_round_trip(self):
+        """Custom tool call round-trips through streaming: provider → IR → provider."""
+        ctx_from = OpenAIResponsesStreamContext()
+        ctx_to = OpenAIResponsesStreamContext()
+
+        # 1. output_item.added
+        added_event = {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": "ctc_001",
+                "type": "custom_tool_call",
+                "call_id": "call_custom_1",
+                "name": "my_tool",
+                "input": "",
+            },
+        }
+        ir_events = cast(
+            list[Any],
+            self.converter.stream_response_from_provider(added_event, context=ctx_from),
+        )
+        assert len(ir_events) == 1
+        restored = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(ir_events[0], context=ctx_to),
+        )
+        assert restored["item"]["type"] == "custom_tool_call"
+        assert restored["item"]["name"] == "my_tool"
+        assert restored["item"]["input"] == ""
+
+        # 2. custom_tool_call_input.delta
+        delta_event = {
+            "type": "response.custom_tool_call_input.delta",
+            "call_id": "call_custom_1",
+            "delta": "search query",
+            "output_index": 0,
+        }
+        ir_events = cast(
+            list[Any],
+            self.converter.stream_response_from_provider(delta_event, context=ctx_from),
+        )
+        assert len(ir_events) == 1
+        restored = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(ir_events[0], context=ctx_to),
+        )
+        assert restored["type"] == "response.custom_tool_call_input.delta"
+        assert restored["delta"] == "search query"


### PR DESCRIPTION
## Summary

- Adds full streaming support for `custom_tool_call` events in the OpenAI Responses converter, complementing the non-streaming support from #200
- Both from-provider (ingest) and to-provider (emit) directions are covered
- Custom tool calls use `response.custom_tool_call_input.delta/done` event types (plain text `input`) vs function calls which use `response.function_call_arguments.delta/done` (JSON `arguments`)

### Changes
- `StreamContext`: added `_tool_call_types` dict, `tool_type` param on `register_tool_call()`, `get_tool_type()` method
- `ToolCallStartEvent` IR type: added optional `tool_type` field  
- `_constants.py`: added `CUSTOM_TOOL_CALL_INPUT_DELTA` / `CUSTOM_TOOL_CALL_INPUT_DONE` event types
- `converter.py`: 
  - From-provider: handle `custom_tool_call` in `output_item.added`/`output_item.done`, add `custom_tool_call_input.delta/done` handlers + dispatch entries
  - To-provider: emit correct item types in `_handle_tool_call_start_to_p`, correct event types in `_handle_tool_call_delta_to_p`, correct done events in `_emit_tool_call_done_events`, correct output items in `_collect_finish_output`

## Test plan

- [x] 12 new streaming tests covering from-provider, to-provider, mixed tool calls, and round-trip
- [x] All 1656 existing tests pass
- [x] `make lint` clean

Closes #182