### PR TITLE
feat(admin): host IP detection + upstream error UX

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -828,7 +828,7 @@ const I18N = {
     'test.connecting':'Connecting...', 'test.cancel':'Cancel', 'test.sending':'Sending request...', 'test.rawRequest':'Raw Request', 'test.rawResponse':'Raw Response', 'test.testImage':'Test Image',
     'test.emptyResponse':'(empty response)',
     'hint.docker':'In Docker, "localhost" refers to the container itself. Use "host.docker.internal" (macOS/Windows) or "172.17.0.1" (Linux) to reach the host machine.',
-    'diag.ip':'IP Location', 'diag.google':'Google', 'diag.runDiag':'Network Diagnostics',
+    'diag.host':'Host IP', 'diag.ip':'IP Location', 'diag.google':'Google', 'diag.runDiag':'Network Diagnostics',
     'diag.testing':'testing...', 'diag.unknown':'unknown', 'diag.direct':'direct, no proxy',
     'label.searchModels':'Search models...',
     'model.count':'{shown} / {total} models',
@@ -1019,7 +1019,10 @@ const api = {
   async get(url) {
     const r = await fetch(url, {headers: _adminHeaders(), cache: 'no-store'});
     if (r.status === 401) { showLoginOverlay(); throw new Error('Unauthorized'); }
-    return r.json();
+    const data = await r.json().catch(() => null);
+    if (!r.ok) throw new Error(data?.error || (r.status === 504 ? 'Request timed out — the upstream service may be unreachable' : `HTTP ${r.status}`));
+    if (data === null) throw new Error('Invalid JSON response');
+    return data;
   },
   async put(url, body) {
     const r = await fetch(url, {method:'PUT', headers:_adminHeaders({'Content-Type':'application/json'}), body:JSON.stringify(body)});
@@ -1239,6 +1242,7 @@ function openProviderModal(name, baseUrl, apiKey, proxy, provType) {
     keyInput.placeholder = '${OPENAI_API_KEY}';
   }
   document.getElementById('provProxy').value = proxy || '';
+  if (window._detectedHostIp) document.getElementById('provProxy').placeholder = `e.g. http://${window._detectedHostIp}:7890`;
   document.getElementById('providerModal').classList.add('open');
   // When editing, fetch the real (unmasked) key
   if (name && _credentialVisible) {
@@ -1324,17 +1328,22 @@ async function runNetDiag() {
   const el = document.getElementById('netDiagResults');
   el.innerHTML = `
     <span class="diag-item"><span class="diag-dot loading"></span>${t('diag.ip')}: ${t('diag.testing')}</span>
+    <span class="diag-item"><span class="diag-dot loading"></span>${t('diag.host')}: ${t('diag.testing')}</span>
     <span class="diag-item"><span class="diag-dot loading"></span>${t('diag.google')}: ${t('diag.testing')}</span>`;
   try {
     const data = await api.get('/admin/api/diagnostics/network');
     const ipInfo = data.ip || {};
+    const hostInfo = data.host || {};
     const googleInfo = data.google || {};
+    // Store detected host IP for provider form hints
+    if (hostInfo.ok) window._detectedHostIp = hostInfo.ip;
     const proxyText = data.proxy ? `(via ${esc(data.proxy)})` : `(${t('diag.direct')})`;
     const ipText = ipInfo.ok ? `${ipInfo.ip} (${ipInfo.city}, ${ipInfo.country})` : (ipInfo.error || t('diag.unknown'));
     const googleText = googleInfo.ok ? 'OK' : (googleInfo.error || 'unreachable');
     el.innerHTML = `
       <span class="diag-item" style="color:var(--text-dim);font-size:11px">${proxyText}</span>
       <span class="diag-item"><span class="diag-dot ${ipInfo.ok ? 'ok' : 'fail'}"></span>${t('diag.ip')}: ${esc(ipText)}</span>
+      <span class="diag-item"><span class="diag-dot ${hostInfo.ok ? 'ok' : 'fail'}"></span>${t('diag.host')}: ${hostInfo.ok ? esc(hostInfo.ip) : esc(hostInfo.error || t('diag.unknown'))}</span>
       <span class="diag-item"><span class="diag-dot ${googleInfo.ok ? 'ok' : 'fail'}"></span>${t('diag.google')}: ${esc(googleText)}</span>`;
   } catch(e) {
     el.innerHTML = `<span class="diag-item"><span class="diag-dot fail"></span>Error: ${esc(String(e))}</span>`;
@@ -1699,8 +1708,13 @@ async function doFetchModels() {
 
   try {
     const data = await api.get(`/admin/api/config/providers/${encodeURIComponent(provider)}/models`);
-    _fetchedModels = data.models || [];
     document.getElementById('fetchModelsLoading').style.display = 'none';
+    if (data.error) {
+      document.getElementById('fetchModelsError').textContent = data.error;
+      document.getElementById('fetchModelsError').style.display = 'block';
+      return;
+    }
+    _fetchedModels = data.models || [];
     if (_fetchedModels.length === 0) {
       document.getElementById('fetchModelsError').textContent = t('fetch.noModels');
       document.getElementById('fetchModelsError').style.display = 'block';

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -528,16 +528,32 @@ async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
     headers = pinfo.auth_headers()
 
     try:
-        client = AsyncClient(timeout=30.0, proxy=pinfo.proxy_url)
+        client = AsyncClient(timeout=10.0, proxy=pinfo.proxy_url)
         raw_resp = await client.get(models_url, headers=headers)
         assert isinstance(raw_resp, HttpResponse), "Expected non-streaming response"
         resp: HttpResponse = raw_resp
         await client.aclose()
     except Exception as exc:
         logger.warning("Failed to fetch models from %s: %s", provider_name, exc)
-        return JSONResponse(
-            {"error": f"Failed to connect to upstream: {exc}"}, status_code=502
-        )
+        err_str = str(exc)
+        # Provide user-friendly error messages for common connection issues
+        if "Connection refused" in err_str or "Errno 111" in err_str:
+            msg = (
+                f"Connection refused at {models_url}. "
+                "Check that the service is running and the port is correct. "
+                "If running in Docker, ensure the host firewall (e.g. ufw) "
+                "allows connections from the Docker bridge network."
+            )
+        elif "timed out" in err_str.lower():
+            msg = (
+                f"Connection to {models_url} timed out. "
+                "Check that the host/port is reachable from this container."
+            )
+        elif "Name or service not known" in err_str or "getaddrinfo" in err_str:
+            msg = f"Cannot resolve hostname in {models_url}. Check the Base URL."
+        else:
+            msg = f"Failed to connect to upstream: {err_str}"
+        return JSONResponse({"error": msg})  # 200 so reverse proxies don't intercept
 
     if resp.status_code >= 400:
         logger.warning(
@@ -550,7 +566,6 @@ async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
                     "This provider may not support model listing."
                 ),
             },
-            status_code=502,
         )
 
     try:
@@ -558,7 +573,6 @@ async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
     except Exception:
         return JSONResponse(
             {"error": "Upstream returned non-JSON response"},
-            status_code=502,
         )
 
     # Resolve model_id_field from shim (e.g. Argo uses "internal_id")

--- a/src/llm_rosetta/gateway/admin/routes/observability.py
+++ b/src/llm_rosetta/gateway/admin/routes/observability.py
@@ -108,6 +108,24 @@ async def network_diagnostics(request: Any) -> Response:
     except Exception as exc:
         results["ip"] = {"ok": False, "error": str(exc)}
 
+    # Host IP detection (Docker gateway — for accessing host services)
+    try:
+        with open("/proc/net/route") as f:
+            for line in f:
+                fields = line.strip().split()
+                if fields[1] == "00000000":  # default route
+                    gw = int(fields[2], 16)
+                    host_ip = (
+                        f"{gw & 0xFF}.{(gw >> 8) & 0xFF}"
+                        f".{(gw >> 16) & 0xFF}.{(gw >> 24) & 0xFF}"
+                    )
+                    results["host"] = {"ok": True, "ip": host_ip}
+                    break
+            else:
+                results["host"] = {"ok": False, "error": "No default route"}
+    except Exception as exc:
+        results["host"] = {"ok": False, "error": str(exc)}
+
     # Google connectivity
     try:
         async with AsyncClient(**client_kwargs) as client:


### PR DESCRIPTION
## Summary

### Host IP Detection
- Detect Docker host IP via `/proc/net/route` default gateway parsing
- Display in Network Diagnostics: **Host IP: 172.29.0.1** (green dot)
- Dynamically set provider proxy URL placeholder to detected host IP

### Upstream Error Messages
Before: `JSON.parse: unexpected character at line 1 column 1` (cryptic)
After: `Request timed out — the upstream service may be unreachable` (actionable)

- Connection refused → suggests checking service, port, and host firewall (ufw)
- Timeout → suggests checking reachability
- DNS failure → suggests checking Base URL
- Return 200 + `{error}` instead of 502 so Caddy/Souin doesn't intercept with its own HTML error page
- `api.get()` gracefully handles non-JSON and non-2xx responses
- Reduce model fetch timeout from 30s → 10s (faster than reverse proxy timeout)

## Test plan
- [x] Network Diagnostics shows Host IP: 172.29.0.1 (verified via Playwright on cloud.usa2)
- [x] Fetch models from unreachable provider shows "Request timed out — the upstream service may be unreachable"
- [x] Error message passes through Caddy/NPS without being intercepted