### PR TITLE
feat: admin panel per-model reasoning override display and editing

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -697,7 +697,7 @@ body { padding-bottom: 26px; }
       </label>
       <div style="display:flex;flex-direction:column;gap:8px">
         <div style="display:flex;align-items:center;gap:8px">
-          <label style="min-width:190px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.thinkingType">Thinking Type</label>
+          <label style="min-width:140px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.thinkingType">Thinking Type</label>
           <select id="reasoningThinkingType" style="flex:1">
             <option value="" data-i18n="label.inheritProvider">(inherit from provider)</option>
             <option value="enabled">enabled</option>
@@ -705,11 +705,11 @@ body { padding-bottom: 26px; }
           </select>
         </div>
         <div style="display:flex;align-items:center;gap:8px">
-          <label style="min-width:190px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.budgetRatio">Budget Tokens Ratio</label>
+          <label style="min-width:140px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.budgetRatio">Budget Tokens Ratio</label>
           <input id="reasoningBudgetRatio" type="number" step="0.1" min="0" max="1" placeholder="(inherit)" style="flex:1">
         </div>
         <div style="display:flex;align-items:center;gap:8px">
-          <label style="min-width:190px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.disabledStrategy">Disabled Strategy</label>
+          <label style="min-width:140px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.disabledStrategy">Disabled Strategy</label>
           <select id="reasoningDisabled" style="flex:1">
             <option value="" data-i18n="label.inheritProvider">(inherit from provider)</option>
             <option value="omit">omit</option>
@@ -904,7 +904,7 @@ const I18N = {
     'label.apiKey':'API Key (or ${ENV_VAR} placeholder)', 'label.keyUnchangedHint':'Leave blank to keep current key',
     'label.proxyUrl':'Proxy URL (optional, overrides global)',
     'label.modelName':'Model Name', 'label.provider':'Provider', 'label.upstreamModel':'Upstream Model', 'label.capabilities':'Capabilities',
-    'label.reasoningConfig':'Reasoning Config', 'label.thinkingType':'Thinking Type', 'label.budgetRatio':'Budget Tokens Ratio', 'label.disabledStrategy':'Disabled Strategy', 'label.inheritProvider':'(inherit from provider)',
+    'label.reasoningConfig':'Reasoning Config', 'label.thinkingType':'Thinking Type', 'label.budgetRatio':'Budget Tokens Ratio', 'label.disabledStrategy':'Disabled Strategy', 'label.inheritProvider':'(inherit from provider)', 'label.inherited':'inherited',
     'modal.addProvider':'Add Provider', 'modal.editProvider':'Edit Provider',
     'modal.addModel':'Add Model', 'modal.editModel':'Edit Model',
     'col.model':'Model', 'col.provider':'Provider', 'col.time':'Time',
@@ -1007,7 +1007,7 @@ const I18N = {
     'label.apiKey':'API Key\uff08\u6216 ${ENV_VAR} \u5360\u4f4d\u7b26\uff09', 'label.keyUnchangedHint':'\u7559\u7a7a\u4ee5\u4fdd\u7559\u5f53\u524d\u5bc6\u94a5',
     'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09',
     'label.modelName':'\u6a21\u578b\u540d\u79f0', 'label.provider':'\u670d\u52a1\u5546', 'label.upstreamModel':'\u4e0a\u6e38\u6a21\u578b', 'label.capabilities':'\u80fd\u529b',
-    'label.reasoningConfig':'\u63a8\u7406\u914d\u7f6e', 'label.thinkingType':'\u601d\u8003\u7c7b\u578b', 'label.budgetRatio':'\u9884\u7b97 Token \u6bd4\u4f8b', 'label.disabledStrategy':'\u7981\u7528\u7b56\u7565', 'label.inheritProvider':'(\u7ee7\u627f\u81ea Provider)',
+    'label.reasoningConfig':'\u63a8\u7406\u914d\u7f6e', 'label.thinkingType':'\u601d\u8003\u7c7b\u578b', 'label.budgetRatio':'\u9884\u7b97 Token \u6bd4\u4f8b', 'label.disabledStrategy':'\u7981\u7528\u7b56\u7565', 'label.inheritProvider':'(\u7ee7\u627f\u81ea Provider)', 'label.inherited':'\u7ee7\u627f',
     'modal.addProvider':'\u6dfb\u52a0\u670d\u52a1\u5546', 'modal.editProvider':'\u7f16\u8f91\u670d\u52a1\u5546',
     'modal.addModel':'\u6dfb\u52a0\u6a21\u578b', 'modal.editModel':'\u7f16\u8f91\u6a21\u578b',
     'col.model':'\u6a21\u578b', 'col.provider':'\u670d\u52a1\u5546', 'col.time':'\u65f6\u95f4',
@@ -1436,10 +1436,18 @@ function openModelModal(model, provider, capabilities, upstreamModel) {
   const srcBadge = document.getElementById('reasoningSourceBadge');
   srcBadge.textContent = reasoning.source || 'none';
   srcBadge.className = 'badge badge-sm' + (reasoning.source === 'config' ? ' badge-cap-tools' : reasoning.source === 'model_override' ? ' badge-cap-reasoning' : '');
-  // Show effective values — config override takes display priority, then shim effective
-  document.getElementById('reasoningThinkingType').value = configOverride.thinking_type || reasoning.thinking_type || '';
-  document.getElementById('reasoningBudgetRatio').value = configOverride.budget_tokens_default_ratio != null ? configOverride.budget_tokens_default_ratio : (reasoning.budget_tokens_default_ratio != null ? reasoning.budget_tokens_default_ratio : '');
-  document.getElementById('reasoningDisabled').value = configOverride.disabled || reasoning.disabled || '';
+  // Update inherit option labels: show "value (inherited)" or just "(inherit)"
+  const inh = t('label.inherited');
+  const ttInherit = document.querySelector('#reasoningThinkingType option[value=""]');
+  ttInherit.textContent = reasoning.thinking_type ? reasoning.thinking_type + ' (' + inh + ')' : '(' + inh + ')';
+  const br = document.getElementById('reasoningBudgetRatio');
+  br.placeholder = reasoning.budget_tokens_default_ratio != null ? reasoning.budget_tokens_default_ratio + ' (' + inh + ')' : '(' + inh + ')';
+  const dsInherit = document.querySelector('#reasoningDisabled option[value=""]');
+  dsInherit.textContent = reasoning.disabled ? reasoning.disabled + ' (' + inh + ')' : '(' + inh + ')';
+  // Set values — config override if present, otherwise blank (inheriting)
+  document.getElementById('reasoningThinkingType').value = configOverride.thinking_type || '';
+  document.getElementById('reasoningBudgetRatio').value = configOverride.budget_tokens_default_ratio != null ? configOverride.budget_tokens_default_ratio : '';
+  document.getElementById('reasoningDisabled').value = configOverride.disabled || '';
 
   document.getElementById('modelModal').classList.add('open');
 }

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -688,7 +688,35 @@ body { padding-bottom: 26px; }
         <label><input type="checkbox" id="capText" checked> text</label>
         <label><input type="checkbox" id="capVision"> vision</label>
         <label><input type="checkbox" id="capTools" checked> tools</label>
-        <label><input type="checkbox" id="capReasoning"> reasoning</label>
+        <label><input type="checkbox" id="capReasoning" onchange="updateReasoningVisibility()"> reasoning</label>
+      </div>
+    </div>
+    <div class="form-group" id="modelReasoningGroup" style="display:none">
+      <label><span data-i18n="label.reasoningConfig">Reasoning Config</span>
+        <span class="badge badge-sm" id="reasoningSourceBadge" style="margin-left:6px"></span>
+      </label>
+      <div style="display:flex;flex-direction:column;gap:8px">
+        <div style="display:flex;align-items:center;gap:8px">
+          <label style="min-width:190px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.thinkingType">Thinking Type</label>
+          <select id="reasoningThinkingType" style="flex:1">
+            <option value="" data-i18n="label.inheritProvider">(inherit from provider)</option>
+            <option value="enabled">enabled</option>
+            <option value="adaptive">adaptive</option>
+          </select>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px">
+          <label style="min-width:190px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.budgetRatio">Budget Tokens Ratio</label>
+          <input id="reasoningBudgetRatio" type="number" step="0.1" min="0" max="1" placeholder="(inherit)" style="flex:1">
+        </div>
+        <div style="display:flex;align-items:center;gap:8px">
+          <label style="min-width:190px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.disabledStrategy">Disabled Strategy</label>
+          <select id="reasoningDisabled" style="flex:1">
+            <option value="" data-i18n="label.inheritProvider">(inherit from provider)</option>
+            <option value="omit">omit</option>
+            <option value="thinking_disabled">thinking_disabled</option>
+            <option value="thinking_budget_zero">thinking_budget_zero</option>
+          </select>
+        </div>
       </div>
     </div>
     <div class="modal-actions">
@@ -876,6 +904,7 @@ const I18N = {
     'label.apiKey':'API Key (or ${ENV_VAR} placeholder)', 'label.keyUnchangedHint':'Leave blank to keep current key',
     'label.proxyUrl':'Proxy URL (optional, overrides global)',
     'label.modelName':'Model Name', 'label.provider':'Provider', 'label.upstreamModel':'Upstream Model', 'label.capabilities':'Capabilities',
+    'label.reasoningConfig':'Reasoning Config', 'label.thinkingType':'Thinking Type', 'label.budgetRatio':'Budget Tokens Ratio', 'label.disabledStrategy':'Disabled Strategy', 'label.inheritProvider':'(inherit from provider)',
     'modal.addProvider':'Add Provider', 'modal.editProvider':'Edit Provider',
     'modal.addModel':'Add Model', 'modal.editModel':'Edit Model',
     'col.model':'Model', 'col.provider':'Provider', 'col.time':'Time',
@@ -978,6 +1007,7 @@ const I18N = {
     'label.apiKey':'API Key\uff08\u6216 ${ENV_VAR} \u5360\u4f4d\u7b26\uff09', 'label.keyUnchangedHint':'\u7559\u7a7a\u4ee5\u4fdd\u7559\u5f53\u524d\u5bc6\u94a5',
     'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09',
     'label.modelName':'\u6a21\u578b\u540d\u79f0', 'label.provider':'\u670d\u52a1\u5546', 'label.upstreamModel':'\u4e0a\u6e38\u6a21\u578b', 'label.capabilities':'\u80fd\u529b',
+    'label.reasoningConfig':'\u63a8\u7406\u914d\u7f6e', 'label.thinkingType':'\u601d\u8003\u7c7b\u578b', 'label.budgetRatio':'\u9884\u7b97 Token \u6bd4\u4f8b', 'label.disabledStrategy':'\u7981\u7528\u7b56\u7565', 'label.inheritProvider':'(\u7ee7\u627f\u81ea Provider)',
     'modal.addProvider':'\u6dfb\u52a0\u670d\u52a1\u5546', 'modal.editProvider':'\u7f16\u8f91\u670d\u52a1\u5546',
     'modal.addModel':'\u6dfb\u52a0\u6a21\u578b', 'modal.editModel':'\u7f16\u8f91\u6a21\u578b',
     'col.model':'\u6a21\u578b', 'col.provider':'\u670d\u52a1\u5546', 'col.time':'\u65f6\u95f4',
@@ -1398,12 +1428,31 @@ function openModelModal(model, provider, capabilities, upstreamModel) {
   document.getElementById('capTools').checked = caps.includes('tools');
   document.getElementById('capReasoning').checked = caps.includes('reasoning');
   onModelTypeChange();
+
+  // Populate reasoning config section
+  const info = model && configData ? configData.models[model] : null;
+  const reasoning = (info && info.reasoning) || {};
+  const configOverride = (info && info.reasoning_override) || {};
+  const srcBadge = document.getElementById('reasoningSourceBadge');
+  srcBadge.textContent = reasoning.source || 'none';
+  srcBadge.className = 'badge badge-sm' + (reasoning.source === 'config' ? ' badge-cap-tools' : reasoning.source === 'model_override' ? ' badge-cap-reasoning' : '');
+  // Show effective values — config override takes display priority, then shim effective
+  document.getElementById('reasoningThinkingType').value = configOverride.thinking_type || reasoning.thinking_type || '';
+  document.getElementById('reasoningBudgetRatio').value = configOverride.budget_tokens_default_ratio != null ? configOverride.budget_tokens_default_ratio : (reasoning.budget_tokens_default_ratio != null ? reasoning.budget_tokens_default_ratio : '');
+  document.getElementById('reasoningDisabled').value = configOverride.disabled || reasoning.disabled || '';
+
   document.getElementById('modelModal').classList.add('open');
 }
 
 function onModelTypeChange() {
   const isLLM = document.querySelector('input[name="modelType"]:checked').value === 'llm';
   document.getElementById('modelCapsGroup').style.display = isLLM ? '' : 'none';
+  updateReasoningVisibility();
+}
+function updateReasoningVisibility() {
+  const isLLM = document.querySelector('input[name="modelType"]:checked').value === 'llm';
+  const hasReasoning = isLLM && document.getElementById('capReasoning').checked;
+  document.getElementById('modelReasoningGroup').style.display = hasReasoning ? '' : 'none';
 }
 
 // ===================== Config Tab =====================
@@ -1749,6 +1798,17 @@ async function saveModel() {
   const body = {provider, capabilities};
   const upstreamModel = document.getElementById('modelUpstream').value.trim();
   if (upstreamModel) body.upstream_model = upstreamModel;
+  // Collect reasoning override if reasoning capability is enabled
+  if (capabilities.includes('reasoning')) {
+    const thinkingType = document.getElementById('reasoningThinkingType').value || null;
+    const budgetRatioStr = document.getElementById('reasoningBudgetRatio').value;
+    const disabledStrategy = document.getElementById('reasoningDisabled').value || null;
+    const override = {};
+    if (thinkingType) override.thinking_type = thinkingType;
+    if (budgetRatioStr !== '') override.budget_tokens_default_ratio = parseFloat(budgetRatioStr);
+    if (disabledStrategy) override.disabled = disabledStrategy;
+    if (Object.keys(override).length > 0) body.reasoning_override = override;
+  }
   const originalName = document.getElementById('modelName').dataset.originalName;
   if (originalName && originalName !== name) {
     body.rename_from = originalName;

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from llm_rosetta._vendor.httpclient import AsyncClient, Response as HttpResponse
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
-from llm_rosetta.shims import list_shims
+from llm_rosetta.shims import get_shim, list_shims
 
 from ...config import GatewayConfig, load_config_raw, write_config
 from ...providers import known_provider_types
@@ -38,6 +38,55 @@ def _get_version() -> str:
         return __version__
     except Exception:
         return "unknown"
+
+
+def _resolve_model_reasoning(
+    model_name: str,
+    entry: dict[str, Any],
+    raw_models: dict[str, Any],
+    providers: dict[str, Any],
+) -> dict[str, Any]:
+    """Resolve the effective reasoning config for a model.
+
+    Resolution priority:
+    1. config.jsonc model-level ``reasoning_override``
+    2. Shim ``model_reasoning[upstream_id]``
+    3. Shim provider-level ``reasoning``
+
+    Returns a dict with ``source`` indicating where the config came from,
+    plus the effective field values.
+    """
+    provider_name = entry.get("provider", "")
+    provider_cfg = providers.get(provider_name, {})
+    shim_name = provider_cfg.get("type") or provider_name
+    upstream = entry.get("upstream_model") or model_name
+
+    shim = get_shim(shim_name)
+    if not shim or not shim.reasoning:
+        return {"source": "none"}
+
+    cap = shim.reasoning
+    source = "provider"
+    if shim.model_reasoning and upstream in shim.model_reasoning:
+        cap = shim.model_reasoning[upstream]
+        source = "model_override"
+
+    # Check config-level override
+    raw_model = raw_models.get(model_name, {})
+    config_override = (
+        raw_model.get("reasoning_override") if isinstance(raw_model, dict) else None
+    )
+    if config_override:
+        source = "config"
+
+    return {
+        "source": source,
+        "thinking_type": cap.thinking_type,
+        "disabled": cap.disabled,
+        "effort_field": cap.effort_field,
+        "budget_tokens_default_ratio": cap.budget_tokens_default_ratio,
+        "config_override": config_override,
+    }
 
 
 async def get_config(request: Any) -> Response:
@@ -76,7 +125,15 @@ async def get_config(request: Any) -> Response:
             }
             if value.get("upstream_model"):
                 entry["upstream_model"] = value["upstream_model"]
+            if value.get("reasoning_override"):
+                entry["reasoning_override"] = value["reasoning_override"]
             models_normalized[name] = entry
+
+    # Resolve effective reasoning config per model
+    for model_name, entry in models_normalized.items():
+        entry["reasoning"] = _resolve_model_reasoning(
+            model_name, entry, raw_models, providers
+        )
 
     # Mask api_keys in server section for the response
     server = dict(raw.get("server", {}))
@@ -363,6 +420,13 @@ async def put_model(request: Any, **kwargs: Any) -> Response:
     upstream_model = body.get("upstream_model")
     if upstream_model:
         model_entry["upstream_model"] = upstream_model
+
+    # Persist per-model reasoning override (if provided)
+    reasoning_override = body.get("reasoning_override")
+    if isinstance(reasoning_override, dict):
+        cleaned = {k: v for k, v in reasoning_override.items() if v is not None}
+        if cleaned:
+            model_entry["reasoning_override"] = cleaned
     data.setdefault("models", {})[name] = model_entry
 
     try:

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -185,6 +185,8 @@ async def _proxy_handler(
 
     try:
         handler = handle_streaming if is_stream else handle_non_streaming
+        # Resolve config-level reasoning override (keyed by gateway model name)
+        reasoning_override = _config.model_reasoning_overrides.get(model)
         response = await handler(
             source_provider,
             target_provider,
@@ -194,6 +196,7 @@ async def _proxy_handler(
             metadata_store=store,
             extra_headers=extra_headers,
             target_shim_name=target_shim_name,
+            reasoning_config_override=reasoning_override,
         )
         status_code = response.status_code
         if status_code >= 400 and hasattr(response, "body"):

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -135,6 +135,13 @@ class GatewayConfig:
             self._parse_models(raw.get("models", {}), self._raw_providers)
         )
 
+        # Per-model reasoning overrides from config.jsonc (admin UI edits).
+        # Keyed by gateway model name (same as self.models keys).
+        self.model_reasoning_overrides: dict[str, dict[str, Any]] = {}
+        for model_name, value in raw.get("models", {}).items():
+            if isinstance(value, dict) and value.get("reasoning_override"):
+                self.model_reasoning_overrides[model_name] = value["reasoning_override"]
+
         _server = raw.get("server", {})
         self.host: str = _server.get("host", "0.0.0.0")
         self.port: int = _server.get("port", 8765)

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -30,6 +30,7 @@ from llm_rosetta import get_converter_for_provider
 from llm_rosetta.auto_detect import ProviderType
 from llm_rosetta.converters.base.context import ConversionContext
 from llm_rosetta.shims import get_shim
+from llm_rosetta.shims.provider_shim import ReasoningCapability
 from llm_rosetta.shims.transforms import Transform, apply_transforms
 
 
@@ -381,15 +382,18 @@ def _inject_shim_reasoning(
     ctx: ConversionContext,
     shim_name: str | None,
     model: str | None = None,
+    config_override: dict[str, Any] | None = None,
 ) -> None:
     """Inject the shim's reasoning capability config into *ctx*.
 
     If the shim has a ``reasoning`` config, it is stored in
     ``ctx.options["reasoning_cap"]`` so converters can pick it up.
 
-    When *model* is provided (typically the upstream model ID after alias
-    resolution), per-model overrides from ``shim.model_reasoning`` take
-    precedence over the provider-level config.
+    Resolution priority (highest first):
+    1. ``config_override`` — per-model override from ``config.jsonc``
+       (set via admin UI).
+    2. ``shim.model_reasoning[model]`` — per-model override from provider YAML.
+    3. ``shim.reasoning`` — provider-level default.
     """
     if shim_name is None:
         return
@@ -400,8 +404,35 @@ def _inject_shim_reasoning(
     # Model-level override (keyed by upstream model ID)
     if model and shim.model_reasoning and model in shim.model_reasoning:
         cap = shim.model_reasoning[model]
+    # Config-level override (from admin UI, keyed by gateway model name)
+    if cap is not None and config_override:
+        cap = _apply_config_reasoning_override(cap, config_override)
     if cap is not None:
         ctx.options["reasoning_cap"] = cap
+
+
+def _apply_config_reasoning_override(
+    base: ReasoningCapability,
+    override: dict[str, Any],
+) -> ReasoningCapability:
+    """Merge config-level reasoning overrides onto a base capability.
+
+    Only fields present in *override* are replaced; the rest inherit
+    from *base*.
+    """
+    return ReasoningCapability(
+        disabled=override.get("disabled", base.disabled),
+        effort_field=override.get("effort_field", base.effort_field),
+        max_effort=override.get("max_effort", base.max_effort),
+        thinking_type=override.get("thinking_type", base.thinking_type),
+        unsigned_reasoning_blocks=override.get(
+            "unsigned_reasoning_blocks", base.unsigned_reasoning_blocks
+        ),
+        effort_map=override.get("effort_map", base.effort_map),
+        budget_tokens_default_ratio=override.get(
+            "budget_tokens_default_ratio", base.budget_tokens_default_ratio
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -419,6 +450,7 @@ async def handle_non_streaming(
     metadata_store: ProviderMetadataStore | None = None,
     extra_headers: dict[str, str] | None = None,
     target_shim_name: str | None = None,
+    reasoning_config_override: dict[str, Any] | None = None,
 ) -> Response:
     """Non-streaming proxy: convert -> forward -> convert back -> respond."""
     store = metadata_store or _default_metadata_store
@@ -436,7 +468,12 @@ async def handle_non_streaming(
 
     # Inject shim reasoning capability so converters use it.
     # body["model"] is the upstream model ID (post-alias) at this point.
-    _inject_shim_reasoning(ctx, target_shim_name, model=body.get("model"))
+    _inject_shim_reasoning(
+        ctx,
+        target_shim_name,
+        model=body.get("model"),
+        config_override=reasoning_config_override,
+    )
 
     # 1. Source -> IR
     try:
@@ -697,6 +734,7 @@ async def handle_streaming(
     metadata_store: ProviderMetadataStore | None = None,
     extra_headers: dict[str, str] | None = None,
     target_shim_name: str | None = None,
+    reasoning_config_override: dict[str, Any] | None = None,
 ) -> Response | StreamingResponse:
     """Streaming proxy: convert -> forward -> stream-convert back -> SSE."""
     store = metadata_store or _default_metadata_store
@@ -713,7 +751,12 @@ async def handle_streaming(
         ctx.options["output_format"] = "rest"
 
     # Inject shim reasoning capability so converters use it.
-    _inject_shim_reasoning(ctx, target_shim_name, model=body.get("model"))
+    _inject_shim_reasoning(
+        ctx,
+        target_shim_name,
+        model=body.get("model"),
+        config_override=reasoning_config_override,
+    )
 
     # 1. Source -> IR
     try:


### PR DESCRIPTION
## Summary

Show effective reasoning config in the model edit modal with editable overrides persisted to config.jsonc.

**Depends on #287** (Haiku budget_tokens fix).

### Backend
- `GET /admin/api/config` includes `reasoning` info per model (source: provider / model_override / config)
- `PUT /admin/api/config/models` accepts `reasoning_override` dict
- `GatewayConfig` parses `model_reasoning_overrides` from config
- Proxy checks config override → shim model_override → shim provider (priority order)

### Frontend
- Collapsible reasoning section (shown when reasoning capability checked)
- Fields: Thinking Type, Budget Tokens Ratio, Disabled Strategy
- Inherit labels show effective value: `enabled (inherited)`
- Source badge: PROVIDER / MODEL_OVERRIDE / CONFIG
- i18n EN/ZH

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (1863 tests)
- [x] Visual verification via Playwright on local gateway