### PR TITLE
fix(admin): log client IP and simplify /health endpoint

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -570,7 +570,7 @@ body { padding-bottom: 26px; }
       <button class="btn btn-danger btn-sm" onclick="clearLogs(this)" data-i18n="btn.clearLog">Clear Log</button>
     </div>
     <div class="table-scroll"><table>
-      <thead><tr><th data-i18n="col.time">Time</th><th data-i18n="col.model">Model</th><th data-i18n="col.sourceTarget">Source &rarr; Target</th><th data-i18n="col.mode">Mode</th><th data-i18n="col.apiKey">API Key</th><th data-i18n="col.status">Status</th><th data-i18n="col.duration">Duration</th></tr></thead>
+      <thead><tr><th data-i18n="col.time">Time</th><th data-i18n="col.model">Model</th><th data-i18n="col.sourceTarget">Source &rarr; Target</th><th data-i18n="col.mode">Mode</th><th data-i18n="col.apiKey">API Key</th><th data-i18n="col.clientIp">Client IP</th><th data-i18n="col.status">Status</th><th data-i18n="col.duration">Duration</th></tr></thead>
       <tbody id="logTable"></tbody>
     </table></div>
     <div class="pagination">
@@ -889,7 +889,7 @@ const I18N = {
     'section.apiKeys':'API Keys',
     'btn.generateKey':'+ Generate Key', 'btn.generate':'Generate', 'btn.copy':'Copy', 'btn.clone':'Clone',
     'col.label':'Label', 'col.key':'Key', 'col.created':'Created',
-    'col.apiKey':'API Key',
+    'col.apiKey':'API Key', 'col.clientIp':'Client IP',
     'modal.generateKey':'Generate API Key',
     'modal.keyCreated':'Key Created',
     'label.keyLabel':'Label (optional)',
@@ -986,7 +986,7 @@ const I18N = {
     'section.apiKeys':'API \u5bc6\u94a5',
     'btn.generateKey':'+ \u751f\u6210\u5bc6\u94a5', 'btn.generate':'\u751f\u6210', 'btn.copy':'\u590d\u5236', 'btn.clone':'\u514b\u9686',
     'col.label':'\u6807\u7b7e', 'col.key':'\u5bc6\u94a5', 'col.created':'\u521b\u5efa\u65f6\u95f4',
-    'col.apiKey':'API \u5bc6\u94a5',
+    'col.apiKey':'API \u5bc6\u94a5', 'col.clientIp':'\u5ba2\u6237\u7aef IP',
     'modal.generateKey':'\u751f\u6210 API \u5bc6\u94a5',
     'modal.keyCreated':'\u5bc6\u94a5\u5df2\u521b\u5efa',
     'label.keyLabel':'\u6807\u7b7e\uff08\u53ef\u9009\uff09',
@@ -2202,7 +2202,7 @@ function resolveProviderName(apiType) {
 function renderLogs(entries, total) {
   const tbody = document.getElementById('logTable');
   if (entries.length === 0) {
-    tbody.innerHTML = `<tr><td colspan="7" style="color:var(--text-dim)">${t('empty.logs')}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="8" style="color:var(--text-dim)">${t('empty.logs')}</td></tr>`;
   } else {
     tbody.innerHTML = entries.map(e => {
       const time = new Date(e.timestamp).toLocaleTimeString();
@@ -2214,17 +2214,19 @@ function renderLogs(entries, total) {
       const isExpanded = expandedLogRows.has(rowId);
       const rowStyle = hasError ? ` style="cursor:pointer" onclick="toggleLogRow('${rowId}',this)"` : '';
       const expandHint = hasError ? ' title="Click to expand error"' : '';
+      const clientIp = e.client_ip || '—';
       let rows = `<tr${rowStyle}${expandHint}>
         <td>${time}</td>
         <td><code>${esc(e.model)}</code></td>
         <td>${esc(e.source_provider)} &rarr; ${esc(e.target_provider_name || resolveProviderName(e.target_provider))}</td>
         <td>${modeBadge}</td>
         <td style="font-size:12px;color:var(--text-dim)">${esc(keyLabel)}</td>
+        <td style="font-size:12px;color:var(--text-dim)">${esc(clientIp)}</td>
         <td><span class="badge ${statusCls}">${e.status_code}${hasError ? ' ▸' : ''}</span></td>
         <td>${e.duration_ms.toFixed(0)} ms</td>
       </tr>`;
       if (hasError) {
-        rows += `<tr${isExpanded ? '' : ' hidden'}><td colspan="7"><pre style="margin:0;padding:8px;background:var(--bg);border-radius:6px;font-size:11px;max-height:200px;overflow:auto;white-space:pre-wrap;word-break:break-all">${esc(e.error_detail)}</pre></td></tr>`;
+        rows += `<tr${isExpanded ? '' : ' hidden'}><td colspan="8"><pre style="margin:0;padding:8px;background:var(--bg);border-radius:6px;font-size:11px;max-height:200px;overflow:auto;white-space:pre-wrap;word-break:break-all">${esc(e.error_detail)}</pre></td></tr>`;
       }
       return rows;
     }).join('');

--- a/src/llm_rosetta/gateway/admin/persistence.py
+++ b/src/llm_rosetta/gateway/admin/persistence.py
@@ -114,7 +114,8 @@ class PersistenceManager:
                 duration_ms     REAL NOT NULL,
                 error_detail    TEXT,
                 api_key_label   TEXT,
-                target_provider_name TEXT
+                target_provider_name TEXT,
+                client_ip       TEXT
             );
             CREATE INDEX IF NOT EXISTS idx_rl_timestamp
                 ON request_log(timestamp DESC);
@@ -125,16 +126,18 @@ class PersistenceManager:
                 value TEXT NOT NULL
             );
         """)
-        self._migrate_add_target_provider_name()
+        self._migrate_add_columns()
 
-    def _migrate_add_target_provider_name(self) -> None:
-        """Add target_provider_name column if missing (upgrade from older schema)."""
+    def _migrate_add_columns(self) -> None:
+        """Add nullable columns missing from older schema versions."""
         cursor = self._conn.execute("PRAGMA table_info(request_log)")
         columns = {row[1] for row in cursor.fetchall()}
-        if "target_provider_name" not in columns:
-            self._conn.execute(
-                "ALTER TABLE request_log ADD COLUMN target_provider_name TEXT"
-            )
+        added = False
+        for col in ("target_provider_name", "client_ip"):
+            if col not in columns:
+                self._conn.execute(f"ALTER TABLE request_log ADD COLUMN {col} TEXT")
+                added = True
+        if added:
             self._conn.commit()
 
     def backfill_provider_names(self, model_to_provider: Mapping[str, str]) -> int:
@@ -180,6 +183,7 @@ class PersistenceManager:
         "error_detail",
         "api_key_label",
         "target_provider_name",
+        "client_ip",
     ]
 
     def insert_log_entries(self, entries: list[dict[str, Any]]) -> None:
@@ -190,8 +194,8 @@ class PersistenceManager:
             "INSERT OR IGNORE INTO request_log "
             "(id, timestamp, model, source_provider, target_provider, "
             "is_stream, status_code, duration_ms, error_detail, api_key_label, "
-            "target_provider_name) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "target_provider_name, client_ip) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [
                 (
                     e["id"],
@@ -205,6 +209,7 @@ class PersistenceManager:
                     e.get("error_detail"),
                     e.get("api_key_label"),
                     e.get("target_provider_name"),
+                    e.get("client_ip"),
                 )
                 for e in entries
             ],
@@ -415,7 +420,7 @@ class PersistenceManager:
         for col, val in zip(cls._LOG_COLUMNS, row):
             if col == "is_stream":
                 d[col] = bool(val)
-            elif col in ("error_detail", "api_key_label") and val is None:
+            elif col in ("error_detail", "api_key_label", "client_ip") and val is None:
                 continue  # omit None optional fields (match old behavior)
             else:
                 d[col] = val

--- a/src/llm_rosetta/gateway/admin/request_log.py
+++ b/src/llm_rosetta/gateway/admin/request_log.py
@@ -31,6 +31,7 @@ class RequestLogEntry:
     error_detail: str | None = None
     api_key_label: str | None = None
     target_provider_name: str | None = None
+    client_ip: str | None = None
 
     @classmethod
     def create(
@@ -45,6 +46,7 @@ class RequestLogEntry:
         error_detail: str | None = None,
         api_key_label: str | None = None,
         target_provider_name: str | None = None,
+        client_ip: str | None = None,
     ) -> RequestLogEntry:
         """Factory with auto-generated id and timestamp."""
         return cls(
@@ -59,6 +61,7 @@ class RequestLogEntry:
             error_detail=error_detail,
             api_key_label=api_key_label,
             target_provider_name=target_provider_name,
+            client_ip=client_ip,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -79,6 +82,8 @@ class RequestLogEntry:
             d["api_key_label"] = self.api_key_label
         if self.target_provider_name is not None:
             d["target_provider_name"] = self.target_provider_name
+        if self.client_ip is not None:
+            d["client_ip"] = self.client_ip
         return d
 
 

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -30,6 +30,26 @@ from .proxy import (
 
 logger = get_logger()
 
+
+def _extract_client_ip(request: Any) -> str | None:
+    """Extract the client IP from the request.
+
+    Checks ``X-Forwarded-For`` and ``X-Real-IP`` headers first (set by
+    reverse proxies), then falls back to the TCP peer address.
+    """
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        # X-Forwarded-For may contain a chain: "client, proxy1, proxy2"
+        return forwarded.split(",")[0].strip()
+    real_ip = request.headers.get("x-real-ip")
+    if real_ip:
+        return real_ip.strip()
+    addr = getattr(request, "client_addr", None)
+    if addr and isinstance(addr, (tuple, list)) and addr[0]:
+        return str(addr[0])
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Route handlers
 # ---------------------------------------------------------------------------
@@ -165,6 +185,7 @@ async def _proxy_handler(
             from .admin.request_log import RequestLogEntry
 
             api_key_label = api_key_label_var.get()
+            client_ip = _extract_client_ip(request)
             request_log.add(
                 RequestLogEntry.create(
                     model=model,
@@ -176,6 +197,7 @@ async def _proxy_handler(
                     duration_ms=duration_ms,
                     error_detail=error_detail,
                     api_key_label=api_key_label,
+                    client_ip=client_ip,
                 )
             )
 
@@ -275,14 +297,7 @@ async def handle_list_models_google(request: Any) -> Response:
 
 
 async def handle_health(request: Any) -> Response:
-    assert _config is not None
-    return JSONResponse(
-        {
-            "status": "ok",
-            "providers": list(_config.providers.keys()),
-            "models": list(_config.models.keys()),
-        }
-    )
+    return JSONResponse({"status": "ok"})
 
 
 # ---------------------------------------------------------------------------

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -143,8 +143,10 @@ async def handle_embeddings(
             )
         if request_log is not None:
             from .admin.request_log import RequestLogEntry
+            from .app import _extract_client_ip
 
             api_key_label = api_key_label_var.get()
+            client_ip = _extract_client_ip(request)
             request_log.add(
                 RequestLogEntry.create(
                     model=model,
@@ -156,5 +158,6 @@ async def handle_embeddings(
                     duration_ms=duration_ms,
                     error_detail=error_detail,
                     api_key_label=api_key_label,
+                    client_ip=client_ip,
                 )
             )

--- a/tests/gateway/test_persistence_sqlite.py
+++ b/tests/gateway/test_persistence_sqlite.py
@@ -314,6 +314,7 @@ class TestPersistenceManagerSizes:
         results, _ = pm.query_log_entries()
         assert "error_detail" not in results[0]
         assert "api_key_label" not in results[0]
+        assert "client_ip" not in results[0]
         pm.close()
 
 


### PR DESCRIPTION
## Summary

- **Client IP logging (#229)**: Extract client IP from `X-Forwarded-For` / `X-Real-IP` / TCP peer and store it in request log entries. Adds a "Client IP" column to the admin log table with i18n support (en/zh).
- **Simplify /health (#230)**: Strip provider and model lists from the `/health` endpoint response — it now returns only `{"status":"ok"}`, preventing information leakage to unauthenticated callers.

Closes #229, closes #230.

## Changes

- `gateway/app.py`: Add `_extract_client_ip()` helper, pass `client_ip` to log entries, simplify `handle_health()`
- `gateway/embeddings.py`: Pass `client_ip` to log entries
- `gateway/admin/request_log.py`: Add `client_ip` field to `RequestLogEntry`
- `gateway/admin/persistence.py`: Add `client_ip` column to schema with migration for existing DBs
- `gateway/admin/admin.html`: Add Client IP column to log table, i18n keys
- `tests/gateway/test_persistence_sqlite.py`: Assert `client_ip` omitted when None

## Test plan

- [x] `make test` passes (38 tests)
- [x] CI green
- [x] Deploy and verify client IP appears in admin log