### PR TITLE
feat: normalize reasoning fields for MiniMax, OpenRouter, Volcengine (#185)

### DIFF
--- a/src/llm_rosetta/shims/providers/minimax/provider.yaml
+++ b/src/llm_rosetta/shims/providers/minimax/provider.yaml
@@ -3,3 +3,13 @@ base: openai_chat
 default_base_url: https://api.minimax.chat/v1
 default_api_key_env: MINIMAX_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/minimax.svg
+reasoning:
+  disabled: thinking_disabled
+  thinking_type: adaptive
+  effort_map:
+    minimal: low
+    low: low
+    medium: medium
+    high: high
+    xhigh: high
+    max: high

--- a/src/llm_rosetta/shims/providers/minimax/transforms.py
+++ b/src/llm_rosetta/shims/providers/minimax/transforms.py
@@ -43,6 +43,7 @@ def _parse_think_tags(body: dict[str, Any]) -> dict[str, Any]:
 
     Fallback for responses where ``reasoning_split`` was not set.
     If ``reasoning_content`` already exists, this is a no-op.
+    Handles multiple ``<think>`` blocks by joining them with newlines.
     """
     choices = body.get("choices")
     if not isinstance(choices, list):
@@ -58,9 +59,9 @@ def _parse_think_tags(body: dict[str, Any]) -> dict[str, Any]:
         content = message.get("content")
         if not isinstance(content, str):
             continue
-        match = _THINK_RE.search(content)
-        if match:
-            message["reasoning_content"] = match.group(1).strip()
+        matches = _THINK_RE.findall(content)
+        if matches:
+            message["reasoning_content"] = "\n".join(m.strip() for m in matches)
             message["content"] = _THINK_RE.sub("", content).strip()
     return body
 

--- a/src/llm_rosetta/shims/providers/minimax/transforms.py
+++ b/src/llm_rosetta/shims/providers/minimax/transforms.py
@@ -1,17 +1,72 @@
 """MiniMax schema transforms.
 
-MiniMax's OpenAI-compatible endpoint does not list ``logprobs``,
-``top_logprobs``, ``seed``, or ``stop`` in its OpenAPI spec.
-Strip them to avoid potential errors.
+Request-side:
+- Strip unsupported fields (logprobs, top_logprobs, seed, stop).
+- Inject ``reasoning_split: true`` when a ``thinking`` object is present,
+  so MiniMax returns ``reasoning_content`` as a separate field instead of
+  embedding ``<think>`` tags in ``content``.
 
-``presence_penalty``, ``frequency_penalty``, and ``logit_bias`` are
-silently ignored (no error) so we do not strip them here.
+Response-side:
+- Parse ``<think>...</think>`` tags from ``content`` into
+  ``reasoning_content`` when ``reasoning_split`` was not set (fallback).
 
 References:
     https://platform.minimaxi.com/document/ChatCompletion%20v2
 """
 
-from llm_rosetta.shims.transforms import strip_fields
+from __future__ import annotations
 
-to_transforms = (strip_fields("logprobs", "top_logprobs", "seed", "stop"),)
-from_transforms = ()
+import re
+from typing import Any
+
+from llm_rosetta.shims.transforms import _NamedTransform, strip_fields
+
+
+def _inject_reasoning_split(body: dict[str, Any]) -> dict[str, Any]:
+    """Inject ``reasoning_split: true`` when thinking is requested.
+
+    MiniMax's OpenAI Chat endpoint defaults to embedding thinking in
+    ``<think>`` tags within ``content``.  Setting ``reasoning_split: true``
+    makes it return ``reasoning_content`` as a separate field, which the
+    converter can parse directly.
+    """
+    if "thinking" in body and "reasoning_split" not in body:
+        body["reasoning_split"] = True
+    return body
+
+
+_THINK_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+
+
+def _parse_think_tags(body: dict[str, Any]) -> dict[str, Any]:
+    """Extract ``<think>`` tags from content into ``reasoning_content``.
+
+    Fallback for responses where ``reasoning_split`` was not set.
+    If ``reasoning_content`` already exists, this is a no-op.
+    """
+    choices = body.get("choices")
+    if not isinstance(choices, list):
+        return body
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        message = choice.get("message")
+        if not isinstance(message, dict):
+            continue
+        if "reasoning_content" in message:
+            continue  # already split
+        content = message.get("content")
+        if not isinstance(content, str):
+            continue
+        match = _THINK_RE.search(content)
+        if match:
+            message["reasoning_content"] = match.group(1).strip()
+            message["content"] = _THINK_RE.sub("", content).strip()
+    return body
+
+
+to_transforms = (
+    strip_fields("logprobs", "top_logprobs", "seed", "stop"),
+    _NamedTransform(_inject_reasoning_split, "inject_reasoning_split()"),
+)
+from_transforms = (_NamedTransform(_parse_think_tags, "parse_think_tags()"),)

--- a/src/llm_rosetta/shims/providers/openrouter/transforms.py
+++ b/src/llm_rosetta/shims/providers/openrouter/transforms.py
@@ -1,0 +1,44 @@
+"""OpenRouter schema transforms.
+
+Response-side: OpenRouter returns reasoning content in ``message.reasoning``
+(string) instead of ``message.reasoning_content``. The converter expects
+``reasoning_content``, so we rename the field before parsing.
+
+Request-side: no transforms needed (OpenRouter accepts standard OpenAI Chat
+fields plus ``reasoning_effort``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta.shims.transforms import _NamedTransform
+
+
+def _rename_reasoning_field(body: dict[str, Any]) -> dict[str, Any]:
+    """Rename ``message.reasoning`` → ``message.reasoning_content``.
+
+    OpenRouter uses ``reasoning`` (not ``reasoning_content``) for the
+    reasoning text field on chat completion response messages.  The
+    OpenAI Chat converter expects ``reasoning_content``.
+
+    Also copies ``reasoning_details`` as-is (the converter ignores it,
+    but preserving it avoids silent data loss for downstream consumers).
+    """
+    choices = body.get("choices")
+    if not isinstance(choices, list):
+        return body
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        message = choice.get("message")
+        if not isinstance(message, dict):
+            continue
+        # Rename reasoning → reasoning_content
+        if "reasoning" in message and "reasoning_content" not in message:
+            message["reasoning_content"] = message.pop("reasoning")
+    return body
+
+
+to_transforms = ()
+from_transforms = (_NamedTransform(_rename_reasoning_field, "rename_reasoning()"),)

--- a/src/llm_rosetta/shims/providers/volcengine/provider.yaml
+++ b/src/llm_rosetta/shims/providers/volcengine/provider.yaml
@@ -4,6 +4,7 @@ default_api_key_env: VOLCENGINE_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/volcengine.svg
 reasoning:
   disabled: thinking_disabled
+  thinking_type: enabled
   effort_map:
     minimal: low
     low: low

--- a/tests/test_provider_reasoning_transforms.py
+++ b/tests/test_provider_reasoning_transforms.py
@@ -1,0 +1,163 @@
+"""Tests for provider-specific reasoning transforms (#185).
+
+Covers MiniMax, OpenRouter reasoning field normalization transforms.
+"""
+
+from __future__ import annotations
+
+from llm_rosetta.shims.providers.minimax.transforms import (
+    _inject_reasoning_split,
+    _parse_think_tags,
+)
+from llm_rosetta.shims.providers.openrouter.transforms import (
+    _rename_reasoning_field,
+)
+
+
+# ===========================================================================
+# MiniMax: _inject_reasoning_split
+# ===========================================================================
+
+
+class TestInjectReasoningSplit:
+    def test_injects_when_thinking_present(self):
+        body = {"thinking": {"type": "adaptive"}, "messages": []}
+        result = _inject_reasoning_split(body)
+        assert result["reasoning_split"] is True
+
+    def test_no_inject_without_thinking(self):
+        body = {"messages": []}
+        result = _inject_reasoning_split(body)
+        assert "reasoning_split" not in result
+
+    def test_no_overwrite_existing_reasoning_split(self):
+        body = {"thinking": {"type": "adaptive"}, "reasoning_split": False}
+        result = _inject_reasoning_split(body)
+        assert result["reasoning_split"] is False
+
+
+# ===========================================================================
+# MiniMax: _parse_think_tags
+# ===========================================================================
+
+
+class TestParseThinkTags:
+    def test_single_think_tag(self):
+        body = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "<think>Let me reason.</think>The answer is 42.",
+                    }
+                }
+            ]
+        }
+        result = _parse_think_tags(body)
+        msg = result["choices"][0]["message"]
+        assert msg["reasoning_content"] == "Let me reason."
+        assert msg["content"] == "The answer is 42."
+
+    def test_multiple_think_tags(self):
+        body = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "<think>Step 1.</think>Middle text.<think>Step 2.</think>Final.",
+                    }
+                }
+            ]
+        }
+        result = _parse_think_tags(body)
+        msg = result["choices"][0]["message"]
+        assert msg["reasoning_content"] == "Step 1.\nStep 2."
+        assert msg["content"] == "Middle text.Final."
+
+    def test_no_think_tags(self):
+        body = {
+            "choices": [
+                {"message": {"role": "assistant", "content": "Just a normal response."}}
+            ]
+        }
+        result = _parse_think_tags(body)
+        msg = result["choices"][0]["message"]
+        assert "reasoning_content" not in msg
+        assert msg["content"] == "Just a normal response."
+
+    def test_skip_when_reasoning_content_exists(self):
+        body = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "<think>Should not parse.</think>Answer.",
+                        "reasoning_content": "Already split.",
+                    }
+                }
+            ]
+        }
+        result = _parse_think_tags(body)
+        msg = result["choices"][0]["message"]
+        assert msg["reasoning_content"] == "Already split."
+        assert "<think>" in msg["content"]
+
+    def test_no_choices(self):
+        body = {"error": "something"}
+        result = _parse_think_tags(body)
+        assert result == body
+
+
+# ===========================================================================
+# OpenRouter: _rename_reasoning_field
+# ===========================================================================
+
+
+class TestRenameReasoningField:
+    def test_renames_reasoning_to_reasoning_content(self):
+        body = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "Answer.",
+                        "reasoning": "Let me think...",
+                    }
+                }
+            ]
+        }
+        result = _rename_reasoning_field(body)
+        msg = result["choices"][0]["message"]
+        assert msg["reasoning_content"] == "Let me think..."
+        assert "reasoning" not in msg
+
+    def test_no_rename_when_reasoning_content_exists(self):
+        body = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "Answer.",
+                        "reasoning": "Original.",
+                        "reasoning_content": "Already there.",
+                    }
+                }
+            ]
+        }
+        result = _rename_reasoning_field(body)
+        msg = result["choices"][0]["message"]
+        assert msg["reasoning_content"] == "Already there."
+        assert msg["reasoning"] == "Original."
+
+    def test_no_reasoning_field(self):
+        body = {
+            "choices": [{"message": {"role": "assistant", "content": "No reasoning."}}]
+        }
+        result = _rename_reasoning_field(body)
+        msg = result["choices"][0]["message"]
+        assert "reasoning_content" not in msg
+
+    def test_no_choices(self):
+        body = {"error": "something"}
+        result = _rename_reasoning_field(body)
+        assert result == body

--- a/tests/test_shim_loader.py
+++ b/tests/test_shim_loader.py
@@ -197,12 +197,12 @@ class TestLoadProviders:
         assert "messages" in result
 
     def test_minimax_has_transforms(self):
-        """MiniMax shim should strip logprobs, top_logprobs, seed, stop."""
+        """MiniMax shim should strip fields + inject reasoning_split."""
         load_providers()
         s = get_shim("minimax")
         assert s is not None
-        assert len(s.to_transforms) == 1
-        assert len(s.from_transforms) == 0
+        assert len(s.to_transforms) == 2  # strip_fields + inject_reasoning_split
+        assert len(s.from_transforms) == 1  # parse_think_tags
         body = {
             "logprobs": True,
             "top_logprobs": 5,


### PR DESCRIPTION
## Summary

Partially addresses #185 — normalize provider-specific reasoning/thinking fields via shim config and transforms.

Based on live API probing against all three providers.

### MiniMax

**Probe findings:**
- Anthropic endpoint: standard Anthropic format (thinking blocks), no transform needed
- OpenAI Chat endpoint: only accepts `thinking.type=adaptive` (rejects `enabled`); defaults to `<think>` tags in content; `reasoning_split=true` makes it return `reasoning_content` as separate field

**Changes:**
- `provider.yaml`: add `thinking_type: adaptive` + reasoning effort map
- `transforms.py`: add `_inject_reasoning_split` (to_transform) — injects `reasoning_split: true` when `thinking` is present; add `_parse_think_tags` (from_transform) — fallback parser for `<think>` tags when `reasoning_split` wasn't set

### OpenRouter

**Probe findings:**
- Chat endpoint returns `message.reasoning` (not `reasoning_content`) + `reasoning_details` array with signatures
- `thinking` object accepted but reasoning field is empty when used

**Changes:**
- New `transforms.py`: `_rename_reasoning_field` (from_transform) — renames `message.reasoning` → `message.reasoning_content` so the converter can parse it

### Volcengine

**Probe findings:**
- Chat endpoint: accepts `thinking.type=enabled` only (rejects `adaptive`)
- Returns `reasoning_content` + `encrypted_content`
- Responses endpoint: standard OpenAI Responses format with `reasoning` items

**Changes:**
- `provider.yaml`: add `thinking_type: enabled` (overrides the base converter's `auto → adaptive` default mapping)

## Verification

- 1773 passed, ty clean, ruff clean
- Live probed with real API keys against MiniMax, OpenRouter, Volcengine