### PR TITLE
fix(argo_anthropic): make _normalize_thinking model-aware (adaptive vs enabled)

### DIFF
--- a/src/llm_rosetta/shims/providers/argo_anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo_anthropic/transforms.py
@@ -1,15 +1,25 @@
 """Argo Anthropic schema transforms.
 
-Argo does not support ``thinking.type = "adaptive"`` — only
-``"enabled"`` (with ``budget_tokens``) and ``"disabled"`` are accepted.
-Convert ``"adaptive"`` to ``"enabled"`` with budget_tokens derived from
-max_tokens so the constraint ``max_tokens > budget_tokens`` is always met.
+Request-side (to_transforms)
+-----------------------------
+``_normalize_thinking`` converts the ``thinking`` block so that Argo accepts it:
 
-Argo's ``/v1/messages`` endpoint inconsistently returns OpenAI Chat
-Completions format (``choices[0].message``) for some Claude model versions
-instead of the standard Anthropic Messages format.  The
-``_normalize_openai_response`` from-transform detects this and converts the
-response to Anthropic format before the converter sees it.
+- Models backed by the **new Vertex AI endpoint** (e.g. ``claudeopus47``) require
+  ``thinking.type = "adaptive"`` and reject ``"enabled"``.  For these, the block
+  is passed through unchanged.
+
+- All other models (e.g. ``claudehaiku45``) only accept ``"enabled"`` /
+  ``"disabled"`` and reject ``"adaptive"``.  For these, ``"adaptive"`` is
+  converted to ``"enabled"`` with ``budget_tokens`` derived from ``max_tokens``
+  (80 %, floor 1024) so the Argo constraint ``max_tokens > budget_tokens`` is
+  always satisfied.
+
+Response-side (from_transforms)
+--------------------------------
+``_normalize_openai_response`` rewrites OpenAI Chat Completions format responses
+to Anthropic Messages format.  Argo's ``/v1/messages`` endpoint inconsistently
+returns ``choices[0].message`` for some Claude model versions; this transform
+normalises those responses before the Anthropic converter sees them.
 """
 
 from __future__ import annotations
@@ -20,9 +30,22 @@ from typing import Any
 
 from llm_rosetta.shims.transforms import _NamedTransform
 
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
 # Fraction of max_tokens to allocate as budget_tokens when converting
-# "adaptive" → "enabled".  80% leaves 20% for the actual response.
+# "adaptive" → "enabled".  80 % leaves 20 % for the actual response.
 _BUDGET_RATIO = 0.8
+
+# Models that natively require (or prefer) thinking.type = "adaptive".
+# The Vertex AI-backed Argo endpoint for these models rejects "enabled".
+# Add new model internal_ids here as Argo rolls them out.
+_ADAPTIVE_THINKING_MODELS: frozenset[str] = frozenset(
+    {
+        "claudeopus47",
+    }
+)
 
 # Finish-reason mapping: OpenAI → Anthropic stop_reason.
 _FINISH_REASON_MAP: dict[str, str] = {
@@ -32,40 +55,63 @@ _FINISH_REASON_MAP: dict[str, str] = {
     "content_filter": "stop_sequence",
 }
 
+# ---------------------------------------------------------------------------
+# Request-side transform
+# ---------------------------------------------------------------------------
+
 
 def _normalize_thinking(body: dict[str, Any]) -> dict[str, Any]:
-    """Normalize thinking block for Argo compatibility.
+    """Normalize the thinking block for Argo compatibility.
 
-    - ``"adaptive"`` → ``"enabled"`` with budget_tokens = 80% of
-      max_tokens (Argo only accepts ``"enabled"`` or ``"disabled"``,
-      and requires ``max_tokens > budget_tokens``)
+    For models that require ``adaptive`` (see ``_ADAPTIVE_THINKING_MODELS``),
+    the block is returned unchanged.  For all other models, ``"adaptive"`` is
+    converted to ``"enabled"`` with a ``budget_tokens`` value that satisfies
+    Argo's constraint ``max_tokens > budget_tokens >= 1024``.
+
+    Args:
+        body: Outbound request body (already converted to Anthropic format).
+
+    Returns:
+        Possibly-modified request body.
     """
     thinking = body.get("thinking")
     if not isinstance(thinking, dict):
         return body
-    if thinking.get("type") == "adaptive":
-        thinking["type"] = "enabled"
-        if "budget_tokens" not in thinking:
-            max_tokens = body.get("max_tokens", 16384)
-            budget = max(1024, int(max_tokens * _BUDGET_RATIO))
-            # Ensure budget < max_tokens; bump max_tokens if needed
-            if budget >= max_tokens:
-                body["max_tokens"] = budget + 1024
-            thinking["budget_tokens"] = budget
+    if thinking.get("type") != "adaptive":
+        return body
+
+    # Models that natively support adaptive — pass through unchanged.
+    model = body.get("model", "")
+    if model in _ADAPTIVE_THINKING_MODELS:
+        return body
+
+    # Convert adaptive → enabled for models that only accept enabled/disabled.
+    thinking["type"] = "enabled"
+    if "budget_tokens" not in thinking:
+        max_tokens = body.get("max_tokens", 16384)
+        budget = max(1024, int(max_tokens * _BUDGET_RATIO))
+        # Argo requires max_tokens > budget_tokens; bump max_tokens if needed.
+        if budget >= max_tokens:
+            body["max_tokens"] = budget + 1024
+        thinking["budget_tokens"] = budget
     return body
+
+
+# ---------------------------------------------------------------------------
+# Response-side transform
+# ---------------------------------------------------------------------------
 
 
 def _normalize_openai_response(body: dict[str, Any]) -> dict[str, Any]:
     """Convert an OpenAI Chat Completions response to Anthropic Messages format.
 
-    Argo's ``/v1/messages`` endpoint returns standard Anthropic format for
-    most Claude models, but falls back to OpenAI Chat format
-    (``choices[0].message``) for some model versions.  This transform
-    detects the OpenAI layout and rewrites it to Anthropic format so the
-    Anthropic converter can parse it correctly.
+    Argo's ``/v1/messages`` endpoint returns standard Anthropic format for most
+    Claude models but falls back to OpenAI Chat format (``choices[0].message``)
+    for some model versions.  This transform detects the OpenAI layout and
+    rewrites it to Anthropic format so the Anthropic converter can parse it.
 
-    Pass-through: responses that already have a top-level ``"content"`` list
-    or ``"type": "message"`` field are returned unchanged.
+    Pass-through: responses that already have a top-level ``"content"`` list or
+    ``"type": "message"`` field are returned unchanged.
 
     Args:
         body: Raw upstream JSON response dict.
@@ -137,6 +183,10 @@ def _normalize_openai_response(body: dict[str, Any]) -> dict[str, Any]:
     result["usage"] = usage
     return result
 
+
+# ---------------------------------------------------------------------------
+# Transform tuples (consumed by the shim loader)
+# ---------------------------------------------------------------------------
 
 to_transforms = (_NamedTransform(_normalize_thinking, "normalize_thinking()"),)
 from_transforms = (

--- a/tests/test_argo_anthropic_transforms.py
+++ b/tests/test_argo_anthropic_transforms.py
@@ -1,7 +1,7 @@
 """Tests for argo_anthropic shim transforms.
 
-Covers both the request-side ``_normalize_thinking`` and the response-side
-``_normalize_openai_response`` transforms.
+Covers both the request-side ``_normalize_thinking`` (to_transform) and the
+response-side ``_normalize_openai_response`` (from_transform).
 """
 
 from __future__ import annotations
@@ -20,14 +20,17 @@ from llm_rosetta.shims.providers.argo_anthropic.transforms import (
 
 
 class TestNormalizeThinking:
+    # --- pass-through cases ---
+
     def test_no_thinking_passthrough(self):
-        body: dict = {"model": "claudeopus46", "max_tokens": 1024}
+        body: dict = {"model": "claudehaiku45", "max_tokens": 1024}
         result = _normalize_thinking(body)
         assert result is body
         assert "thinking" not in result
 
     def test_enabled_unchanged(self):
         body: dict = {
+            "model": "claudehaiku45",
             "max_tokens": 1024,
             "thinking": {"type": "enabled", "budget_tokens": 512},
         }
@@ -35,41 +38,131 @@ class TestNormalizeThinking:
         assert result["thinking"]["type"] == "enabled"
         assert result["thinking"]["budget_tokens"] == 512
 
-    def test_adaptive_converted_to_enabled(self):
-        body: dict = {"max_tokens": 2048, "thinking": {"type": "adaptive"}}
+    def test_disabled_unchanged(self):
+        body: dict = {"model": "claudehaiku45", "thinking": {"type": "disabled"}}
+        result = _normalize_thinking(body)
+        assert result["thinking"]["type"] == "disabled"
+
+    def test_non_dict_thinking_passthrough(self):
+        body: dict = {"thinking": "enabled"}
+        result = _normalize_thinking(body)
+        assert result["thinking"] == "enabled"
+
+    # --- adaptive models: pass through unchanged ---
+
+    def test_adaptive_model_claudeopus47_passthrough(self):
+        """claudeopus47 requires adaptive — transform must not touch it."""
+        body: dict = {
+            "model": "claudeopus47",
+            "max_tokens": 2048,
+            "thinking": {"type": "adaptive"},
+        }
+        result = _normalize_thinking(body)
+        assert result["thinking"]["type"] == "adaptive"
+        assert "budget_tokens" not in result["thinking"]
+
+    def test_adaptive_model_with_budget_tokens_passthrough(self):
+        """Even if budget_tokens is already set, adaptive models pass through."""
+        body: dict = {
+            "model": "claudeopus47",
+            "max_tokens": 4096,
+            "thinking": {"type": "adaptive", "budget_tokens": 999},
+        }
+        result = _normalize_thinking(body)
+        assert result["thinking"]["type"] == "adaptive"
+        assert result["thinking"]["budget_tokens"] == 999
+
+    # --- non-adaptive models: convert adaptive → enabled ---
+
+    def test_adaptive_converted_to_enabled_for_haiku(self):
+        """claudehaiku45 rejects adaptive — must be converted to enabled."""
+        body: dict = {
+            "model": "claudehaiku45",
+            "max_tokens": 2048,
+            "thinking": {"type": "adaptive"},
+        }
         result = _normalize_thinking(body)
         assert result["thinking"]["type"] == "enabled"
         assert "budget_tokens" in result["thinking"]
         # budget = max(1024, int(2048 * 0.8)) = 1638
         assert result["thinking"]["budget_tokens"] == 1638
 
-    def test_adaptive_budget_less_than_max_tokens(self):
-        body: dict = {"max_tokens": 2000, "thinking": {"type": "adaptive"}}
+    def test_adaptive_converted_for_opus46(self):
+        """claudeopus46 is not in the adaptive allowlist — converts to enabled."""
+        body: dict = {
+            "model": "claudeopus46",
+            "max_tokens": 4096,
+            "thinking": {"type": "adaptive"},
+        }
+        result = _normalize_thinking(body)
+        assert result["thinking"]["type"] == "enabled"
+
+    def test_adaptive_converted_for_no_model_field(self):
+        """Missing model field — safe default: convert adaptive → enabled."""
+        body: dict = {"max_tokens": 2048, "thinking": {"type": "adaptive"}}
+        result = _normalize_thinking(body)
+        assert result["thinking"]["type"] == "enabled"
+
+    def test_budget_less_than_max_tokens_invariant(self):
+        body: dict = {
+            "model": "claudehaiku45",
+            "max_tokens": 2000,
+            "thinking": {"type": "adaptive"},
+        }
         result = _normalize_thinking(body)
         budget = result["thinking"]["budget_tokens"]
         assert budget < result["max_tokens"], "budget_tokens must be < max_tokens"
 
-    def test_adaptive_small_max_tokens_bumps_max_tokens(self):
-        """When max_tokens is very small, max_tokens is bumped to keep invariant."""
-        body: dict = {"max_tokens": 100, "thinking": {"type": "adaptive"}}
+    def test_small_max_tokens_bumps_max_tokens(self):
+        """When max_tokens is too small, max_tokens is bumped to keep invariant."""
+        body: dict = {
+            "model": "claudehaiku45",
+            "max_tokens": 100,
+            "thinking": {"type": "adaptive"},
+        }
         result = _normalize_thinking(body)
         budget = result["thinking"]["budget_tokens"]
         assert budget >= 1024
         assert budget < result["max_tokens"]
 
-    def test_adaptive_existing_budget_tokens_preserved(self):
+    def test_existing_budget_tokens_preserved(self):
         """If budget_tokens is already set, do not overwrite it."""
         body: dict = {
+            "model": "claudehaiku45",
             "max_tokens": 4096,
             "thinking": {"type": "adaptive", "budget_tokens": 999},
         }
         result = _normalize_thinking(body)
         assert result["thinking"]["budget_tokens"] == 999
 
-    def test_non_dict_thinking_passthrough(self):
-        body: dict = {"thinking": "enabled"}
+    # --- regression: real error patterns from lambda5 ---
+
+    def test_haiku_adaptive_rejected_in_production(self):
+        """Regression: haiku sent adaptive → Argo 400. Must convert to enabled."""
+        # Reproduces the 2026-05-15/16 errors: "Input tag 'adaptive' found
+        # using 'type' does not match any of the expected tags: 'disabled', 'enabled'"
+        body: dict = {
+            "model": "claudehaiku45",
+            "max_tokens": 1024,
+            "thinking": {"type": "adaptive"},
+        }
         result = _normalize_thinking(body)
-        assert result["thinking"] == "enabled"
+        assert result["thinking"]["type"] == "enabled"
+        budget = result["thinking"]["budget_tokens"]
+        assert budget >= 1024
+        assert result["max_tokens"] > budget
+
+    def test_opus47_enabled_rejected_in_production(self):
+        """Regression: opus47 received enabled → Argo 400. Must stay adaptive."""
+        # Reproduces the 2026-05-16 error: "'thinking.type.enabled' is not
+        # supported for this model. Use 'thinking.type.adaptive'."
+        body: dict = {
+            "model": "claudeopus47",
+            "max_tokens": 8192,
+            "thinking": {"type": "adaptive"},
+        }
+        result = _normalize_thinking(body)
+        assert result["thinking"]["type"] == "adaptive"
 
 
 # ---------------------------------------------------------------------------
@@ -95,7 +188,6 @@ class TestNormalizeOpenAIResponse:
         assert result is body
 
     def test_type_message_passthrough(self):
-        """Responses with 'type: message' are returned unchanged."""
         body = {"type": "message", "role": "assistant"}
         result = _normalize_openai_response(body)
         assert result is body
@@ -123,7 +215,6 @@ class TestNormalizeOpenAIResponse:
     # --- conversion cases ---
 
     def test_plain_text_response(self):
-        """Simple OpenAI Chat format with text content is converted correctly."""
         body = {
             "id": "chatcmpl-001",
             "object": "chat.completion",
@@ -145,10 +236,8 @@ class TestNormalizeOpenAIResponse:
         assert result["stop_reason"] == "end_turn"
         assert result["usage"]["input_tokens"] == 10
         assert result["usage"]["output_tokens"] == 4
-        # OpenAI-specific keys should be gone
         assert "choices" not in result
         assert "object" not in result
-        # Non-format keys preserved
         assert result["id"] == "chatcmpl-001"
         assert result["model"] == "claudeopus46"
 
@@ -236,7 +325,6 @@ class TestNormalizeOpenAIResponse:
         assert block["input"] == tool_input
 
     def test_tool_calls_with_bad_json_arguments(self):
-        """Malformed tool arguments fall back to empty dict."""
         body = {
             "choices": [
                 {
@@ -300,7 +388,6 @@ class TestNormalizeOpenAIResponse:
         assert result["usage"] == {"input_tokens": 0, "output_tokens": 0}
 
     def test_original_body_not_mutated(self):
-        """The original body dict should not be mutated."""
         body = {
             "id": "chatcmpl-x",
             "choices": [
@@ -312,8 +399,52 @@ class TestNormalizeOpenAIResponse:
         }
         original_choices = body["choices"]
         _normalize_openai_response(body)
-        # Original still has choices
         assert body["choices"] is original_choices
+
+    def test_real_argo_claudeopus46_response_round_trip(self):
+        """Regression: claudeopus46 returned OpenAI format → 502 on lambda5.
+
+        After normalization the Anthropic converter must parse it successfully.
+        """
+        body = {
+            "id": "chatcmpl-argo46",
+            "object": "chat.completion",
+            "created": 1779058858,
+            "model": "claudeopus46",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Hello! How can I assist you?",
+                        "tool_calls": None,
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 13,
+                "completion_tokens": 9,
+                "total_tokens": 22,
+            },
+        }
+        result = _normalize_openai_response(body)
+
+        assert result["type"] == "message"
+        assert result["role"] == "assistant"
+        assert result["content"] == [
+            {"type": "text", "text": "Hello! How can I assist you?"}
+        ]
+        assert result["stop_reason"] == "end_turn"
+
+        from llm_rosetta.converters.anthropic import AnthropicConverter
+
+        conv = AnthropicConverter()
+        ir = conv.response_from_provider(result)
+        choices = ir.get("choices", [])
+        assert choices
+        parts = choices[0].get("message", {}).get("content", [])
+        assert any(p.get("type") == "text" for p in parts)
 
     def test_real_argo_claudeopus46_response(self):
         """Reproduce the exact format seen in the lambda5 502 errors.


### PR DESCRIPTION
## Summary

- `argo:claude-opus-4.7` (Vertex AI-backed) rejects `thinking.type = "enabled"` and requires `"adaptive"` — the old blanket `adaptive → enabled` conversion broke it with a 400 error
- `argo:claude-haiku-4.5` rejects `"adaptive"` but the transform wasn't being triggered in some cases, letting `adaptive` pass through raw to Argo
- Adds `_ADAPTIVE_THINKING_MODELS` frozenset: models listed here have their `thinking` block passed through unchanged; all others get `adaptive → enabled` with the existing budget_tokens logic
- Also includes the `_normalize_openai_response` from-transform (originally in PR #206) so all `argo_anthropic` fixes are consolidated in one place

## Root cause (from lambda5 `gateway.db`)

| timestamp | model | error |
|-----------|-------|-------|
| 2026-05-16 09:13 | `argo:claude-opus-4.7` | `"thinking.type.enabled" is not supported. Use "thinking.type.adaptive"` |
| 2026-05-15 23:56 | `argo:claude-haiku-4.5` | `Input tag 'adaptive' does not match: 'disabled', 'enabled'` |
| 2026-05-16 00:29 | `argo:claude-haiku-4.5` | `max_tokens must be greater than thinking.budget_tokens` |
| 2026-05-16 00:33 | `argo:claude-haiku-4.5` | `thinking.enabled.budget_tokens: Input should be >= 1024` |

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (1687 tests, 0 failures)
- [x] `test_haiku_adaptive_rejected_in_production` — reproduces exact haiku error
- [x] `test_opus47_enabled_rejected_in_production` — reproduces exact opus-4.7 error
- [x] `test_real_argo_claudeopus46_response_round_trip` — OpenAI-format response parsed by Anthropic converter

Fixes #205