### PR TITLE
fix(shim): unwind parallel tool calls for Argo Gemini models

### DIFF
--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -407,6 +407,41 @@ def _apply_image_limit(
     return truncate_images(ir_request, shim.max_images, request_id=request_id)
 
 
+def _apply_tool_call_unwind(
+    ir_request: dict[str, Any],
+    shim_name: str | None,
+    *,
+    upstream_model: str | None = None,
+) -> dict[str, Any]:
+    """Unwind parallel tool calls if the target shim requires it.
+
+    When the shim declares ``unwind_parallel_tool_calls`` *and* the
+    upstream model matches ``unwind_parallel_tool_calls_pattern`` (if
+    set), parallel tool calls in the IR request are converted to
+    sequential call-result pairs.
+
+    This works around upstream gateways (e.g. Argo) whose internal
+    OpenAI→Gemini conversion does not support parallel tool calls.
+    """
+    if shim_name is None:
+        return ir_request
+    shim = get_shim(shim_name)
+    if shim is None or not shim.unwind_parallel_tool_calls:
+        return ir_request
+    if shim.unwind_parallel_tool_calls_pattern is not None:
+        import re
+
+        if not upstream_model or not re.search(
+            shim.unwind_parallel_tool_calls_pattern, upstream_model
+        ):
+            return ir_request
+    from llm_rosetta.shims.providers.argo.utils.tool_call_unwind import (
+        unwind_parallel_tool_calls_ir,
+    )
+
+    return unwind_parallel_tool_calls_ir(ir_request)
+
+
 def _inject_shim_reasoning(
     ctx: ConversionContext,
     shim_name: str | None,
@@ -521,6 +556,14 @@ async def handle_non_streaming(
         target_shim_name,
         upstream_model=body.get("model"),
         request_id=ctx.options.get("request_id", "-"),
+    )
+
+    # 1d. Unwind parallel tool calls for providers that require it
+    #     (e.g. Argo Gemini models)
+    ir_request = _apply_tool_call_unwind(
+        ir_request,
+        target_shim_name,
+        upstream_model=body.get("model"),
     )
 
     # -- body log: IR request (after source -> IR) --
@@ -812,6 +855,14 @@ async def handle_streaming(
         target_shim_name,
         upstream_model=body.get("model"),
         request_id=ctx.options.get("request_id", "-"),
+    )
+
+    # 1d. Unwind parallel tool calls for providers that require it
+    #     (e.g. Argo Gemini models)
+    ir_request = _apply_tool_call_unwind(
+        ir_request,
+        target_shim_name,
+        upstream_model=body.get("model"),
     )
 
     # -- body log: IR request (after source -> IR) --

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -135,6 +135,10 @@ class ProviderShim:
     max_images_pattern: str | None = (
         None  # regex; if set, only apply when model matches
     )
+    unwind_parallel_tool_calls: bool = False
+    unwind_parallel_tool_calls_pattern: str | None = (
+        None  # regex; if set, only apply when upstream model matches
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -177,6 +177,10 @@ def _load_single_provider(
         model_reasoning=model_reasoning,
         max_images=cfg.get("max_images"),
         max_images_pattern=cfg.get("max_images_pattern"),
+        unwind_parallel_tool_calls=bool(cfg.get("unwind_parallel_tool_calls", False)),
+        unwind_parallel_tool_calls_pattern=cfg.get(
+            "unwind_parallel_tool_calls_pattern"
+        ),
     )
     register_shim(shim)
     logger.debug("Registered provider shim: %s (base=%s)", shim.name, shim.base)

--- a/src/llm_rosetta/shims/providers/argo/openai_chat/provider.yaml
+++ b/src/llm_rosetta/shims/providers/argo/openai_chat/provider.yaml
@@ -2,6 +2,8 @@ name: argo--openai_chat
 base: openai_chat
 max_images: 50
 max_images_pattern: "^(gpt|o\\d)"
+unwind_parallel_tool_calls: true
+unwind_parallel_tool_calls_pattern: "^gemini"
 default_base_url: https://apps.inside.anl.gov/argoapi/v1
 default_api_key_env: ARGO_API_KEY
 model_id_field: internal_id

--- a/src/llm_rosetta/shims/providers/argo/utils/__init__.py
+++ b/src/llm_rosetta/shims/providers/argo/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Argo-specific utility modules.
+
+Shared helpers for the Argo provider shims (``argo--openai_chat``,
+``argo--anthropic``).  These utilities address Argo gateway quirks that
+are not part of the base conversion logic.
+"""

--- a/src/llm_rosetta/shims/providers/argo/utils/tool_call_unwind.py
+++ b/src/llm_rosetta/shims/providers/argo/utils/tool_call_unwind.py
@@ -1,0 +1,255 @@
+"""Unwind parallel tool calls into sequential call-result pairs (IR level).
+
+The Argo gateway rejects requests where a single model turn contains
+multiple ``functionCall`` parts paired with separate ``functionResponse``
+turns.  This module converts parallel tool calls into sequential
+assistant+tool message pairs so that every assistant message contains
+exactly one tool call followed by its corresponding tool result.
+
+The algorithm operates on **IR messages** (``role: "assistant"`` with
+``type: "tool_call"`` content parts, ``role: "tool"`` with
+``type: "tool_result"`` content parts).
+
+Ported from argo-proxy ``utils/tool_calls.py`` (which operates on
+OpenAI Chat format).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from llm_rosetta.types.ir import (
+    is_message,
+    is_tool_call_part,
+    is_tool_result_part,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Detection helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_parallel_tool_call_message(message: dict[str, Any]) -> bool:
+    """Check if an IR message has multiple tool_call content parts."""
+    if message.get("role") != "assistant":
+        return False
+    content = message.get("content", [])
+    tool_calls = [p for p in content if is_tool_call_part(p)]
+    return len(tool_calls) > 1
+
+
+def _collect_tool_result_messages(
+    messages: list[dict[str, Any]],
+    start_index: int,
+) -> tuple[list[dict[str, Any]], int]:
+    """Collect consecutive ``role: "tool"`` messages from *start_index*.
+
+    Returns:
+        ``(tool_messages, next_index)`` where *next_index* points to the
+        first message after the collected tool results.
+    """
+    tool_messages: list[dict[str, Any]] = []
+    j = start_index
+    while (
+        j < len(messages)
+        and is_message(messages[j])
+        and messages[j].get("role") == "tool"
+    ):
+        tool_messages.append(messages[j])
+        j += 1
+    return tool_messages, j
+
+
+# ---------------------------------------------------------------------------
+# Matching helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_result_id_map(
+    tool_messages: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Map ``tool_call_id`` → tool result message for O(1) lookup."""
+    mapping: dict[str, dict[str, Any]] = {}
+    for msg in tool_messages:
+        for part in msg.get("content", []):
+            if is_tool_result_part(part):
+                tcid = part.get("tool_call_id", "")
+                if tcid:
+                    mapping[tcid] = msg
+    return mapping
+
+
+def _find_matching_result(
+    tool_call_id: str,
+    result_id_map: dict[str, dict[str, Any]],
+    tool_messages: list[dict[str, Any]],
+    index: int,
+) -> dict[str, Any] | None:
+    """Find the matching tool result message for a given tool_call_id.
+
+    Tries ID-based matching first; falls back to positional matching.
+
+    Args:
+        tool_call_id: The tool_call_id to match.
+        result_id_map: Mapping of tool_call_id → tool result message.
+        tool_messages: Ordered list of tool messages (positional fallback).
+        index: Position index for fallback matching.
+
+    Returns:
+        The matching tool result message, or None.
+    """
+    # ID-based matching
+    if tool_call_id and tool_call_id in result_id_map:
+        logger.debug(
+            "Unwind: ID match for tool_call_id=%s",
+            tool_call_id,
+        )
+        return result_id_map[tool_call_id]
+
+    # Positional fallback
+    if index < len(tool_messages):
+        logger.debug(
+            "Unwind: positional match for tool call %d",
+            index + 1,
+        )
+        return tool_messages[index]
+
+    logger.warning(
+        "Unwind: no matching result for tool_call_id=%s (index %d)",
+        tool_call_id,
+        index,
+    )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Core unwind
+# ---------------------------------------------------------------------------
+
+
+def _create_sequential_pairs(
+    tool_call_parts: list[dict[str, Any]],
+    tool_messages: list[dict[str, Any]],
+    non_tool_call_parts: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Convert parallel tool calls into sequential call-result pairs.
+
+    Args:
+        tool_call_parts: List of tool_call content parts from the assistant.
+        tool_messages: List of corresponding tool result messages.
+        non_tool_call_parts: Non-tool-call content parts (text, reasoning)
+            from the original assistant message.
+
+    Returns:
+        List of alternating assistant and tool messages.
+    """
+    sequential: list[dict[str, Any]] = []
+    result_map = _build_result_id_map(tool_messages)
+
+    for idx, tc_part in enumerate(tool_call_parts):
+        tc_id = tc_part.get("tool_call_id", "")
+        result_msg = _find_matching_result(tc_id, result_map, tool_messages, idx)
+        if result_msg is None:
+            continue
+
+        # Build assistant message with a single tool call.
+        # First pair gets the non-tool-call parts (text, reasoning);
+        # subsequent pairs get only the tool call.
+        if idx == 0 and non_tool_call_parts:
+            content = non_tool_call_parts + [tc_part]
+        else:
+            content = [tc_part]
+
+        sequential.append({"role": "assistant", "content": content})
+        sequential.append(result_msg)
+
+    return sequential
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def unwind_parallel_tool_calls_ir(
+    ir_request: dict[str, Any],
+) -> dict[str, Any]:
+    """Unwind parallel tool calls into sequential call-result pairs.
+
+    Transforms IR messages like::
+
+        [user, assistant(tc_1, tc_2), tool(tr_1), tool(tr_2)]
+
+    into::
+
+        [user, assistant(tc_1), tool(tr_1), assistant(tc_2), tool(tr_2)]
+
+    Messages without parallel tool calls are passed through unchanged.
+    When tool call count does not match tool result count, the message
+    group is left unchanged (safety).
+
+    The original request is NOT modified; a new dict is returned only
+    when changes are needed.
+
+    Args:
+        ir_request: IR request dict with ``messages`` key.
+
+    Returns:
+        The original or a new IR request with unwound messages.
+    """
+    messages = ir_request.get("messages", [])
+    if not messages:
+        return ir_request
+
+    transformed: list[dict[str, Any]] = []
+    changed = False
+    i = 0
+
+    while i < len(messages):
+        msg = messages[i]
+
+        if _is_parallel_tool_call_message(msg):
+            content = msg.get("content", [])
+            tool_call_parts = [p for p in content if is_tool_call_part(p)]
+            non_tool_call_parts = [p for p in content if not is_tool_call_part(p)]
+            n_calls = len(tool_call_parts)
+
+            # Collect consecutive tool result messages
+            tool_messages, next_index = _collect_tool_result_messages(messages, i + 1)
+
+            if len(tool_messages) != n_calls:
+                logger.warning(
+                    "Unwind: mismatch — %d tool calls but %d tool results, "
+                    "skipping reorder",
+                    n_calls,
+                    len(tool_messages),
+                )
+                transformed.append(msg)
+                i += 1
+                continue
+
+            pairs = _create_sequential_pairs(
+                tool_call_parts, tool_messages, non_tool_call_parts
+            )
+            transformed.extend(pairs)
+            changed = True
+
+            logger.info(
+                "Unwind: converted %d parallel tool calls to %d sequential pairs",
+                n_calls,
+                len(pairs) // 2,
+            )
+
+            i = next_index
+        else:
+            transformed.append(msg)
+            i += 1
+
+    if not changed:
+        return ir_request
+
+    return {**ir_request, "messages": transformed}

--- a/tests/test_tool_call_unwind.py
+++ b/tests/test_tool_call_unwind.py
@@ -1,0 +1,273 @@
+"""Tests for Argo parallel tool call unwind utility."""
+
+from typing import Any
+
+from llm_rosetta.shims.providers.argo.utils.tool_call_unwind import (
+    unwind_parallel_tool_calls_ir,
+)
+
+
+def _tc(tool_call_id: str, name: str = "get_weather", **kwargs: Any) -> dict:
+    """Build an IR tool_call content part."""
+    return {
+        "type": "tool_call",
+        "tool_call_id": tool_call_id,
+        "tool_name": name,
+        "tool_input": kwargs or {"city": "NYC"},
+        "tool_type": "function",
+    }
+
+
+def _tr(tool_call_id: str, result: str = "Sunny") -> dict:
+    """Build an IR tool_result content part."""
+    return {
+        "type": "tool_result",
+        "tool_call_id": tool_call_id,
+        "result": result,
+    }
+
+
+class TestUnwindNoOp:
+    """Cases where unwind should NOT modify messages."""
+
+    def test_no_messages(self):
+        req = {"model": "test", "messages": []}
+        result = unwind_parallel_tool_calls_ir(req)
+        assert result is req
+
+    def test_no_tool_calls(self):
+        req = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+                {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+            ]
+        }
+        result = unwind_parallel_tool_calls_ir(req)
+        assert result is req
+
+    def test_single_tool_call(self):
+        """Single tool call should NOT be unwound."""
+        req = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "weather?"}]},
+                {"role": "assistant", "content": [_tc("c1")]},
+                {"role": "tool", "content": [_tr("c1")]},
+            ]
+        }
+        result = unwind_parallel_tool_calls_ir(req)
+        assert result is req
+
+
+class TestUnwindParallel:
+    """Cases where parallel tool calls should be unwound."""
+
+    def test_two_parallel_calls(self):
+        req = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "weather?"}]},
+                {"role": "assistant", "content": [_tc("c1"), _tc("c2", city="LA")]},
+                {"role": "tool", "content": [_tr("c1", "Sunny")]},
+                {"role": "tool", "content": [_tr("c2", "Cloudy")]},
+            ]
+        }
+        result = unwind_parallel_tool_calls_ir(req)
+        assert result is not req
+        msgs = result["messages"]
+        assert len(msgs) == 5  # user + 2*(assistant + tool)
+        # First pair
+        assert msgs[1]["role"] == "assistant"
+        tc_parts = [p for p in msgs[1]["content"] if p["type"] == "tool_call"]
+        assert len(tc_parts) == 1
+        assert tc_parts[0]["tool_call_id"] == "c1"
+        assert msgs[2]["role"] == "tool"
+        # Second pair
+        assert msgs[3]["role"] == "assistant"
+        tc_parts = [p for p in msgs[3]["content"] if p["type"] == "tool_call"]
+        assert len(tc_parts) == 1
+        assert tc_parts[0]["tool_call_id"] == "c2"
+        assert msgs[4]["role"] == "tool"
+
+    def test_three_parallel_calls(self):
+        req = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "weather?"}]},
+                {
+                    "role": "assistant",
+                    "content": [
+                        _tc("c1", city="NYC"),
+                        _tc("c2", city="LA"),
+                        _tc("c3", city="SF"),
+                    ],
+                },
+                {"role": "tool", "content": [_tr("c1", "Sunny")]},
+                {"role": "tool", "content": [_tr("c2", "Cloudy")]},
+                {"role": "tool", "content": [_tr("c3", "Rainy")]},
+            ]
+        }
+        result = unwind_parallel_tool_calls_ir(req)
+        msgs = result["messages"]
+        assert len(msgs) == 7  # user + 3*(assistant + tool)
+        for i in range(3):
+            assert msgs[1 + i * 2]["role"] == "assistant"
+            assert msgs[2 + i * 2]["role"] == "tool"
+
+    def test_preserves_non_tool_call_parts_on_first_pair(self):
+        """Text/reasoning parts go on the first unwound assistant message."""
+        req = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "weather?"}]},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "Let me check both cities"},
+                        _tc("c1"),
+                        _tc("c2", city="LA"),
+                    ],
+                },
+                {"role": "tool", "content": [_tr("c1")]},
+                {"role": "tool", "content": [_tr("c2")]},
+            ]
+        }
+        result = unwind_parallel_tool_calls_ir(req)
+        msgs = result["messages"]
+        # First assistant has text + tool_call
+        first_assistant = msgs[1]
+        assert any(p.get("type") == "text" for p in first_assistant["content"])
+        assert any(p.get("type") == "tool_call" for p in first_assistant["content"])
+        # Second assistant has only tool_call
+        second_assistant = msgs[3]
+        assert all(p.get("type") == "tool_call" for p in second_assistant["content"])
+
+
+class TestUnwindMatching:
+    """Test ID-based vs positional matching."""
+
+    def test_id_based_matching(self):
+        """Results matched by tool_call_id regardless of order."""
+        req = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "weather?"}]},
+                {"role": "assistant", "content": [_tc("c1"), _tc("c2", city="LA")]},
+                # Results in reverse order
+                {"role": "tool", "content": [_tr("c2", "Cloudy")]},
+                {"role": "tool", "content": [_tr("c1", "Sunny")]},
+            ]
+        }
+        result = unwind_parallel_tool_calls_ir(req)
+        msgs = result["messages"]
+        # c1 should be matched with its result regardless of order
+        tool_1 = msgs[2]
+        assert tool_1["content"][0]["tool_call_id"] == "c1"
+        assert tool_1["content"][0]["result"] == "Sunny"
+
+    def test_positional_fallback(self):
+        """When IDs don't match, fall back to position."""
+        req = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "weather?"}]},
+                {"role": "assistant", "content": [_tc("c1"), _tc("c2", city="LA")]},
+                # Results with different IDs
+                {"role": "tool", "content": [_tr("x1", "Sunny")]},
+                {"role": "tool", "content": [_tr("x2", "Cloudy")]},
+            ]
+        }
+        result = unwind_parallel_tool_calls_ir(req)
+        msgs = result["messages"]
+        assert len(msgs) == 5
+
+
+class TestUnwindSafety:
+    """Safety: mismatch between call count and result count."""
+
+    def test_mismatch_skips_reorder(self):
+        """When counts don't match, leave messages unchanged."""
+        req = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "weather?"}]},
+                {"role": "assistant", "content": [_tc("c1"), _tc("c2", city="LA")]},
+                # Only 1 result for 2 calls
+                {"role": "tool", "content": [_tr("c1")]},
+            ]
+        }
+        result = unwind_parallel_tool_calls_ir(req)
+        # Should not be modified (mismatch)
+        assert result is req
+
+    def test_extra_results_skips_reorder(self):
+        """More results than calls — skip reorder."""
+        req = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "weather?"}]},
+                {"role": "assistant", "content": [_tc("c1"), _tc("c2", city="LA")]},
+                {"role": "tool", "content": [_tr("c1")]},
+                {"role": "tool", "content": [_tr("c2")]},
+                {"role": "tool", "content": [_tr("c3")]},  # extra
+            ]
+        }
+        result = unwind_parallel_tool_calls_ir(req)
+        assert result is req
+
+
+class TestUnwindMultiTurn:
+    """Multi-turn conversations with mixed tool call patterns."""
+
+    def test_multi_turn_mixed(self):
+        """Conversation with both single and parallel tool calls."""
+        req = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "weather NYC?"}]},
+                # Turn 1: single call (no change)
+                {"role": "assistant", "content": [_tc("c1")]},
+                {"role": "tool", "content": [_tr("c1", "Sunny")]},
+                # Turn 2: model responds
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "NYC is sunny"}],
+                },
+                # Turn 3: user asks for more
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "now LA and SF?"}],
+                },
+                # Turn 4: parallel calls (should be unwound)
+                {
+                    "role": "assistant",
+                    "content": [_tc("c2", city="LA"), _tc("c3", city="SF")],
+                },
+                {"role": "tool", "content": [_tr("c2", "Cloudy")]},
+                {"role": "tool", "content": [_tr("c3", "Rainy")]},
+            ]
+        }
+        result = unwind_parallel_tool_calls_ir(req)
+        msgs = result["messages"]
+        # user(0), assistant(1,c1), tool(2), assistant(3,text), user(4),
+        # assistant(5,c2), tool(6), assistant(7,c3), tool(8)
+        assert len(msgs) == 9
+        # First 5 unchanged
+        assert msgs[0]["role"] == "user"
+        assert msgs[1]["role"] == "assistant"
+        assert len([p for p in msgs[1]["content"] if p["type"] == "tool_call"]) == 1
+        assert msgs[2]["role"] == "tool"
+        assert msgs[3]["role"] == "assistant"
+        assert msgs[4]["role"] == "user"
+        # Unwound parallel calls
+        assert msgs[5]["role"] == "assistant"
+        assert msgs[6]["role"] == "tool"
+        assert msgs[7]["role"] == "assistant"
+        assert msgs[8]["role"] == "tool"
+
+    def test_preserves_other_request_fields(self):
+        """Non-messages fields are preserved in the returned request."""
+        req = {
+            "model": "gemini25flash",
+            "tools": [{"type": "function", "name": "test"}],
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+                {"role": "assistant", "content": [_tc("c1"), _tc("c2", city="LA")]},
+                {"role": "tool", "content": [_tr("c1")]},
+                {"role": "tool", "content": [_tr("c2")]},
+            ],
+        }
+        result = unwind_parallel_tool_calls_ir(req)
+        assert result["model"] == "gemini25flash"
+        assert result["tools"] == [{"type": "function", "name": "test"}]


### PR DESCRIPTION
## Summary

Fixes #300. Argo gateway's internal OpenAI→Gemini conversion rejects parallel tool calls — it requires each `functionCall` to be in its own model turn with a matching `functionResponse` immediately after. This PR adds IR-level unwind logic to the Argo shim.

- **`shims/providers/argo/utils/tool_call_unwind.py`** — Core algorithm ported from argo-proxy's `utils/tool_calls.py`, adapted to operate on IR messages instead of OpenAI Chat format
- **`ProviderShim`** — New `unwind_parallel_tool_calls` + `unwind_parallel_tool_calls_pattern` fields (same pattern as `max_images` in #301)
- **Argo OpenAI Chat provider.yaml** — Enabled with pattern `^gemini` (GPT/o-series support parallel natively)
- **Gateway proxy** — `_apply_tool_call_unwind()` called in both streaming and non-streaming paths

### Root cause investigation

Tested all paths thoroughly:

| Path | 2.5 series | 3.x series |
|------|:-:|:-:|
| Google official GenAI API (split) | ✅ tolerant | ✅ tolerant |
| Google OpenAI-compat layer | ✅ auto-merges | ✅ auto-merges |
| Argo direct (:44500, no argo-proxy) | ❌ function response mismatch | ❌ function response mismatch |
| argo-proxy (:44501, has unwind) | ✅ | ✅ |

The gateway connects directly to Argo via SSH tunnel (:44500), bypassing argo-proxy's existing `reorder_parallel_tool_calls`. This PR adds equivalent logic on the gateway side.

## Test plan

- [x] 12 unit tests covering: no-op, 2/3 parallel calls, text preservation, ID vs positional matching, mismatch safety, multi-turn mixed, field preservation
- [x] `make lint` clean
- [x] `make test` — 1876 passed
- [ ] Manual verification on cloud.usa2 with `argo:gemini-2.5-flash`