### PR TITLE
fix(admin): provider filter + system clock + i18n

### DIFF
--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -88,6 +88,16 @@ def setup_admin(
                 metrics.total_requests,
             )
 
+    # Backfill target_provider_name for legacy log entries
+    if persistence is not None:
+        model_to_provider = {model: config.models[model] for model in config.models}
+        backfilled = persistence.backfill_provider_names(model_to_provider)
+        if backfilled:
+            logger.info(
+                "Backfilled target_provider_name for %d log entries",
+                backfilled,
+            )
+
     # Request log delegates to persistence when available
     request_log = RequestLog(persistence=persistence)
 

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -2190,6 +2190,15 @@ async function loadLogs() {
   renderLogs(data.entries, data.total);
 }
 
+// Reverse-lookup: provider API type → display name from config
+function resolveProviderName(apiType) {
+  if (!configData) return apiType;
+  for (const [name, cfg] of Object.entries(configData.providers || {})) {
+    if (cfg.type === apiType) return name;
+  }
+  return apiType;
+}
+
 function renderLogs(entries, total) {
   const tbody = document.getElementById('logTable');
   if (entries.length === 0) {
@@ -2208,7 +2217,7 @@ function renderLogs(entries, total) {
       let rows = `<tr${rowStyle}${expandHint}>
         <td>${time}</td>
         <td><code>${esc(e.model)}</code></td>
-        <td>${esc(e.source_provider)} &rarr; ${esc(e.target_provider_name || e.target_provider)}</td>
+        <td>${esc(e.source_provider)} &rarr; ${esc(e.target_provider_name || resolveProviderName(e.target_provider))}</td>
         <td>${modeBadge}</td>
         <td style="font-size:12px;color:var(--text-dim)">${esc(keyLabel)}</td>
         <td><span class="badge ${statusCls}">${e.status_code}${hasError ? ' ▸' : ''}</span></td>

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -440,6 +440,7 @@ body { padding-bottom: 26px; }
     <h1>llm-rosetta <span>gateway admin</span></h1>
   </div>
   <div class="header-right">
+    <span style="font-size:12px;color:var(--text-dim);margin-right:8px"><span style="margin-right:4px">System Time</span><span id="systemClock" style="font-family:var(--mono)"></span></span>
     <button class="btn btn-sm" onclick="openSettings()" data-i18n-title="modal.settings" title="Settings"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></button>
     <button id="logoutBtn" class="btn btn-sm" onclick="doLogout()" style="display:none" data-i18n="btn.logout">Logout</button>
   </div>
@@ -2200,7 +2201,7 @@ function renderLogs(entries, total) {
       let rows = `<tr${rowStyle}${expandHint}>
         <td>${time}</td>
         <td><code>${esc(e.model)}</code></td>
-        <td>${esc(e.source_provider)} &rarr; ${esc(e.target_provider)}</td>
+        <td>${esc(e.source_provider)} &rarr; ${esc(e.target_provider_name || e.target_provider)}</td>
         <td>${modeBadge}</td>
         <td style="font-size:12px;color:var(--text-dim)">${esc(keyLabel)}</td>
         <td><span class="badge ${statusCls}">${e.status_code}${hasError ? ' ▸' : ''}</span></td>
@@ -2633,7 +2634,19 @@ async function runTest(model, type) {
 function initApp() {
   loadConfig();
   api.get('/admin/api/internal-token').then(r => { internalToken = r.token; }).catch(() => {});
+  // Always load the DB footer regardless of the active tab
+  api.get('/admin/api/metrics?seconds=1').then(data => {
+    renderPersistence(data.persistence);
+  }).catch(() => {});
 }
+// ===================== System Clock =====================
+(function initClock() {
+  const el = document.getElementById('systemClock');
+  function tick() { el.textContent = new Date().toLocaleTimeString(); }
+  tick();
+  setInterval(tick, 1000);
+})();
+
 setLang(currentLang);
 checkAuthAndInit();
 </script>

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -440,7 +440,7 @@ body { padding-bottom: 26px; }
     <h1>llm-rosetta <span>gateway admin</span></h1>
   </div>
   <div class="header-right">
-    <span style="font-size:12px;color:var(--text-dim);margin-right:8px"><span style="margin-right:4px">System Time</span><span id="systemClock" style="font-family:var(--mono)"></span></span>
+    <span style="font-size:12px;color:var(--text-dim);margin-right:8px"><span style="margin-right:4px" data-i18n="label.systemTime">System Time</span><span id="systemClock" style="font-family:var(--mono)"></span></span>
     <button class="btn btn-sm" onclick="openSettings()" data-i18n-title="modal.settings" title="Settings"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></button>
     <button id="logoutBtn" class="btn btn-sm" onclick="doLogout()" style="display:none" data-i18n="btn.logout">Logout</button>
   </div>
@@ -921,6 +921,7 @@ const I18N = {
     'login.btn':'Login',
     'login.error':'Invalid password',
     'btn.logout':'Logout',
+    'label.systemTime':'System Time',
     'confirm.sure':'Sure?',
     'confirm.yes':'Yes',
   },
@@ -1014,6 +1015,7 @@ const I18N = {
     'login.subtitle':'Admin \u9762\u677f\u5df2\u542f\u7528\u5bc6\u7801\u4fdd\u62a4',
     'login.btn':'\u767b\u5f55',
     'login.error':'\u5bc6\u7801\u9519\u8bef',
+    'label.systemTime':'\u7cfb\u7edf\u65f6\u95f4',
     'confirm.sure':'\u786e\u5b9a\uff1f',
     'confirm.yes':'\u662f',
   },

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -922,6 +922,8 @@ const I18N = {
     'login.error':'Invalid password',
     'btn.logout':'Logout',
     'label.systemTime':'System Time',
+    'footer.title':'Gateway persistence status',
+    'footer.db':'DB', 'footer.ok':'ok', 'footer.err':'err',
     'confirm.sure':'Sure?',
     'confirm.yes':'Yes',
   },
@@ -974,15 +976,15 @@ const I18N = {
     'error.fieldsRequired':'\u540d\u79f0\u3001Base URL \u548c API Key \u4e3a\u5fc5\u586b\u9879',
     'error.modelRequired':'\u6240\u6709\u5b57\u6bb5\u4e3a\u5fc5\u586b\u9879',
     'page.info':'\u7b2c {current} / {total} \u9875\uff08\u5171 {count} \u6761\uff09',
-    'test.connecting':'\u8fde\u63a5\u4e2d...', 'test.sending':'\u53d1\u9001\u8bf7\u6c42\u4e2d...', 'test.rawRequest':'\u539f\u59cb\u8bf7\u6c42', 'test.rawResponse':'\u539f\u59cb\u54cd\u5e94', 'test.testImage':'\u6d4b\u8bd5\u56fe\u7247',
+    'test.connecting':'\u8fde\u63a5\u4e2d...', 'test.cancel':'\u53d6\u6d88', 'test.sending':'\u53d1\u9001\u8bf7\u6c42\u4e2d...', 'test.rawRequest':'\u539f\u59cb\u8bf7\u6c42', 'test.rawResponse':'\u539f\u59cb\u54cd\u5e94', 'test.testImage':'\u6d4b\u8bd5\u56fe\u7247',
     'test.emptyResponse':'\uff08\u7a7a\u54cd\u5e94\uff09',
     'hint.docker':'\u5728 Docker \u4e2d\uff0c"localhost" \u6307\u7684\u662f\u5bb9\u5668\u81ea\u8eab\u3002\u8981\u8bbf\u95ee\u5bbf\u4e3b\u673a\uff0c\u8bf7\u4f7f\u7528 "host.docker.internal"\uff08macOS/Windows\uff09\u6216 "172.17.0.1"\uff08Linux\uff09\u3002',
-    'diag.ip':'IP \u5f52\u5c5e', 'diag.google':'Google', 'diag.runDiag':'\u7f51\u7edc\u8bca\u65ad',
+    'diag.host':'\u4e3b\u673a IP', 'diag.ip':'IP \u5f52\u5c5e', 'diag.google':'Google', 'diag.runDiag':'\u7f51\u7edc\u8bca\u65ad',
     'diag.testing':'\u68c0\u6d4b\u4e2d...', 'diag.unknown':'\u672a\u77e5', 'diag.direct':'\u76f4\u8fde\uff0c\u672a\u4f7f\u7528\u4ee3\u7406',
     'label.searchModels':'\u641c\u7d22\u6a21\u578b...',
     'model.count':'{shown} / {total} \u4e2a\u6a21\u578b',
     'section.apiKeys':'API \u5bc6\u94a5',
-    'btn.generateKey':'+ \u751f\u6210\u5bc6\u94a5', 'btn.generate':'\u751f\u6210', 'btn.copy':'\u590d\u5236',
+    'btn.generateKey':'+ \u751f\u6210\u5bc6\u94a5', 'btn.generate':'\u751f\u6210', 'btn.copy':'\u590d\u5236', 'btn.clone':'\u514b\u9686',
     'col.label':'\u6807\u7b7e', 'col.key':'\u5bc6\u94a5', 'col.created':'\u521b\u5efa\u65f6\u95f4',
     'col.apiKey':'API \u5bc6\u94a5',
     'modal.generateKey':'\u751f\u6210 API \u5bc6\u94a5',
@@ -1016,6 +1018,8 @@ const I18N = {
     'login.btn':'\u767b\u5f55',
     'login.error':'\u5bc6\u7801\u9519\u8bef',
     'label.systemTime':'\u7cfb\u7edf\u65f6\u95f4',
+    'footer.title':'\u7f51\u5173\u6301\u4e45\u5316\u72b6\u6001',
+    'footer.db':'DB', 'footer.ok':'\u6b63\u5e38', 'footer.err':'\u9519\u8bef',
     'confirm.sure':'\u786e\u5b9a\uff1f',
     'confirm.yes':'\u662f',
   },
@@ -2065,10 +2069,11 @@ function renderPersistence(p) {
   const errorPct = errorCap > 0 ? Math.round((errorN / errorCap) * 100) : 0;
   const pctClass = (pct) => pct >= 95 ? 'crit' : (pct >= 75 ? 'warn' : '');
 
+  el.title = t('footer.title');
   el.innerHTML = `
-    <span class="seg"><span class="k">DB</span><span class="v">${fmtBytes(p.db_bytes)}</span></span>
-    <span class="seg"><span class="k">ok</span><span class="v ${pctClass(successPct)}">${successN}/${successCap} (${successPct}%)</span></span>
-    <span class="seg"><span class="k">err</span><span class="v ${pctClass(errorPct)}">${errorN}/${errorCap} (${errorPct}%)</span></span>
+    <span class="seg"><span class="k">${t('footer.db')}</span><span class="v">${fmtBytes(p.db_bytes)}</span></span>
+    <span class="seg"><span class="k">${t('footer.ok')}</span><span class="v ${pctClass(successPct)}">${successN}/${successCap} (${successPct}%)</span></span>
+    <span class="seg"><span class="k">${t('footer.err')}</span><span class="v ${pctClass(errorPct)}">${errorN}/${errorCap} (${errorPct}%)</span></span>
     <span class="seg"><span class="k">WAL</span><span class="v">${fmtBytes(p.wal_bytes)}</span></span>
   `;
 }
@@ -2652,6 +2657,6 @@ function initApp() {
 setLang(currentLang);
 checkAuthAndInit();
 </script>
-<div class="db-footer hidden" id="dbFooter" title="Gateway persistence status"></div>
+<div class="db-footer hidden" id="dbFooter"></div>
 </body>
 </html>

--- a/src/llm_rosetta/gateway/admin/persistence.py
+++ b/src/llm_rosetta/gateway/admin/persistence.py
@@ -227,9 +227,17 @@ class PersistenceManager:
         offset: int = 0,
         model: str | None = None,
         provider: str | None = None,
+        provider_type: str | None = None,
         status: str | None = None,
     ) -> tuple[list[dict[str, Any]], int]:
         """Query request log with optional filters, newest first.
+
+        Args:
+            provider: Provider display name (e.g. ``"Gemini"``).
+            provider_type: Resolved API type for *provider* (e.g.
+                ``"google"``).  Enables matching legacy rows that only
+                have ``target_provider`` (the API type) without a
+                ``target_provider_name`` backfill.
 
         Returns:
             A ``(entries, total)`` tuple.
@@ -241,8 +249,20 @@ class PersistenceManager:
             where_clauses.append("model = ?")
             params.append(model)
         if provider:
-            where_clauses.append("(target_provider_name = ? OR target_provider = ?)")
-            params.extend([provider, provider])
+            if provider_type and provider_type != provider:
+                # Match by name, OR fall back to API type only for legacy
+                # rows that have no target_provider_name (avoids cross-
+                # contamination when multiple providers share a base type).
+                where_clauses.append(
+                    "(target_provider_name = ? OR target_provider = ? "
+                    "OR (target_provider_name IS NULL AND target_provider = ?))"
+                )
+                params.extend([provider, provider, provider_type])
+            else:
+                where_clauses.append(
+                    "(target_provider_name = ? OR target_provider = ?)"
+                )
+                params.extend([provider, provider])
         if status == "ok":
             where_clauses.append("status_code < 400")
         elif status == "error":

--- a/src/llm_rosetta/gateway/admin/persistence.py
+++ b/src/llm_rosetta/gateway/admin/persistence.py
@@ -12,6 +12,7 @@ import json
 import logging
 import sqlite3
 import warnings
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -136,7 +137,7 @@ class PersistenceManager:
             )
             self._conn.commit()
 
-    def backfill_provider_names(self, model_to_provider: dict[str, str]) -> int:
+    def backfill_provider_names(self, model_to_provider: Mapping[str, str]) -> int:
         """Backfill target_provider_name for old entries using the model→provider mapping.
 
         Only updates rows where target_provider_name is NULL and the

--- a/src/llm_rosetta/gateway/admin/persistence.py
+++ b/src/llm_rosetta/gateway/admin/persistence.py
@@ -112,7 +112,8 @@ class PersistenceManager:
                 status_code     INTEGER NOT NULL,
                 duration_ms     REAL NOT NULL,
                 error_detail    TEXT,
-                api_key_label   TEXT
+                api_key_label   TEXT,
+                target_provider_name TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_rl_timestamp
                 ON request_log(timestamp DESC);
@@ -123,6 +124,44 @@ class PersistenceManager:
                 value TEXT NOT NULL
             );
         """)
+        self._migrate_add_target_provider_name()
+
+    def _migrate_add_target_provider_name(self) -> None:
+        """Add target_provider_name column if missing (upgrade from older schema)."""
+        cursor = self._conn.execute("PRAGMA table_info(request_log)")
+        columns = {row[1] for row in cursor.fetchall()}
+        if "target_provider_name" not in columns:
+            self._conn.execute(
+                "ALTER TABLE request_log ADD COLUMN target_provider_name TEXT"
+            )
+            self._conn.commit()
+
+    def backfill_provider_names(self, model_to_provider: dict[str, str]) -> int:
+        """Backfill target_provider_name for old entries using the model→provider mapping.
+
+        Only updates rows where target_provider_name is NULL and the
+        model exists in the current config.
+
+        Args:
+            model_to_provider: Mapping from model name to provider name
+                (e.g. ``{"argo:claude-opus-4.6": "Argo Claude"}``).
+
+        Returns:
+            Number of rows updated.
+        """
+        if not model_to_provider:
+            return 0
+        total = 0
+        for model_name, provider_name in model_to_provider.items():
+            cursor = self._conn.execute(
+                "UPDATE request_log SET target_provider_name = ? "
+                "WHERE model = ? AND target_provider_name IS NULL",
+                (provider_name, model_name),
+            )
+            total += cursor.rowcount
+        if total:
+            self._conn.commit()
+        return total
 
     # ------------------------------------------------------------------
     # Request log
@@ -139,6 +178,7 @@ class PersistenceManager:
         "duration_ms",
         "error_detail",
         "api_key_label",
+        "target_provider_name",
     ]
 
     def insert_log_entries(self, entries: list[dict[str, Any]]) -> None:
@@ -148,8 +188,9 @@ class PersistenceManager:
         self._conn.executemany(
             "INSERT OR IGNORE INTO request_log "
             "(id, timestamp, model, source_provider, target_provider, "
-            "is_stream, status_code, duration_ms, error_detail, api_key_label) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "is_stream, status_code, duration_ms, error_detail, api_key_label, "
+            "target_provider_name) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [
                 (
                     e["id"],
@@ -162,6 +203,7 @@ class PersistenceManager:
                     e["duration_ms"],
                     e.get("error_detail"),
                     e.get("api_key_label"),
+                    e.get("target_provider_name"),
                 )
                 for e in entries
             ],
@@ -199,8 +241,8 @@ class PersistenceManager:
             where_clauses.append("model = ?")
             params.append(model)
         if provider:
-            where_clauses.append("target_provider = ?")
-            params.append(provider)
+            where_clauses.append("(target_provider_name = ? OR target_provider = ?)")
+            params.extend([provider, provider])
         if status == "ok":
             where_clauses.append("status_code < 400")
         elif status == "error":

--- a/src/llm_rosetta/gateway/admin/request_log.py
+++ b/src/llm_rosetta/gateway/admin/request_log.py
@@ -115,15 +115,25 @@ class RequestLog:
         offset: int = 0,
         model: str | None = None,
         provider: str | None = None,
+        provider_type: str | None = None,
         status: str | None = None,
     ) -> tuple[list[dict[str, Any]], int]:
-        """Return filtered entries (newest-first) and total count."""
+        """Return filtered entries (newest-first) and total count.
+
+        Args:
+            provider: Provider display name (e.g. ``"Gemini"``).
+            provider_type: Resolved API type for *provider* (e.g.
+                ``"google"``).  When supplied the filter also matches
+                legacy entries whose ``target_provider`` stores the API
+                type but have no ``target_provider_name`` backfill.
+        """
         if self._persistence is not None:
             return self._persistence.query_log_entries(
                 limit=limit,
                 offset=offset,
                 model=model,
                 provider=provider,
+                provider_type=provider_type,
                 status=status,
             )
 
@@ -135,7 +145,13 @@ class RequestLog:
             filtered = [
                 e
                 for e in filtered
-                if e.target_provider_name == provider or e.target_provider == provider
+                if e.target_provider_name == provider
+                or e.target_provider == provider
+                or (
+                    provider_type
+                    and e.target_provider_name is None
+                    and e.target_provider == provider_type
+                )
             ]
         if status == "ok":
             filtered = [e for e in filtered if e.status_code < 400]

--- a/src/llm_rosetta/gateway/admin/request_log.py
+++ b/src/llm_rosetta/gateway/admin/request_log.py
@@ -30,6 +30,7 @@ class RequestLogEntry:
     duration_ms: float
     error_detail: str | None = None
     api_key_label: str | None = None
+    target_provider_name: str | None = None
 
     @classmethod
     def create(
@@ -43,6 +44,7 @@ class RequestLogEntry:
         duration_ms: float,
         error_detail: str | None = None,
         api_key_label: str | None = None,
+        target_provider_name: str | None = None,
     ) -> RequestLogEntry:
         """Factory with auto-generated id and timestamp."""
         return cls(
@@ -56,6 +58,7 @@ class RequestLogEntry:
             duration_ms=round(duration_ms, 2),
             error_detail=error_detail,
             api_key_label=api_key_label,
+            target_provider_name=target_provider_name,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -74,6 +77,8 @@ class RequestLogEntry:
             d["error_detail"] = self.error_detail
         if self.api_key_label is not None:
             d["api_key_label"] = self.api_key_label
+        if self.target_provider_name is not None:
+            d["target_provider_name"] = self.target_provider_name
         return d
 
 
@@ -127,7 +132,11 @@ class RequestLog:
         if model:
             filtered = [e for e in filtered if e.model == model]
         if provider:
-            filtered = [e for e in filtered if e.target_provider == provider]
+            filtered = [
+                e
+                for e in filtered
+                if e.target_provider_name == provider or e.target_provider == provider
+            ]
         if status == "ok":
             filtered = [e for e in filtered if e.status_code < 400]
         elif status == "error":

--- a/src/llm_rosetta/gateway/admin/routes/observability.py
+++ b/src/llm_rosetta/gateway/admin/routes/observability.py
@@ -84,8 +84,40 @@ async def get_requests(request: Any) -> Response:
     provider = _qp(request, "provider")
     status = _qp(request, "status")
 
+    # Resolve provider name → provider type so the query can match old
+    # entries that only have target_provider (the API type) without a
+    # target_provider_name backfill.  Use the raw config so that even
+    # disabled providers (missing API key, etc.) are resolvable.
+    provider_type: str | None = None
+    if provider:
+        config: GatewayConfig | None = getattr(request.app, "gateway_config", None)
+        if config is not None:
+            provider_type = config.provider_types.get(provider)
+        if provider_type is None:
+            # Fallback: read from raw config file (covers disabled providers)
+            from ._shared import _get_config_path
+            from ...config import load_config_raw
+
+            config_path = _get_config_path(request)
+            if config_path:
+                try:
+                    raw = load_config_raw(config_path)
+                    raw_prov = raw.get("providers", {}).get(provider, {})
+                    raw_type = raw_prov.get("type") or raw_prov.get("shim")
+                    if raw_type:
+                        from llm_rosetta.shims import resolve_base
+
+                        provider_type = resolve_base(raw_type)
+                except Exception:
+                    pass
+
     entries, total = log.get_entries(
-        limit=limit, offset=offset, model=model, provider=provider, status=status
+        limit=limit,
+        offset=offset,
+        model=model,
+        provider=provider,
+        provider_type=provider_type,
+        status=status,
     )
     return JSONResponse({"entries": entries, "total": total})
 

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -65,9 +65,13 @@ async def _proxy_handler(
 
     # Resolve target provider
     try:
-        target_provider_str, provider_info, target_shim_name, upstream_model = (
-            _config.resolve_model(model)
-        )
+        (
+            target_provider_str,
+            provider_info,
+            target_shim_name,
+            upstream_model,
+            provider_name,
+        ) = _config.resolve_model(model)
         target_provider: ProviderType = cast(ProviderType, target_provider_str)
     except KeyError:
         configured = ", ".join(sorted(_config.models.keys()))
@@ -166,6 +170,7 @@ async def _proxy_handler(
                     model=model,
                     source_provider=source_provider,
                     target_provider=target_provider,
+                    target_provider_name=provider_name,
                     is_stream=is_stream,
                     status_code=status_code,
                     duration_ms=duration_ms,

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -254,8 +254,8 @@ class GatewayConfig:
 
     def resolve_model(
         self, model: str
-    ) -> tuple[str, ProviderInfo, str | None, str | None]:
-        """Return (provider_type, provider_info, shim_name, upstream_model).
+    ) -> tuple[str, ProviderInfo, str | None, str | None, str]:
+        """Return (provider_type, provider_info, shim_name, upstream_model, provider_name).
 
         ``provider_type`` is the API standard (e.g. ``"openai_chat"``),
         resolved from the provider's ``type`` field or its name as fallback.
@@ -268,10 +268,20 @@ class GatewayConfig:
         as-is.  This enables model aliasing — e.g. gateway name
         ``"argo:claude-opus-4.5"`` mapping to upstream ``"claudeopus45"``.
 
+        ``provider_name`` is the user-configured provider name (e.g.
+        ``"deepseek"``, ``"my-openai"``), used for admin UI filtering
+        and display.
+
         Raises KeyError if the model is not in the routing table.
         """
         provider_name = self.models[model]
         provider_type = self.provider_types[provider_name]
         shim_name = self.provider_shim_names.get(provider_name)
         upstream_model = self.model_upstream_names.get(model)
-        return provider_type, self.providers[provider_name], shim_name, upstream_model
+        return (
+            provider_type,
+            self.providers[provider_name],
+            shim_name,
+            upstream_model,
+            provider_name,
+        )

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -65,7 +65,7 @@ async def handle_embeddings(
 
     # --- Resolve provider ---
     try:
-        _, provider_info, _, _ = config.resolve_model(model)
+        _, provider_info, _, _, provider_name = config.resolve_model(model)
     except KeyError:
         configured = ", ".join(sorted(config.models.keys()))
         return JSONResponse(
@@ -150,6 +150,7 @@ async def handle_embeddings(
                     model=model,
                     source_provider="openai_chat",
                     target_provider=provider_type,
+                    target_provider_name=provider_name,
                     is_stream=False,
                     status_code=status_code,
                     duration_ms=duration_ms,


### PR DESCRIPTION
## Summary

- **Provider filter on Request Log**: was broken because `target_provider` stores the API type (e.g. `openai_chat`) but the dropdown uses config provider names (e.g. `Argo OpenAI`). Added `target_provider_name` column to persist the display name, with startup backfill for existing entries and a fallback query path for entries that can't be backfilled (disabled providers).
- **System clock**: live-updating clock in the admin header bar for correlating log timestamps.
- **i18n completeness**: added missing zh translations for footer status bar, diagnostic labels, button labels; all hardcoded strings replaced with `t()` calls.

## Changes

- `config.py`: `resolve_model()` now returns 5-tuple including `provider_name`
- `app.py` / `embeddings.py`: thread `provider_name` through to `RequestLogEntry`
- `request_log.py`: add `target_provider_name` field, update filter logic
- `persistence.py`: add column + migration, backfill method, query with `provider_type` fallback for legacy rows
- `admin/__init__.py`: call backfill at startup
- `routes/observability.py`: resolve provider name → API type for filter queries
- `admin.html`: system clock, `resolveProviderName()` display fallback, i18n keys

## Test plan

- [x] Provider filter returns correct results for all providers (including disabled ones like Gemini)
- [x] No cross-contamination between providers sharing a base type (e.g. DeepSeek vs Argo OpenAI both use `openai_chat`)
- [x] Legacy entries without `target_provider_name` display resolved provider name
- [x] System clock ticks in header
- [x] i18n: switch to zh, verify footer/status bar/buttons all translated
- [x] Deployed to cloud.usa2, backfill ran successfully (7404 entries)