### PR TITLE
Fix embedding endpoint ignoring upstream_model alias

### DIFF
--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -65,7 +65,7 @@ async def handle_embeddings(
 
     # --- Resolve provider ---
     try:
-        _, provider_info, _, _, provider_name = config.resolve_model(model)
+        _, provider_info, _, upstream_model, provider_name = config.resolve_model(model)
     except KeyError:
         configured = ", ".join(sorted(config.models.keys()))
         return JSONResponse(
@@ -77,6 +77,11 @@ async def handle_embeddings(
             },
             status_code=404,
         )
+
+    # Model alias: replace the model name in the request body with the
+    # actual upstream identifier so the upstream provider sees the correct name.
+    if upstream_model:
+        body["model"] = upstream_model
 
     # --- Build upstream URL ---
     base_url = provider_info.base_url

--- a/tests/gateway/test_embeddings.py
+++ b/tests/gateway/test_embeddings.py
@@ -1,0 +1,142 @@
+"""Tests for the embeddings passthrough handler."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from llm_rosetta.gateway.config import GatewayConfig
+from llm_rosetta.gateway.embeddings import handle_embeddings
+from llm_rosetta.gateway.proxy import _http_clients
+
+
+# ---------------------------------------------------------------------------
+# Fake upstream server that echoes back the received model name
+# ---------------------------------------------------------------------------
+
+
+class _EchoEmbeddingHandler(BaseHTTPRequestHandler):
+    """Returns an embedding response that echoes the request model name."""
+
+    def log_message(self, format, *args):  # noqa: A002
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length)) if length else {}
+        model = body.get("model", "")
+        response = {
+            "object": "list",
+            "data": [
+                {
+                    "object": "embedding",
+                    "embedding": [0.1, 0.2, 0.3],
+                    "index": 0,
+                }
+            ],
+            "model": model,
+            "usage": {"prompt_tokens": 5, "total_tokens": 5},
+        }
+        payload = json.dumps(response).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+@pytest.fixture(scope="module")
+def echo_embedding_server():
+    """Start a local server that echoes the model name in embedding responses."""
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _EchoEmbeddingHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}"
+    server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(base_url: str, upstream_model: str | None = None) -> GatewayConfig:
+    """Build a minimal GatewayConfig for embedding tests."""
+    model_entry: dict[str, Any] = {
+        "provider": "test-provider",
+        "capabilities": ["embedding"],
+    }
+    if upstream_model:
+        model_entry["upstream_model"] = upstream_model
+
+    raw = {
+        "providers": {
+            "test-provider": {
+                "api_key": "test-key",
+                "base_url": base_url,
+                "type": "openai",
+            }
+        },
+        "models": {
+            "my-embed": model_entry,
+        },
+    }
+    return GatewayConfig(raw)
+
+
+def _make_request(body: dict[str, Any]) -> MagicMock:
+    """Create a mock HTTP request with the given JSON body."""
+    req = MagicMock()
+    req.json.return_value = body
+    req.headers = {}
+
+    # Provide app-level attributes that handle_embeddings accesses
+    app = MagicMock()
+    app.metrics = None
+    app.request_log = None
+    req.app = app
+    return req
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingUpstreamModel:
+    """Tests for upstream_model substitution in embedding requests."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_http_clients(self):
+        """Clear the shared HTTP client pool between tests to avoid stale
+        connections across ``asyncio.run()`` calls."""
+        _http_clients.clear()
+
+    def test_upstream_model_substituted(self, echo_embedding_server: str):
+        """When upstream_model is configured, the body sent to upstream should
+        contain the upstream model name, not the gateway alias."""
+        config = _make_config(echo_embedding_server, upstream_model="BAAI/bge-m3")
+        request = _make_request({"model": "my-embed", "input": "hello"})
+
+        response = asyncio.run(handle_embeddings(request, config))
+
+        body = json.loads(response.body)
+        # The echo server returns the model it received — should be the upstream name
+        assert body["model"] == "BAAI/bge-m3"
+
+    def test_no_upstream_model(self, echo_embedding_server: str):
+        """When no upstream_model is configured, the original model name is used."""
+        config = _make_config(echo_embedding_server, upstream_model=None)
+        request = _make_request({"model": "my-embed", "input": "hello"})
+
+        response = asyncio.run(handle_embeddings(request, config))
+
+        body = json.loads(response.body)
+        assert body["model"] == "my-embed"


### PR DESCRIPTION
## Summary

- The `/v1/embeddings` passthrough handler discarded the `upstream_model` returned by `config.resolve_model()`, sending the gateway alias name (e.g. `bge-m3`) to the upstream provider instead of the actual upstream model name (e.g. `BAAI/bge-m3`)
- Added the same model substitution logic that `_proxy_handler` already has for chat completions
- Added tests with a local echo server to verify both the alias and no-alias cases

Fixes #238

## Test plan

- [x] `make test` passes (1704 passed)
- [x] `make lint` passes
- [x] New test `test_embedding_upstream_model_substitution` verifies alias is substituted
- [x] New test `test_no_upstream_model` verifies no-alias case still works