### PR TITLE
refactor: tighten usage type annotations and deduplicate Anthropic stream cache

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -15,7 +15,7 @@ Key Anthropic differences from OpenAI:
 """
 
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 from ...types.ir import (
@@ -362,7 +362,7 @@ class AnthropicConverter(BaseConverter):
 
         # Usage (always present — Anthropic responses require usage field)
         ir_usage = ir_response.get("usage") or {}
-        provider_response["usage"] = self._build_provider_usage(ir_usage)  # ty: ignore[invalid-argument-type]
+        provider_response["usage"] = self._build_provider_usage(ir_usage)
 
         # Preserve mode: inject captured extra fields
         ctx = context if context is not None else ConversionContext()
@@ -403,7 +403,7 @@ class AnthropicConverter(BaseConverter):
                 )
 
     @staticmethod
-    def _build_ir_usage(p_usage: dict[str, Any]) -> dict[str, Any]:
+    def _build_ir_usage(p_usage: dict[str, Any]) -> UsageInfo:
         """Build IR usage dict from Anthropic usage."""
         input_tokens = p_usage.get("input_tokens") or 0
         output_tokens = p_usage.get("output_tokens") or 0
@@ -416,10 +416,10 @@ class AnthropicConverter(BaseConverter):
             usage_info["cache_read_tokens"] = p_usage["cache_read_input_tokens"]
         if "cache_creation_input_tokens" in p_usage:
             usage_info["cache_creation_tokens"] = p_usage["cache_creation_input_tokens"]
-        return usage_info
+        return cast(UsageInfo, usage_info)
 
     @staticmethod
-    def _build_provider_usage(ir_usage: dict[str, Any]) -> dict[str, Any]:
+    def _build_provider_usage(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
         """Build Anthropic usage dict from IR usage."""
         usage: dict[str, Any] = {
             "input_tokens": ir_usage.get("prompt_tokens") or 0,
@@ -618,22 +618,14 @@ class AnthropicConverter(BaseConverter):
 
         usage = message.get("usage")
         if usage:
-            input_tokens = usage.get("input_tokens") or 0
-            usage_info: dict[str, Any] = {
-                "prompt_tokens": input_tokens,
-                "completion_tokens": 0,
-                "total_tokens": input_tokens,
-            }
-            if "cache_read_input_tokens" in usage:
-                usage_info["cache_read_tokens"] = usage["cache_read_input_tokens"]
-            if "cache_creation_input_tokens" in usage:
-                usage_info["cache_creation_tokens"] = usage[
-                    "cache_creation_input_tokens"
-                ]
+            # message_start.usage reports initial output_tokens (often 1);
+            # zero it out here — the real output count comes from message_delta.
+            start_usage = dict(usage)
+            start_usage["output_tokens"] = 0
             events.append(
                 UsageEvent(
                     type="usage",
-                    usage=cast(UsageInfo, usage_info),
+                    usage=self._build_ir_usage(start_usage),
                 )
             )
 
@@ -766,23 +758,10 @@ class AnthropicConverter(BaseConverter):
         # Emit UsageEvent before FinishEvent
         usage = chunk.get("usage")
         if usage:
-            input_tokens = usage.get("input_tokens") or 0
-            output_tokens = usage.get("output_tokens") or 0
-            usage_info: dict[str, Any] = {
-                "prompt_tokens": input_tokens,
-                "completion_tokens": output_tokens,
-                "total_tokens": input_tokens + output_tokens,
-            }
-            if "cache_read_input_tokens" in usage:
-                usage_info["cache_read_tokens"] = usage["cache_read_input_tokens"]
-            if "cache_creation_input_tokens" in usage:
-                usage_info["cache_creation_tokens"] = usage[
-                    "cache_creation_input_tokens"
-                ]
             events.append(
                 UsageEvent(
                     type="usage",
-                    usage=cast(UsageInfo, usage_info),
+                    usage=self._build_ir_usage(usage),
                 )
             )
 

--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -6,13 +6,13 @@ Defines the basic interface for converters (abstract base class, functional doma
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 from ...types.ir.extensions import ExtensionItem
 from ...types.ir.messages import Message
 from ...types.ir.request import IRRequest
-from ...types.ir.response import IRResponse
+from ...types.ir.response import IRResponse, UsageInfo
 from ...types.ir.stream import IRStreamEvent
 from ...types.ir.validation import validate_ir_request, validate_ir_response
 from .context import ConversionContext, StreamContext
@@ -297,7 +297,7 @@ class BaseConverter(ABC):
 
     @staticmethod
     @abstractmethod
-    def _build_ir_usage(p_usage: dict[str, Any]) -> dict[str, Any]:
+    def _build_ir_usage(p_usage: dict[str, Any]) -> UsageInfo:
         """Convert provider usage dict to IR usage format.
 
         Called by ``response_from_provider`` to normalize provider-specific
@@ -308,7 +308,7 @@ class BaseConverter(ABC):
 
     @staticmethod
     @abstractmethod
-    def _build_provider_usage(ir_usage: dict[str, Any]) -> dict[str, Any]:
+    def _build_provider_usage(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
         """Convert IR usage dict to provider-specific usage format.
 
         Called by ``response_to_provider`` to map IR token usage fields

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -16,7 +16,7 @@ Also maintains backward compatibility with the old to_provider/from_provider API
 
 import json
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 
@@ -502,7 +502,7 @@ class GoogleGenAIConverter(BaseConverter):
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            provider_response["usageMetadata"] = self._build_provider_usage(ir_usage)  # ty: ignore[invalid-argument-type]
+            provider_response["usageMetadata"] = self._build_provider_usage(ir_usage)
 
         return provider_response
 
@@ -529,7 +529,7 @@ class GoogleGenAIConverter(BaseConverter):
                 config["tool_config"] = tc_p
 
     @staticmethod
-    def _build_ir_usage(p_usage: dict[str, Any]) -> dict[str, Any]:
+    def _build_ir_usage(p_usage: dict[str, Any]) -> UsageInfo:
         """Build IR usage dict from Google usage metadata."""
         usage_info: dict[str, Any] = {
             "prompt_tokens": p_usage.get(
@@ -576,10 +576,10 @@ class GoogleGenAIConverter(BaseConverter):
                 else candidates_details
             )
 
-        return usage_info
+        return cast(UsageInfo, usage_info)
 
     @staticmethod
-    def _build_provider_usage(ir_usage: dict[str, Any]) -> dict[str, Any]:
+    def _build_provider_usage(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
         """Build Google usage metadata dict from IR usage."""
         usage_metadata: dict[str, Any] = {
             "promptTokenCount": ir_usage.get("prompt_tokens") or 0,

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -6,7 +6,7 @@ Composes ContentOps, ToolOps, MessageOps, and ConfigOps for full bidirectional
 conversion between IR and OpenAI Chat Completions API format.
 """
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 from ...types.ir import (
@@ -148,7 +148,7 @@ class OpenAIChatConverter(BaseConverter):
         return result, ctx.warnings
 
     @staticmethod
-    def _build_ir_usage(p_usage: dict[str, Any]) -> dict[str, Any]:
+    def _build_ir_usage(p_usage: dict[str, Any]) -> UsageInfo:
         """Build IR usage dict from OpenAI Chat usage."""
         usage_info: dict[str, Any] = {
             "prompt_tokens": p_usage.get("prompt_tokens") or 0,
@@ -167,7 +167,7 @@ class OpenAIChatConverter(BaseConverter):
                 usage_info["reasoning_tokens"] = p_completion_details[
                     "reasoning_tokens"
                 ]
-        return usage_info
+        return cast(UsageInfo, usage_info)
 
     def _convert_tools_from_p(self, tools: list[Any]) -> list[Any]:
         """Convert provider tool definitions to IR."""
@@ -474,7 +474,7 @@ class OpenAIChatConverter(BaseConverter):
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            provider_response["usage"] = self._build_provider_usage(ir_usage)  # ty: ignore[invalid-argument-type]
+            provider_response["usage"] = self._build_provider_usage(ir_usage)
 
         if "service_tier" in ir_response:
             provider_response["service_tier"] = ir_response["service_tier"]
@@ -485,7 +485,7 @@ class OpenAIChatConverter(BaseConverter):
         return provider_response
 
     @staticmethod
-    def _build_provider_usage(ir_usage: dict[str, Any]) -> dict[str, Any]:
+    def _build_provider_usage(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
         """Build OpenAI Chat usage dict from IR usage."""
         usage: dict[str, Any] = {
             "prompt_tokens": ir_usage.get("prompt_tokens") or 0,
@@ -749,7 +749,7 @@ class OpenAIChatConverter(BaseConverter):
         events.append(
             UsageEvent(
                 type="usage",
-                usage=cast(UsageInfo, self._build_ir_usage(usage)),
+                usage=self._build_ir_usage(usage),
             )
         )
 
@@ -1013,5 +1013,5 @@ class OpenAIChatConverter(BaseConverter):
             return {}
         return {
             "choices": [],
-            "usage": self._build_provider_usage(usage),  # ty: ignore[invalid-argument-type]
+            "usage": self._build_provider_usage(usage),
         }

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -10,7 +10,7 @@ nested messages. The converter handles this structural difference.
 """
 
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 from ...types.ir import (
@@ -420,7 +420,7 @@ class OpenAIResponsesConverter(BaseConverter):
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            provider_response["usage"] = self._build_provider_usage(ir_usage)  # ty: ignore[invalid-argument-type]
+            provider_response["usage"] = self._build_provider_usage(ir_usage)
 
         if "service_tier" in ir_response:
             provider_response["service_tier"] = ir_response["service_tier"]
@@ -437,7 +437,7 @@ class OpenAIResponsesConverter(BaseConverter):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _build_ir_usage(p_usage: dict[str, Any]) -> dict[str, Any]:
+    def _build_ir_usage(p_usage: dict[str, Any]) -> UsageInfo:
         """Build IR usage dict from Responses API usage."""
         usage_info: dict[str, Any] = {
             "prompt_tokens": p_usage.get("input_tokens") or 0,
@@ -452,10 +452,10 @@ class OpenAIResponsesConverter(BaseConverter):
         if p_output_details:
             if "reasoning_tokens" in p_output_details:
                 usage_info["reasoning_tokens"] = p_output_details["reasoning_tokens"]
-        return usage_info
+        return cast(UsageInfo, usage_info)
 
     @staticmethod
-    def _build_provider_usage(ir_usage: dict[str, Any]) -> dict[str, Any]:
+    def _build_provider_usage(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
         """Build Responses API usage dict from IR usage."""
         return {
             "input_tokens": ir_usage.get("prompt_tokens") or 0,
@@ -1037,7 +1037,7 @@ class OpenAIResponsesConverter(BaseConverter):
             events.append(
                 UsageEvent(
                     type="usage",
-                    usage=cast(UsageInfo, self._build_ir_usage(usage)),
+                    usage=self._build_ir_usage(usage),
                 )
             )
 

--- a/tests/test_converters_base.py
+++ b/tests/test_converters_base.py
@@ -10,7 +10,7 @@ Tests for LLM-Rosetta Converters Base Module
 """
 
 from abc import ABC
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, Union, cast
 
 import pytest
@@ -53,6 +53,7 @@ from llm_rosetta.types.ir import (
     ToolResultPart,
     UserMessage,
 )
+from llm_rosetta.types.ir.response import UsageInfo
 from llm_rosetta.types.ir.stream import IRStreamEvent
 
 # ============================================================================
@@ -474,12 +475,12 @@ class MockConverter(BaseConverter):
         return {}
 
     @staticmethod
-    def _build_ir_usage(p_usage: dict[str, Any]) -> dict[str, Any]:
-        return p_usage
+    def _build_ir_usage(p_usage: dict[str, Any]) -> UsageInfo:
+        return cast(UsageInfo, p_usage)
 
     @staticmethod
-    def _build_provider_usage(ir_usage: dict[str, Any]) -> dict[str, Any]:
-        return ir_usage
+    def _build_provider_usage(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
+        return dict(ir_usage)
 
     def _convert_tools_from_p(self, tools: list[Any]) -> list[Any]:
         return tools


### PR DESCRIPTION
## Summary

Cleanup follow-up to #252.

### Type annotations
- `BaseConverter._build_ir_usage` return type: `dict[str, Any]` → `UsageInfo`
- `BaseConverter._build_provider_usage` param type: `dict[str, Any]` → `Mapping[str, Any]`
- All four converter overrides updated accordingly
- Removes all usage-related `# ty: ignore[invalid-argument-type]` comments (5 remain for unrelated `FinishReason` / `_build_choice_to_provider` issues)

### Anthropic stream deduplication
- `_handle_message_start_from_p` and `_handle_message_delta_from_p` now call `self._build_ir_usage()` instead of duplicating cache field extraction inline
- Preserves existing behavior: message_start zeroes `output_tokens` before passing to `_build_ir_usage`

## Verification
- `ruff check` + `ruff format`: passed
- `ty check`: passed (0 new diagnostics)
- `pytest tests/ --ignore=tests/integration`: 1755 passed