### PR TITLE
fix(argo_anthropic): normalize OpenAI Chat format responses from /v1/messages

### DIFF
--- a/src/llm_rosetta/shims/providers/argo_anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo_anthropic/transforms.py
@@ -4,10 +4,18 @@ Argo does not support ``thinking.type = "adaptive"`` — only
 ``"enabled"`` (with ``budget_tokens``) and ``"disabled"`` are accepted.
 Convert ``"adaptive"`` to ``"enabled"`` with budget_tokens derived from
 max_tokens so the constraint ``max_tokens > budget_tokens`` is always met.
+
+Argo's ``/v1/messages`` endpoint inconsistently returns OpenAI Chat
+Completions format (``choices[0].message``) for some Claude model versions
+instead of the standard Anthropic Messages format.  The
+``_normalize_openai_response`` from-transform detects this and converts the
+response to Anthropic format before the converter sees it.
 """
 
 from __future__ import annotations
 
+import copy
+import json
 from typing import Any
 
 from llm_rosetta.shims.transforms import _NamedTransform
@@ -15,6 +23,14 @@ from llm_rosetta.shims.transforms import _NamedTransform
 # Fraction of max_tokens to allocate as budget_tokens when converting
 # "adaptive" → "enabled".  80% leaves 20% for the actual response.
 _BUDGET_RATIO = 0.8
+
+# Finish-reason mapping: OpenAI → Anthropic stop_reason.
+_FINISH_REASON_MAP: dict[str, str] = {
+    "stop": "end_turn",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
+    "content_filter": "stop_sequence",
+}
 
 
 def _normalize_thinking(body: dict[str, Any]) -> dict[str, Any]:
@@ -39,5 +55,90 @@ def _normalize_thinking(body: dict[str, Any]) -> dict[str, Any]:
     return body
 
 
+def _normalize_openai_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Convert an OpenAI Chat Completions response to Anthropic Messages format.
+
+    Argo's ``/v1/messages`` endpoint returns standard Anthropic format for
+    most Claude models, but falls back to OpenAI Chat format
+    (``choices[0].message``) for some model versions.  This transform
+    detects the OpenAI layout and rewrites it to Anthropic format so the
+    Anthropic converter can parse it correctly.
+
+    Pass-through: responses that already have a top-level ``"content"`` list
+    or ``"type": "message"`` field are returned unchanged.
+
+    Args:
+        body: Raw upstream JSON response dict.
+
+    Returns:
+        Anthropic-format response dict (possibly the same object if no
+        conversion was needed).
+    """
+    # Already Anthropic format — nothing to do.
+    if "content" in body or body.get("type") == "message":
+        return body
+
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return body
+
+    choice = choices[0]
+    if not isinstance(choice, dict):
+        return body
+
+    message = choice.get("message")
+    if not isinstance(message, dict):
+        return body
+
+    # Build Anthropic-format content from the OpenAI message.
+    raw_content = message.get("content") or ""
+    tool_calls = message.get("tool_calls") or []
+
+    anthropic_content: list[dict[str, Any]] = []
+
+    if raw_content:
+        anthropic_content.append({"type": "text", "text": raw_content})
+
+    for tc in tool_calls:
+        if not isinstance(tc, dict):
+            continue
+        fn = tc.get("function", {})
+        try:
+            input_data = json.loads(fn.get("arguments", "{}"))
+        except (ValueError, TypeError):
+            input_data = {}
+        anthropic_content.append(
+            {
+                "type": "tool_use",
+                "id": tc.get("id", ""),
+                "name": fn.get("name", ""),
+                "input": input_data,
+            }
+        )
+
+    # Map finish_reason → stop_reason.
+    finish_reason = choice.get("finish_reason") or "stop"
+    stop_reason = _FINISH_REASON_MAP.get(finish_reason, "end_turn")
+
+    # Build usage block.
+    oai_usage = body.get("usage") or {}
+    usage: dict[str, Any] = {
+        "input_tokens": oai_usage.get("prompt_tokens", 0),
+        "output_tokens": oai_usage.get("completion_tokens", 0),
+    }
+
+    result = copy.copy(body)
+    result.pop("choices", None)
+    result.pop("object", None)
+    result["type"] = "message"
+    result["role"] = message.get("role", "assistant")
+    result["content"] = anthropic_content
+    result["stop_reason"] = stop_reason
+    result["usage"] = usage
+    return result
+
+
 to_transforms = (_NamedTransform(_normalize_thinking, "normalize_thinking()"),)
-from_transforms = ()
+from_transforms = (
+    _NamedTransform(_normalize_openai_response, "normalize_openai_response()"),
+)

--- a/tests/test_argo_anthropic_transforms.py
+++ b/tests/test_argo_anthropic_transforms.py
@@ -1,0 +1,365 @@
+"""Tests for argo_anthropic shim transforms.
+
+Covers both the request-side ``_normalize_thinking`` and the response-side
+``_normalize_openai_response`` transforms.
+"""
+
+from __future__ import annotations
+
+import json
+
+from llm_rosetta.shims.providers.argo_anthropic.transforms import (
+    _normalize_openai_response,
+    _normalize_thinking,
+)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_thinking (to_transform, request-side)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeThinking:
+    def test_no_thinking_passthrough(self):
+        body: dict = {"model": "claudeopus46", "max_tokens": 1024}
+        result = _normalize_thinking(body)
+        assert result is body
+        assert "thinking" not in result
+
+    def test_enabled_unchanged(self):
+        body: dict = {
+            "max_tokens": 1024,
+            "thinking": {"type": "enabled", "budget_tokens": 512},
+        }
+        result = _normalize_thinking(body)
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 512
+
+    def test_adaptive_converted_to_enabled(self):
+        body: dict = {"max_tokens": 2048, "thinking": {"type": "adaptive"}}
+        result = _normalize_thinking(body)
+        assert result["thinking"]["type"] == "enabled"
+        assert "budget_tokens" in result["thinking"]
+        # budget = max(1024, int(2048 * 0.8)) = 1638
+        assert result["thinking"]["budget_tokens"] == 1638
+
+    def test_adaptive_budget_less_than_max_tokens(self):
+        body: dict = {"max_tokens": 2000, "thinking": {"type": "adaptive"}}
+        result = _normalize_thinking(body)
+        budget = result["thinking"]["budget_tokens"]
+        assert budget < result["max_tokens"], "budget_tokens must be < max_tokens"
+
+    def test_adaptive_small_max_tokens_bumps_max_tokens(self):
+        """When max_tokens is very small, max_tokens is bumped to keep invariant."""
+        body: dict = {"max_tokens": 100, "thinking": {"type": "adaptive"}}
+        result = _normalize_thinking(body)
+        budget = result["thinking"]["budget_tokens"]
+        assert budget >= 1024
+        assert budget < result["max_tokens"]
+
+    def test_adaptive_existing_budget_tokens_preserved(self):
+        """If budget_tokens is already set, do not overwrite it."""
+        body: dict = {
+            "max_tokens": 4096,
+            "thinking": {"type": "adaptive", "budget_tokens": 999},
+        }
+        result = _normalize_thinking(body)
+        assert result["thinking"]["budget_tokens"] == 999
+
+    def test_non_dict_thinking_passthrough(self):
+        body: dict = {"thinking": "enabled"}
+        result = _normalize_thinking(body)
+        assert result["thinking"] == "enabled"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_openai_response (from_transform, response-side)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeOpenAIResponse:
+    # --- pass-through cases ---
+
+    def test_anthropic_format_passthrough(self):
+        """Responses that already have 'content' are returned unchanged."""
+        body = {
+            "id": "msg_001",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hi!"}],
+            "stop_reason": "end_turn",
+            "model": "claude-haiku-4-5",
+            "usage": {"input_tokens": 10, "output_tokens": 4},
+        }
+        result = _normalize_openai_response(body)
+        assert result is body
+
+    def test_type_message_passthrough(self):
+        """Responses with 'type: message' are returned unchanged."""
+        body = {"type": "message", "role": "assistant"}
+        result = _normalize_openai_response(body)
+        assert result is body
+
+    def test_empty_choices_passthrough(self):
+        body = {"id": "x", "choices": []}
+        result = _normalize_openai_response(body)
+        assert result is body
+
+    def test_no_choices_passthrough(self):
+        body = {"id": "x", "model": "some-model"}
+        result = _normalize_openai_response(body)
+        assert result is body
+
+    def test_bad_choice_type_passthrough(self):
+        body = {"choices": ["not-a-dict"]}
+        result = _normalize_openai_response(body)
+        assert result is body
+
+    def test_no_message_in_choice_passthrough(self):
+        body = {"choices": [{"index": 0, "finish_reason": "stop"}]}
+        result = _normalize_openai_response(body)
+        assert result is body
+
+    # --- conversion cases ---
+
+    def test_plain_text_response(self):
+        """Simple OpenAI Chat format with text content is converted correctly."""
+        body = {
+            "id": "chatcmpl-001",
+            "object": "chat.completion",
+            "model": "claudeopus46",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hello!"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14},
+        }
+        result = _normalize_openai_response(body)
+
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["content"] == [{"type": "text", "text": "Hello!"}]
+        assert result["stop_reason"] == "end_turn"
+        assert result["usage"]["input_tokens"] == 10
+        assert result["usage"]["output_tokens"] == 4
+        # OpenAI-specific keys should be gone
+        assert "choices" not in result
+        assert "object" not in result
+        # Non-format keys preserved
+        assert result["id"] == "chatcmpl-001"
+        assert result["model"] == "claudeopus46"
+
+    def test_finish_reason_length_maps_to_max_tokens(self):
+        body = {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "..."},
+                    "finish_reason": "length",
+                }
+            ]
+        }
+        result = _normalize_openai_response(body)
+        assert result["stop_reason"] == "max_tokens"
+
+    def test_finish_reason_tool_calls_maps_to_tool_use(self):
+        body = {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": None, "tool_calls": []},
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        }
+        result = _normalize_openai_response(body)
+        assert result["stop_reason"] == "tool_use"
+
+    def test_finish_reason_unknown_defaults_to_end_turn(self):
+        body = {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "some_unknown_reason",
+                }
+            ]
+        }
+        result = _normalize_openai_response(body)
+        assert result["stop_reason"] == "end_turn"
+
+    def test_null_content_produces_no_text_block(self):
+        body = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": None,
+                    },
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+        result = _normalize_openai_response(body)
+        assert result["content"] == []
+
+    def test_tool_calls_converted_to_tool_use_blocks(self):
+        tool_input = {"location": "Chicago"}
+        body = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_abc",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": json.dumps(tool_input),
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        }
+        result = _normalize_openai_response(body)
+        assert len(result["content"]) == 1
+        block = result["content"][0]
+        assert block["type"] == "tool_use"
+        assert block["id"] == "call_abc"
+        assert block["name"] == "get_weather"
+        assert block["input"] == tool_input
+
+    def test_tool_calls_with_bad_json_arguments(self):
+        """Malformed tool arguments fall back to empty dict."""
+        body = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_x",
+                                "function": {
+                                    "name": "bad_tool",
+                                    "arguments": "not-valid-json{",
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        }
+        result = _normalize_openai_response(body)
+        block = result["content"][0]
+        assert block["input"] == {}
+
+    def test_mixed_text_and_tool_calls(self):
+        body = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "Let me check that.",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "function": {
+                                    "name": "lookup",
+                                    "arguments": '{"q": "hello"}',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        }
+        result = _normalize_openai_response(body)
+        assert len(result["content"]) == 2
+        assert result["content"][0] == {"type": "text", "text": "Let me check that."}
+        assert result["content"][1]["type"] == "tool_use"
+
+    def test_usage_missing_defaults_to_zero(self):
+        body = {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "hi"},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+        result = _normalize_openai_response(body)
+        assert result["usage"] == {"input_tokens": 0, "output_tokens": 0}
+
+    def test_original_body_not_mutated(self):
+        """The original body dict should not be mutated."""
+        body = {
+            "id": "chatcmpl-x",
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "hi"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+        original_choices = body["choices"]
+        _normalize_openai_response(body)
+        # Original still has choices
+        assert body["choices"] is original_choices
+
+    def test_real_argo_claudeopus46_response(self):
+        """Reproduce the exact format seen in the lambda5 502 errors.
+
+        Argo returns OpenAI Chat format from ``/v1/messages`` for claudeopus46.
+        After normalization the Anthropic converter must be able to parse it.
+        """
+        body = {
+            "id": "chatcmpl-argo46",
+            "object": "chat.completion",
+            "created": 1779058858,
+            "model": "claudeopus46",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Hello! How can I assist you?",
+                        "tool_calls": None,
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 13,
+                "completion_tokens": 9,
+                "total_tokens": 22,
+            },
+        }
+        result = _normalize_openai_response(body)
+
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["content"] == [
+            {"type": "text", "text": "Hello! How can I assist you?"}
+        ]
+        assert result["stop_reason"] == "end_turn"
+        assert result["model"] == "claudeopus46"
+
+        # Verify the Anthropic converter can now parse this
+        from llm_rosetta.converters.anthropic import AnthropicConverter
+
+        conv = AnthropicConverter()
+        ir = conv.response_from_provider(result)
+        choices = ir.get("choices", [])
+        assert choices
+        msg = choices[0].get("message", {})
+        parts = msg.get("content", [])
+        assert any(p.get("type") == "text" for p in parts)


### PR DESCRIPTION
## Summary

- Argo's `/v1/messages` endpoint returns OpenAI Chat Completions format (`choices[0].message`) for some Claude model versions (confirmed: `claudeopus46`) instead of standard Anthropic Messages format, causing the Anthropic converter to crash with a 502 validation error
- Adds a `_normalize_openai_response` from-transform to the `argo_anthropic` shim that detects the OpenAI layout and rewrites it to Anthropic format before the converter processes it
- Anthropic-format responses pass through unchanged, so other Claude models on Argo are unaffected
- 24 new unit tests cover all paths including pass-through, text/tool conversion, finish reason mapping, and an end-to-end round-trip through the Anthropic converter

## Root cause

From the gateway DB on lambda5, 502 errors for `argo:claude-opus-4.6` all share the same error:

```
Failed to parse upstream response: 1 validation error(s): Value at 'choices[0].message' does not match any variant of SystemMessage | UserMessage | AssistantMessage | ToolMessage
```

This confirms Argo's `/v1/messages` sometimes returns `{"choices": [{"message": {...}}], ...}` (OpenAI format) instead of `{"content": [...], "role": "assistant", ...}` (Anthropic format). The `from_transforms` hook in the proxy pipeline (applied before `response_from_provider`) is the correct place to fix this without touching converter logic.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (1680 tests, 0 failures)
- [x] New test `test_real_argo_claudeopus46_response` reproduces the exact response shape from the DB and verifies the Anthropic converter can parse the normalized output

Fixes #204