### PR TITLE
fix(admin): inline confirm i18n keys and onclick restore

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -864,6 +864,8 @@ const I18N = {
     'login.btn':'Login',
     'login.error':'Invalid password',
     'btn.logout':'Logout',
+    'confirm.sure':'Sure?',
+    'confirm.yes':'Yes',
   },
   zh: {
     'btn.logout':'\u9000\u51fa\u767b\u5f55',
@@ -954,6 +956,8 @@ const I18N = {
     'login.subtitle':'Admin \u9762\u677f\u5df2\u542f\u7528\u5bc6\u7801\u4fdd\u62a4',
     'login.btn':'\u767b\u5f55',
     'login.error':'\u5bc6\u7801\u9519\u8bef',
+    'confirm.sure':'\u786e\u5b9a\uff1f',
+    'confirm.yes':'\u662f',
   },
 };
 
@@ -1662,10 +1666,11 @@ function inlineConfirm(btn, action) {
   btn.dataset.confirming = '1';
   const orig = btn.innerHTML;
   const origClass = btn.className;
-  btn.innerHTML = `${t('confirm.sure')} <span style="text-decoration:underline;cursor:pointer" onclick="event.stopPropagation()">${t('confirm.yes')}</span>`;
+  const origOnclick = btn.onclick;
+  btn.innerHTML = `${t('confirm.sure')} <span style="text-decoration:underline;cursor:pointer">${t('confirm.yes')}</span>`;
   btn.className = btn.className.replace('btn-danger', 'btn-warning');
   btn.style.minWidth = btn.offsetWidth + 'px';
-  const revert = () => { btn.innerHTML = orig; btn.className = origClass; btn.style.minWidth = ''; delete btn.dataset.confirming; };
+  const revert = () => { btn.innerHTML = orig; btn.className = origClass; btn.style.minWidth = ''; btn.onclick = origOnclick; delete btn.dataset.confirming; };
   const timer = setTimeout(revert, 3000);
   btn.querySelector('span').onclick = (e) => { e.stopPropagation(); clearTimeout(timer); revert(); action(); };
   btn.onclick = (e) => { e.stopPropagation(); clearTimeout(timer); revert(); };

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -34,6 +34,7 @@ def _get_version() -> str:
     """Return the llm-rosetta package version."""
     try:
         from llm_rosetta import __version__
+
         return __version__
     except Exception:
         return "unknown"
@@ -509,6 +510,26 @@ async def reload_config(request: Any) -> Response:
     )
 
 
+def _format_connection_error(exc: Exception, url: str) -> str:
+    """Return a user-friendly message for common upstream connection errors."""
+    err_str = str(exc)
+    if "Connection refused" in err_str or "Errno 111" in err_str:
+        return (
+            f"Connection refused at {url}. "
+            "Check that the service is running and the port is correct. "
+            "If running in Docker, ensure the host firewall (e.g. ufw) "
+            "allows connections from the Docker bridge network."
+        )
+    if "timed out" in err_str.lower():
+        return (
+            f"Connection to {url} timed out. "
+            "Check that the host/port is reachable from this container."
+        )
+    if "Name or service not known" in err_str or "getaddrinfo" in err_str:
+        return f"Cannot resolve hostname in {url}. Check the Base URL."
+    return f"Failed to connect to upstream: {err_str}"
+
+
 async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
     """Fetch the model list from an upstream provider's /v1/models endpoint."""
     from llm_rosetta.shims import get_shim
@@ -545,24 +566,7 @@ async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
         await client.aclose()
     except Exception as exc:
         logger.warning("Failed to fetch models from %s: %s", provider_name, exc)
-        err_str = str(exc)
-        # Provide user-friendly error messages for common connection issues
-        if "Connection refused" in err_str or "Errno 111" in err_str:
-            msg = (
-                f"Connection refused at {models_url}. "
-                "Check that the service is running and the port is correct. "
-                "If running in Docker, ensure the host firewall (e.g. ufw) "
-                "allows connections from the Docker bridge network."
-            )
-        elif "timed out" in err_str.lower():
-            msg = (
-                f"Connection to {models_url} timed out. "
-                "Check that the host/port is reachable from this container."
-            )
-        elif "Name or service not known" in err_str or "getaddrinfo" in err_str:
-            msg = f"Cannot resolve hostname in {models_url}. Check the Base URL."
-        else:
-            msg = f"Failed to connect to upstream: {err_str}"
+        msg = _format_connection_error(exc, models_url)
         return JSONResponse({"error": msg})  # 200 so reverse proxies don't intercept
 
     if resp.status_code >= 400:


### PR DESCRIPTION
## Summary
- Add missing `confirm.sure` / `confirm.yes` i18n entries for EN and ZH — the inline delete confirmation was showing raw keys instead of translated text
- Save and restore original `btn.onclick` in `inlineConfirm()` so the Delete button remains clickable after the 3-second confirmation window reverts

## Test plan
- [ ] Click Delete on a model row — should show "Sure? Yes" (EN) or "确定？ 是" (ZH)
- [ ] Let the confirmation revert after 3s — click Delete again, should work
- [ ] Click "Yes" — model should be deleted