### PR TITLE
fix: map IR mode auto→adaptive in OpenAI Chat thinking type (#219)

### DIFF
--- a/src/llm_rosetta/converters/reasoning_helpers.py
+++ b/src/llm_rosetta/converters/reasoning_helpers.py
@@ -169,7 +169,7 @@ def apply_reasoning_config(
 
     # 4. Converter-specific structural pass-through.
     if converter_type == "openai_chat":
-        _apply_openai_chat_extras(ir, result, mode, budget_tokens)
+        _apply_openai_chat_extras(ir, result, mode, budget_tokens, cap)
     elif converter_type == "openai_responses":
         _apply_openai_responses_extras(ir, result, mode, budget_tokens)
     elif converter_type == "anthropic":
@@ -261,15 +261,29 @@ def _apply_openai_chat_extras(
     result: dict[str, Any],
     mode: str | None,
     budget_tokens: int | None,
+    cap: ReasoningCapability | None = None,
 ) -> None:
     """OpenAI Chat extras: thinking object for mode/budget_tokens (DeepSeek ext)."""
     thinking: dict[str, Any] = {}
     if mode:
-        thinking["type"] = mode
+        # IR "auto" is not a valid upstream value; map to "adaptive"
+        # (DeepSeek/Volcengine vocabulary).
+        thinking["type"] = "adaptive" if mode == "auto" else mode
     if budget_tokens is not None:
         thinking["budget_tokens"] = budget_tokens
     if thinking:
         result["thinking"] = thinking
+
+    # Apply shim thinking_type override if set.
+    if cap is not None and cap.thinking_type is not None and "thinking" in result:
+        current_type = result["thinking"].get("type")
+        target_type = cap.thinking_type
+        if target_type == "enabled" and "budget_tokens" not in result["thinking"]:
+            target_type = "adaptive"
+        if current_type != target_type:
+            result["thinking"]["type"] = target_type
+            if target_type == "adaptive" and "budget_tokens" in result["thinking"]:
+                del result["thinking"]["budget_tokens"]
 
 
 def _apply_openai_responses_extras(

--- a/tests/converters/openai_chat/test_config_ops.py
+++ b/tests/converters/openai_chat/test_config_ops.py
@@ -192,12 +192,13 @@ class TestOpenAIChatConfigOps:
         assert result["thinking"]["type"] == "enabled"
 
     def test_ir_reasoning_config_mode_auto_with_effort(self):
-        """Test mode: auto outputs both reasoning_effort and thinking."""
+        """Test mode: auto outputs reasoning_effort and thinking.type=adaptive."""
         result = OpenAIChatConfigOps.ir_reasoning_config_to_p(
             {"mode": "auto", "effort": "medium"}
         )
         assert result["reasoning_effort"] == "medium"
-        assert result["thinking"]["type"] == "auto"
+        # IR "auto" maps to "adaptive" (DeepSeek/Volcengine vocabulary)
+        assert result["thinking"]["type"] == "adaptive"
 
     def test_ir_reasoning_config_all_fields(self):
         """Test mode + effort + budget_tokens coexistence."""

--- a/tests/converters/test_reasoning_helpers.py
+++ b/tests/converters/test_reasoning_helpers.py
@@ -110,6 +110,35 @@ class TestOpenAIChatShim:
         )
         assert result["reasoning_effort"] == "high"
 
+    def test_mode_auto_maps_to_adaptive_not_auto(self):
+        """IR mode 'auto' must never appear as thinking.type — maps to 'adaptive'."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto"}),
+            self.cap,
+            converter_type="openai_chat",
+        )
+        assert result["thinking"]["type"] == "adaptive"
+
+    def test_mode_enabled_with_budget(self):
+        """mode=enabled + budget_tokens → thinking.type=enabled."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "enabled", "budget_tokens": 2048}),
+            self.cap,
+            converter_type="openai_chat",
+        )
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 2048
+
+    def test_mode_auto_with_budget(self):
+        """mode=auto + budget_tokens → adaptive + budget_tokens."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto", "budget_tokens": 4096}),
+            self.cap,
+            converter_type="openai_chat",
+        )
+        assert result["thinking"]["type"] == "adaptive"
+        assert result["thinking"]["budget_tokens"] == 4096
+
 
 # ── OpenAI Responses shim ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #219.

IR `mode: "auto"` is an IR-only concept — no upstream provider accepts it as a literal value. `_apply_openai_chat_extras` was passing it through verbatim, causing DeepSeek/Volcengine to reject with `unknown variant 'auto'`.

## Changes

### `reasoning_helpers.py`
- `_apply_openai_chat_extras`: map `auto → adaptive` (DeepSeek/Volcengine vocabulary)
- Add `cap` parameter + `thinking_type` override support (same pattern as `_apply_anthropic_extras`)
- Safety: `thinking_type=enabled` without `budget_tokens` falls back to `adaptive`

### Tests
- `test_mode_auto_maps_to_adaptive_not_auto` — IR auto never appears as thinking.type
- `test_mode_enabled_with_budget` — enabled + budget preserved
- `test_mode_auto_with_budget` — auto + budget → adaptive + budget
- Updated existing `test_ir_reasoning_config_mode_auto_with_effort` to expect `adaptive`

## Verification

```
Anthropic adaptive → DeepSeek adaptive ✅ (was: auto ❌)
Anthropic enabled  → DeepSeek enabled  ✅
Anthropic disabled → DeepSeek disabled ✅
```

1766 passed, ty clean, ruff clean.