### PR TITLE
fix(admin): prevent login overlay from dismissing password manager popup

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -1071,7 +1071,13 @@ function doLogout() {
 
 function showLoginOverlay() {
   localStorage.removeItem('admin_token');
-  document.getElementById('loginOverlay').style.display = 'flex';
+  // Stop background polling timers to prevent repeated 401 → showLoginOverlay loops
+  if (dashboardTimer) { clearInterval(dashboardTimer); dashboardTimer = null; }
+  if (logTimer) { clearInterval(logTimer); logTimer = null; }
+  const overlay = document.getElementById('loginOverlay');
+  // Don't re-clear fields if already showing (would dismiss password manager popup)
+  if (overlay.style.display === 'flex') return;
+  overlay.style.display = 'flex';
   document.getElementById('loginPassword').value = '';
   document.getElementById('loginError').textContent = '';
   document.getElementById('loginPassword').focus();


### PR DESCRIPTION
## Summary

Background API polling (metrics every 3s, logs every 5s) returns 401 when the admin token is invalid. Each 401 calls `showLoginOverlay()` which clears the password field and re-focuses it — dismissing any open password manager popup.

**Fix:**
- Stop `dashboardTimer` and `logTimer` intervals when the login overlay shows
- Guard: if the overlay is already visible, return early (don't re-clear the password field)

This fix was supposed to be in PR #209 but the code change was lost during branch operations.

## Test plan
- [x] Deploy verified: container has the guard code
- [x] Fill password field, wait 10s — field value preserved