### PR TITLE
fix: include image_url in is_image_part type guard

### DIFF
--- a/src/llm_rosetta/types/ir/type_guards.py
+++ b/src/llm_rosetta/types/ir/type_guards.py
@@ -51,8 +51,14 @@ def is_text_part(part: ContentPart) -> TypeGuard[TextPart]:
 
 
 def is_image_part(part: ContentPart) -> TypeGuard[ImagePart]:
-    """Check if a content part is an ImagePart."""
-    return isinstance(part, dict) and part.get("type") == "image"
+    """Check if a content part is an ImagePart.
+
+    Matches both ``type: "image"`` (Anthropic/IR canonical) and
+    ``type: "image_url"`` (OpenAI format retained in IR) so that
+    image-counting utilities (e.g. ``truncate_images``) work
+    regardless of the source format.
+    """
+    return isinstance(part, dict) and part.get("type") in ("image", "image_url")
 
 
 def is_file_part(part: ContentPart) -> TypeGuard[FilePart]:
@@ -223,6 +229,7 @@ _TYPE_STRING_MAP: dict[type, str] = {
 TYPE_CLASS_MAP: dict[str, type[ContentPart]] = {
     "text": TextPart,
     "image": ImagePart,
+    "image_url": ImagePart,  # OpenAI format alias
     "file": FilePart,
     "tool_call": ToolCallPart,
     "tool_result": ToolResultPart,

--- a/tests/test_types/ir/test_ir_types.py
+++ b/tests/test_types/ir/test_ir_types.py
@@ -283,6 +283,7 @@ class TestTypeGuards:
         expected_types = {
             "text",
             "image",
+            "image_url",  # OpenAI format alias for image
             "file",
             "tool_call",
             "tool_result",


### PR DESCRIPTION
## Summary

`is_image_part()` only matched `type: "image"` (Anthropic/IR canonical form) but not `type: "image_url"` (OpenAI format retained in IR). This caused `truncate_images()` from #301 to miss all OpenAI-format images, allowing requests with >50 images to pass through to Argo untruncated.

**Root cause**: When the source client sends images in OpenAI format (e.g. Claude Code via Responses API → gateway → Argo OpenAI), the IR retains `type: "image_url"`. The image count enforcement added in #301 used `is_image_part()` which only checked for `type: "image"`, so all `image_url` parts were invisible to the truncation logic.

**Confirmed on rosetta-dev**: 51-image request to `argo:gpt-5.5` hit the upstream "Too many images" error despite `max_images: 50` being correctly configured on the shim. No truncation warning appeared in logs.

## Changes

- `is_image_part()`: now matches both `type: "image"` and `type: "image_url"`
- `TYPE_CLASS_MAP`: added `"image_url": ImagePart` alias
- Test: updated `test_type_class_map` expected keys

Follow-up to #301. Fixes the production failure reported in #299.

## Test plan

- [x] `make test` — 1895 passed
- [x] `make lint` — clean
- [ ] Deploy to rosetta-dev and verify truncation works for OpenAI-format image requests