### PR TITLE
fix(ci): use pre-commit for all lint/type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[all]"
 
-      - name: Lint with ruff
-        run: ruff check
-
-      - name: Check formatting with ruff
-        run: ruff format --check
-
-      - name: Type check with ty
-        run: ty check
+      - name: Run pre-commit checks
+        uses: pre-commit/action@v3.0.1
 
       - name: Run converter tests
         run: python -m pytest tests/converters/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,10 @@ dev = [
     "python-dotenv",
     "pytest",
     "pytest-cov",
+    "pre-commit>=4.0.0",
     "complexipy>=5.2.0",
     "ruff>=0.15.0",
-    "ty>=0.0.32",
+    "ty==0.0.34",
     "build>=1.2.2.post1",
     "twine>=6.1.0",
 ]
@@ -68,7 +69,7 @@ llm-rosetta-gateway = "llm_rosetta.gateway:main"
 where = ["src"]
 
 [tool.setuptools.package-data]
-"llm_rosetta" = ["py.typed", "shims/providers/*/provider.yaml"]
+"llm_rosetta" = ["py.typed", "shims/providers/*/provider.yaml", "shims/providers/*/*/provider.yaml"]
 "llm_rosetta.gateway.admin" = ["admin.html"]
 
 [tool.setuptools.dynamic]

--- a/tests/integration/test_google_genai_sdk_e2e.py
+++ b/tests/integration/test_google_genai_sdk_e2e.py
@@ -174,7 +174,7 @@ def build_sdk_config(provider_req):
             )
         )
 
-    return types.GenerateContentConfig(**config_kwargs) if config_kwargs else None  # ty: ignore[invalid-argument-type]
+    return types.GenerateContentConfig(**config_kwargs) if config_kwargs else None
 
 
 def build_sdk_contents(provider_req):

--- a/tests/test_converters_base.py
+++ b/tests/test_converters_base.py
@@ -205,7 +205,7 @@ class MockMessageOps(BaseMessageOps):
 
             ir_messages.append(ir_msg)
 
-        return ir_messages  # ty: ignore[invalid-return-type]
+        return ir_messages
 
 
 class MockToolOps(BaseToolOps):


### PR DESCRIPTION
## Summary

- Replace separate `ruff check` / `ruff format --check` / `ty check` CI steps with `pre-commit/action@v3.0.1`, so CI checks are always identical to local pre-commit hooks
- Pin `ty==0.0.34` in dev deps — ty uses `language: system` in pre-commit (no official pre-commit repo yet, see astral-sh/ty#269), so the installed version must be explicitly pinned to avoid drift
- Add `pre-commit>=4.0.0` to dev deps
- Remove `# ty: ignore` comments that were only needed for ty 0.0.39
- Fix `package-data` glob to include grouped provider YAML files (`shims/providers/*/*/provider.yaml`)

## Test plan

- [ ] CI passes with pre-commit/action (ruff + ruff-format + ty all run through pre-commit)
- [ ] `make test` still passes (1692 tests)
- [ ] `ty check` passes clean locally with 0.0.34