### PR TITLE
feat(gateway): Unix domain socket support via --socket/-S

### DIFF
--- a/src/llm_rosetta/_vendor/httpserver.py
+++ b/src/llm_rosetta/_vendor/httpserver.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.1.1"
+# version = "0.2.0"
 # deps = []
 # tier = "subsystem"
 # category = "network"
@@ -947,33 +947,44 @@ class App:
         self,
         host: str = DEFAULT_HOST,
         port: int = DEFAULT_PORT,
+        *,
+        socket: str | None = None,
     ) -> None:
         """Start the server (blocking).
 
         Args:
-            host: Bind address.
-            port: Bind port. Use ``0`` for OS-assigned port.
+            host: Bind address (ignored when *socket* is set).
+            port: Bind port. Use ``0`` for OS-assigned port (ignored when
+                *socket* is set).
+            socket: Unix domain socket path. When set, the server listens
+                on a Unix socket instead of TCP. The socket file permissions
+                are restricted to owner-only (``0o600``) after creation.
+                Only available on Unix-like systems.
         """
         try:
-            asyncio.run(self._serve(host, port))
+            asyncio.run(self._serve(host, port, socket=socket))
         except KeyboardInterrupt:
             pass
 
-    async def _serve(self, host: str, port: int) -> None:
+    async def _serve(self, host: str, port: int, *, socket: str | None = None) -> None:
         """Internal async server loop."""
         self._shutdown_event = asyncio.Event()
+        self._socket_path: str | None = None
 
-        server = await asyncio.start_server(
-            self._handle_connection,
-            host,
-            port,
-        )
+        if socket:
+            server = await self._start_unix_socket(socket)
+        else:
+            server = await asyncio.start_server(
+                self._handle_connection,
+                host,
+                port,
+            )
+            addrs = server.sockets[0].getsockname() if server.sockets else (host, port)
+            self.host = addrs[0]
+            self.port = addrs[1]
+            logger.info("Serving on %s:%d", self.host, self.port)
 
         self._server = server
-        addrs = server.sockets[0].getsockname() if server.sockets else (host, port)
-        self.host = addrs[0]
-        self.port = addrs[1]
-        logger.info("Serving on %s:%d", self.host, self.port)
 
         loop = asyncio.get_running_loop()
         if sys.platform != "win32":
@@ -983,6 +994,70 @@ class App:
         async with server:
             await self._shutdown_event.wait()
             logger.info("Shutting down server")
+            if self._socket_path:
+                self._cleanup_socket()
+
+    async def _start_unix_socket(self, socket_path: str) -> asyncio.Server:
+        """Start listening on a Unix domain socket.
+
+        Handles stale socket cleanup, permission hardening (``0o600``),
+        and registers the path for shutdown cleanup.
+
+        Args:
+            socket_path: Path for the Unix domain socket file.
+
+        Returns:
+            The ``asyncio.Server`` instance.
+
+        Raises:
+            SystemExit: If the path exists but is not a socket, or the
+                parent directory does not exist.
+        """
+        import stat as stat_mod
+
+        path = os.path.realpath(socket_path)
+
+        # Remove stale socket if present
+        if os.path.exists(path):
+            try:
+                st = os.stat(path)
+                if stat_mod.S_ISSOCK(st.st_mode):
+                    os.unlink(path)
+                    logger.info("Removed stale socket: %s", path)
+                else:
+                    logger.error("Socket path exists and is not a socket: %s", path)
+                    sys.exit(1)
+            except OSError as exc:
+                logger.error("Cannot remove stale socket %s: %s", path, exc)
+                sys.exit(1)
+
+        # Ensure parent directory exists
+        parent = os.path.dirname(path)
+        if not os.path.isdir(parent):
+            logger.error("Socket parent directory does not exist: %s", parent)
+            sys.exit(1)
+
+        server = await asyncio.start_unix_server(
+            self._handle_connection,
+            path=path,
+        )
+
+        # Restrict permissions to owner-only
+        if os.path.exists(path):
+            os.chmod(path, 0o600)
+
+        self._socket_path = path
+        logger.info("Serving on unix:%s (mode 0600)", path)
+        return server
+
+    def _cleanup_socket(self) -> None:
+        """Remove the Unix socket file on shutdown."""
+        if self._socket_path and os.path.exists(self._socket_path):
+            try:
+                os.unlink(self._socket_path)
+                logger.info("Removed socket: %s", self._socket_path)
+            except OSError:
+                pass
 
     def shutdown(self) -> None:
         """Request a graceful server shutdown.

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -557,14 +557,16 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
     return app
 
 
-async def run_gateway(app: App, host: str, port: int) -> None:
+async def run_gateway(
+    app: App, host: str, port: int, *, socket: str | None = None
+) -> None:
     """Start the gateway with lifecycle management."""
     # Expose bind address so admin test tasks can self-call.
     setattr(app, "_bind_host", host)
     setattr(app, "_bind_port", port)
     flush_task = asyncio.create_task(_periodic_flush(app))
     try:
-        await app._serve(host, port)
+        await app._serve(host, port, socket=socket)
     finally:
         flush_task.cancel()
         try:

--- a/src/llm_rosetta/gateway/cli.py
+++ b/src/llm_rosetta/gateway/cli.py
@@ -238,6 +238,12 @@ def main() -> None:
     parser.add_argument("--host", default=None, help="Override server host")
     parser.add_argument("--port", type=int, default=None, help="Override server port")
     parser.add_argument(
+        "--socket",
+        "-S",
+        default=None,
+        help="Listen on a Unix domain socket instead of TCP (e.g. /run/user/1000/rosetta.sock)",
+    )
+    parser.add_argument(
         "--proxy",
         default=None,
         help="HTTP/SOCKS proxy URL for upstream requests (overrides config)",
@@ -346,9 +352,13 @@ def main() -> None:
 
     host = args.host or config.host
     port = args.port or config.port
+    socket_path = args.socket or config.socket
 
     logger.info("Config loaded from %s", config_path)
-    logger.info("Starting llm-rosetta gateway on %s:%d", host, port)
+    if socket_path:
+        logger.info("Starting llm-rosetta gateway on unix:%s", socket_path)
+    else:
+        logger.info("Starting llm-rosetta gateway on %s:%d", host, port)
     logger.info("Configured providers: %s", list(config.providers.keys()))
     logger.info("Configured models: %s", list(config.models.keys()))
     if verbose:
@@ -361,6 +371,6 @@ def main() -> None:
     from .app import run_gateway
 
     try:
-        asyncio.run(run_gateway(app, host, port))
+        asyncio.run(run_gateway(app, host, port, socket=socket_path))
     except KeyboardInterrupt:
         pass

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -146,6 +146,7 @@ class GatewayConfig:
         self.host: str = _server.get("host", "0.0.0.0")
         self.port: int = _server.get("port", 8765)
         self.proxy: str | None = _server.get("proxy")
+        self.socket: str | None = _server.get("socket")
         self.credential_visible: bool = _server.get("credential_visible", True)
         self.admin_password: str | None = _server.get("admin_password")
         if self.admin_password and _ENV_VAR_RE.search(self.admin_password):


### PR DESCRIPTION
## Summary

Add Unix domain socket listening support to the gateway, matching the feature added to argo-proxy in [Oaklight/zerodep#103](https://github.com/Oaklight/zerodep/pull/103).

### Usage

```bash
llm-rosetta-gateway --socket /run/user/$(id -u)/rosetta.sock
```

Or in `config.jsonc`:
```jsonc
{ "server": { "socket": "/run/user/1000/rosetta.sock" } }
```

CLI `--socket` flag takes precedence over config.

### Use case

Secure deployments on shared multi-user hosts (e.g. HPC login nodes) where binding to `127.0.0.1` still exposes the service to all local users. Combined with SSH `LocalForward` to a Unix socket path, the entire access chain is locked down end-to-end.

### Changes

1. **`_vendor/httpserver.py`**: updated to v0.2.0 from zerodep v2026.6.21 — adds `App.run(socket=...)` with stale socket cleanup, 0600 permissions, and shutdown cleanup
2. **`gateway/config.py`**: `GatewayConfig` gains `socket: str | None` field from `server.socket` config
3. **`gateway/cli.py`**: `--socket/-S` CLI flag, passed through to `run_gateway()`
4. **`gateway/app.py`**: `run_gateway()` accepts `socket` kwarg, passes to `app._serve()`

## Test plan

- [x] `make test` — 1905 passed
- [x] `make lint` — clean
- [ ] Manual: `llm-rosetta-gateway --socket /tmp/test.sock` → verify socket created, `curl --unix-socket /tmp/test.sock http://localhost/health` works, socket removed on Ctrl+C