### PR TITLE
feat: strip images for non-vision models at runtime

### DIFF
--- a/src/llm_rosetta/converters/base/helpers/image_limit.py
+++ b/src/llm_rosetta/converters/base/helpers/image_limit.py
@@ -1,4 +1,4 @@
-"""Image truncation for providers with max_images limits."""
+"""Image handling for providers with max_images limits or no vision support."""
 
 from __future__ import annotations
 
@@ -9,6 +9,10 @@ from typing import Any, cast
 from llm_rosetta.types.ir.type_guards import is_image_part, is_tool_result_part
 
 logger = logging.getLogger(__name__)
+
+# Placeholders for different image removal scenarios.
+_PLACEHOLDER_NO_VISION = {"type": "text", "text": "[image not available]"}
+_PLACEHOLDER_LIMIT = {"type": "text", "text": "[image omitted due to limit]"}
 
 # Position types for image locations in the IR.
 # Direct: (msg_idx, part_idx, None)  — image in message content
@@ -33,6 +37,44 @@ def _collect_image_positions(messages: list[Any]) -> list[_ImagePos]:
                         if isinstance(block, dict) and is_image_part(cast(Any, block)):
                             positions.append((msg_idx, part_idx, block_idx))
     return positions
+
+
+def _replace_images(
+    ir_request: dict[str, Any],
+    positions: list[_ImagePos],
+    placeholder: dict[str, str],
+) -> dict[str, Any]:
+    """Replace image parts at the given positions with placeholders.
+
+    Only deep-copies affected messages to avoid copying hundreds of MB
+    of base64 image data in large conversations.
+
+    Args:
+        ir_request: The IR request dict.
+        positions: List of (msg_idx, part_idx, block_idx) to replace.
+        placeholder: The text part dict to use as replacement.
+
+    Returns:
+        A new IR request dict with affected messages replaced.
+    """
+    messages = ir_request.get("messages", [])
+
+    # Group by message index to minimize copies
+    affected_msgs: dict[int, list[tuple[int, int | None]]] = {}
+    for msg_idx, part_idx, block_idx in positions:
+        affected_msgs.setdefault(msg_idx, []).append((part_idx, block_idx))
+
+    new_messages: list[Any] = list(messages)  # shallow copy of list
+    for msg_idx, replacements in affected_msgs.items():
+        msg_copy = copy.deepcopy(messages[msg_idx])
+        for part_idx, block_idx in replacements:
+            if block_idx is None:
+                msg_copy["content"][part_idx] = placeholder.copy()
+            else:
+                msg_copy["content"][part_idx]["result"][block_idx] = placeholder.copy()
+        new_messages[msg_idx] = msg_copy
+
+    return {**ir_request, "messages": new_messages}
 
 
 def truncate_images(
@@ -76,28 +118,40 @@ def truncate_images(
         max_images,
     )
 
-    placeholder = {
-        "type": "text",
-        "text": f"[image omitted: provider limit of {max_images} images per request]",
-    }
+    return _replace_images(ir_request, to_replace, _PLACEHOLDER_LIMIT)
 
-    # Group replacements by message index so we only copy affected messages.
-    # Avoids deepcopy of the entire message list — a 200-message conversation
-    # with base64 images can be hundreds of MB; copying it all to replace one
-    # image is wasteful.
-    affected_msgs: dict[int, list[tuple[int, int | None]]] = {}
-    for msg_idx, part_idx, block_idx in to_replace:
-        affected_msgs.setdefault(msg_idx, []).append((part_idx, block_idx))
 
-    new_messages: list[Any] = list(messages)  # shallow copy of list
-    for msg_idx, replacements in affected_msgs.items():
-        # Deep-copy only the affected message
-        msg_copy = copy.deepcopy(messages[msg_idx])
-        for part_idx, block_idx in replacements:
-            if block_idx is None:
-                msg_copy["content"][part_idx] = placeholder.copy()
-            else:
-                msg_copy["content"][part_idx]["result"][block_idx] = placeholder.copy()
-        new_messages[msg_idx] = msg_copy
+def strip_images_for_non_vision(
+    ir_request: dict[str, Any],
+    *,
+    model: str = "",
+    request_id: str = "-",
+) -> dict[str, Any]:
+    """Strip ALL images from an IR request for a non-vision model.
 
-    return {**ir_request, "messages": new_messages}
+    Replaces every image part (direct and inside tool results) with a
+    ``[image not available]`` text placeholder.
+
+    Args:
+        ir_request: The IR request dict to inspect/modify.
+        model: Model name for log messages.
+        request_id: Used in log messages for traceability.
+
+    Returns:
+        The original dict if no images found, otherwise a new dict
+        with all images replaced by text placeholders.
+    """
+    messages = ir_request.get("messages", [])
+    image_positions = _collect_image_positions(messages)
+
+    if not image_positions:
+        return ir_request
+
+    logger.warning(
+        "[%s] stripped %d images: model %s does not have vision capability",
+        request_id,
+        len(image_positions),
+        model,
+    )
+
+    return _replace_images(ir_request, image_positions, _PLACEHOLDER_NO_VISION)

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -200,6 +200,7 @@ async def _proxy_handler(
         handler = handle_streaming if is_stream else handle_non_streaming
         # Resolve config-level reasoning override (keyed by gateway model name)
         reasoning_override = _config.model_reasoning_overrides.get(model)
+        model_caps = _config.model_capabilities.get(model, ["text"])
         response = await handler(
             source_provider,
             target_provider,
@@ -210,6 +211,7 @@ async def _proxy_handler(
             extra_headers=extra_headers,
             target_shim_name=target_shim_name,
             reasoning_config_override=reasoning_override,
+            model_capabilities=model_caps,
         )
         status_code = response.status_code
         if status_code >= 400 and hasattr(response, "body"):

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -442,6 +442,23 @@ def _apply_tool_call_unwind(
     return unwind_parallel_tool_calls_ir(ir_request)
 
 
+def _strip_non_vision_images(
+    ir_request: dict[str, Any],
+    model_capabilities: list[str],
+    *,
+    model: str = "",
+    request_id: str = "-",
+) -> dict[str, Any]:
+    """Strip all images if the model does not have vision capability."""
+    if "vision" in model_capabilities:
+        return ir_request
+    from llm_rosetta.converters.base.helpers.image_limit import (
+        strip_images_for_non_vision,
+    )
+
+    return strip_images_for_non_vision(ir_request, model=model, request_id=request_id)
+
+
 def _inject_shim_reasoning(
     ctx: ConversionContext,
     shim_name: str | None,
@@ -515,6 +532,7 @@ async def handle_non_streaming(
     extra_headers: dict[str, str] | None = None,
     target_shim_name: str | None = None,
     reasoning_config_override: dict[str, Any] | None = None,
+    model_capabilities: list[str] | None = None,
 ) -> Response:
     """Non-streaming proxy: convert -> forward -> convert back -> respond."""
     store = metadata_store or _default_metadata_store
@@ -550,15 +568,26 @@ async def handle_non_streaming(
     # 1b. Restore cached provider_metadata (e.g. Google thought_signature)
     store.inject_into_request(ir_request)
 
-    # 1c. Enforce per-shim image count limit (e.g. Argo GPT/o*: 50 images max)
+    request_id = ctx.options.get("request_id", "-")
+
+    # 1c. Strip images for non-vision models (e.g. DeepSeek text-only)
+    if model_capabilities is not None:
+        ir_request = _strip_non_vision_images(
+            ir_request,
+            model_capabilities,
+            model=model,
+            request_id=request_id,
+        )
+
+    # 1d. Enforce per-shim image count limit (e.g. Argo GPT/o*: 50 images max)
     ir_request = _apply_image_limit(
         ir_request,
         target_shim_name,
         upstream_model=body.get("model"),
-        request_id=ctx.options.get("request_id", "-"),
+        request_id=request_id,
     )
 
-    # 1d. Unwind parallel tool calls for providers that require it
+    # 1e. Unwind parallel tool calls for providers that require it
     #     (e.g. Argo Gemini models)
     ir_request = _apply_tool_call_unwind(
         ir_request,
@@ -815,6 +844,7 @@ async def handle_streaming(
     extra_headers: dict[str, str] | None = None,
     target_shim_name: str | None = None,
     reasoning_config_override: dict[str, Any] | None = None,
+    model_capabilities: list[str] | None = None,
 ) -> Response | StreamingResponse:
     """Streaming proxy: convert -> forward -> stream-convert back -> SSE."""
     store = metadata_store or _default_metadata_store
@@ -849,15 +879,26 @@ async def handle_streaming(
     # 1b. Inject cached provider_metadata (e.g. Google thought_signature)
     store.inject_into_request(ir_request)
 
-    # 1c. Enforce per-shim image count limit (e.g. Argo GPT/o*: 50 images max)
+    request_id = ctx.options.get("request_id", "-")
+
+    # 1c. Strip images for non-vision models (e.g. DeepSeek text-only)
+    if model_capabilities is not None:
+        ir_request = _strip_non_vision_images(
+            ir_request,
+            model_capabilities,
+            model=model,
+            request_id=request_id,
+        )
+
+    # 1d. Enforce per-shim image count limit (e.g. Argo GPT/o*: 50 images max)
     ir_request = _apply_image_limit(
         ir_request,
         target_shim_name,
         upstream_model=body.get("model"),
-        request_id=ctx.options.get("request_id", "-"),
+        request_id=request_id,
     )
 
-    # 1d. Unwind parallel tool calls for providers that require it
+    # 1e. Unwind parallel tool calls for providers that require it
     #     (e.g. Argo Gemini models)
     ir_request = _apply_tool_call_unwind(
         ir_request,

--- a/tests/converters/test_image_limit.py
+++ b/tests/converters/test_image_limit.py
@@ -30,7 +30,11 @@ def _count_placeholders(ir_request: dict) -> int:
         1
         for msg in ir_request["messages"]
         for part in msg.get("content", [])
-        if part.get("type") == "text" and "image omitted" in part.get("text", "")
+        if part.get("type") == "text"
+        and (
+            "image omitted" in part.get("text", "")
+            or "image not available" in part.get("text", "")
+        )
     )
 
 
@@ -73,8 +77,7 @@ class TestTruncateImages:
         req = _make_request([3])
         result = truncate_images(req, 2)
         placeholder = result["messages"][0]["content"][0]
-        assert "50" not in placeholder["text"] or "2" in placeholder["text"]
-        assert "image omitted" in placeholder["text"]
+        assert "image omitted due to limit" in placeholder["text"]
 
     def test_original_not_mutated(self):
         req = _make_request([3])
@@ -240,3 +243,77 @@ class TestApplyImageLimitPattern:
         req = _make_request([60])
         result = self._apply(req, 50, None, "gemini-2.0-flash")
         assert _count_images(result) == 50
+
+
+class TestStripImagesForNonVision:
+    """Tests for strip_images_for_non_vision."""
+
+    def test_strips_all_images(self):
+        req = _make_request([5])
+        from llm_rosetta.converters.base.helpers.image_limit import (
+            strip_images_for_non_vision,
+        )
+
+        result = strip_images_for_non_vision(req, model="deepseek-v4-pro")
+        assert _count_images(result) == 0
+        assert _count_placeholders(result) == 5
+
+    def test_placeholder_text(self):
+        req = _make_request([1])
+        from llm_rosetta.converters.base.helpers.image_limit import (
+            strip_images_for_non_vision,
+        )
+
+        result = strip_images_for_non_vision(req, model="test")
+        placeholder = result["messages"][0]["content"][0]
+        assert placeholder["text"] == "[image not available]"
+
+    def test_no_images_returns_same_object(self):
+        req = {
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        }
+        from llm_rosetta.converters.base.helpers.image_limit import (
+            strip_images_for_non_vision,
+        )
+
+        result = strip_images_for_non_vision(req, model="test")
+        assert result is req
+
+    def test_strips_tool_result_images(self):
+        content: list[dict] = [
+            {"type": "image", "image_url": "https://example.com/1.png"},
+            {
+                "type": "tool_result",
+                "tool_call_id": "call_1",
+                "result": [
+                    {
+                        "type": "image",
+                        "image_data": {"data": "abc", "media_type": "image/png"},
+                    },
+                ],
+            },
+        ]
+        req = {"messages": [{"role": "user", "content": content}]}
+        from llm_rosetta.converters.base.helpers.image_limit import (
+            strip_images_for_non_vision,
+        )
+
+        result = strip_images_for_non_vision(req, model="deepseek")
+        # Both direct and tool result images stripped
+        assert result["messages"][0]["content"][0]["text"] == "[image not available]"
+        assert (
+            result["messages"][0]["content"][1]["result"][0]["text"]
+            == "[image not available]"
+        )
+
+    def test_original_not_mutated(self):
+        req = _make_request([3])
+        import copy
+
+        original = copy.deepcopy(req)
+        from llm_rosetta.converters.base.helpers.image_limit import (
+            strip_images_for_non_vision,
+        )
+
+        strip_images_for_non_vision(req, model="test")
+        assert req == original


### PR DESCRIPTION
## Summary

Models without `vision` capability now have all images automatically stripped (replaced with `[image not available]`) instead of being forwarded to upstream where they cause opaque errors.

### Problem (production, 2026-06-21)

```
anthropic -> openai_chat | model=deepseek-v4-pro
ERROR: Failed to deserialize the JSON body: unknown variant `image_url`, expected `text`
```

DeepSeek v4-pro has no vision capability but Claude Code sessions accumulate screenshots naturally. The gateway forwarded them verbatim.

### Solution

- **Non-vision models**: all images → `[image not available]`
- **Provider image limit exceeded**: oldest images → `[image omitted due to limit]`
- Both placeholders are short and context-neutral — models naturally respond with "I can't see images"
- Gateway logs a warning with image count and model name

### Changes

- `image_limit.py`: new `strip_images_for_non_vision()`, refactored `_replace_images()` with parameterized placeholder
- `proxy.py`: new `_strip_non_vision_images()`, called in both streaming and non-streaming paths before `_apply_image_limit`
- `app.py`: passes `model_capabilities` to handlers
- 5 new tests for vision stripping, updated existing placeholder assertions

Fixes #313

## Related

- #299 / #301 / #308 — image truncation infrastructure
- #307 — planned refactor to move all IR transforms into converter layer