### PR TITLE
fix(admin): reverse proxy cache bypass + login UX improvements

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -354,10 +354,14 @@ th.sortable.desc::after { content:'\25BC';opacity:.8; }
   <div class="login-box">
     <h2>llm-rosetta <span style="font-weight:400;color:var(--text-dim)">gateway</span></h2>
     <div class="login-subtitle" data-i18n="login.subtitle">Admin panel is password-protected</div>
-    <input id="loginPassword" type="password" placeholder="Password" autofocus
-      onkeydown="if(event.key==='Enter')doLogin()">
-    <div class="login-error" id="loginError"></div>
-    <button onclick="doLogin()" data-i18n="login.btn">Login</button>
+    <form id="loginForm" autocomplete="on" onsubmit="doLogin();return false;">
+      <input type="text" name="username" autocomplete="username"
+        value="admin" style="display:none" aria-hidden="true">
+      <input id="loginPassword" type="password" name="password"
+        autocomplete="current-password" placeholder="Password" autofocus>
+      <div class="login-error" id="loginError"></div>
+      <button type="submit" data-i18n="login.btn">Login</button>
+    </form>
   </div>
 </div>
 
@@ -380,6 +384,7 @@ th.sortable.desc::after { content:'\25BC';opacity:.8; }
       <option value="en">EN</option>
       <option value="zh">中文</option>
     </select>
+    <button id="logoutBtn" class="btn btn-sm" onclick="doLogout()" style="display:none" data-i18n="btn.logout">Logout</button>
   </div>
 </div>
 
@@ -851,8 +856,10 @@ const I18N = {
     'login.subtitle':'Admin panel is password-protected',
     'login.btn':'Login',
     'login.error':'Invalid password',
+    'btn.logout':'Logout',
   },
   zh: {
+    'btn.logout':'\u9000\u51fa\u767b\u5f55',
     'tab.providers':'\u670d\u52a1\u5546', 'tab.models':'\u6a21\u578b', 'tab.keys':'API \u5bc6\u94a5',
     'tab.dashboard':'\u76d1\u63a7\u9762\u677f', 'tab.logs':'\u8bf7\u6c42\u65e5\u5fd7',
     'section.server':'\u670d\u52a1\u5668\u8bbe\u7f6e', 'section.providers':'\u670d\u52a1\u5546', 'section.models':'\u6a21\u578b\u8def\u7531',
@@ -993,7 +1000,7 @@ setTheme(currentTheme);
 // ===================== API =====================
 function _adminHeaders(extra) {
   const h = extra ? {...extra} : {};
-  const token = sessionStorage.getItem('admin_token');
+  const token = localStorage.getItem('admin_token');
   if (token) h['X-Admin-Token'] = token;
   return h;
 }
@@ -1024,8 +1031,36 @@ const api = {
   }
 };
 
+// ===================== Inactivity auto-logout =====================
+const INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+let _inactivityTimer = null;
+
+function _resetInactivityTimer() {
+  if (_inactivityTimer) clearTimeout(_inactivityTimer);
+  _inactivityTimer = setTimeout(() => doLogout(), INACTIVITY_TIMEOUT_MS);
+}
+
+function _startInactivityTracking() {
+  ['mousemove', 'keydown', 'mousedown', 'touchstart', 'scroll', 'click'].forEach(evt => {
+    document.addEventListener(evt, _resetInactivityTimer, { passive: true });
+  });
+  _resetInactivityTimer();
+}
+
+function _stopInactivityTracking() {
+  if (_inactivityTimer) { clearTimeout(_inactivityTimer); _inactivityTimer = null; }
+}
+
+function doLogout() {
+  localStorage.removeItem('admin_token');
+  _stopInactivityTracking();
+  const btn = document.getElementById('logoutBtn');
+  if (btn) btn.style.display = 'none';
+  showLoginOverlay();
+}
+
 function showLoginOverlay() {
-  sessionStorage.removeItem('admin_token');
+  localStorage.removeItem('admin_token');
   document.getElementById('loginOverlay').style.display = 'flex';
   document.getElementById('loginPassword').value = '';
   document.getElementById('loginError').textContent = '';
@@ -1043,8 +1078,11 @@ async function doLogin() {
     });
     const data = await r.json();
     if (r.ok && data.token) {
-      sessionStorage.setItem('admin_token', data.token);
+      localStorage.setItem('admin_token', data.token);
       document.getElementById('loginOverlay').style.display = 'none';
+      const btn = document.getElementById('logoutBtn');
+      if (btn) btn.style.display = '';
+      _startInactivityTracking();
       initApp();
     } else {
       document.getElementById('loginError').textContent = t('login.error');
@@ -1060,7 +1098,7 @@ async function checkAuthAndInit() {
     const data = await r.json();
     if (data.requires_auth) {
       // Check if we have a valid stored token
-      const token = sessionStorage.getItem('admin_token');
+      const token = localStorage.getItem('admin_token');
       if (token) {
         // Verify token by trying to load config
         const test = await fetch('/admin/api/config', {headers: {'X-Admin-Token': token}});
@@ -1068,6 +1106,9 @@ async function checkAuthAndInit() {
           showLoginOverlay();
           return;
         }
+        const btn = document.getElementById('logoutBtn');
+        if (btn) btn.style.display = '';
+        _startInactivityTracking();
       } else {
         showLoginOverlay();
         return;
@@ -2122,7 +2163,7 @@ const TEST_IMAGE_URL = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDA
 function getTestLabel(type) { return t('test.' + type); }
 
 function buildTestPayload(model, type) {
-  const base = {model, max_tokens: 4096};
+  const base = {model, max_tokens: 256};
   switch(type) {
     case 'text':
       return {...base, messages:[{role:'user', content:'Say "Hello! The gateway test is working." and nothing else.'}]};

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -1007,7 +1007,7 @@ function _adminHeaders(extra) {
 
 const api = {
   async get(url) {
-    const r = await fetch(url, {headers: _adminHeaders()});
+    const r = await fetch(url, {headers: _adminHeaders(), cache: 'no-store'});
     if (r.status === 401) { showLoginOverlay(); throw new Error('Unauthorized'); }
     return r.json();
   },
@@ -2298,7 +2298,7 @@ async function runTest(model, type) {
 
         _testPollTimer = setInterval(async () => {
           try {
-            const r = await api.get('/admin/api/test/' + taskId);
+            const r = await api.post('/admin/api/test/' + taskId + '/poll');
             if (r.status === 'pending') return; // keep polling
             clearInterval(_testPollTimer);
             _testPollTimer = null;

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -105,4 +105,5 @@ def register_admin_routes(app: Any) -> None:
     # Async model test
     app.route("/admin/api/test", methods=["POST"])(start_test)
     app.route("/admin/api/test/<task_id>", methods=["GET"])(get_test_result)
+    app.route("/admin/api/test/<task_id>/poll", methods=["POST"])(get_test_result)
     app.route("/admin/api/test/<task_id>", methods=["DELETE"])(cancel_test)

--- a/src/llm_rosetta/gateway/admin/routes/testing.py
+++ b/src/llm_rosetta/gateway/admin/routes/testing.py
@@ -159,7 +159,7 @@ async def get_test_result(request: Any, task_id: str = "") -> Response:
 
     # Return only serialisable fields (skip _task_obj, _base_url)
     result: dict[str, Any] = {k: v for k, v in task.items() if not k.startswith("_")}
-    return JSONResponse(result, headers={"Cache-Control": "no-store"})
+    return JSONResponse(result)
 
 
 async def cancel_test(request: Any, task_id: str = "") -> Response:

--- a/src/llm_rosetta/gateway/admin/routes/testing.py
+++ b/src/llm_rosetta/gateway/admin/routes/testing.py
@@ -159,7 +159,7 @@ async def get_test_result(request: Any, task_id: str = "") -> Response:
 
     # Return only serialisable fields (skip _task_obj, _base_url)
     result: dict[str, Any] = {k: v for k, v in task.items() if not k.startswith("_")}
-    return JSONResponse(result)
+    return JSONResponse(result, headers={"Cache-Control": "no-store"})
 
 
 async def cancel_test(request: Any, task_id: str = "") -> Response:

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -369,6 +369,12 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
         response.headers["Access-Control-Allow-Origin"] = "*"
         response.headers["Access-Control-Allow-Methods"] = "*"
         response.headers["Access-Control-Allow-Headers"] = "*"
+        # Prevent reverse-proxy caching of admin API responses (e.g. Caddy/Souin).
+        # Uses the full directive set that Souin recognises as NO-STORE-DIRECTIVE.
+        if request.path.startswith("/admin/api/"):
+            response.headers.setdefault(
+                "Cache-Control", "no-cache, no-store, must-revalidate"
+            )
         return response
 
     @app.route("/<path:_path>", methods=["OPTIONS"])


### PR DESCRIPTION
## Summary

- **Login persistence**: switch from `sessionStorage` to `localStorage` so admin token survives browser restarts
- **Logout button**: add visible Logout button in header-right (hidden until authenticated)
- **Inactivity auto-logout**: 30-min idle timer tracking mouse/key/scroll/click events
- **Password manager compat**: wrap login in `<form>` with `autocomplete` attributes + hidden username field
- **Fix test poll caching**: NPS edges use Caddy + Souin cache plugin which cached GET poll responses, causing the test spinner to hang forever. Switch poll to POST (never cached per RFC)
- **Global Cache-Control**: add `no-cache, no-store, must-revalidate` to ALL `/admin/api/*` responses via `after_request` hook, preventing stale data for dashboard metrics (3s poll), request logs (5s poll), config reads after writes, and key listings

### Root cause analysis

Souin cached the first `{"status":"pending"}` GET response for `/admin/api/test/{id}`, and all subsequent polls hit the cache indefinitely. The `Cache-Control: no-store` header alone wasn't respected by Souin — it requires the full `no-cache, no-store, must-revalidate` directive set (verified by `cache-status: Souin; detail=NO-STORE-DIRECTIVE`).

## Test plan

- [x] Verified via Playwright: test completes with `200 OK` through `rosetta.service.oaklight.cn` (NPS + Souin)
- [x] Verified `Cache-Control` header on all admin API responses: `curl -D - .../admin/api/auth-check` shows `no-cache, no-store, must-revalidate`
- [x] Verified Souin respects it: `cache-status: Souin; detail=NO-STORE-DIRECTIVE`
- [ ] Verify dashboard metrics update in real-time through reverse proxy
- [ ] Verify request log updates after new requests