### PR TITLE
Add shim policy for unsigned reasoning blocks

### DIFF
--- a/src/llm_rosetta/converters/anthropic/content_ops.py
+++ b/src/llm_rosetta/converters/anthropic/content_ops.py
@@ -240,7 +240,7 @@ class AnthropicContentOps(BaseContentOps):
         }
 
         signature = ir_reasoning.get("signature")
-        if signature:
+        if signature is not None:
             result["signature"] = signature
 
         # Preserve provider_metadata for cross-provider round-trip
@@ -267,7 +267,7 @@ class AnthropicContentOps(BaseContentOps):
         )
 
         signature = provider_reasoning.get("signature")
-        if signature:
+        if signature is not None:
             result["signature"] = signature
 
         # Read back provider_metadata for cross-provider round-trip

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -117,7 +117,12 @@ class AnthropicConverter(BaseConverter):
                 if text_parts and "system" not in result:
                     result["system"] = " ".join(text_parts)
 
-        converted_msgs, msg_warnings = self.message_ops.ir_messages_to_p(ir_messages)
+        message_kwargs: dict[str, Any] = {}
+        if ctx and "reasoning_cap" in ctx.options:
+            message_kwargs["reasoning_cap"] = ctx.options["reasoning_cap"]
+        converted_msgs, msg_warnings = self.message_ops.ir_messages_to_p(
+            ir_messages, **message_kwargs
+        )
         ctx.warnings.extend(msg_warnings)
         result["messages"] = converted_msgs
 

--- a/src/llm_rosetta/converters/anthropic/message_ops.py
+++ b/src/llm_rosetta/converters/anthropic/message_ops.py
@@ -15,6 +15,7 @@ Key Anthropic differences:
 from collections.abc import Sequence
 from typing import Any, cast
 
+from ...shims.provider_shim import ReasoningCapability
 from ...types.ir import (
     ContentPart,
     ExtensionItem,
@@ -73,6 +74,9 @@ class AnthropicMessageOps(BaseMessageOps):
         """
         messages: list[dict[str, Any]] = []
         warnings: list[str] = []
+        reasoning_cap = kwargs.get("reasoning_cap")
+        if not isinstance(reasoning_cap, ReasoningCapability):
+            reasoning_cap = None
 
         for item in ir_messages:
             if is_message(item):
@@ -81,7 +85,9 @@ class AnthropicMessageOps(BaseMessageOps):
                 if role == "system":
                     # System messages handled at converter level
                     continue
-                converted, msg_warnings = self._ir_message_to_p(msg, **kwargs)
+                converted, msg_warnings = self._ir_message_to_p(
+                    msg, reasoning_cap=reasoning_cap
+                )
                 warnings.extend(msg_warnings)
                 if isinstance(converted, list):
                     messages.extend(converted)
@@ -96,7 +102,10 @@ class AnthropicMessageOps(BaseMessageOps):
         return messages, warnings
 
     def _ir_message_to_p(
-        self, message: Message, **kwargs: Any
+        self,
+        message: Message,
+        *,
+        reasoning_cap: ReasoningCapability | None = None,
     ) -> tuple[Any, list[str]]:
         """Convert a single IR message to Anthropic format.
 
@@ -115,7 +124,9 @@ class AnthropicMessageOps(BaseMessageOps):
         elif role == "user":
             return self._ir_user_to_p(content, warnings)
         elif role == "assistant":
-            return self._ir_assistant_to_p(content, warnings, **kwargs)
+            return self._ir_assistant_to_p(
+                content, warnings, reasoning_cap=reasoning_cap
+            )
         elif role == "tool":
             return self._ir_tool_to_p(content, warnings)
 
@@ -166,7 +177,11 @@ class AnthropicMessageOps(BaseMessageOps):
         return {"role": "user", "content": anthropic_content}, warnings
 
     def _ir_assistant_to_p(
-        self, content: list, warnings: list[str], **kwargs: Any
+        self,
+        content: list,
+        warnings: list[str],
+        *,
+        reasoning_cap: ReasoningCapability | None = None,
     ) -> tuple[dict[str, Any] | None, list[str]]:
         """Convert IR assistant message content to Anthropic assistant message.
 
@@ -181,9 +196,10 @@ class AnthropicMessageOps(BaseMessageOps):
             elif is_tool_call_part(part):
                 anthropic_content.append(self.tool_ops.ir_tool_call_to_p(part))
             elif is_reasoning_part(part):
-                reasoning_cap = kwargs.get("reasoning_cap")
-                unsigned_policy = getattr(
-                    reasoning_cap, "unsigned_reasoning_blocks", "as_is"
+                unsigned_policy = (
+                    reasoning_cap.unsigned_reasoning_blocks
+                    if reasoning_cap is not None
+                    else "as_is"
                 )
                 if unsigned_policy == "preserve" and not part.get("signature"):
                     self._preserve_unsigned_reasoning(part)

--- a/src/llm_rosetta/converters/anthropic/message_ops.py
+++ b/src/llm_rosetta/converters/anthropic/message_ops.py
@@ -167,7 +167,7 @@ class AnthropicMessageOps(BaseMessageOps):
 
     def _ir_assistant_to_p(
         self, content: list, warnings: list[str], **kwargs: Any
-    ) -> tuple[dict[str, Any], list[str]]:
+    ) -> tuple[dict[str, Any] | None, list[str]]:
         """Convert IR assistant message content to Anthropic assistant message.
 
         All content parts become content blocks in the assistant message.
@@ -206,6 +206,12 @@ class AnthropicMessageOps(BaseMessageOps):
                 warnings.append(
                     f"Unsupported content part type in assistant message: {part.get('type')}"
                 )
+
+        if not anthropic_content:
+            warnings.append(
+                "Assistant message has no Anthropic-compatible content, ignored"
+            )
+            return None, warnings
 
         return {"role": "assistant", "content": anthropic_content}, warnings
 

--- a/src/llm_rosetta/converters/anthropic/message_ops.py
+++ b/src/llm_rosetta/converters/anthropic/message_ops.py
@@ -19,6 +19,7 @@ from ...types.ir import (
     ContentPart,
     ExtensionItem,
     Message,
+    ReasoningPart,
     TextPart,
     is_audio_part,
     is_citation_part,
@@ -80,7 +81,7 @@ class AnthropicMessageOps(BaseMessageOps):
                 if role == "system":
                     # System messages handled at converter level
                     continue
-                converted, msg_warnings = self._ir_message_to_p(msg)
+                converted, msg_warnings = self._ir_message_to_p(msg, **kwargs)
                 warnings.extend(msg_warnings)
                 if isinstance(converted, list):
                     messages.extend(converted)
@@ -94,7 +95,9 @@ class AnthropicMessageOps(BaseMessageOps):
 
         return messages, warnings
 
-    def _ir_message_to_p(self, message: Message) -> tuple[Any, list[str]]:
+    def _ir_message_to_p(
+        self, message: Message, **kwargs: Any
+    ) -> tuple[Any, list[str]]:
         """Convert a single IR message to Anthropic format.
 
         Args:
@@ -112,7 +115,7 @@ class AnthropicMessageOps(BaseMessageOps):
         elif role == "user":
             return self._ir_user_to_p(content, warnings)
         elif role == "assistant":
-            return self._ir_assistant_to_p(content, warnings)
+            return self._ir_assistant_to_p(content, warnings, **kwargs)
         elif role == "tool":
             return self._ir_tool_to_p(content, warnings)
 
@@ -163,7 +166,7 @@ class AnthropicMessageOps(BaseMessageOps):
         return {"role": "user", "content": anthropic_content}, warnings
 
     def _ir_assistant_to_p(
-        self, content: list, warnings: list[str]
+        self, content: list, warnings: list[str], **kwargs: Any
     ) -> tuple[dict[str, Any], list[str]]:
         """Convert IR assistant message content to Anthropic assistant message.
 
@@ -178,6 +181,16 @@ class AnthropicMessageOps(BaseMessageOps):
             elif is_tool_call_part(part):
                 anthropic_content.append(self.tool_ops.ir_tool_call_to_p(part))
             elif is_reasoning_part(part):
+                reasoning_cap = kwargs.get("reasoning_cap")
+                unsigned_policy = getattr(
+                    reasoning_cap, "unsigned_reasoning_blocks", "as_is"
+                )
+                if unsigned_policy == "preserve" and not part.get("signature"):
+                    self._preserve_unsigned_reasoning(part)
+                    warnings.append(
+                        "Unsigned reasoning content in assistant message not supported by target provider, preserved in metadata"
+                    )
+                    continue
                 anthropic_content.append(self.content_ops.ir_reasoning_to_p(part))
             elif is_refusal_part(part):
                 # Convert refusal to text since Anthropic has no refusal type
@@ -195,6 +208,19 @@ class AnthropicMessageOps(BaseMessageOps):
                 )
 
         return {"role": "assistant", "content": anthropic_content}, warnings
+
+    @staticmethod
+    def _preserve_unsigned_reasoning(part: ReasoningPart) -> None:
+        provider_metadata = part.setdefault("provider_metadata", {})
+        anthropic_meta = provider_metadata.setdefault("anthropic", {})
+        preserved = anthropic_meta.setdefault("unsigned_reasoning_blocks", [])
+        preserved.append(
+            {
+                "reasoning": part.get("reasoning", ""),
+                "signature": part.get("signature"),
+                "status": part.get("status"),
+            }
+        )
 
     def _ir_tool_to_p(
         self, content: list, warnings: list[str]

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -35,6 +35,9 @@ EffortLevel = Literal["minimal", "low", "medium", "high", "xhigh", "max"]
 #: How the provider expects ``thinking.type`` to be serialised.
 ThinkingType = Literal["enabled", "adaptive"]
 
+#: How outbound unsigned reasoning blocks are handled.
+UnsignedReasoningBlocks = Literal["as_is", "preserve"]
+
 #: Mapping from normalised IR effort levels to provider-specific values.
 #: Any IR level absent from the map is unsupported and will be warned/skipped.
 EffortMap = dict[str, str]  # e.g. {"minimal": "low", "max": "high"}
@@ -49,6 +52,7 @@ class ReasoningCapability:
         effort_field: Where the provider expects the effort value.
         max_effort: Highest normalised effort this shim should emit.
         thinking_type: Force ``thinking.type`` to this value.
+        unsigned_reasoning_blocks: Policy for outbound unsigned reasoning blocks.
         effort_map: Map from normalised IR effort to provider effort string.
     """
 
@@ -56,6 +60,7 @@ class ReasoningCapability:
     effort_field: EffortField = "reasoning_effort"
     max_effort: EffortLevel | None = None
     thinking_type: ThinkingType | None = None
+    unsigned_reasoning_blocks: UnsignedReasoningBlocks = "as_is"
     effort_map: EffortMap = field(
         default_factory=lambda: {
             "minimal": "low",

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -87,6 +87,9 @@ def _load_single_provider(
             effort_field=reasoning_cfg.get("effort_field", "reasoning_effort"),
             max_effort=reasoning_cfg.get("max_effort"),
             thinking_type=reasoning_cfg.get("thinking_type"),
+            unsigned_reasoning_blocks=reasoning_cfg.get(
+                "unsigned_reasoning_blocks", "as_is"
+            ),
             effort_map=reasoning_cfg.get("effort_map", {}),
         )
 
@@ -106,6 +109,10 @@ def _load_single_provider(
                 max_effort=overrides.get("max_effort", reasoning_cap.max_effort),
                 thinking_type=overrides.get(
                     "thinking_type", reasoning_cap.thinking_type
+                ),
+                unsigned_reasoning_blocks=overrides.get(
+                    "unsigned_reasoning_blocks",
+                    reasoning_cap.unsigned_reasoning_blocks,
                 ),
                 effort_map=overrides.get("effort_map", reasoning_cap.effort_map),
             )

--- a/src/llm_rosetta/shims/providers/argo/anthropic/provider.yaml
+++ b/src/llm_rosetta/shims/providers/argo/anthropic/provider.yaml
@@ -7,6 +7,7 @@ reasoning:
   disabled: thinking_disabled
   effort_field: output_config.effort
   thinking_type: enabled
+  unsigned_reasoning_blocks: preserve
   effort_map:
     minimal: low
     low: low

--- a/tests/converters/anthropic/test_content_ops.py
+++ b/tests/converters/anthropic/test_content_ops.py
@@ -209,6 +209,13 @@ class TestAnthropicContentOps:
         assert result["thinking"] == "thinking..."
         assert result["signature"] == "sig123"
 
+    def test_ir_reasoning_to_p_with_empty_signature(self):
+        """Test empty signature is preserved for validation behavior."""
+        ir_reasoning = ReasoningPart(type="reasoning", reasoning="thinking...")
+        ir_reasoning["signature"] = ""
+        result = AnthropicContentOps.ir_reasoning_to_p(ir_reasoning)
+        assert result["signature"] == ""
+
     def test_p_reasoning_to_ir(self):
         """Test Anthropic thinking block → IR ReasoningPart."""
         provider = {"type": "thinking", "thinking": "I should use a tool."}
@@ -227,6 +234,12 @@ class TestAnthropicContentOps:
         assert result["type"] == "reasoning"
         assert result["reasoning"] == "thinking..."
         assert result["signature"] == "sig456"
+
+    def test_p_reasoning_to_ir_with_empty_signature(self):
+        """Test empty signature is preserved for downstream policy decisions."""
+        provider = {"type": "thinking", "thinking": "thinking...", "signature": ""}
+        result = AnthropicContentOps.p_reasoning_to_ir(provider)
+        assert result["signature"] == ""
 
     def test_reasoning_round_trip(self):
         """Test reasoning round-trip."""

--- a/tests/converters/anthropic/test_message_ops.py
+++ b/tests/converters/anthropic/test_message_ops.py
@@ -241,6 +241,27 @@ class TestAnthropicMessageOps:
             "Unsigned reasoning content in assistant message not supported by target provider, preserved in metadata"
         ]
 
+    def test_ir_assistant_preserve_policy_skips_empty_message(self):
+        """Test preserve policy skips messages with only unsigned reasoning."""
+        reasoning_part = {"type": "reasoning", "reasoning": "I need to think."}
+        ir_messages = cast(
+            list[Message],
+            [{"role": "assistant", "content": [reasoning_part]}],
+        )
+        cap = ReasoningCapability(unsigned_reasoning_blocks="preserve")
+        result, warnings = self.message_ops.ir_messages_to_p(
+            ir_messages, reasoning_cap=cap
+        )
+        assert result == []
+        assert len(warnings) == 2
+        assert warnings[0] == (
+            "Unsigned reasoning content in assistant message not supported by target provider, preserved in metadata"
+        )
+        assert (
+            warnings[1]
+            == "Assistant message has no Anthropic-compatible content, ignored"
+        )
+
     def test_ir_assistant_preserve_policy_keeps_signed_reasoning(self):
         """Test preserve policy only filters reasoning with no usable signature."""
         ir_messages = cast(

--- a/tests/converters/anthropic/test_message_ops.py
+++ b/tests/converters/anthropic/test_message_ops.py
@@ -7,6 +7,7 @@ from typing import Any, Union, cast
 from llm_rosetta.converters.anthropic.content_ops import AnthropicContentOps
 from llm_rosetta.converters.anthropic.message_ops import AnthropicMessageOps
 from llm_rosetta.converters.anthropic.tool_ops import AnthropicToolOps
+from llm_rosetta.shims.provider_shim import ReasoningCapability
 from llm_rosetta.types.ir import Message
 from llm_rosetta.types.ir.extensions import ExtensionItem
 
@@ -204,6 +205,65 @@ class TestAnthropicMessageOps:
         assert msg["content"][0]["type"] == "thinking"
         assert msg["content"][0]["thinking"] == "I need to think."
         assert msg["content"][1]["type"] == "text"
+
+    def test_ir_assistant_preserves_unsigned_reasoning_in_metadata(self):
+        """Test preserve policy keeps unsigned reasoning in IR metadata."""
+        reasoning_part = {"type": "reasoning", "reasoning": "I need to think."}
+        ir_messages = cast(
+            list[Message],
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        reasoning_part,
+                        {"type": "text", "text": "Here is my answer."},
+                    ],
+                }
+            ],
+        )
+        cap = ReasoningCapability(unsigned_reasoning_blocks="preserve")
+        result, warnings = self.message_ops.ir_messages_to_p(
+            ir_messages, reasoning_cap=cap
+        )
+        assert result[0]["content"] == [{"type": "text", "text": "Here is my answer."}]
+        assert reasoning_part["provider_metadata"] == {
+            "anthropic": {
+                "unsigned_reasoning_blocks": [
+                    {
+                        "reasoning": "I need to think.",
+                        "signature": None,
+                        "status": None,
+                    }
+                ]
+            }
+        }
+        assert warnings == [
+            "Unsigned reasoning content in assistant message not supported by target provider, preserved in metadata"
+        ]
+
+    def test_ir_assistant_preserve_policy_keeps_signed_reasoning(self):
+        """Test preserve policy only filters reasoning with no usable signature."""
+        ir_messages = cast(
+            list[Message],
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "reasoning",
+                            "reasoning": "I need to think.",
+                            "signature": "sig_valid",
+                        },
+                    ],
+                }
+            ],
+        )
+        cap = ReasoningCapability(unsigned_reasoning_blocks="preserve")
+        result, warnings = self.message_ops.ir_messages_to_p(
+            ir_messages, reasoning_cap=cap
+        )
+        assert result[0]["content"][0]["signature"] == "sig_valid"
+        assert warnings == []
 
     def test_extension_item_system_event(self):
         """Test extension item system_event produces warning."""

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -172,6 +172,16 @@ class TestBuiltinShims:
         assert shim is not None
         assert shim.base == "anthropic"
 
+    def test_argo_anthropic_preserves_unsigned_reasoning_blocks(self):
+        shim = get_shim("argo--anthropic")
+        assert shim is not None
+        assert shim.reasoning is not None
+        assert shim.reasoning.unsigned_reasoning_blocks == "preserve"
+        assert shim.model_reasoning is not None
+        assert (
+            shim.model_reasoning["claudeopus47"].unsigned_reasoning_blocks == "preserve"
+        )
+
     def test_google_base_type(self):
         shim = get_shim("google")
         assert shim is not None


### PR DESCRIPTION
## Summary

- Adds `unsigned_reasoning_blocks: as_is | preserve` to `ReasoningCapability`
- Configures `argo--anthropic` with `unsigned_reasoning_blocks: preserve`
- Preserves unsigned Anthropic reasoning blocks in IR metadata instead of forwarding invalid/missing signatures upstream
- Keeps empty Anthropic signatures round-trippable so policy decisions can see the original field state

Fixes #268.

## Why

Dev-test reproduced Argo Anthropic 400s when Claude CLI sent history containing a `thinking` block with `signature: ""`:

```text
messages.61.content.0.thinking.signature: Field required
messages.9.content.0: Invalid `signature` in `thinking` block
```

The converter previously dropped empty signatures via truthiness checks. Preserving the empty string exposed that Argo treats it as invalid, so this PR makes the target shim decide whether unsigned reasoning should be sent as-is or preserved out-of-band.

## Test plan

- [x] `conda run -n llm-rosetta pytest tests/converters/anthropic/test_content_ops.py tests/converters/anthropic/test_message_ops.py tests/test_shims.py -q`
- [x] `/usr/bin/ruff check --fix ...changed files...`
- [x] `/usr/bin/ruff format --check ...changed files...`
- [x] `conda run -n llm-rosetta ty check`
- [x] `make deploy-dev SSH_TARGET=cloud.usa2`
- [x] Manual dev-test replay of the failing Claude CLI session

Disclosure: AI was used to assist with implementation.