### PR TITLE
fix: prevent flash of admin content before auth check

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -1230,6 +1230,7 @@ function openSettings() {
 
 function showLoginOverlay() {
   localStorage.removeItem('admin_token');
+  document.body.classList.add('auth-pending');
   // Stop background polling timers to prevent repeated 401 → showLoginOverlay loops
   if (dashboardTimer) { clearInterval(dashboardTimer); dashboardTimer = null; }
   if (logTimer) { clearInterval(logTimer); logTimer = null; }

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -25,6 +25,11 @@
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body { font-family: var(--font); background: var(--bg); color: var(--text); min-height: 100vh; }
+/* Hide main content until auth check completes to prevent flash of unauthenticated content */
+body.auth-pending > .header,
+body.auth-pending > .tabs,
+body.auth-pending > .content,
+body.auth-pending > .db-footer { display: none !important; }
 a { color: var(--accent); text-decoration: none; }
 
 /* Header */
@@ -424,7 +429,7 @@ th.sortable.desc::after { content:'\25BC';opacity:.8; }
 body { padding-bottom: 26px; }
 </style>
 </head>
-<body>
+<body class="auth-pending">
 
 <!-- Login overlay (shown when admin_password is configured) -->
 <div class="login-overlay" id="loginOverlay" style="display:none">
@@ -1250,6 +1255,7 @@ async function doLogin() {
     if (r.ok && data.token) {
       localStorage.setItem('admin_token', data.token);
       document.getElementById('loginOverlay').style.display = 'none';
+      document.body.classList.remove('auth-pending');
       const btn = document.getElementById('logoutBtn');
       if (btn) btn.style.display = '';
       _startInactivityTracking();
@@ -1284,9 +1290,11 @@ async function checkAuthAndInit() {
         return;
       }
     }
+    document.body.classList.remove('auth-pending');
     initApp();
   } catch(e) {
     console.error('Auth check failed:', e);
+    document.body.classList.remove('auth-pending');
     initApp(); // fallback: try to load anyway
   }
 }


### PR DESCRIPTION
## Summary

- Fix flash of unauthenticated content (FOUC) on the admin page when `admin_password` is configured
- The admin UI (header, tabs, provider list, etc.) was briefly visible before the async auth check completed and the login overlay appeared
- Added `auth-pending` CSS class to `<body>` that hides main content until auth resolves, then removed in all auth-success and fallback paths

## How it works

1. `<body class="auth-pending">` — main content hidden on initial render via CSS
2. `checkAuthAndInit()` completes auth check → removes `auth-pending` class → content appears
3. `doLogin()` success → also removes `auth-pending` class
4. Login overlay remains unaffected (shown/hidden independently)