### PR TITLE
feat(admin): dual-threshold retention + DB sizing footer

### DIFF
--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -7,7 +7,7 @@ import os
 from typing import TYPE_CHECKING, Any
 
 from .metrics import MetricsCollector
-from .persistence import PersistenceManager
+from .persistence import DEFAULT_ERROR_MAX, DEFAULT_SUCCESS_MAX, PersistenceManager
 from .request_log import RequestLog
 
 if TYPE_CHECKING:
@@ -16,6 +16,46 @@ if TYPE_CHECKING:
 __all__ = ["setup_admin", "MetricsCollector", "RequestLog", "PersistenceManager"]
 
 logger = logging.getLogger("llm-rosetta-gateway")
+
+
+def _resolve_log_caps(config: GatewayConfig) -> tuple[int, int]:
+    """Resolve (success_max, error_max) from env vars and config.
+
+    Precedence: env vars > config.request_log.{success,error}_max >
+    legacy config.request_log.max_entries > built-in defaults.
+    """
+    rl_cfg: dict[str, Any] = getattr(config, "request_log", {}) or {}
+
+    def _parse_int_env(name: str) -> int | None:
+        raw = os.environ.get(name)
+        if raw is None or raw == "":
+            return None
+        try:
+            return int(raw)
+        except ValueError:
+            logger.warning("Ignoring non-integer %s=%r", name, raw)
+            return None
+
+    success_max = _parse_int_env("REQUEST_LOG_SUCCESS_MAX")
+    error_max = _parse_int_env("REQUEST_LOG_ERROR_MAX")
+
+    if success_max is None:
+        success_max = rl_cfg.get("success_max")
+    if error_max is None:
+        error_max = rl_cfg.get("error_max")
+
+    legacy = rl_cfg.get("max_entries")
+    if legacy is not None and success_max is None:
+        logger.warning(
+            "config: server.request_log.max_entries is deprecated; "
+            "use success_max (and optionally error_max) instead."
+        )
+        success_max = legacy
+
+    return (
+        int(success_max) if success_max is not None else DEFAULT_SUCCESS_MAX,
+        int(error_max) if error_max is not None else DEFAULT_ERROR_MAX,
+    )
 
 
 def setup_admin(
@@ -34,7 +74,10 @@ def setup_admin(
     persistence: PersistenceManager | None = None
     if config_path:
         data_dir = os.path.join(os.path.dirname(config_path), "data")
-        persistence = PersistenceManager(data_dir)
+        success_max, error_max = _resolve_log_caps(config)
+        persistence = PersistenceManager(
+            data_dir, success_max=success_max, error_max=error_max
+        )
 
         # Restore persisted metrics counters
         saved_metrics = persistence.load_metrics()

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -389,6 +389,32 @@ th.sortable.desc::after { content:'\25BC';opacity:.8; }
   .table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
   .section-header { flex-wrap: wrap; gap: 8px; }
 }
+
+/* DB status footer */
+.db-footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  padding: 4px 12px;
+  font-size: 11px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--text-dim);
+  background: var(--bg-card);
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: flex-end;
+  gap: 14px;
+  user-select: none;
+}
+.db-footer .seg { display: inline-flex; gap: 4px; }
+.db-footer .k { opacity: 0.7; }
+.db-footer .v { font-weight: 500; color: var(--text); }
+.db-footer .v.warn { color: var(--orange); }
+.db-footer .v.crit { color: var(--red); }
+.db-footer.hidden { display: none; }
+body { padding-bottom: 26px; }
 </style>
 </head>
 <body>
@@ -2008,6 +2034,40 @@ async function loadMetrics() {
   drawChart('chartThroughput', data.series, 'count', 'req/s');
   drawChart('chartLatency', data.series, 'avg_ms', 'ms');
   renderProviderBreakdown(data);
+  renderPersistence(data.persistence);
+}
+
+// Format bytes as "1.4 M", "832 K", "5.4 G". Fixed-width-ish for footer.
+function fmtBytes(n) {
+  if (!Number.isFinite(n) || n < 0) return '–';
+  if (n < 1024) return n + ' B';
+  if (n < 1024 * 1024) return (n / 1024).toFixed(0) + ' K';
+  if (n < 1024 * 1024 * 1024) return (n / (1024 * 1024)).toFixed(1) + ' M';
+  return (n / (1024 * 1024 * 1024)).toFixed(2) + ' G';
+}
+
+// Render the persistent DB status footer.  Hidden when the metrics
+// snapshot lacks a persistence block (no config file, in-memory only).
+function renderPersistence(p) {
+  const el = document.getElementById('dbFooter');
+  if (!el) return;
+  if (!p) { el.classList.add('hidden'); return; }
+  el.classList.remove('hidden');
+
+  const successCap = p.log_max_success || 0;
+  const errorCap = p.log_max_error || 0;
+  const successN = p.log_success_entries || 0;
+  const errorN = p.log_error_entries || 0;
+  const successPct = successCap > 0 ? Math.round((successN / successCap) * 100) : 0;
+  const errorPct = errorCap > 0 ? Math.round((errorN / errorCap) * 100) : 0;
+  const pctClass = (pct) => pct >= 95 ? 'crit' : (pct >= 75 ? 'warn' : '');
+
+  el.innerHTML = `
+    <span class="seg"><span class="k">DB</span><span class="v">${fmtBytes(p.db_bytes)}</span></span>
+    <span class="seg"><span class="k">ok</span><span class="v ${pctClass(successPct)}">${successN}/${successCap} (${successPct}%)</span></span>
+    <span class="seg"><span class="k">err</span><span class="v ${pctClass(errorPct)}">${errorN}/${errorCap} (${errorPct}%)</span></span>
+    <span class="seg"><span class="k">WAL</span><span class="v">${fmtBytes(p.wal_bytes)}</span></span>
+  `;
 }
 
 function renderStats(d) {
@@ -2577,5 +2637,6 @@ function initApp() {
 setLang(currentLang);
 checkAuthAndInit();
 </script>
+<div class="db-footer hidden" id="dbFooter" title="Gateway persistence status"></div>
 </body>
 </html>

--- a/src/llm_rosetta/gateway/admin/persistence.py
+++ b/src/llm_rosetta/gateway/admin/persistence.py
@@ -11,6 +11,7 @@ import gzip
 import json
 import logging
 import sqlite3
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -22,22 +23,56 @@ _DB_FILENAME = "gateway.db"
 _LEGACY_LOG = "request_log.jsonl"
 _LEGACY_METRICS = "metrics.json"
 
+# Retention defaults: keep many successes for capacity planning, keep
+# errors longer because they are rare and operationally valuable.
+DEFAULT_SUCCESS_MAX = 50000
+DEFAULT_ERROR_MAX = 10000
+
 
 class PersistenceManager:
     """SQLite-backed persistence for request logs and metrics.
 
+    The request log uses a dual-threshold retention policy: successful
+    requests (status_code < 400) and error requests (status_code >= 400)
+    are pruned independently.  Errors typically make up a tiny fraction
+    of traffic but are the most valuable rows to keep around for
+    debugging, so they get their own cap that the success rotation
+    cannot evict.
+
     Args:
         data_dir: Directory for the database file (created if missing).
-        max_entries: Maximum request log entries to retain.
+        success_max: Maximum number of successful request log entries to
+            retain.  Defaults to :data:`DEFAULT_SUCCESS_MAX`.
+        error_max: Maximum number of error request log entries to retain
+            (status_code >= 400).  Defaults to :data:`DEFAULT_ERROR_MAX`.
+        max_entries: Deprecated.  When provided and ``success_max`` is
+            not, used as the success cap for backward compatibility.
+            Emits a :class:`DeprecationWarning`.
     """
 
     def __init__(
         self,
         data_dir: str,
-        max_entries: int = 5000,
+        success_max: int | None = None,
+        error_max: int | None = None,
+        *,
+        max_entries: int | None = None,
     ) -> None:
+        if max_entries is not None:
+            warnings.warn(
+                "PersistenceManager(max_entries=...) is deprecated; "
+                "use success_max= (and optionally error_max=) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if success_max is None:
+                success_max = max_entries
+
         self._data_dir = Path(data_dir)
-        self._max_entries = max_entries
+        self._success_max = (
+            success_max if success_max is not None else DEFAULT_SUCCESS_MAX
+        )
+        self._error_max = error_max if error_max is not None else DEFAULT_ERROR_MAX
         self._insert_count = 0
         self._data_dir.mkdir(parents=True, exist_ok=True)
 
@@ -46,6 +81,16 @@ class PersistenceManager:
         self._conn.execute("PRAGMA synchronous=NORMAL")
         self._init_tables()
         self._migrate_legacy()
+
+    @property
+    def success_max(self) -> int:
+        """Cap on retained successful request log entries."""
+        return self._success_max
+
+    @property
+    def error_max(self) -> int:
+        """Cap on retained error request log entries (status_code >= 400)."""
+        return self._error_max
 
     @property
     def db_path(self) -> Path:
@@ -123,10 +168,14 @@ class PersistenceManager:
         )
         self._conn.commit()
         self._insert_count += len(entries)
+        # Periodic prune amortizes the DELETE cost; opportunistic prune
+        # bounds memory when the success cap is small.
         if self._insert_count >= 100:
             self._prune()
             self._insert_count = 0
-        elif self.count_log_entries() > self._max_entries:
+        elif self.count_success_entries() > self._success_max or (
+            self.count_error_entries() > self._error_max
+        ):
             self._prune()
 
     def query_log_entries(
@@ -189,6 +238,41 @@ class PersistenceManager:
         row = self._conn.execute("SELECT COUNT(*) FROM request_log").fetchone()
         return row[0] if row else 0
 
+    def count_success_entries(self) -> int:
+        """Return the number of successful log entries (status_code < 400)."""
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM request_log WHERE status_code < 400"
+        ).fetchone()
+        return row[0] if row else 0
+
+    def count_error_entries(self) -> int:
+        """Return the number of error log entries (status_code >= 400)."""
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM request_log WHERE status_code >= 400"
+        ).fetchone()
+        return row[0] if row else 0
+
+    def db_file_sizes(self) -> dict[str, int]:
+        """Return on-disk byte sizes of the SQLite database files.
+
+        Returns:
+            Dict with keys ``db_bytes`` (main file), ``wal_bytes`` (WAL),
+            and ``shm_bytes`` (shared memory).  Missing files report 0.
+        """
+        db = self.db_path
+        sizes = {"db_bytes": 0, "wal_bytes": 0, "shm_bytes": 0}
+        for key, suffix in (
+            ("db_bytes", ""),
+            ("wal_bytes", "-wal"),
+            ("shm_bytes", "-shm"),
+        ):
+            p = db.with_name(db.name + suffix)
+            try:
+                sizes[key] = p.stat().st_size
+            except OSError:
+                sizes[key] = 0
+        return sizes
+
     def clear_log(self) -> None:
         """Delete all request log entries."""
         self._conn.execute("DELETE FROM request_log")
@@ -239,11 +323,26 @@ class PersistenceManager:
     # ------------------------------------------------------------------
 
     def _prune(self) -> None:
-        """Remove oldest entries beyond the retention limit."""
+        """Remove oldest entries beyond the per-class retention limits.
+
+        Success and error rows are pruned independently so that rare
+        error rows are not evicted by a flood of successful traffic.
+        """
         self._conn.execute(
-            "DELETE FROM request_log WHERE id NOT IN "
-            "(SELECT id FROM request_log ORDER BY timestamp DESC LIMIT ?)",
-            (self._max_entries,),
+            "DELETE FROM request_log "
+            "WHERE status_code < 400 AND id NOT IN ("
+            "    SELECT id FROM request_log WHERE status_code < 400 "
+            "    ORDER BY timestamp DESC LIMIT ?"
+            ")",
+            (self._success_max,),
+        )
+        self._conn.execute(
+            "DELETE FROM request_log "
+            "WHERE status_code >= 400 AND id NOT IN ("
+            "    SELECT id FROM request_log WHERE status_code >= 400 "
+            "    ORDER BY timestamp DESC LIMIT ?"
+            ")",
+            (self._error_max,),
         )
         self._conn.commit()
 

--- a/src/llm_rosetta/gateway/admin/routes/observability.py
+++ b/src/llm_rosetta/gateway/admin/routes/observability.py
@@ -36,12 +36,43 @@ def _detect_host_ip() -> dict[str, Any]:
         return {"ok": False, "error": str(exc)}
 
 
+def _persistence_snapshot(persistence: Any) -> dict[str, Any] | None:
+    """Build the persistence sub-block for the metrics snapshot.
+
+    Returns a dict with on-disk byte sizes and per-class entry counts
+    plus retention caps, or ``None`` when persistence is not configured
+    (e.g. in tests without a config file).
+    """
+    if persistence is None:
+        return None
+    try:
+        sizes = persistence.db_file_sizes()
+        return {
+            **sizes,
+            "log_entries": persistence.count_log_entries(),
+            "log_success_entries": persistence.count_success_entries(),
+            "log_error_entries": persistence.count_error_entries(),
+            "log_max_success": persistence.success_max,
+            "log_max_error": persistence.error_max,
+        }
+    except Exception:
+        # Persistence introspection is purely informational; never let
+        # it block the metrics endpoint.
+        return None
+
+
 async def get_metrics(request: Any) -> Response:
     """Return a full metrics snapshot."""
     metrics = request.app.metrics
     seconds = int(_qp(request, "seconds", "60"))
     seconds = max(1, min(seconds, 300))
-    return JSONResponse(metrics.snapshot(series_seconds=seconds))
+    snap = metrics.snapshot(series_seconds=seconds)
+
+    persistence_snap = _persistence_snapshot(getattr(request.app, "persistence", None))
+    if persistence_snap is not None:
+        snap["persistence"] = persistence_snap
+
+    return JSONResponse(snap)
 
 
 async def get_requests(request: Any) -> Response:

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -187,6 +187,10 @@ class GatewayConfig:
         self.credential_visible: bool = _server.get("credential_visible", True)
         self.admin_password: str | None = _server.get("admin_password")
 
+        # Request-log retention knobs (consumed by setup_admin).  Kept as
+        # a raw dict here so admin layer owns the resolution policy.
+        self.request_log: dict[str, Any] = _server.get("request_log", {}) or {}
+
         # Multi-key auth: server.api_keys takes precedence over server.api_key
         self.api_keys: list[dict[str, str]] = _server.get("api_keys", [])
         if not self.api_keys and _server.get("api_key"):

--- a/tests/gateway/test_persistence_sqlite.py
+++ b/tests/gateway/test_persistence_sqlite.py
@@ -4,7 +4,13 @@ import gzip
 import json
 import time
 
-from llm_rosetta.gateway.admin.persistence import PersistenceManager
+import pytest
+
+from llm_rosetta.gateway.admin.persistence import (
+    DEFAULT_ERROR_MAX,
+    DEFAULT_SUCCESS_MAX,
+    PersistenceManager,
+)
 from llm_rosetta.gateway.admin.request_log import RequestLog, RequestLogEntry
 
 
@@ -169,13 +175,108 @@ class TestPersistenceManagerRequestLog:
         pm.close()
 
     def test_prune(self, tmp_path):
-        pm = PersistenceManager(str(tmp_path), max_entries=10)
-        # Insert 15 entries in batches to trigger prune
+        # Legacy max_entries=N caps successes only; emits DeprecationWarning.
+        with pytest.warns(DeprecationWarning):
+            pm = PersistenceManager(str(tmp_path), max_entries=10)
+        # Insert 150 successful entries in batches to trigger prune.
         for batch in range(3):
             entries = [_make_entry_dict(model=f"m-{batch}-{i}") for i in range(50)]
             pm.insert_log_entries(entries)
 
-        assert pm.count_log_entries() <= 10
+        assert pm.count_success_entries() <= 10
+        pm.close()
+
+
+class TestPersistenceManagerRetention:
+    """Dual-threshold prune: success and error caps are independent."""
+
+    def test_defaults(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        assert pm.success_max == DEFAULT_SUCCESS_MAX
+        assert pm.error_max == DEFAULT_ERROR_MAX
+        pm.close()
+
+    def test_explicit_caps(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path), success_max=123, error_max=45)
+        assert pm.success_max == 123
+        assert pm.error_max == 45
+        pm.close()
+
+    def test_legacy_max_entries_maps_to_success(self, tmp_path):
+        with pytest.warns(DeprecationWarning, match="success_max"):
+            pm = PersistenceManager(str(tmp_path), max_entries=77)
+        assert pm.success_max == 77
+        assert pm.error_max == DEFAULT_ERROR_MAX
+        pm.close()
+
+    def test_legacy_does_not_override_explicit_success_max(self, tmp_path):
+        with pytest.warns(DeprecationWarning):
+            pm = PersistenceManager(str(tmp_path), success_max=200, max_entries=77)
+        # Explicit success_max wins over legacy alias.
+        assert pm.success_max == 200
+        pm.close()
+
+    def test_errors_not_evicted_by_success_flood(self, tmp_path):
+        # Tiny success cap, generous error cap: a flood of successes must
+        # not evict the rare error rows.
+        pm = PersistenceManager(str(tmp_path), success_max=20, error_max=10)
+
+        err_entries = [_make_entry_dict(status=500, model=f"e-{i}") for i in range(5)]
+        pm.insert_log_entries(err_entries)
+
+        for batch in range(2):
+            ok_entries = [_make_entry_dict(model=f"ok-{batch}-{i}") for i in range(100)]
+            pm.insert_log_entries(ok_entries)
+
+        assert pm.count_success_entries() <= 20
+        assert pm.count_error_entries() == 5
+        pm.close()
+
+    def test_error_cap_pruned_independently(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path), success_max=1000, error_max=10)
+        # 150 errors, batched to trigger periodic prune at 100.
+        for batch in range(3):
+            entries = [
+                _make_entry_dict(status=500, model=f"e-{batch}-{i}") for i in range(50)
+            ]
+            pm.insert_log_entries(entries)
+
+        assert pm.count_error_entries() <= 10
+        assert pm.count_success_entries() == 0
+        pm.close()
+
+    def test_count_success_and_error_separately(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        pm.insert_log_entries(
+            [
+                _make_entry_dict(status=200),
+                _make_entry_dict(status=201),
+                _make_entry_dict(status=404),
+                _make_entry_dict(status=500),
+                _make_entry_dict(status=502),
+            ]
+        )
+        assert pm.count_log_entries() == 5
+        assert pm.count_success_entries() == 2
+        assert pm.count_error_entries() == 3
+        pm.close()
+
+
+class TestPersistenceManagerSizes:
+    def test_db_file_sizes_keys(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        sizes = pm.db_file_sizes()
+        assert set(sizes.keys()) == {"db_bytes", "wal_bytes", "shm_bytes"}
+        assert all(isinstance(v, int) for v in sizes.values())
+        pm.close()
+
+    def test_db_file_sizes_nonzero_after_insert(self, tmp_path):
+        pm = PersistenceManager(str(tmp_path))
+        pm.insert_log_entries([_make_entry_dict(model=f"m-{i}") for i in range(50)])
+        sizes = pm.db_file_sizes()
+        # Main db file always exists after init; WAL is created on first write.
+        assert sizes["db_bytes"] > 0
+        assert sizes["wal_bytes"] >= 0
         pm.close()
 
     def test_bool_roundtrip(self, tmp_path):


### PR DESCRIPTION
## Summary

- Rotate successful and error request-log entries on **independent caps** so a flood of successes can't evict the rare error rows operators actually need for debugging.
- Bump defaults from `5000` total to **`50000` success + `10000` error**. Tunable via `REQUEST_LOG_SUCCESS_MAX` / `REQUEST_LOG_ERROR_MAX` env vars or `server.request_log.{success,error}_max` config keys.
- Add a **fixed footer status line** to the admin UI showing `DB · ok N/cap · err N/cap · WAL`, refreshed every 3s along with the existing metrics poll. Warn (≥75%) and crit (≥95%) color thresholds surface capacity pressure at a glance.
- Legacy `server.request_log.max_entries` and `PersistenceManager(max_entries=...)` still work but emit a `DeprecationWarning` and map to `success_max`.

Refs #226.

## Why

Production traffic on cloud.usa2 was overwriting valuable error rows after a few days because the prune treated success and error rows identically. With ~0.24% error rate, a single success burst would silently evict the small set of 4xx/5xx rows needed for debugging gemini `thoughtSignature` (#226) and similar issues.

## Behavioral notes

- New backend field `metrics.persistence` is omitted entirely when persistence is not configured (e.g. in tests without a config file), so the existing snapshot contract for non-persistence callers is unchanged.
- `_persistence_snapshot` swallows introspection errors and returns `None` — admin endpoint never gates on it.
- WAL footer cell shows `wal_bytes + shm_bytes` so transient SQLite WAL volume is visible.

## Test plan

- [x] `make lint` — green
- [x] `make test` — 1701 passed, 4 skipped
- [x] New tests cover: defaults, explicit caps, legacy alias warns + maps to success, errors not evicted by success flood, error cap pruned independently, `count_success_entries`/`count_error_entries`, `db_file_sizes()`.
- [x] Local smoke test with Playwright: footer renders 4 segments with live counts; warn at 80% triggers `.v.warn` (2 cells); crit at 97% triggers `.v.crit` (2 cells); no relevant JS console errors.
- [x] Deploy devtest image to cloud.usa2 and verify footer reads production DB live (follow-up).

## AI disclosure

AI was used to assist with implementation and PR drafting.