### PR TITLE
Add plugin shim loader via entry points

### DIFF
--- a/src/llm_rosetta/shims/__init__.py
+++ b/src/llm_rosetta/shims/__init__.py
@@ -23,6 +23,7 @@ from .transforms import (
 
 # Scan provider directories and register shims from YAML + transforms.py.
 from .providers import load_providers as _load_providers
+from .providers import load_providers_from_dir
 
 _load_providers()
 
@@ -40,4 +41,5 @@ __all__ = [
     "strip_fields",
     "rename_field",
     "set_defaults",
+    "load_providers_from_dir",
 ]

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -7,10 +7,9 @@ optional transforms to bridge schema differences.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Literal
-
-import logging
 
 from .transforms import Transform
 

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
+import logging
+
 from .transforms import Transform
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -132,7 +136,14 @@ _BASE_TYPES: frozenset[str] = frozenset(
 
 
 def register_shim(shim: ProviderShim) -> None:
-    """Register (or replace) a :class:`ProviderShim` in the global registry."""
+    """Register (or replace) a :class:`ProviderShim` in the global registry.
+
+    If a shim with the same name is already registered, it is silently
+    replaced and an INFO-level log is emitted.  This allows plugin shims
+    to override built-in defaults without raising errors.
+    """
+    if shim.name in _SHIM_REGISTRY:
+        logger.info("Shim %r overridden (base: %s)", shim.name, shim.base)
     _SHIM_REGISTRY[shim.name] = shim
 
 

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -134,8 +134,14 @@ def _load_single_provider(
     return shim
 
 
-def load_providers() -> list[ProviderShim]:
-    """Scan subdirectories for provider shims and register them.
+def load_providers_from_dir(
+    providers_dir: Path, *, group: str | None = None
+) -> list[ProviderShim]:
+    """Scan *providers_dir* for provider shims and register them.
+
+    This is the public entry point for loading shims from an arbitrary
+    directory.  Downstream packages (e.g. argo-proxy) can call this to
+    load their own shim directories alongside the built-in ones.
 
     Supports two layouts:
 
@@ -143,26 +149,83 @@ def load_providers() -> list[ProviderShim]:
     * **Grouped** — a child WITHOUT ``provider.yaml`` whose own children
       each contain one (e.g. ``argo/anthropic/``, ``argo/openai_chat/``).
 
+    Args:
+        providers_dir: Root directory to scan for provider subdirectories.
+        group: Optional group name prefix for all shims loaded from this
+            directory.  When ``None``, the directory structure determines
+            grouping automatically.
+
     Returns:
         List of registered :class:`ProviderShim` instances.
     """
     shims: list[ProviderShim] = []
-    for d in sorted(_PROVIDERS_DIR.iterdir()):
+    for d in sorted(providers_dir.iterdir()):
         if not d.is_dir() or d.name.startswith(("_", ".")):
             continue
         yaml_path = d / "provider.yaml"
         if yaml_path.exists():
-            # Leaf shim at top level.
-            shim = _load_single_provider(d)
+            shim = _load_single_provider(d, group=group)
             if shim is not None:
                 shims.append(shim)
         else:
             # Potential group folder — scan children.
+            child_group = f"{group}.{d.name}" if group else d.name
             for sub in sorted(d.iterdir()):
                 if not sub.is_dir() or sub.name.startswith(("_", ".")):
                     continue
                 if (sub / "provider.yaml").exists():
-                    shim = _load_single_provider(sub, group=d.name)
+                    shim = _load_single_provider(sub, group=child_group)
                     if shim is not None:
                         shims.append(shim)
     return shims
+
+
+def load_providers() -> list[ProviderShim]:
+    """Load built-in provider shims and any plugin shims.
+
+    1. Scans the built-in ``providers/`` directory.
+    2. Discovers entry points in the ``llm_rosetta.shim_providers`` group
+       and calls each one to let plugins register their own shims.
+
+    Returns:
+        List of registered :class:`ProviderShim` instances (built-in only;
+        plugin shims register themselves via :func:`register_shim`).
+    """
+    # 1. Built-in shims
+    shims = load_providers_from_dir(_PROVIDERS_DIR)
+
+    # 2. Plugin shims via entry points
+    _load_plugin_shims()
+
+    return shims
+
+
+def _load_plugin_shims() -> None:
+    """Discover and invoke ``llm_rosetta.shim_providers`` entry points.
+
+    Each entry point should be a callable that registers shims via
+    :func:`register_shim` when called (no arguments).  Errors in
+    individual plugins are logged and do not prevent other plugins
+    from loading.
+    """
+    try:
+        from importlib.metadata import entry_points
+    except ImportError:
+        return
+
+    eps = entry_points()
+    # Python 3.12+: eps.select(); Python 3.10–3.11: dict-style
+    if hasattr(eps, "select"):
+        plugin_eps = eps.select(group="llm_rosetta.shim_providers")
+    else:
+        plugin_eps = eps.get("llm_rosetta.shim_providers", [])
+
+    for ep in plugin_eps:
+        try:
+            loader = ep.load()
+            loader()
+            logger.info("Loaded plugin shims from entry point: %s", ep.name)
+        except Exception:
+            logger.warning(
+                "Failed to load plugin shim entry point: %s", ep.name, exc_info=True
+            )

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+from importlib.metadata import entry_points
 from pathlib import Path
 
 from llm_rosetta._vendor.yaml import load as yaml_load
@@ -28,23 +29,25 @@ _PROVIDERS_DIR = Path(__file__).parent
 
 
 def _load_transforms(
-    provider_dir: Path, *, group: str | None = None
+    provider_dir: Path, *, group: str | None = None, _builtin: bool = True
 ) -> tuple[tuple, tuple]:
     """Import transforms.py if present, return (from_transforms, to_transforms).
 
     Args:
         provider_dir: Path to the leaf provider directory.
         group: Name of the parent group folder, if this is a grouped shim.
+        _builtin: Whether this is a built-in provider directory.  Plugin
+            transforms use a separate module namespace to avoid collisions
+            with built-in modules in ``sys.modules``.
     """
     tf_path = provider_dir / "transforms.py"
     if not tf_path.exists():
         return (), ()
+    prefix = "llm_rosetta.shims.providers" if _builtin else "_llm_rosetta_plugin_shims"
     if group is not None:
-        module_name = (
-            f"llm_rosetta.shims.providers.{group}.{provider_dir.name}.transforms"
-        )
+        module_name = f"{prefix}.{group}.{provider_dir.name}.transforms"
     else:
-        module_name = f"llm_rosetta.shims.providers.{provider_dir.name}.transforms"
+        module_name = f"{prefix}.{provider_dir.name}.transforms"
     spec = importlib.util.spec_from_file_location(module_name, tf_path)
     if spec is None or spec.loader is None:
         logger.warning("Could not load %s", tf_path)
@@ -58,13 +61,14 @@ def _load_transforms(
 
 
 def _load_single_provider(
-    provider_dir: Path, *, group: str | None = None
+    provider_dir: Path, *, group: str | None = None, _builtin: bool = True
 ) -> ProviderShim | None:
     """Load a single provider from *provider_dir* and register it.
 
     Args:
         provider_dir: Directory containing ``provider.yaml``.
         group: Name of the parent group folder (``None`` for top-level shims).
+        _builtin: Whether this is a built-in provider directory.
 
     Returns:
         The registered :class:`ProviderShim`, or ``None`` on failure.
@@ -76,7 +80,7 @@ def _load_single_provider(
         logger.warning("Skipping %s: missing 'name' or 'base'", yaml_path)
         return None
 
-    from_t, to_t = _load_transforms(provider_dir, group=group)
+    from_t, to_t = _load_transforms(provider_dir, group=group, _builtin=_builtin)
 
     # Parse optional reasoning capability config from YAML.
     reasoning_cfg = cfg.get("reasoning")
@@ -143,6 +147,10 @@ def load_providers_from_dir(
     directory.  Downstream packages (e.g. argo-proxy) can call this to
     load their own shim directories alongside the built-in ones.
 
+    Plugin transforms use a separate module namespace
+    (``_llm_rosetta_plugin_shims.*``) to avoid collisions with built-in
+    modules in ``sys.modules``.
+
     Supports two layouts:
 
     * **Flat** — a direct child with ``provider.yaml`` (e.g. ``openai/``).
@@ -158,13 +166,14 @@ def load_providers_from_dir(
     Returns:
         List of registered :class:`ProviderShim` instances.
     """
+    builtin = providers_dir == _PROVIDERS_DIR
     shims: list[ProviderShim] = []
     for d in sorted(providers_dir.iterdir()):
         if not d.is_dir() or d.name.startswith(("_", ".")):
             continue
         yaml_path = d / "provider.yaml"
         if yaml_path.exists():
-            shim = _load_single_provider(d, group=group)
+            shim = _load_single_provider(d, group=group, _builtin=builtin)
             if shim is not None:
                 shims.append(shim)
         else:
@@ -174,7 +183,9 @@ def load_providers_from_dir(
                 if not sub.is_dir() or sub.name.startswith(("_", ".")):
                     continue
                 if (sub / "provider.yaml").exists():
-                    shim = _load_single_provider(sub, group=child_group)
+                    shim = _load_single_provider(
+                        sub, group=child_group, _builtin=builtin
+                    )
                     if shim is not None:
                         shims.append(shim)
     return shims
@@ -188,30 +199,30 @@ def load_providers() -> list[ProviderShim]:
        and calls each one to let plugins register their own shims.
 
     Returns:
-        List of registered :class:`ProviderShim` instances (built-in only;
-        plugin shims register themselves via :func:`register_shim`).
+        Combined list of all registered :class:`ProviderShim` instances
+        (built-in + plugin).
     """
     # 1. Built-in shims
     shims = load_providers_from_dir(_PROVIDERS_DIR)
 
     # 2. Plugin shims via entry points
-    _load_plugin_shims()
+    shims.extend(_load_plugin_shims())
 
     return shims
 
 
-def _load_plugin_shims() -> None:
+def _load_plugin_shims() -> list[ProviderShim]:
     """Discover and invoke ``llm_rosetta.shim_providers`` entry points.
 
     Each entry point should be a callable that registers shims via
-    :func:`register_shim` when called (no arguments).  Errors in
-    individual plugins are logged and do not prevent other plugins
-    from loading.
+    :func:`register_shim` when called (no arguments).  The callable may
+    optionally return a ``list[ProviderShim]`` for inclusion in the
+    combined result of :func:`load_providers`.
+
+    Errors in individual plugins are logged and do not prevent other
+    plugins from loading.
     """
-    try:
-        from importlib.metadata import entry_points
-    except ImportError:
-        return
+    registered: list[ProviderShim] = []
 
     eps = entry_points()
     # Python 3.12+: eps.select(); Python 3.10–3.11: dict-style
@@ -223,9 +234,13 @@ def _load_plugin_shims() -> None:
     for ep in plugin_eps:
         try:
             loader = ep.load()
-            loader()
+            result = loader()
+            if isinstance(result, list):
+                registered.extend(result)
             logger.info("Loaded plugin shims from entry point: %s", ep.name)
         except Exception:
             logger.warning(
                 "Failed to load plugin shim entry point: %s", ep.name, exc_info=True
             )
+
+    return registered

--- a/tests/test_shim_loader.py
+++ b/tests/test_shim_loader.py
@@ -11,7 +11,12 @@ from llm_rosetta.shims.provider_shim import (
     _reset_registry,
     get_shim,
 )
-from llm_rosetta.shims.providers import load_providers, _load_transforms
+from llm_rosetta.shims.providers import (
+    _load_plugin_shims,
+    _load_transforms,
+    load_providers,
+    load_providers_from_dir,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -319,3 +324,108 @@ class TestLoadProviders:
         shims = load_providers()
         assert len(shims) == 1
         assert shims[0].name == "good"
+
+
+class TestLoadProvidersFromDir:
+    """Tests for the public load_providers_from_dir API."""
+
+    def test_loads_from_arbitrary_path(self, tmp_path: Path):
+        """load_providers_from_dir loads from any directory."""
+        d = tmp_path / "mything"
+        d.mkdir()
+        (d / "provider.yaml").write_text("name: mything\nbase: openai_chat\n")
+        shims = load_providers_from_dir(tmp_path)
+        assert any(s.name == "mything" for s in shims)
+
+    def test_plugin_transforms_loaded(self, tmp_path: Path):
+        """Plugin transforms are loaded from arbitrary directories."""
+        d = tmp_path / "myplugin"
+        d.mkdir()
+        (d / "provider.yaml").write_text("name: myplugin\nbase: openai_chat\n")
+        (d / "transforms.py").write_text(
+            "from llm_rosetta.shims.transforms import strip_fields\n"
+            'to_transforms = (strip_fields("foo"),)\n'
+        )
+        shims = load_providers_from_dir(tmp_path)
+        s = [s for s in shims if s.name == "myplugin"][0]
+        assert len(s.to_transforms) == 1
+        # Verify the transform works
+        body = {"foo": 1, "bar": 2}
+        result = s.to_transforms[0](body)
+        assert "foo" not in result
+        assert result["bar"] == 2
+
+
+class TestPluginEntryPoints:
+    """Tests for the entry-point plugin loader."""
+
+    def test_invokes_entry_points(self, monkeypatch):
+        """_load_plugin_shims discovers and calls entry points."""
+        calls: list[str] = []
+
+        class FakeEP:
+            name = "fake"
+
+            def load(self):
+                def register():
+                    calls.append("called")
+
+                return register
+
+        class FakeEPs:
+            def select(self, *, group: str):
+                assert group == "llm_rosetta.shim_providers"
+                return [FakeEP()]
+
+        monkeypatch.setattr(
+            "llm_rosetta.shims.providers.entry_points", lambda: FakeEPs()
+        )
+        _load_plugin_shims()
+        assert calls == ["called"]
+
+    def test_collects_returned_shims(self, monkeypatch):
+        """Entry points that return list[ProviderShim] are collected."""
+        from llm_rosetta.shims.provider_shim import ProviderShim
+
+        test_shim = ProviderShim(name="ep-test", base="openai_chat")
+
+        class FakeEP:
+            name = "returner"
+
+            def load(self):
+                def register():
+                    return [test_shim]
+
+                return register
+
+        class FakeEPs:
+            def select(self, *, group: str):
+                return [FakeEP()]
+
+        monkeypatch.setattr(
+            "llm_rosetta.shims.providers.entry_points", lambda: FakeEPs()
+        )
+        result = _load_plugin_shims()
+        assert test_shim in result
+
+    def test_handles_plugin_errors_gracefully(self, monkeypatch):
+        """A failing plugin does not crash the loader."""
+
+        class BadEP:
+            name = "bad"
+
+            def load(self):
+                def register():
+                    raise RuntimeError("plugin broken")
+
+                return register
+
+        class FakeEPs:
+            def select(self, *, group: str):
+                return [BadEP()]
+
+        monkeypatch.setattr(
+            "llm_rosetta.shims.providers.entry_points", lambda: FakeEPs()
+        )
+        result = _load_plugin_shims()
+        assert result == []


### PR DESCRIPTION
## Summary

- Extract `load_providers_from_dir(path)` as public API for loading shims from arbitrary directories
- Add entry-point discovery: `load_providers()` now scans the `llm_rosetta.shim_providers` group after loading built-in shims, letting downstream packages register their own shims declaratively
- `register_shim()` logs INFO when overriding an existing shim (instead of silent replace)
- Export `load_providers_from_dir` in `shims.__init__`

This is the prerequisite for argo-proxy (and other consumers) to ship their own shim YAML+transforms as a plugin package instead of relying on llm-rosetta's built-in shim directory.

### Plugin usage

Downstream packages declare an entry point:

```toml
[project.entry-points."llm_rosetta.shim_providers"]
my_provider = "my_package.shims:register_shims"
```

The callable receives no arguments and registers shims via `register_shim()`.

## Test plan

- [x] `pytest tests/test_shims.py tests/test_shim_loader.py -q` — 48 passed
- [x] `ruff check --fix && ruff format`
- [x] `ty check`