### PR TITLE
fix: disable effort param for Anthropic Official Haiku 4.5

### DIFF
--- a/src/llm_rosetta/shims/providers/anthropic/provider.yaml
+++ b/src/llm_rosetta/shims/providers/anthropic/provider.yaml
@@ -14,14 +14,17 @@ reasoning:
     xhigh: xhigh
     max: max
   # Anthropic Official thinking support matrix (tested 2026-06-18):
-  #   Haiku 4.5:  enabled+budget only (adaptive → 400)
+  #   Haiku 4.5:  enabled+budget only (adaptive → 400, effort → 400)
   #   Sonnet 4.6: both enabled+budget and adaptive work
   #   Opus 4.6:   both work
   #   Opus 4.7+:  adaptive only (enabled → 400)
+  # The effort param is only supported on Opus 4.5/4.6/4.7/4.8 and Sonnet 4.6.
+  # Haiku rejects it (400), so disable effort emission for Haiku.
   model_overrides:
     claude-haiku-4-5-20251001:
       thinking_type: enabled
       budget_tokens_default_ratio: 0.8
+      effort_field: none
     claude-opus-4-7:
       thinking_type: adaptive
     claude-opus-4-8:

--- a/tests/converters/test_reasoning_helpers.py
+++ b/tests/converters/test_reasoning_helpers.py
@@ -589,6 +589,31 @@ class TestCustomShim:
         assert result["thinking"]["type"] == "enabled"
         assert result["thinking"]["budget_tokens"] == 8000
 
+    def test_haiku_effort_field_none_drops_effort_keeps_thinking(self):
+        """Haiku-style cap: effort_field=none drops effort, keeps enabled+budget.
+
+        Mirrors the Anthropic Official Haiku 4.5 override — the model accepts
+        thinking.type=enabled + budget_tokens but rejects output_config.effort.
+        """
+        custom = ReasoningCapability(
+            disabled="thinking_disabled",
+            effort_field="none",
+            thinking_type="enabled",
+            effort_map={},
+            budget_tokens_default_ratio=0.8,
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto", "effort": "medium"}),
+            custom,
+            converter_type="anthropic",
+            max_tokens=8192,
+        )
+        # effort must NOT be emitted
+        assert "output_config" not in result
+        # thinking still derived from ratio
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 6553
+
     def test_custom_thinking_budget_zero_disabled(self):
         custom = ReasoningCapability(
             disabled="thinking_budget_zero",


### PR DESCRIPTION
## Summary

Found during live verification on cloud.usa2 devtest: `claude-haiku-4-5-20251001` on Anthropic Official returns `400 This model does not support the effort parameter` when a request includes `reasoning_effort`.

Per [Anthropic docs](https://platform.claude.com/docs/en/build-with-claude/effort), the `effort` parameter is supported **only** on Opus 4.5/4.6/4.7/4.8 and Sonnet 4.6 — **not** any Haiku. Our anthropic shim was emitting `output_config.effort` for all models.

## Fix

Add `effort_field: none` to the Haiku 4.5 `model_override`. This keeps the working `thinking.type=enabled` + `budget_tokens` path (which Haiku 4.5 *does* support, verified live) and drops only the unsupported `effort` field.

Only the **official anthropic** shim is changed — Argo and OpenRouter silently tolerate/drop the effort param (verified live), so no override needed there.

## Verification

- [x] Anthropic docs cross-checked (effort support list excludes Haiku)
- [x] Live test: Haiku + `thinking.type=enabled`+budget → 200 with real thinking_tokens
- [x] Live test: Haiku + effort → 400 (the bug)
- [x] New unit test `test_haiku_effort_field_none_drops_effort_keeps_thinking`
- [x] `make lint` + `make test` pass (1864 tests)