### PR TITLE
fix: refuse to start if admin_password contains unresolved env var

### DIFF
--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -148,6 +148,11 @@ class GatewayConfig:
         self.proxy: str | None = _server.get("proxy")
         self.credential_visible: bool = _server.get("credential_visible", True)
         self.admin_password: str | None = _server.get("admin_password")
+        if self.admin_password and _ENV_VAR_RE.search(self.admin_password):
+            raise ValueError(
+                "config: admin_password contains an unresolved ${...} placeholder. "
+                "Set the environment variable or use a literal password."
+            )
 
         # Request-log retention knobs (consumed by setup_admin).  Kept as
         # a raw dict here so admin layer owns the resolution policy.

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1,0 +1,48 @@
+"""Tests for gateway configuration parsing and validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_rosetta.gateway.config import GatewayConfig
+
+
+def _minimal_raw(**server_overrides) -> dict:
+    """Return a minimal valid config dict with optional server overrides."""
+    raw = {
+        "providers": {
+            "test": {
+                "api_key": "sk-test",
+                "base_url": "https://api.example.com",
+                "type": "openai",
+            }
+        },
+        "models": {"gpt-test": "test"},
+        "server": {},
+    }
+    raw["server"].update(server_overrides)
+    return raw
+
+
+class TestAdminPasswordUnresolvedEnvVar:
+    """admin_password must not contain unresolved ${...} placeholders."""
+
+    def test_reject_unresolved_placeholder(self):
+        raw = _minimal_raw(admin_password="${ADMIN_PASSWORD}")
+        with pytest.raises(ValueError, match="unresolved"):
+            GatewayConfig(raw)
+
+    def test_reject_partial_placeholder(self):
+        raw = _minimal_raw(admin_password="prefix-${SOME_VAR}-suffix")
+        with pytest.raises(ValueError, match="unresolved"):
+            GatewayConfig(raw)
+
+    def test_accept_literal_password(self):
+        raw = _minimal_raw(admin_password="my-secret-password")
+        cfg = GatewayConfig(raw)
+        assert cfg.admin_password == "my-secret-password"
+
+    def test_accept_none(self):
+        raw = _minimal_raw()
+        cfg = GatewayConfig(raw)
+        assert cfg.admin_password is None


### PR DESCRIPTION
## Summary

When `admin_password` is set to `${ADMIN_PASSWORD}` in config but the env var isn't defined, `_substitute_env_vars` leaves the literal `${ADMIN_PASSWORD}` as the password. This makes the admin panel accessible with a predictable, guessable string — a security risk in any deployment that forgets to export the variable.

This PR adds a startup check in `GatewayConfig.__init__`: if `admin_password` still contains an unresolved `${...}` placeholder after env-var substitution, the gateway raises `ValueError` and refuses to start, forcing the operator to either set the env var or use a literal password.

## Changes

- `src/llm_rosetta/gateway/config.py` — validate `admin_password` against `_ENV_VAR_RE` after assignment
- `tests/gateway/test_config.py` — new test class covering reject/accept cases

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (1868 passed)
- [x] Unresolved placeholder → `ValueError`
- [x] Partial placeholder (e.g. `prefix-${VAR}-suffix`) → `ValueError`
- [x] Literal password → accepted
- [x] No password (`None`) → accepted