### PR TITLE
fix: derive budget_tokens for non-adaptive thinking models (Haiku 4.5)

### DIFF
--- a/src/llm_rosetta/converters/anthropic/config_ops.py
+++ b/src/llm_rosetta/converters/anthropic/config_ops.py
@@ -253,6 +253,7 @@ class AnthropicConfigOps(BaseConfigOps):
             ir_reasoning,
             cap,
             converter_type="anthropic",
+            max_tokens=kwargs.get("max_tokens"),
         )
 
     @staticmethod

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -152,15 +152,7 @@ class AnthropicConverter(BaseConverter):
             result.update(stream_fields)
 
         # 9. Reasoning config
-        reasoning = ir_request.get("reasoning")
-        if reasoning:
-            rc_kwargs: dict[str, Any] = {}
-            if ctx and "reasoning_cap" in ctx.options:
-                rc_kwargs["reasoning_cap"] = ctx.options["reasoning_cap"]
-            reasoning_fields = self.config_ops.ir_reasoning_config_to_p(
-                reasoning, **rc_kwargs
-            )
-            result.update(reasoning_fields)
+        self._apply_reasoning_config(ir_request, result, ctx)
 
         # 10. Cache config (block-level, warning)
         cache = ir_request.get("cache")
@@ -378,6 +370,28 @@ class AnthropicConverter(BaseConverter):
         return provider_response
 
     # ------------------------------------------------------------------
+    def _apply_reasoning_config(
+        self,
+        ir_request: IRRequest,
+        result: dict[str, Any],
+        ctx: ConversionContext,
+    ) -> None:
+        """Apply reasoning/thinking config to provider request."""
+        reasoning = ir_request.get("reasoning")
+        if not reasoning:
+            return
+        rc_kwargs: dict[str, Any] = {}
+        if "reasoning_cap" in ctx.options:
+            rc_kwargs["reasoning_cap"] = ctx.options["reasoning_cap"]
+        # Pass max_tokens so budget_tokens_default_ratio can derive a
+        # default budget when the caller didn't provide one.
+        if "max_tokens" in result:
+            rc_kwargs["max_tokens"] = result["max_tokens"]
+        reasoning_fields = self.config_ops.ir_reasoning_config_to_p(
+            reasoning, **rc_kwargs
+        )
+        result.update(reasoning_fields)
+
     # Cross-provider consistency helpers
     # ------------------------------------------------------------------
 

--- a/src/llm_rosetta/converters/openai_chat/config_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/config_ops.py
@@ -265,6 +265,7 @@ class OpenAIChatConfigOps(BaseConfigOps):
             ir_reasoning,
             cap,
             converter_type="openai_chat",
+            max_tokens=kwargs.get("max_tokens"),
         )
 
     @staticmethod

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -131,6 +131,11 @@ class OpenAIChatConverter(BaseConverter):
             rc_kwargs: dict[str, Any] = {}
             if ctx and "reasoning_cap" in ctx.options:
                 rc_kwargs["reasoning_cap"] = ctx.options["reasoning_cap"]
+            # Pass max_tokens so budget_tokens_default_ratio can derive a
+            # default budget when the caller didn't provide one.
+            mt = result.get("max_tokens") or result.get("max_completion_tokens")
+            if mt is not None:
+                rc_kwargs["max_tokens"] = mt
             reasoning_fields = self.config_ops.ir_reasoning_config_to_p(
                 reasoning, **rc_kwargs
             )

--- a/src/llm_rosetta/converters/reasoning_helpers.py
+++ b/src/llm_rosetta/converters/reasoning_helpers.py
@@ -362,7 +362,7 @@ def _apply_anthropic_extras(
                     "falling back to 'adaptive'",
                     stacklevel=2,
                 )
-                result["thinking"] = {"type": "adaptive"}
+                result["thinking"]: dict[str, Any] = {"type": "adaptive"}
     elif mode == "auto" or effort is not None:
         thinking: dict[str, Any] = {"type": "adaptive"}
         if budget_tokens is not None:

--- a/src/llm_rosetta/converters/reasoning_helpers.py
+++ b/src/llm_rosetta/converters/reasoning_helpers.py
@@ -120,6 +120,7 @@ def apply_reasoning_config(
     cap: ReasoningCapability,
     *,
     converter_type: str | None = None,
+    max_tokens: int | None = None,
 ) -> dict[str, Any]:
     """Convert IR ``ReasoningConfig`` → provider parameters using *cap*.
 
@@ -169,11 +170,13 @@ def apply_reasoning_config(
 
     # 4. Converter-specific structural pass-through.
     if converter_type == "openai_chat":
-        _apply_openai_chat_extras(ir, result, mode, budget_tokens, cap)
+        _apply_openai_chat_extras(ir, result, mode, budget_tokens, cap, max_tokens)
     elif converter_type == "openai_responses":
         _apply_openai_responses_extras(ir, result, mode, budget_tokens)
     elif converter_type == "anthropic":
-        _apply_anthropic_extras(ir, result, mode, effort, budget_tokens, cap)
+        _apply_anthropic_extras(
+            ir, result, mode, effort, budget_tokens, cap, max_tokens
+        )
     elif converter_type == "google":
         _apply_google_extras(ir, result, mode, budget_tokens)
 
@@ -253,6 +256,31 @@ def _deep_merge(target: dict[str, Any], source: dict[str, Any]) -> None:
             target[k] = v
 
 
+# ── Budget tokens default derivation ──────────────────────────────────────
+
+#: Anthropic's minimum budget_tokens value (per official docs).
+_MIN_BUDGET_TOKENS = 1024
+
+
+def _derive_budget_tokens(
+    cap: ReasoningCapability,
+    max_tokens: int | None,
+) -> int | None:
+    """Derive ``budget_tokens`` from ``cap.budget_tokens_default_ratio`` and *max_tokens*.
+
+    Returns ``None`` when derivation is impossible (no ratio configured,
+    no ``max_tokens``, or ``max_tokens`` too small to satisfy the minimum).
+    """
+    if cap.budget_tokens_default_ratio is None or max_tokens is None:
+        return None
+    if max_tokens <= _MIN_BUDGET_TOKENS:
+        # Can't satisfy budget_tokens >= 1024 AND < max_tokens.
+        return None
+    budget = max(_MIN_BUDGET_TOKENS, int(max_tokens * cap.budget_tokens_default_ratio))
+    # Anthropic requires budget_tokens < max_tokens.
+    return min(budget, max_tokens - 1)
+
+
 # ── Converter-specific pass-through extras ─────────────────────────────────
 
 
@@ -262,6 +290,7 @@ def _apply_openai_chat_extras(
     mode: str | None,
     budget_tokens: int | None,
     cap: ReasoningCapability | None = None,
+    max_tokens: int | None = None,
 ) -> None:
     """OpenAI Chat extras: thinking object for mode/budget_tokens (DeepSeek ext)."""
     thinking: dict[str, Any] = {}
@@ -279,7 +308,11 @@ def _apply_openai_chat_extras(
         current_type = result["thinking"].get("type")
         target_type = cap.thinking_type
         if target_type == "enabled" and "budget_tokens" not in result["thinking"]:
-            target_type = "adaptive"
+            derived = _derive_budget_tokens(cap, max_tokens)
+            if derived is not None:
+                result["thinking"]["budget_tokens"] = derived
+            else:
+                target_type = "adaptive"
         if current_type != target_type:
             result["thinking"]["type"] = target_type
             if target_type == "adaptive" and "budget_tokens" in result["thinking"]:
@@ -312,18 +345,24 @@ def _apply_anthropic_extras(
     effort: str | None,
     budget_tokens: int | None,
     cap: ReasoningCapability | None = None,
+    max_tokens: int | None = None,
 ) -> None:
     """Anthropic extras: thinking object with type/budget_tokens."""
     if mode == "enabled":
         if budget_tokens is not None:
             result["thinking"] = {"type": "enabled", "budget_tokens": budget_tokens}
         else:
-            warnings.warn(
-                "Anthropic 'enabled' thinking requires budget_tokens, "
-                "falling back to 'adaptive'",
-                stacklevel=2,
-            )
-            result["thinking"] = {"type": "adaptive"}
+            # Try to derive budget from ratio before falling back to adaptive.
+            derived = _derive_budget_tokens(cap, max_tokens) if cap else None
+            if derived is not None:
+                result["thinking"] = {"type": "enabled", "budget_tokens": derived}
+            else:
+                warnings.warn(
+                    "Anthropic 'enabled' thinking requires budget_tokens, "
+                    "falling back to 'adaptive'",
+                    stacklevel=2,
+                )
+                result["thinking"] = {"type": "adaptive"}
     elif mode == "auto" or effort is not None:
         thinking: dict[str, Any] = {"type": "adaptive"}
         if budget_tokens is not None:
@@ -337,9 +376,13 @@ def _apply_anthropic_extras(
         current_type = result["thinking"].get("type")
         target_type = cap.thinking_type
         # Anthropic requires budget_tokens when type=enabled; if missing,
-        # fall back to adaptive instead of emitting an invalid payload.
+        # try to derive from ratio, otherwise fall back to adaptive.
         if target_type == "enabled" and "budget_tokens" not in result["thinking"]:
-            target_type = "adaptive"
+            derived = _derive_budget_tokens(cap, max_tokens)
+            if derived is not None:
+                result["thinking"]["budget_tokens"] = derived
+            else:
+                target_type = "adaptive"
         if current_type != target_type:
             result["thinking"]["type"] = target_type
             if target_type == "adaptive" and "budget_tokens" in result["thinking"]:

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -62,6 +62,11 @@ class ReasoningCapability:
         thinking_type: Force ``thinking.type`` to this value.
         unsigned_reasoning_blocks: Policy for outbound unsigned reasoning blocks.
         effort_map: Map from normalised IR effort to provider effort string.
+        budget_tokens_default_ratio: When ``thinking_type`` is ``"enabled"``
+            but no ``budget_tokens`` is provided, derive a default budget as
+            ``max(1024, int(max_tokens * ratio))`` clamped to ``max_tokens - 1``.
+            Anthropic requires ``budget_tokens >= 1024`` and ``< max_tokens``.
+            When ``None``, the existing ``"adaptive"`` fallback is used instead.
     """
 
     disabled: DisabledStrategy = "omit"
@@ -79,6 +84,7 @@ class ReasoningCapability:
             "max": "high",
         }
     )
+    budget_tokens_default_ratio: float | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -131,6 +131,9 @@ def _load_single_provider(
                 "unsigned_reasoning_blocks", "as_is"
             ),
             effort_map=reasoning_cfg.get("effort_map", {}),
+            budget_tokens_default_ratio=reasoning_cfg.get(
+                "budget_tokens_default_ratio"
+            ),
         )
 
     # Parse per-model reasoning overrides (inherit provider defaults).
@@ -155,6 +158,10 @@ def _load_single_provider(
                     reasoning_cap.unsigned_reasoning_blocks,
                 ),
                 effort_map=overrides.get("effort_map", reasoning_cap.effort_map),
+                budget_tokens_default_ratio=overrides.get(
+                    "budget_tokens_default_ratio",
+                    reasoning_cap.budget_tokens_default_ratio,
+                ),
             )
 
     shim = ProviderShim(

--- a/src/llm_rosetta/shims/providers/anthropic/provider.yaml
+++ b/src/llm_rosetta/shims/providers/anthropic/provider.yaml
@@ -13,7 +13,16 @@ reasoning:
     high: high
     xhigh: xhigh
     max: max
+  # Anthropic Official thinking support matrix (tested 2026-06-18):
+  #   Haiku 4.5:  enabled+budget only (adaptive → 400)
+  #   Sonnet 4.6: both enabled+budget and adaptive work
+  #   Opus 4.6:   both work
+  #   Opus 4.7+:  adaptive only (enabled → 400)
   model_overrides:
     claude-haiku-4-5-20251001:
       thinking_type: enabled
       budget_tokens_default_ratio: 0.8
+    claude-opus-4-7:
+      thinking_type: adaptive
+    claude-opus-4-8:
+      thinking_type: adaptive

--- a/src/llm_rosetta/shims/providers/anthropic/provider.yaml
+++ b/src/llm_rosetta/shims/providers/anthropic/provider.yaml
@@ -13,3 +13,7 @@ reasoning:
     high: high
     xhigh: xhigh
     max: max
+  model_overrides:
+    claude-haiku-4-5-20251001:
+      thinking_type: enabled
+      budget_tokens_default_ratio: 0.8

--- a/src/llm_rosetta/shims/providers/argo/anthropic/provider.yaml
+++ b/src/llm_rosetta/shims/providers/argo/anthropic/provider.yaml
@@ -18,3 +18,6 @@ reasoning:
   model_overrides:
     claudeopus47:
       thinking_type: adaptive
+    claudehaiku45:
+      thinking_type: enabled
+      budget_tokens_default_ratio: 0.8

--- a/src/llm_rosetta/shims/providers/argo/anthropic/provider.yaml
+++ b/src/llm_rosetta/shims/providers/argo/anthropic/provider.yaml
@@ -15,9 +15,19 @@ reasoning:
     high: high
     xhigh: xhigh
     max: max
+  # Argo Anthropic thinking support matrix (tested 2026-06-18):
+  #   claudehaiku45:  enabled+budget only (adaptive → 400)
+  #   claudesonnet4:  enabled+budget only (adaptive → 400)
+  #   claudeopus46:   both enabled and adaptive work
+  #   claudeopus47+:  adaptive only (enabled → 400)
   model_overrides:
-    claudeopus47:
-      thinking_type: adaptive
     claudehaiku45:
       thinking_type: enabled
       budget_tokens_default_ratio: 0.8
+    claudesonnet4:
+      thinking_type: enabled
+      budget_tokens_default_ratio: 0.8
+    claudeopus47:
+      thinking_type: adaptive
+    claudeopus48:
+      thinking_type: adaptive

--- a/tests/converters/test_reasoning_helpers.py
+++ b/tests/converters/test_reasoning_helpers.py
@@ -438,6 +438,157 @@ class TestCustomShim:
         assert result["thinking"]["type"] == "enabled"
         assert result["thinking"]["budget_tokens"] == 2048
 
+    def test_budget_ratio_derives_tokens_from_max_tokens(self):
+        """budget_tokens_default_ratio derives budget from max_tokens."""
+        custom = ReasoningCapability(
+            disabled="thinking_disabled",
+            effort_field="output_config.effort",
+            thinking_type="enabled",
+            effort_map={
+                "minimal": "low",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+                "max": "max",
+            },
+            budget_tokens_default_ratio=0.8,
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
+            custom,
+            converter_type="anthropic",
+            max_tokens=10000,
+        )
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 8000
+
+    def test_budget_ratio_clamps_to_max_minus_one(self):
+        """budget_tokens must be < max_tokens."""
+        custom = ReasoningCapability(
+            disabled="thinking_disabled",
+            effort_field="output_config.effort",
+            thinking_type="enabled",
+            effort_map={},
+            budget_tokens_default_ratio=1.0,
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
+            custom,
+            converter_type="anthropic",
+            max_tokens=2000,
+        )
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 1999
+
+    def test_budget_ratio_floor_1024(self):
+        """budget_tokens must be >= 1024 (Anthropic minimum)."""
+        custom = ReasoningCapability(
+            disabled="thinking_disabled",
+            effort_field="output_config.effort",
+            thinking_type="enabled",
+            effort_map={},
+            budget_tokens_default_ratio=0.3,
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
+            custom,
+            converter_type="anthropic",
+            max_tokens=2000,
+        )
+        assert result["thinking"]["type"] == "enabled"
+        # 2000 * 0.3 = 600, floored to 1024
+        assert result["thinking"]["budget_tokens"] == 1024
+
+    def test_budget_ratio_max_tokens_too_small_falls_back(self):
+        """When max_tokens <= 1024, can't satisfy both constraints → adaptive."""
+        custom = ReasoningCapability(
+            disabled="thinking_disabled",
+            effort_field="output_config.effort",
+            thinking_type="enabled",
+            effort_map={},
+            budget_tokens_default_ratio=0.8,
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
+            custom,
+            converter_type="anthropic",
+            max_tokens=1024,
+        )
+        # max_tokens <= 1024 → can't derive → falls back to adaptive
+        assert result["thinking"]["type"] == "adaptive"
+
+    def test_budget_ratio_none_falls_back_to_adaptive(self):
+        """Without budget_tokens_default_ratio, still falls back to adaptive."""
+        custom = ReasoningCapability(
+            disabled="thinking_disabled",
+            effort_field="output_config.effort",
+            thinking_type="enabled",
+            effort_map={},
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
+            custom,
+            converter_type="anthropic",
+            max_tokens=10000,
+        )
+        # No ratio → can't derive → adaptive
+        assert result["thinking"]["type"] == "adaptive"
+
+    def test_budget_ratio_without_max_tokens_falls_back(self):
+        """With ratio but no max_tokens, falls back to adaptive."""
+        custom = ReasoningCapability(
+            disabled="thinking_disabled",
+            effort_field="output_config.effort",
+            thinking_type="enabled",
+            effort_map={},
+            budget_tokens_default_ratio=0.8,
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
+            custom,
+            converter_type="anthropic",
+        )
+        # No max_tokens → can't derive → adaptive
+        assert result["thinking"]["type"] == "adaptive"
+
+    def test_budget_ratio_mode_enabled_no_budget_anthropic(self):
+        """mode=enabled without budget_tokens uses ratio to derive budget."""
+        custom = ReasoningCapability(
+            disabled="thinking_disabled",
+            effort_field="output_config.effort",
+            thinking_type="enabled",
+            effort_map={},
+            budget_tokens_default_ratio=0.8,
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "enabled"}),
+            custom,
+            converter_type="anthropic",
+            max_tokens=8192,
+        )
+        assert result["thinking"]["type"] == "enabled"
+        # 8192 * 0.8 = 6553
+        assert result["thinking"]["budget_tokens"] == 6553
+
+    def test_budget_ratio_openai_chat(self):
+        """budget_tokens_default_ratio works for openai_chat converter too."""
+        custom = ReasoningCapability(
+            disabled="omit",
+            effort_field="reasoning_effort",
+            thinking_type="enabled",
+            effort_map={},
+            budget_tokens_default_ratio=0.8,
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto"}),
+            custom,
+            converter_type="openai_chat",
+            max_tokens=10000,
+        )
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 8000
+
     def test_custom_thinking_budget_zero_disabled(self):
         custom = ReasoningCapability(
             disabled="thinking_budget_zero",


### PR DESCRIPTION
## Summary

Haiku 4.5 supports extended thinking but only accepts `thinking.type="enabled"` + `budget_tokens`, not `"adaptive"`. The previous fallback caused 400 errors on Haiku from Anthropic Official, Argo, and OpenRouter.

- Adds `budget_tokens_default_ratio` to `ReasoningCapability` — derives `budget_tokens = min(max(1024, max_tokens × ratio), max_tokens - 1)` instead of falling back to `"adaptive"`
- Adds `model_overrides` for Haiku (enabled + ratio=0.8) and Opus 4.7/4.8 (adaptive-only) in both `anthropic` and `argo--anthropic` shims
- Threads `max_tokens` from converters into reasoning helpers
- 8 new tests covering ratio derivation, clamping, floor, and fallbacks

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (1863 tests)
- [ ] Deploy and verify Haiku reasoning test in gateway admin UI