### PR TITLE
fix: count images inside tool_result.result for truncation

### DIFF
--- a/src/llm_rosetta/converters/base/image_limit.py
+++ b/src/llm_rosetta/converters/base/image_limit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import copy
 import logging
-from typing import Any
+from typing import Any, cast
 
 from llm_rosetta.types.ir.type_guards import is_image_part, is_tool_result_part
 
@@ -33,7 +33,7 @@ def _collect_image_positions(messages: list[Any]) -> list[_ImagePos]:
                 result = part.get("result")
                 if isinstance(result, list):
                     for block_idx, block in enumerate(result):
-                        if isinstance(block, dict) and is_image_part(block):
+                        if isinstance(block, dict) and is_image_part(cast(Any, block)):
                             positions.append((msg_idx, part_idx, block_idx))
     return positions
 
@@ -81,15 +81,23 @@ def truncate_images(
 
     placeholder = {"type": "text", "text": _PLACEHOLDER.format(limit=max_images)}
 
-    new_messages: list[Any] = copy.deepcopy(messages)
+    # Group replacements by message index so we only copy affected messages.
+    # Avoids deepcopy of the entire message list — a 200-message conversation
+    # with base64 images can be hundreds of MB; copying it all to replace one
+    # image is wasteful.
+    affected_msgs: dict[int, list[tuple[int, int | None]]] = {}
     for msg_idx, part_idx, block_idx in to_replace:
-        if block_idx is None:
-            # Direct image in message content
-            new_messages[msg_idx]["content"][part_idx] = placeholder.copy()
-        else:
-            # Image inside tool_result.result list
-            new_messages[msg_idx]["content"][part_idx]["result"][block_idx] = (
-                placeholder.copy()
-            )
+        affected_msgs.setdefault(msg_idx, []).append((part_idx, block_idx))
+
+    new_messages: list[Any] = list(messages)  # shallow copy of list
+    for msg_idx, replacements in affected_msgs.items():
+        # Deep-copy only the affected message
+        msg_copy = copy.deepcopy(messages[msg_idx])
+        for part_idx, block_idx in replacements:
+            if block_idx is None:
+                msg_copy["content"][part_idx] = placeholder.copy()
+            else:
+                msg_copy["content"][part_idx]["result"][block_idx] = placeholder.copy()
+        new_messages[msg_idx] = msg_copy
 
     return {**ir_request, "messages": new_messages}

--- a/src/llm_rosetta/converters/base/image_limit.py
+++ b/src/llm_rosetta/converters/base/image_limit.py
@@ -10,9 +10,6 @@ from llm_rosetta.types.ir.type_guards import is_image_part, is_tool_result_part
 
 logger = logging.getLogger(__name__)
 
-# Placeholder text for replaced images.
-_PLACEHOLDER = "[image omitted: provider limit of {limit} images per request]"
-
 # Position types for image locations in the IR.
 # Direct: (msg_idx, part_idx, None)  — image in message content
 # Nested: (msg_idx, part_idx, block_idx)  — image inside tool_result.result list
@@ -79,7 +76,10 @@ def truncate_images(
         max_images,
     )
 
-    placeholder = {"type": "text", "text": _PLACEHOLDER.format(limit=max_images)}
+    placeholder = {
+        "type": "text",
+        "text": f"[image omitted: provider limit of {max_images} images per request]",
+    }
 
     # Group replacements by message index so we only copy affected messages.
     # Avoids deepcopy of the entire message list — a 200-message conversation

--- a/src/llm_rosetta/converters/base/image_limit.py
+++ b/src/llm_rosetta/converters/base/image_limit.py
@@ -2,12 +2,40 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 from typing import Any
 
-from llm_rosetta.types.ir.type_guards import is_image_part
+from llm_rosetta.types.ir.type_guards import is_image_part, is_tool_result_part
 
 logger = logging.getLogger(__name__)
+
+# Placeholder text for replaced images.
+_PLACEHOLDER = "[image omitted: provider limit of {limit} images per request]"
+
+# Position types for image locations in the IR.
+# Direct: (msg_idx, part_idx, None)  — image in message content
+# Nested: (msg_idx, part_idx, block_idx)  — image inside tool_result.result list
+_ImagePos = tuple[int, int, int | None]
+
+
+def _collect_image_positions(messages: list[Any]) -> list[_ImagePos]:
+    """Find all image positions in messages, including inside tool results.
+
+    Returns positions in conversation order (oldest first).
+    """
+    positions: list[_ImagePos] = []
+    for msg_idx, msg in enumerate(messages):
+        for part_idx, part in enumerate(msg.get("content", [])):
+            if is_image_part(part):
+                positions.append((msg_idx, part_idx, None))
+            elif is_tool_result_part(part):
+                result = part.get("result")
+                if isinstance(result, list):
+                    for block_idx, block in enumerate(result):
+                        if isinstance(block, dict) and is_image_part(block):
+                            positions.append((msg_idx, part_idx, block_idx))
+    return positions
 
 
 def truncate_images(
@@ -21,6 +49,10 @@ def truncate_images(
     Strategy: keep the MOST RECENT images; replace earlier ones with a
     text placeholder so the conversation context is preserved.
 
+    Scans both direct message content and images embedded inside
+    ``tool_result.result`` lists (which the OpenAI Chat converter
+    unpacks into synthetic user messages with ``image_url`` parts).
+
     Args:
         ir_request: The IR request dict to inspect/modify.
         max_images: Maximum number of image parts allowed.
@@ -30,19 +62,14 @@ def truncate_images(
         The original dict if no truncation needed, otherwise a shallow copy
         with ``messages`` replaced by a new list with excess images replaced.
     """
-    # Collect all (msg_idx, part_idx) for image parts, in order
     messages = ir_request.get("messages", [])
-    image_positions: list[tuple[int, int]] = []
-    for msg_idx, msg in enumerate(messages):
-        for part_idx, part in enumerate(msg.get("content", [])):
-            if is_image_part(part):
-                image_positions.append((msg_idx, part_idx))
+    image_positions = _collect_image_positions(messages)
 
     total = len(image_positions)
     if total <= max_images:
         return ir_request
 
-    # Keep the last max_images, truncate the rest
+    # Keep the last max_images, truncate the rest (oldest first)
     to_replace = image_positions[: total - max_images]
     logger.warning(
         "[%s] truncated %d images to %d (provider limit of %d)",
@@ -52,14 +79,17 @@ def truncate_images(
         max_images,
     )
 
-    # Build new messages list with placeholders
-    import copy
+    placeholder = {"type": "text", "text": _PLACEHOLDER.format(limit=max_images)}
 
     new_messages: list[Any] = copy.deepcopy(messages)
-    for msg_idx, part_idx in to_replace:
-        new_messages[msg_idx]["content"][part_idx] = {
-            "type": "text",
-            "text": f"[image omitted: provider limit of {max_images} images per request]",
-        }
+    for msg_idx, part_idx, block_idx in to_replace:
+        if block_idx is None:
+            # Direct image in message content
+            new_messages[msg_idx]["content"][part_idx] = placeholder.copy()
+        else:
+            # Image inside tool_result.result list
+            new_messages[msg_idx]["content"][part_idx]["result"][block_idx] = (
+                placeholder.copy()
+            )
 
     return {**ir_request, "messages": new_messages}

--- a/tests/converters/test_image_limit.py
+++ b/tests/converters/test_image_limit.py
@@ -84,6 +84,111 @@ class TestTruncateImages:
         assert req["messages"][0]["content"] == original_content
 
 
+class TestTruncateToolResultImages:
+    """Images embedded in tool_result.result lists must also be counted."""
+
+    def _make_tool_result_request(
+        self, direct_images: int, tool_result_images: int
+    ) -> dict:
+        """Build a request with images in both content and tool results."""
+        content: list[dict] = []
+        for i in range(direct_images):
+            content.append(
+                {"type": "image", "image_url": f"https://example.com/img{i}.png"}
+            )
+        content.append(
+            {
+                "type": "tool_result",
+                "tool_call_id": "call_1",
+                "result": [
+                    {
+                        "type": "image",
+                        "image_data": {
+                            "data": f"base64data{i}",
+                            "media_type": "image/png",
+                        },
+                    }
+                    for i in range(tool_result_images)
+                ],
+            }
+        )
+        return {"messages": [{"role": "user", "content": content}]}
+
+    def _total_images(self, req: dict) -> int:
+        """Count all images including those in tool results."""
+        count = 0
+        for msg in req["messages"]:
+            for part in msg.get("content", []):
+                if part.get("type") in ("image", "image_url"):
+                    count += 1
+                elif part.get("type") == "tool_result":
+                    result = part.get("result")
+                    if isinstance(result, list):
+                        count += sum(
+                            1
+                            for b in result
+                            if isinstance(b, dict)
+                            and b.get("type") in ("image", "image_url")
+                        )
+        return count
+
+    def test_tool_result_images_counted(self):
+        """49 direct + 2 in tool result = 51, should truncate to 50."""
+        req = self._make_tool_result_request(49, 2)
+        assert self._total_images(req) == 51
+        result = truncate_images(req, 50)
+        assert result is not req
+        assert self._total_images(result) == 50
+
+    def test_tool_result_only_images(self):
+        """All images inside tool results, none direct."""
+        req = self._make_tool_result_request(0, 55)
+        assert self._total_images(req) == 55
+        result = truncate_images(req, 50)
+        assert self._total_images(result) == 50
+
+    def test_no_truncation_with_tool_results(self):
+        """Images in tool results under limit — no truncation."""
+        req = self._make_tool_result_request(20, 10)
+        assert self._total_images(req) == 30
+        result = truncate_images(req, 50)
+        assert result is req
+
+    def test_mixed_keeps_most_recent(self):
+        """Oldest images replaced first, whether direct or in tool results."""
+        # 2 direct images (oldest), then tool result with 2 images, limit 3
+        content: list[dict] = [
+            {"type": "image", "image_url": "https://example.com/old1.png"},
+            {"type": "image", "image_url": "https://example.com/old2.png"},
+            {
+                "type": "tool_result",
+                "tool_call_id": "call_1",
+                "result": [
+                    {
+                        "type": "image",
+                        "image_data": {"data": "new1", "media_type": "image/png"},
+                    },
+                    {
+                        "type": "image",
+                        "image_data": {"data": "new2", "media_type": "image/png"},
+                    },
+                ],
+            },
+        ]
+        req = {"messages": [{"role": "user", "content": content}]}
+        result = truncate_images(req, 3)
+        # Oldest direct image replaced, 3 kept (1 direct + 2 in tool result)
+        assert self._total_images(result) == 3
+
+    def test_original_not_mutated_with_tool_results(self):
+        req = self._make_tool_result_request(49, 2)
+        import copy
+
+        original = copy.deepcopy(req)
+        truncate_images(req, 50)
+        assert req == original
+
+
 class TestApplyImageLimitPattern:
     """Tests for model-scoped max_images_pattern logic."""
 


### PR DESCRIPTION
## Summary

`truncate_images()` only scanned direct message content parts for images, missing images embedded inside `tool_result.result` lists. The OpenAI Chat converter unpacks tool result images into synthetic user messages with `image_url` parts — so a request could have ≤50 images at the IR level but exceed 50 after conversion.

### Root cause

Claude Code sessions accumulate screenshots in tool results (e.g. `computer_use` output, file previews). These images live in `ToolResultPart.result` as nested content blocks, not as direct message content parts. `truncate_images()` wasn't scanning this nested level.

### Fix

`_collect_image_positions()` now scans both:
1. Direct message content: `messages[].content[]` where `is_image_part(part)`
2. Tool result images: `messages[].content[].result[]` where part is `tool_result` and result blocks contain images

Position tracking extended to 3-tuple `(msg_idx, part_idx, block_idx | None)` to handle both levels.

### Testing

5 new tests covering:
- Mixed direct + tool result images exceeding limit
- Tool-result-only images
- Under-limit with tool results (no truncation)
- Oldest-first replacement across both levels
- Original not mutated

Confirmed on rosetta-dev: 51-image request to `argo:gpt-5.5` where 49 were direct images and 2 were in tool results — previously passed truncation, now caught.

Fixes #299

## Related

- #301 — original image truncation implementation
- #306 — `is_image_part` type guard fix for `image_url`
- #307 — planned refactor to move truncation into converter layer