### PR TITLE
fix: response reasoning losslessness across converters (#259, #260, #261)

### DIFF
--- a/src/llm_rosetta/converters/anthropic/content_ops.py
+++ b/src/llm_rosetta/converters/anthropic/content_ops.py
@@ -45,7 +45,7 @@ class AnthropicContentOps(BaseContentOps):
         """
         result: dict[str, Any] = {"type": "text", "text": ir_text["text"]}
         # Preserve provider_metadata for cross-provider round-trip
-        pm = ir_text.get("provider_metadata")  # type: ignore[typeddict-item]
+        pm = ir_text.get("provider_metadata")
         if pm:
             result["_provider_metadata"] = pm
         return result

--- a/src/llm_rosetta/converters/anthropic/content_ops.py
+++ b/src/llm_rosetta/converters/anthropic/content_ops.py
@@ -43,7 +43,12 @@ class AnthropicContentOps(BaseContentOps):
         Returns:
             Anthropic text content dict: ``{"type": "text", "text": "..."}``
         """
-        return {"type": "text", "text": ir_text["text"]}
+        result: dict[str, Any] = {"type": "text", "text": ir_text["text"]}
+        # Preserve provider_metadata for cross-provider round-trip
+        pm = ir_text.get("provider_metadata")  # type: ignore[typeddict-item]
+        if pm:
+            result["_provider_metadata"] = pm
+        return result
 
     @staticmethod
     def p_text_to_ir(provider_text: Any, **kwargs: Any) -> TextPart:
@@ -63,7 +68,12 @@ class AnthropicContentOps(BaseContentOps):
         if isinstance(provider_text, str):
             return TextPart(type="text", text=provider_text)
         if isinstance(provider_text, dict) and provider_text.get("type") == "text":
-            return TextPart(type="text", text=provider_text["text"])
+            result = TextPart(type="text", text=provider_text["text"])
+            # Read back provider_metadata for cross-provider round-trip
+            pm = provider_text.get("_provider_metadata")
+            if pm:
+                result["provider_metadata"] = pm
+            return result
         raise ValueError(f"Cannot convert to TextPart: {provider_text!r}")
 
     # ==================== Image ====================

--- a/src/llm_rosetta/converters/google_genai/content_ops.py
+++ b/src/llm_rosetta/converters/google_genai/content_ops.py
@@ -313,9 +313,16 @@ class GoogleGenAIContentOps(BaseContentOps):
         Returns:
             IR ReasoningPart.
         """
-        return ReasoningPart(
+        result = ReasoningPart(
             type="reasoning", reasoning=provider_reasoning.get("text", "")
         )
+        # Preserve thoughtSignature in provider_metadata (same as text/tool parts)
+        thought_sig = provider_reasoning.get(
+            "thoughtSignature"
+        ) or provider_reasoning.get("thought_signature")
+        if thought_sig:
+            result["provider_metadata"] = {"google": {"thought_signature": thought_sig}}
+        return result
 
     # ==================== Refusal (not natively supported) ====================
 

--- a/src/llm_rosetta/converters/google_genai/message_ops.py
+++ b/src/llm_rosetta/converters/google_genai/message_ops.py
@@ -21,7 +21,6 @@ from ...types.ir import (
     ContentPart,
     ExtensionItem,
     Message,
-    ReasoningPart,
     is_audio_part,
     is_extension_item,
     is_file_part,
@@ -325,9 +324,7 @@ class GoogleGenAIMessageOps(BaseMessageOps):
         for part in parts:
             # Handle reasoning (thoughts)
             if part.get("thought") is True:
-                content_parts.append(
-                    ReasoningPart(type="reasoning", reasoning=part.get("text", ""))
-                )
+                content_parts.append(self.content_ops.p_reasoning_to_ir(part))
                 continue
 
             # Handle function_call and function_response via tool_ops

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -13,6 +13,7 @@ from ...types.ir import (
     ExtensionItem,
     Message,
     is_citation_part,
+    is_reasoning_part,
     is_refusal_part,
     is_text_part,
     is_tool_call_part,
@@ -213,7 +214,7 @@ class OpenAIChatConverter(BaseConverter):
                     "OpenAI Chat does not support max_tool_calls, ignored"
                 )
 
-    def _build_choice_to_provider(
+    def _build_choice_to_provider(  # noqa: C901
         self, choice: dict[str, Any]
     ) -> dict[str, Any] | None:
         """Build a single OpenAI Chat choice dict from an IR choice."""
@@ -225,6 +226,7 @@ class OpenAIChatConverter(BaseConverter):
 
         content_parts = message.get("content", [])
         text_parts: list[str] = []
+        reasoning_parts: list[str] = []
         tool_calls: list[dict[str, Any]] = []
         refusal_text: str | None = None
         annotations: list[dict[str, Any]] = []
@@ -232,6 +234,8 @@ class OpenAIChatConverter(BaseConverter):
         for part in content_parts:
             if is_text_part(part):
                 text_parts.append(part["text"])
+            elif is_reasoning_part(part):
+                reasoning_parts.append(part.get("reasoning", ""))
             elif is_tool_call_part(part):
                 tool_calls.append(self.tool_ops.ir_tool_call_to_p(part))
             elif is_refusal_part(part):
@@ -256,6 +260,9 @@ class OpenAIChatConverter(BaseConverter):
 
         if annotations:
             openai_message["annotations"] = annotations
+
+        if reasoning_parts:
+            openai_message["reasoning_content"] = "\n".join(reasoning_parts)
 
         reason = choice.get("finish_reason", {}).get("reason", "stop")
         openai_choice: dict[str, Any] = {


### PR DESCRIPTION
## Summary

Fixes #259, #260, #261 — three gaps in response-direction reasoning/metadata round-trips.

### #259: Google reasoning part drops `thoughtSignature`

- `google_genai/content_ops.py` `p_reasoning_to_ir`: read `thoughtSignature` into `provider_metadata.google.thought_signature`
- `google_genai/message_ops.py`: delegate `thought: true` parts to `content_ops.p_reasoning_to_ir()` instead of inline `ReasoningPart()` construction (which skipped the `provider_metadata` logic)

### #260: Anthropic text/reasoning blocks drop `provider_metadata`

- `anthropic/content_ops.py` `ir_text_to_p`: serialize `provider_metadata` as `_provider_metadata` on outbound text blocks
- `anthropic/content_ops.py` `p_text_to_ir`: read `_provider_metadata` back into IR `provider_metadata`
- Reasoning blocks already handled by PR #257

### #261: OpenAI Chat `response_to_provider` drops `reasoning_content`

- `openai_chat/converter.py` `_build_choice_to_provider`: collect reasoning parts and emit `reasoning_content` on the message object
- Affects DeepSeek/Volcengine round-trips and any cross-provider conversion targeting OpenAI Chat format

## Cross-converter verification

| Source → IR → Target | reasoning | provider_metadata |
|---|---|---|
| Google → IR | ✅ (was ❌) | ✅ (was ❌ for reasoning) |
| IR → Anthropic | ✅ | ✅ (was ❌ for text/reasoning) |
| IR → OpenAI Chat | ✅ `reasoning_content` (was ❌) | N/A |
| IR → Google | ✅ | ✅ |

## Verification

- `ty check`: passed
- `1773 passed, 4 skipped`
- ruff clean