### PR TITLE
Fix admin test timer leak and add server-side timeout

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -2455,6 +2455,7 @@ const _TEST_TIMEOUT_MS = 120_000;
 let _testAbortCtrl = null;   // AbortController for stream tests
 let _testTaskId = null;       // server-side task id for async tests
 let _testPollTimer = null;    // setInterval id for polling
+let _testElapsedTimer = null; // setInterval id for elapsed-time display
 
 function _abortPendingTest() {
   // Cancel browser-side stream fetch
@@ -2466,6 +2467,8 @@ function _abortPendingTest() {
   }
   // Stop polling
   if (_testPollTimer) { clearInterval(_testPollTimer); _testPollTimer = null; }
+  // Stop elapsed timer from previous test
+  if (_testElapsedTimer) { clearInterval(_testElapsedTimer); _testElapsedTimer = null; }
 }
 
 function _newTestSignal() {
@@ -2523,11 +2526,12 @@ async function runTest(model, type) {
     const cancelBtn = document.getElementById('testCancelBtn');
     if (cancelBtn) cancelBtn.style.display = '';
     let _elapsedSec = 0;
-    const _elapsedTimer = setInterval(() => {
+    if (_testElapsedTimer) clearInterval(_testElapsedTimer);
+    _testElapsedTimer = setInterval(() => {
       _elapsedSec++;
       output.innerHTML = `<span class="test-spinner"></span>${t('test.sending')} ${_elapsedSec}s`;
     }, 1000);
-    const _stopElapsed = () => { clearInterval(_elapsedTimer); if (cancelBtn) cancelBtn.style.display = 'none'; };
+    const _stopElapsed = () => { clearInterval(_testElapsedTimer); _testElapsedTimer = null; if (cancelBtn) cancelBtn.style.display = 'none'; };
     try {
       const startResp = await api.post('/admin/api/test', {endpoint, payload});
       const taskId = startResp.task_id;
@@ -2539,6 +2543,11 @@ async function runTest(model, type) {
           clearInterval(_testPollTimer);
           _testPollTimer = null;
           _stopElapsed();
+          // Cancel the server-side task on timeout
+          if (_testTaskId) {
+            api.del('/admin/api/test/' + _testTaskId).catch(() => {});
+            _testTaskId = null;
+          }
           reject(new DOMException('Test timed out', 'AbortError'));
         }, _TEST_TIMEOUT_MS);
 

--- a/src/llm_rosetta/gateway/admin/routes/testing.py
+++ b/src/llm_rosetta/gateway/admin/routes/testing.py
@@ -15,6 +15,7 @@ from ...config import GatewayConfig
 # In-memory store: task_id → {status, result, asyncio_task, started, ...}
 _test_tasks: dict[str, dict[str, Any]] = {}
 _MAX_TASK_AGE = 300  # seconds — auto-cleanup threshold
+_TASK_TIMEOUT = 120  # seconds — per-task execution timeout
 
 
 def _cleanup_stale_tasks() -> None:
@@ -52,7 +53,7 @@ async def _run_test_task(
     try:
         # Use a per-task client to avoid lock contention / deadlock
         # with the shared proxy client.
-        client = AsyncClient(timeout=300.0)
+        client = AsyncClient(timeout=float(_TASK_TIMEOUT))
         try:
             headers = {
                 "Content-Type": "application/json",
@@ -62,7 +63,12 @@ async def _run_test_task(
             base_url = _test_tasks[task_id].get("_base_url", "http://127.0.0.1:28765")
             url = f"{base_url}{endpoint}"
 
-            resp = await client.post(url, json=payload, headers=headers)
+            # Enforce per-task timeout so hung upstream calls don't
+            # linger for the full _MAX_TASK_AGE cleanup window.
+            resp = await asyncio.wait_for(
+                client.post(url, json=payload, headers=headers),
+                timeout=_TASK_TIMEOUT,
+            )
             assert isinstance(resp, HttpResponse)
 
             # Try to parse JSON body
@@ -82,6 +88,13 @@ async def _run_test_task(
             await client.aclose()
     except asyncio.CancelledError:
         _test_tasks[task_id]["status"] = "cancelled"
+    except asyncio.TimeoutError:
+        _test_tasks[task_id].update(
+            {
+                "status": "error",
+                "error": f"Test timed out after {_TASK_TIMEOUT}s",
+            }
+        )
     except Exception as exc:
         _test_tasks[task_id].update(
             {


### PR DESCRIPTION
## Summary

- Fix elapsed timer leaking between tests — the timer was a local variable inside `runTest()`, so starting a new test didn't cancel the previous timer. This caused alternating counter values (e.g. 1, 71, 2, 72) when two tests overlapped.
- Cancel server-side task when browser-side 120s timeout fires (previously only rejected the Promise without notifying the server).
- Add `asyncio.wait_for()` in `_run_test_task` to enforce 120s per-task timeout server-side, so hung upstream calls don't linger until the 300s cleanup window.

## Test plan

- [ ] Start a long-running test (e.g. model with slow/unreachable upstream), then start another test before the first finishes — verify the timer shows correct monotonic values without alternating
- [ ] Let a test run past 120s — verify it auto-cancels and shows timeout error
- [ ] Normal test flow still works end-to-end