### PR TITLE
fix(admin): show date in request log timestamps

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -2354,7 +2354,7 @@ function renderLogs(entries, total) {
     tbody.innerHTML = `<tr><td colspan="8" style="color:var(--text-dim)">${t('empty.logs')}</td></tr>`;
   } else {
     tbody.innerHTML = entries.map(e => {
-      const time = new Date(e.timestamp).toLocaleTimeString();
+      const time = new Date(e.timestamp).toLocaleString(undefined, {month:'2-digit', day:'2-digit', hour:'2-digit', minute:'2-digit', second:'2-digit'});
       const statusCls = e.status_code < 400 ? 'badge-ok' : 'badge-error';
       const modeBadge = e.is_stream ? '<span class="badge badge-stream">stream</span>' : '';
       const keyLabel = e.api_key_label || '—';


### PR DESCRIPTION
## Summary
- Request log entries now show date + time (e.g. "06/19, 20:25:29") instead of time only.
- Changed `toLocaleTimeString()` → `toLocaleString()` with compact month/day/hour/minute/second options.

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (1864 passed)