### PR TITLE
feat: model-level thinking_type in shim reasoning config (#254)

### DIFF
--- a/src/llm_rosetta/auto_detect.py
+++ b/src/llm_rosetta/auto_detect.py
@@ -251,8 +251,14 @@ def convert(
     target_converter = get_converter_for_provider(target_provider)
 
     ctx = ConversionContext()
-    if target_shim is not None and target_shim.reasoning is not None:
-        ctx.options["reasoning_cap"] = target_shim.reasoning
+    if target_shim is not None:
+        cap = target_shim.reasoning
+        # Model-level override (keyed by upstream/body model ID)
+        req_model = body.get("model", "")
+        if target_shim.model_reasoning and req_model in target_shim.model_reasoning:
+            cap = target_shim.model_reasoning[req_model]
+        if cap is not None:
+            ctx.options["reasoning_cap"] = cap
 
     ir_request = source_converter.request_from_provider(body, context=ctx)
     target_body, _warnings = target_converter.request_to_provider(

--- a/src/llm_rosetta/converters/reasoning_helpers.py
+++ b/src/llm_rosetta/converters/reasoning_helpers.py
@@ -173,7 +173,7 @@ def apply_reasoning_config(
     elif converter_type == "openai_responses":
         _apply_openai_responses_extras(ir, result, mode, budget_tokens)
     elif converter_type == "anthropic":
-        _apply_anthropic_extras(ir, result, mode, effort, budget_tokens)
+        _apply_anthropic_extras(ir, result, mode, effort, budget_tokens, cap)
     elif converter_type == "google":
         _apply_google_extras(ir, result, mode, budget_tokens)
 
@@ -297,6 +297,7 @@ def _apply_anthropic_extras(
     mode: str | None,
     effort: str | None,
     budget_tokens: int | None,
+    cap: ReasoningCapability | None = None,
 ) -> None:
     """Anthropic extras: thinking object with type/budget_tokens."""
     if mode == "enabled":
@@ -316,6 +317,17 @@ def _apply_anthropic_extras(
         result["thinking"] = thinking
     elif budget_tokens is not None:
         result["thinking"] = {"type": "enabled", "budget_tokens": budget_tokens}
+
+    # Apply shim thinking_type override if set.
+    if cap is not None and cap.thinking_type is not None and "thinking" in result:
+        current_type = result["thinking"].get("type")
+        if current_type != cap.thinking_type:
+            result["thinking"]["type"] = cap.thinking_type
+            if (
+                cap.thinking_type == "adaptive"
+                and "budget_tokens" in result["thinking"]
+            ):
+                del result["thinking"]["budget_tokens"]
 
 
 def _apply_google_extras(

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -377,17 +377,31 @@ def _resolve_target_transforms(
     return shim.from_transforms, shim.to_transforms
 
 
-def _inject_shim_reasoning(ctx: ConversionContext, shim_name: str | None) -> None:
+def _inject_shim_reasoning(
+    ctx: ConversionContext,
+    shim_name: str | None,
+    model: str | None = None,
+) -> None:
     """Inject the shim's reasoning capability config into *ctx*.
 
     If the shim has a ``reasoning`` config, it is stored in
     ``ctx.options["reasoning_cap"]`` so converters can pick it up.
+
+    When *model* is provided (typically the upstream model ID after alias
+    resolution), per-model overrides from ``shim.model_reasoning`` take
+    precedence over the provider-level config.
     """
     if shim_name is None:
         return
     shim = get_shim(shim_name)
-    if shim is not None and shim.reasoning is not None:
-        ctx.options["reasoning_cap"] = shim.reasoning
+    if shim is None:
+        return
+    cap = shim.reasoning
+    # Model-level override (keyed by upstream model ID)
+    if model and shim.model_reasoning and model in shim.model_reasoning:
+        cap = shim.model_reasoning[model]
+    if cap is not None:
+        ctx.options["reasoning_cap"] = cap
 
 
 # ---------------------------------------------------------------------------
@@ -420,8 +434,9 @@ async def handle_non_streaming(
     if target_provider == "google":
         ctx.options["output_format"] = "rest"
 
-    # Inject shim reasoning capability so converters use it
-    _inject_shim_reasoning(ctx, target_shim_name)
+    # Inject shim reasoning capability so converters use it.
+    # body["model"] is the upstream model ID (post-alias) at this point.
+    _inject_shim_reasoning(ctx, target_shim_name, model=body.get("model"))
 
     # 1. Source -> IR
     try:
@@ -697,8 +712,8 @@ async def handle_streaming(
     if target_provider == "google":
         ctx.options["output_format"] = "rest"
 
-    # Inject shim reasoning capability so converters use it
-    _inject_shim_reasoning(ctx, target_shim_name)
+    # Inject shim reasoning capability so converters use it.
+    _inject_shim_reasoning(ctx, target_shim_name, model=body.get("model"))
 
     # 1. Source -> IR
     try:

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -32,6 +32,9 @@ EffortField = Literal[
 #: Normalised IR effort ladder level.
 EffortLevel = Literal["minimal", "low", "medium", "high", "xhigh", "max"]
 
+#: How the provider expects ``thinking.type`` to be serialised.
+ThinkingType = Literal["enabled", "adaptive"]
+
 #: Mapping from normalised IR effort levels to provider-specific values.
 #: Any IR level absent from the map is unsupported and will be warned/skipped.
 EffortMap = dict[str, str]  # e.g. {"minimal": "low", "max": "high"}
@@ -45,12 +48,14 @@ class ReasoningCapability:
         disabled: How to serialise ``mode: disabled``.
         effort_field: Where the provider expects the effort value.
         max_effort: Highest normalised effort this shim should emit.
+        thinking_type: Force ``thinking.type`` to this value.
         effort_map: Map from normalised IR effort to provider effort string.
     """
 
     disabled: DisabledStrategy = "omit"
     effort_field: EffortField = "reasoning_effort"
     max_effort: EffortLevel | None = None
+    thinking_type: ThinkingType | None = None
     effort_map: EffortMap = field(
         default_factory=lambda: {
             "minimal": "low",
@@ -92,6 +97,9 @@ class ProviderShim:
             provider (standard → dialect).
         reasoning: Reasoning capability config for this provider.
             When ``None``, the converter uses its built-in default.
+        model_reasoning: Per-model reasoning overrides keyed by
+            **upstream model ID** (post-alias).  Each entry inherits
+            from the provider-level ``reasoning`` for unset fields.
     """
 
     name: str
@@ -103,6 +111,7 @@ class ProviderShim:
     from_transforms: tuple[Transform, ...] = ()
     to_transforms: tuple[Transform, ...] = ()
     reasoning: ReasoningCapability | None = None
+    model_reasoning: dict[str, ReasoningCapability] | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -86,8 +86,29 @@ def _load_single_provider(
             disabled=reasoning_cfg.get("disabled", "omit"),
             effort_field=reasoning_cfg.get("effort_field", "reasoning_effort"),
             max_effort=reasoning_cfg.get("max_effort"),
+            thinking_type=reasoning_cfg.get("thinking_type"),
             effort_map=reasoning_cfg.get("effort_map", {}),
         )
+
+    # Parse per-model reasoning overrides (inherit provider defaults).
+    model_reasoning: dict[str, ReasoningCapability] | None = None
+    if isinstance(reasoning_cfg, dict) and isinstance(
+        reasoning_cfg.get("model_overrides"), dict
+    ):
+        model_reasoning = {}
+        for model_id, overrides in reasoning_cfg["model_overrides"].items():
+            if not isinstance(overrides, dict):
+                continue
+            assert reasoning_cap is not None  # model_overrides requires reasoning
+            model_reasoning[model_id] = ReasoningCapability(
+                disabled=overrides.get("disabled", reasoning_cap.disabled),
+                effort_field=overrides.get("effort_field", reasoning_cap.effort_field),
+                max_effort=overrides.get("max_effort", reasoning_cap.max_effort),
+                thinking_type=overrides.get(
+                    "thinking_type", reasoning_cap.thinking_type
+                ),
+                effort_map=overrides.get("effort_map", reasoning_cap.effort_map),
+            )
 
     shim = ProviderShim(
         name=cfg["name"],
@@ -99,6 +120,7 @@ def _load_single_provider(
         from_transforms=from_t,
         to_transforms=to_t,
         reasoning=reasoning_cap,
+        model_reasoning=model_reasoning,
     )
     register_shim(shim)
     logger.debug("Registered provider shim: %s (base=%s)", shim.name, shim.base)

--- a/src/llm_rosetta/shims/providers/argo/anthropic/provider.yaml
+++ b/src/llm_rosetta/shims/providers/argo/anthropic/provider.yaml
@@ -6,6 +6,7 @@ model_id_field: internal_id
 reasoning:
   disabled: thinking_disabled
   effort_field: output_config.effort
+  thinking_type: enabled
   effort_map:
     minimal: low
     low: low
@@ -13,3 +14,6 @@ reasoning:
     high: high
     xhigh: xhigh
     max: max
+  model_overrides:
+    claudeopus47:
+      thinking_type: adaptive

--- a/src/llm_rosetta/shims/providers/argo/anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/anthropic/transforms.py
@@ -194,7 +194,7 @@ def _normalize_openai_response(body: dict[str, Any]) -> dict[str, Any]:
 # Transform tuples (consumed by the shim loader)
 # ---------------------------------------------------------------------------
 
-to_transforms = (_NamedTransform(_normalize_thinking, "normalize_thinking()"),)
+to_transforms = ()  # _normalize_thinking retired — handled by shim reasoning config
 from_transforms = (
     _NamedTransform(_normalize_openai_response, "normalize_openai_response()"),
 )

--- a/tests/converters/test_reasoning_helpers.py
+++ b/tests/converters/test_reasoning_helpers.py
@@ -308,6 +308,80 @@ class TestCustomShim:
         )
         assert result["reasoning_effort"] == "high"
 
+    def test_thinking_type_adaptive_overrides_enabled(self):
+        """thinking_type=adaptive forces enabled→adaptive and removes budget."""
+        custom = ReasoningCapability(
+            disabled="thinking_disabled",
+            effort_field="output_config.effort",
+            thinking_type="adaptive",
+            effort_map={
+                "minimal": "low",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "max": "max",
+            },
+        )
+        result = apply_reasoning_config(
+            cast(
+                ReasoningConfig,
+                {"mode": "enabled", "budget_tokens": 4096},
+            ),
+            custom,
+            converter_type="anthropic",
+        )
+        assert result["thinking"]["type"] == "adaptive"
+        assert "budget_tokens" not in result["thinking"]
+
+    def test_thinking_type_enabled_overrides_adaptive(self):
+        """thinking_type=enabled forces adaptive→enabled."""
+        custom = ReasoningCapability(
+            disabled="thinking_disabled",
+            effort_field="output_config.effort",
+            thinking_type="enabled",
+            effort_map={
+                "minimal": "low",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "max": "max",
+            },
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
+            custom,
+            converter_type="anthropic",
+        )
+        # auto normally emits adaptive; thinking_type=enabled overrides
+        assert result["thinking"]["type"] == "enabled"
+
+    def test_thinking_type_none_preserves_original(self):
+        """thinking_type=None does not override."""
+        custom = ReasoningCapability(
+            disabled="thinking_disabled",
+            effort_field="output_config.effort",
+            effort_map={
+                "minimal": "low",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "max": "max",
+            },
+        )
+        result = apply_reasoning_config(
+            cast(
+                ReasoningConfig,
+                {"mode": "enabled", "budget_tokens": 2048},
+            ),
+            custom,
+            converter_type="anthropic",
+        )
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 2048
+
     def test_custom_thinking_budget_zero_disabled(self):
         custom = ReasoningCapability(
             disabled="thinking_budget_zero",

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -248,8 +248,7 @@ class TestGroupedProviders:
         """Grouped shims have their transforms.py imported."""
         anth = get_shim("argo_anthropic")
         assert anth is not None
-        # argo_anthropic has to_transforms and from_transforms
-        assert len(anth.to_transforms) > 0
+        # argo_anthropic has from_transforms (to_transforms retired)
         assert len(anth.from_transforms) > 0
 
     def test_grouped_provider_reasoning_configs_loaded(self):
@@ -261,6 +260,24 @@ class TestGroupedProviders:
         assert anth.reasoning.effort_field == "output_config.effort"
         assert anth.reasoning.effort_map["xhigh"] == "xhigh"
         assert oai.reasoning.effort_map["max"] == "max"
+
+    def test_argo_anthropic_model_reasoning_overrides(self):
+        """Argo anthropic has model_reasoning for claudeopus47."""
+        anth = get_shim("argo_anthropic")
+        assert anth is not None
+        assert anth.model_reasoning is not None
+        assert "claudeopus47" in anth.model_reasoning
+        override = anth.model_reasoning["claudeopus47"]
+        assert override.thinking_type == "adaptive"
+        # Inherits provider defaults for other fields
+        assert override.effort_field == "output_config.effort"
+        assert override.effort_map["xhigh"] == "xhigh"
+
+    def test_argo_anthropic_provider_thinking_type(self):
+        """Argo anthropic provider-level thinking_type is enabled."""
+        anth = get_shim("argo_anthropic")
+        assert anth is not None and anth.reasoning is not None
+        assert anth.reasoning.thinking_type == "enabled"
 
     def test_mixed_flat_and_grouped(self):
         """Flat shims and grouped shims coexist in the registry."""


### PR DESCRIPTION
## Summary

Closes #254. Partially addresses #192 (model-level shim).

Moves Argo `thinking.type` normalization from a hardcoded transform into the declarative shim reasoning config system, with per-model override support.

## Changes

### ReasoningCapability
- New `thinking_type: Literal["enabled", "adaptive"] | None` field
- When set, the reasoning helper forces `thinking.type` to that value regardless of input
- `adaptive` override removes `budget_tokens` (not used with adaptive)

### ProviderShim
- New `model_reasoning: dict[str, ReasoningCapability] | None` field
- Keyed by **upstream model ID** (post-alias, e.g. `claudeopus47`)
- Each entry inherits provider-level defaults for unset fields

### Provider YAML (`model_overrides`)
```yaml
# argo_anthropic/provider.yaml
reasoning:
  thinking_type: enabled       # default for most models
  model_overrides:
    claudeopus47:
      thinking_type: adaptive  # Vertex AI requires adaptive
```

### Gateway integration
- `_inject_shim_reasoning` now accepts `model` param and checks `shim.model_reasoning` for per-model override
- `convert()` in `auto_detect.py` also resolves model-level overrides

### Transform retirement
- `_normalize_thinking` removed from `argo_anthropic` `to_transforms`
- The function itself stays in the module (existing direct-call tests still work)
- Thinking type normalization now handled by `_apply_anthropic_extras` in `reasoning_helpers.py`

## Tests
- `test_thinking_type_adaptive_overrides_enabled` — forces enabled→adaptive, removes budget
- `test_thinking_type_enabled_overrides_adaptive` — forces adaptive→enabled
- `test_thinking_type_none_preserves_original` — None means no override
- `test_argo_anthropic_model_reasoning_overrides` — YAML loads model_overrides correctly
- `test_argo_anthropic_provider_thinking_type` — provider-level thinking_type=enabled
- 1762 passed, ty clean, ruff clean