### PR TITLE
fix: restore legacy converters/base import paths (v0.6.12)

### DIFF
--- a/src/llm_rosetta/__init__.py
+++ b/src/llm_rosetta/__init__.py
@@ -35,7 +35,7 @@ from .shims import (
     unregister_shim,
 )
 
-__version__ = "0.6.11"
+__version__ = "0.6.12"
 
 __all__ = [
     # Converters

--- a/src/llm_rosetta/converters/base/cache.py
+++ b/src/llm_rosetta/converters/base/cache.py
@@ -1,0 +1,40 @@
+"""Backward-compatibility shim for ``llm_rosetta.converters.base.cache``.
+
+This module moved to ``llm_rosetta.converters.base.helpers.cache`` in v0.6.11.
+It is re-exported here so the old import path keeps working.  The cache
+singletons (``tool_entry_cache``, ``sanitize_cache``, ``ir_validation_cache``)
+are the same objects as in the canonical module — importing from either path
+shares one cache.
+
+New code should import from ``llm_rosetta.converters.base.helpers`` instead.
+"""
+
+from .helpers.cache import (
+    LRUCache,
+    cache_info,
+    clear_all_caches,
+    entry_cache_key,
+    get_cached_tool,
+    ir_validation_cache,
+    is_ir_validated,
+    mark_ir_validated,
+    put_cached_tool,
+    sanitize_cache,
+    schema_cache_key,
+    tool_entry_cache,
+)
+
+__all__ = [
+    "LRUCache",
+    "cache_info",
+    "clear_all_caches",
+    "entry_cache_key",
+    "get_cached_tool",
+    "ir_validation_cache",
+    "is_ir_validated",
+    "mark_ir_validated",
+    "put_cached_tool",
+    "sanitize_cache",
+    "schema_cache_key",
+    "tool_entry_cache",
+]

--- a/src/llm_rosetta/converters/base/schema.py
+++ b/src/llm_rosetta/converters/base/schema.py
@@ -1,0 +1,11 @@
+"""Backward-compatibility shim for ``llm_rosetta.converters.base.schema``.
+
+This module moved to ``llm_rosetta.converters.base.helpers.schema`` in
+v0.6.11.  It is re-exported here so the old import path keeps working.
+
+New code should import from ``llm_rosetta.converters.base.helpers`` instead.
+"""
+
+from .helpers.schema import sanitize_schema
+
+__all__ = ["sanitize_schema"]

--- a/src/llm_rosetta/converters/base/tool_content.py
+++ b/src/llm_rosetta/converters/base/tool_content.py
@@ -1,0 +1,17 @@
+"""Backward-compatibility shim for ``llm_rosetta.converters.base.tool_content``.
+
+This module moved to ``llm_rosetta.converters.base.helpers.tool_content`` in
+v0.6.11.  It is re-exported here so the old import path keeps working.
+
+New code should import from ``llm_rosetta.converters.base.helpers`` instead.
+"""
+
+from .helpers.tool_content import (
+    convert_content_blocks_to_ir,
+    convert_ir_content_blocks_to_p,
+)
+
+__all__ = [
+    "convert_content_blocks_to_ir",
+    "convert_ir_content_blocks_to_p",
+]

--- a/src/llm_rosetta/converters/base/tools.py
+++ b/src/llm_rosetta/converters/base/tools.py
@@ -21,6 +21,20 @@ from ...types.ir import (
 )
 from ...types.ir.tools import ToolCallConfig
 
+# Backward-compatibility re-exports.  These utilities moved to the ``helpers``
+# subpackage in v0.6.11, but external callers (e.g. argo-proxy) historically
+# imported them from this module via
+# ``from llm_rosetta.converters.base.tools import sanitize_schema``.
+# Re-export them here so the old import paths keep working.  The canonical
+# location is ``llm_rosetta.converters.base.helpers``.
+from .helpers.schema import sanitize_schema  # noqa: F401
+from .helpers.tool_orphan_fix import (  # noqa: F401
+    extract_part_ids,
+    fix_orphaned_tool_calls_ir,
+    log_orphan_warnings,
+    strip_orphaned_tool_config,
+)
+
 
 class BaseToolOps(ABC):
     """Abstract base class for tool conversion operations.


### PR DESCRIPTION
## What

Patch release **v0.6.12** restoring backward compatibility broken by the v0.6.11 `helpers/` reorganization (#310).

## Why

v0.6.11 moved `sanitize_schema`, the orphan-fix utilities, and the `cache`/`schema`/`tool_content` modules into `converters/base/helpers/`. This silently broke import paths external callers relied on — e.g. argo-proxy's `from llm_rosetta.converters.base.tools import sanitize_schema` started raising `ImportError`, breaking `argo-proxy serve`.

## Changes

- Re-export `sanitize_schema`, `extract_part_ids`, `log_orphan_warnings`, `fix_orphaned_tool_calls_ir`, `strip_orphaned_tool_config` from `converters.base.tools`
- Add compat shim modules at `converters.base.schema`, `converters.base.tool_content`, `converters.base.cache` redirecting to their `helpers/` locations
- Cache singletons shared across both paths (verified by identity check)
- Bump version 0.6.11 → 0.6.12
- Changelog updated in both `docs_en` and `docs_zh`

Canonical path remains `llm_rosetta.converters.base.helpers`; the old paths keep working without changes.

## Verification

- All legacy import paths confirmed restored; cache singleton identity verified
- `make lint` ✅ `make test` ✅ (1905 passed) `ty check` ✅

AI was used to assist with implementation.