### PR TITLE
refactor: unify shim-driven IR transforms into shims/pipeline.py

### DIFF
--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -30,7 +30,7 @@ from llm_rosetta import get_converter_for_provider
 from llm_rosetta.auto_detect import ProviderType
 from llm_rosetta.converters.base.context import ConversionContext
 from llm_rosetta.shims import get_shim
-from llm_rosetta.shims.provider_shim import ReasoningCapability
+from llm_rosetta.shims.pipeline import apply_shim_to_ir, setup_shim_context
 from llm_rosetta.shims.transforms import Transform, apply_transforms
 
 
@@ -378,144 +378,6 @@ def _resolve_target_transforms(
     return shim.from_transforms, shim.to_transforms
 
 
-def _apply_image_limit(
-    ir_request: dict[str, Any],
-    shim_name: str | None,
-    *,
-    upstream_model: str | None = None,
-    request_id: str = "-",
-) -> dict[str, Any]:
-    """Truncate images in *ir_request* if the target shim declares max_images.
-
-    When the shim also declares ``max_images_pattern``, truncation only fires
-    when *upstream_model* matches the pattern (re.search).  This allows a
-    single provider (e.g. Argo) to enforce limits only for the model families
-    that actually have them (e.g. gpt-*, o*) while leaving others untouched.
-    """
-    if shim_name is None:
-        return ir_request
-    shim = get_shim(shim_name)
-    if shim is None or shim.max_images is None:
-        return ir_request
-    if shim.max_images_pattern is not None:
-        import re
-
-        if not upstream_model or not re.search(shim.max_images_pattern, upstream_model):
-            return ir_request
-    from llm_rosetta.converters.base.helpers.image_limit import truncate_images
-
-    return truncate_images(ir_request, shim.max_images, request_id=request_id)
-
-
-def _apply_tool_call_unwind(
-    ir_request: dict[str, Any],
-    shim_name: str | None,
-    *,
-    upstream_model: str | None = None,
-) -> dict[str, Any]:
-    """Unwind parallel tool calls if the target shim requires it.
-
-    When the shim declares ``unwind_parallel_tool_calls`` *and* the
-    upstream model matches ``unwind_parallel_tool_calls_pattern`` (if
-    set), parallel tool calls in the IR request are converted to
-    sequential call-result pairs.
-
-    This works around upstream gateways (e.g. Argo) whose internal
-    OpenAI→Gemini conversion does not support parallel tool calls.
-    """
-    if shim_name is None:
-        return ir_request
-    shim = get_shim(shim_name)
-    if shim is None or not shim.unwind_parallel_tool_calls:
-        return ir_request
-    if shim.unwind_parallel_tool_calls_pattern is not None:
-        import re
-
-        if not upstream_model or not re.search(
-            shim.unwind_parallel_tool_calls_pattern, upstream_model
-        ):
-            return ir_request
-    from llm_rosetta.converters.base.helpers.tool_call_unwind import (
-        unwind_parallel_tool_calls_ir,
-    )
-
-    return unwind_parallel_tool_calls_ir(ir_request)
-
-
-def _strip_non_vision_images(
-    ir_request: dict[str, Any],
-    model_capabilities: list[str],
-    *,
-    model: str = "",
-    request_id: str = "-",
-) -> dict[str, Any]:
-    """Strip all images if the model does not have vision capability."""
-    if "vision" in model_capabilities:
-        return ir_request
-    from llm_rosetta.converters.base.helpers.image_limit import (
-        strip_images_for_non_vision,
-    )
-
-    return strip_images_for_non_vision(ir_request, model=model, request_id=request_id)
-
-
-def _inject_shim_reasoning(
-    ctx: ConversionContext,
-    shim_name: str | None,
-    model: str | None = None,
-    config_override: dict[str, Any] | None = None,
-) -> None:
-    """Inject the shim's reasoning capability config into *ctx*.
-
-    If the shim has a ``reasoning`` config, it is stored in
-    ``ctx.options["reasoning_cap"]`` so converters can pick it up.
-
-    Resolution priority (highest first):
-    1. ``config_override`` — per-model override from ``config.jsonc``
-       (set via admin UI).
-    2. ``shim.model_reasoning[model]`` — per-model override from provider YAML.
-    3. ``shim.reasoning`` — provider-level default.
-    """
-    if shim_name is None:
-        return
-    shim = get_shim(shim_name)
-    if shim is None:
-        return
-    cap = shim.reasoning
-    # Model-level override (keyed by upstream model ID)
-    if model and shim.model_reasoning and model in shim.model_reasoning:
-        cap = shim.model_reasoning[model]
-    # Config-level override (from admin UI, keyed by gateway model name)
-    if cap is not None and config_override:
-        cap = _apply_config_reasoning_override(cap, config_override)
-    if cap is not None:
-        ctx.options["reasoning_cap"] = cap
-
-
-def _apply_config_reasoning_override(
-    base: ReasoningCapability,
-    override: dict[str, Any],
-) -> ReasoningCapability:
-    """Merge config-level reasoning overrides onto a base capability.
-
-    Only fields present in *override* are replaced; the rest inherit
-    from *base*.
-    """
-    return ReasoningCapability(
-        disabled=override.get("disabled", base.disabled),
-        effort_field=override.get("effort_field", base.effort_field),
-        max_effort=override.get("max_effort", base.max_effort),
-        thinking_type=override.get("thinking_type", base.thinking_type),
-        unsigned_reasoning_blocks=override.get(
-            "unsigned_reasoning_blocks", base.unsigned_reasoning_blocks
-        ),
-        effort_map=override.get("effort_map", base.effort_map),
-        budget_tokens_default_ratio=override.get(
-            "budget_tokens_default_ratio", base.budget_tokens_default_ratio
-        ),
-    )
-
-
 # ---------------------------------------------------------------------------
 # Core proxy handlers
 # ---------------------------------------------------------------------------
@@ -549,8 +411,7 @@ async def handle_non_streaming(
         ctx.options["output_format"] = "rest"
 
     # Inject shim reasoning capability so converters use it.
-    # body["model"] is the upstream model ID (post-alias) at this point.
-    _inject_shim_reasoning(
+    setup_shim_context(
         ctx,
         target_shim_name,
         model=body.get("model"),
@@ -570,29 +431,13 @@ async def handle_non_streaming(
 
     request_id = ctx.options.get("request_id", "-")
 
-    # 1c. Strip images for non-vision models (e.g. DeepSeek text-only)
-    if model_capabilities is not None:
-        ir_request = _strip_non_vision_images(
-            ir_request,
-            model_capabilities,
-            model=model,
-            request_id=request_id,
-        )
-
-    # 1d. Enforce per-shim image count limit (e.g. Argo GPT/o*: 50 images max)
-    ir_request = _apply_image_limit(
+    # 1c–1e. Shim-driven IR transforms (non-vision strip, image limit, unwind)
+    ir_request = apply_shim_to_ir(
         ir_request,
         target_shim_name,
         upstream_model=body.get("model"),
+        model_capabilities=model_capabilities,
         request_id=request_id,
-    )
-
-    # 1e. Unwind parallel tool calls for providers that require it
-    #     (e.g. Argo Gemini models)
-    ir_request = _apply_tool_call_unwind(
-        ir_request,
-        target_shim_name,
-        upstream_model=body.get("model"),
     )
 
     # -- body log: IR request (after source -> IR) --
@@ -861,7 +706,7 @@ async def handle_streaming(
         ctx.options["output_format"] = "rest"
 
     # Inject shim reasoning capability so converters use it.
-    _inject_shim_reasoning(
+    setup_shim_context(
         ctx,
         target_shim_name,
         model=body.get("model"),
@@ -881,29 +726,13 @@ async def handle_streaming(
 
     request_id = ctx.options.get("request_id", "-")
 
-    # 1c. Strip images for non-vision models (e.g. DeepSeek text-only)
-    if model_capabilities is not None:
-        ir_request = _strip_non_vision_images(
-            ir_request,
-            model_capabilities,
-            model=model,
-            request_id=request_id,
-        )
-
-    # 1d. Enforce per-shim image count limit (e.g. Argo GPT/o*: 50 images max)
-    ir_request = _apply_image_limit(
+    # 1c–1e. Shim-driven IR transforms (non-vision strip, image limit, unwind)
+    ir_request = apply_shim_to_ir(
         ir_request,
         target_shim_name,
         upstream_model=body.get("model"),
+        model_capabilities=model_capabilities,
         request_id=request_id,
-    )
-
-    # 1e. Unwind parallel tool calls for providers that require it
-    #     (e.g. Argo Gemini models)
-    ir_request = _apply_tool_call_unwind(
-        ir_request,
-        target_shim_name,
-        upstream_model=body.get("model"),
     )
 
     # -- body log: IR request (after source -> IR) --

--- a/src/llm_rosetta/shims/__init__.py
+++ b/src/llm_rosetta/shims/__init__.py
@@ -9,6 +9,7 @@ Public API:
 - **Registration** (startup): ``register_shim``, ``load_providers_from_dir``
 - **Query** (per request): ``get_shim``, ``list_shims``, ``resolve_base``
 - **Transforms**: ``apply_transforms``, ``strip_fields``, ``rename_field``, ``set_defaults``
+- **Pipeline**: ``setup_shim_context``, ``apply_shim_to_ir``
 """
 
 from .provider_shim import (
@@ -49,4 +50,9 @@ __all__ = [
     "rename_field",
     "set_defaults",
     "load_providers_from_dir",
+    # Pipeline
+    "apply_shim_to_ir",
+    "setup_shim_context",
 ]
+
+from .pipeline import apply_shim_to_ir, setup_shim_context  # noqa: E402

--- a/src/llm_rosetta/shims/pipeline.py
+++ b/src/llm_rosetta/shims/pipeline.py
@@ -1,0 +1,208 @@
+"""Unified shim pipeline — single entry points for shim-driven transforms.
+
+Provides two public functions that encapsulate all shim-driven behavior
+so consumers (gateway, argo-proxy, etc.) don't need to manually wire
+each shim field.  This is the "Phase 2a" of the conversion pipeline:
+
+- :func:`setup_shim_context` — inject reasoning config into the
+  :class:`~llm_rosetta.converters.base.context.ConversionContext`
+  before conversion begins.
+- :func:`apply_shim_to_ir` — apply all IR-level shim transforms
+  (image stripping, image limit, tool call unwind) after
+  source → IR conversion.
+
+Both functions accept a ``ProviderShim`` instance, a registered shim
+name (``str``), or ``None`` (no-op).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.shims.provider_shim import ProviderShim, ReasoningCapability, get_shim
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_shim(shim: ProviderShim | str | None) -> ProviderShim | None:
+    """Resolve a shim argument to a ProviderShim instance.
+
+    Args:
+        shim: A ProviderShim instance, a registered name, or None.
+
+    Returns:
+        The resolved ProviderShim, or None.
+    """
+    if shim is None:
+        return None
+    if isinstance(shim, ProviderShim):
+        return shim
+    return get_shim(shim)
+
+
+def _apply_config_reasoning_override(
+    base: ReasoningCapability,
+    override: dict[str, Any],
+) -> ReasoningCapability:
+    """Merge config-level reasoning overrides onto a base capability.
+
+    Only fields present in *override* are replaced; the rest inherit
+    from *base*.
+
+    Args:
+        base: The base reasoning capability from the shim.
+        override: A dict of field overrides (e.g. from admin UI).
+
+    Returns:
+        A new ReasoningCapability with merged values.
+    """
+    return ReasoningCapability(
+        disabled=override.get("disabled", base.disabled),
+        effort_field=override.get("effort_field", base.effort_field),
+        max_effort=override.get("max_effort", base.max_effort),
+        thinking_type=override.get("thinking_type", base.thinking_type),
+        unsigned_reasoning_blocks=override.get(
+            "unsigned_reasoning_blocks", base.unsigned_reasoning_blocks
+        ),
+        effort_map=override.get("effort_map", base.effort_map),
+        budget_tokens_default_ratio=override.get(
+            "budget_tokens_default_ratio", base.budget_tokens_default_ratio
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def setup_shim_context(
+    ctx: ConversionContext,
+    shim: ProviderShim | str | None,
+    *,
+    model: str | None = None,
+    config_override: dict[str, Any] | None = None,
+) -> None:
+    """Inject shim-driven options into a ConversionContext.
+
+    Currently injects ``reasoning_cap`` so converters produce the correct
+    thinking/reasoning output for the target provider.
+
+    Resolution priority (highest first):
+
+    1. *config_override* — per-model override from external config
+       (e.g. gateway admin UI).
+    2. ``shim.model_reasoning[model]`` — per-model override from the
+       provider YAML.
+    3. ``shim.reasoning`` — provider-level default.
+
+    Args:
+        ctx: Conversion context to mutate.
+        shim: ProviderShim instance, registered name, or None (no-op).
+        model: Upstream model ID (for per-model reasoning overrides).
+        config_override: External reasoning override (highest priority).
+    """
+    resolved = _resolve_shim(shim)
+    if resolved is None:
+        return
+
+    cap = resolved.reasoning
+    # Model-level override (keyed by upstream model ID)
+    if model and resolved.model_reasoning and model in resolved.model_reasoning:
+        cap = resolved.model_reasoning[model]
+    # Config-level override (from admin UI, keyed by gateway model name)
+    if cap is not None and config_override:
+        cap = _apply_config_reasoning_override(cap, config_override)
+    if cap is not None:
+        ctx.options["reasoning_cap"] = cap
+
+
+def apply_shim_to_ir(
+    ir_request: dict[str, Any],
+    shim: ProviderShim | str | None,
+    *,
+    upstream_model: str | None = None,
+    model_capabilities: list[str] | None = None,
+    request_id: str = "-",
+) -> dict[str, Any]:
+    """Apply all shim-driven IR-level transforms in canonical order.
+
+    Operations applied (in order):
+
+    1. **Strip non-vision images** — if *model_capabilities* is provided
+       and does not include ``"vision"``, replace all images with text
+       placeholders.  Driven by the caller, not by the shim.
+    2. **Enforce image count limit** — if the shim declares
+       ``max_images`` (and the upstream model matches
+       ``max_images_pattern`` when set), truncate excess images.
+    3. **Unwind parallel tool calls** — if the shim declares
+       ``unwind_parallel_tool_calls`` (and the upstream model matches
+       ``unwind_parallel_tool_calls_pattern`` when set), split parallel
+       tool calls into sequential call-result pairs.
+
+    All operations are no-ops when the corresponding shim field is unset
+    or when the pattern guard doesn't match.
+
+    Args:
+        ir_request: The IR request dict (modified in-place where possible).
+        shim: ProviderShim instance, registered name, or None (no-op).
+        upstream_model: The upstream model ID (for pattern matching).
+        model_capabilities: Model capability list (e.g. ``["text", "vision"]``).
+            When ``None``, the non-vision image stripping step is skipped.
+        request_id: Request identifier for logging.
+
+    Returns:
+        The (possibly modified) IR request dict.
+    """
+    # 1. Strip images for non-vision models (caller-driven, not shim-driven)
+    if model_capabilities is not None and "vision" not in model_capabilities:
+        from llm_rosetta.converters.base.helpers.image_limit import (
+            strip_images_for_non_vision,
+        )
+
+        ir_request = strip_images_for_non_vision(
+            ir_request, model=upstream_model or "", request_id=request_id
+        )
+
+    resolved = _resolve_shim(shim)
+    if resolved is None:
+        return ir_request
+
+    # 2. Enforce per-shim image count limit
+    if resolved.max_images is not None:
+        apply_limit = True
+        if resolved.max_images_pattern is not None:
+            apply_limit = bool(
+                upstream_model
+                and re.search(resolved.max_images_pattern, upstream_model)
+            )
+        if apply_limit:
+            from llm_rosetta.converters.base.helpers.image_limit import truncate_images
+
+            ir_request = truncate_images(
+                ir_request, resolved.max_images, request_id=request_id
+            )
+
+    # 3. Unwind parallel tool calls
+    if resolved.unwind_parallel_tool_calls:
+        apply_unwind = True
+        if resolved.unwind_parallel_tool_calls_pattern is not None:
+            apply_unwind = bool(
+                upstream_model
+                and re.search(
+                    resolved.unwind_parallel_tool_calls_pattern, upstream_model
+                )
+            )
+        if apply_unwind:
+            from llm_rosetta.converters.base.helpers.tool_call_unwind import (
+                unwind_parallel_tool_calls_ir,
+            )
+
+            ir_request = unwind_parallel_tool_calls_ir(ir_request)
+
+    return ir_request

--- a/tests/test_shim_pipeline.py
+++ b/tests/test_shim_pipeline.py
@@ -1,6 +1,7 @@
 """Tests for llm_rosetta.shims.pipeline — unified shim entry points."""
 
 import copy
+from typing import Any
 
 import pytest
 
@@ -38,9 +39,9 @@ _MODEL_REASONING_CAP = ReasoningCapability(
 )
 
 
-def _make_shim(**kwargs):
+def _make_shim(**kwargs: Any) -> ProviderShim:
     """Create a ProviderShim with sensible defaults, overridable via kwargs."""
-    defaults = dict(name="test-shim", base="openai_chat")
+    defaults: dict[str, Any] = dict(name="test-shim", base="openai_chat")
     defaults.update(kwargs)
     return ProviderShim(**defaults)
 
@@ -53,9 +54,11 @@ def _register_cleanup():
         unregister_shim(name)
 
 
-def _simple_ir_request(n_messages=1, n_images=0):
+def _simple_ir_request(n_messages: int = 1, n_images: int = 0) -> dict[str, Any]:
     """Build a minimal IR request dict for testing."""
-    content = [{"type": "text", "text": f"message {i}"} for i in range(n_messages)]
+    content: list[dict[str, Any]] = [
+        {"type": "text", "text": f"message {i}"} for i in range(n_messages)
+    ]
     for i in range(n_images):
         content.append(
             {

--- a/tests/test_shim_pipeline.py
+++ b/tests/test_shim_pipeline.py
@@ -1,0 +1,403 @@
+"""Tests for llm_rosetta.shims.pipeline — unified shim entry points."""
+
+import copy
+
+import pytest
+
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.shims.pipeline import (
+    _apply_config_reasoning_override,
+    _resolve_shim,
+    apply_shim_to_ir,
+    setup_shim_context,
+)
+from llm_rosetta.shims.provider_shim import (
+    ProviderShim,
+    ReasoningCapability,
+    register_shim,
+    unregister_shim,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_REASONING_CAP = ReasoningCapability(
+    disabled="omit",
+    effort_field="reasoning_effort",
+    effort_map={"low": "low", "medium": "medium", "high": "high"},
+)
+
+_MODEL_REASONING_CAP = ReasoningCapability(
+    disabled="thinking_disabled",
+    effort_field="output_config.effort",
+    thinking_type="enabled",
+    effort_map={"low": "low", "high": "high"},
+    budget_tokens_default_ratio=0.8,
+)
+
+
+def _make_shim(**kwargs):
+    """Create a ProviderShim with sensible defaults, overridable via kwargs."""
+    defaults = dict(name="test-shim", base="openai_chat")
+    defaults.update(kwargs)
+    return ProviderShim(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def _register_cleanup():
+    """Ensure test shims are cleaned up after each test."""
+    yield
+    for name in ("test-shim", "test-shim-img", "test-shim-unwind"):
+        unregister_shim(name)
+
+
+def _simple_ir_request(n_messages=1, n_images=0):
+    """Build a minimal IR request dict for testing."""
+    content = [{"type": "text", "text": f"message {i}"} for i in range(n_messages)]
+    for i in range(n_images):
+        content.append(
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "data": f"img{i}",
+                    "media_type": "image/png",
+                },
+            }
+        )
+    return {
+        "messages": [{"role": "user", "content": content}],
+        "tools": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# _resolve_shim
+# ---------------------------------------------------------------------------
+
+
+class TestResolveShim:
+    def test_none(self):
+        assert _resolve_shim(None) is None
+
+    def test_provider_shim_instance(self):
+        shim = _make_shim()
+        assert _resolve_shim(shim) is shim
+
+    def test_registered_name(self):
+        shim = _make_shim()
+        register_shim(shim)
+        assert _resolve_shim("test-shim") is shim
+
+    def test_unknown_name(self):
+        assert _resolve_shim("nonexistent-shim") is None
+
+
+# ---------------------------------------------------------------------------
+# setup_shim_context
+# ---------------------------------------------------------------------------
+
+
+class TestSetupShimContext:
+    def test_none_shim_is_noop(self):
+        ctx = ConversionContext()
+        setup_shim_context(ctx, None)
+        assert "reasoning_cap" not in ctx.options
+
+    def test_shim_without_reasoning_is_noop(self):
+        ctx = ConversionContext()
+        shim = _make_shim(reasoning=None)
+        setup_shim_context(ctx, shim)
+        assert "reasoning_cap" not in ctx.options
+
+    def test_provider_level_reasoning(self):
+        ctx = ConversionContext()
+        shim = _make_shim(reasoning=_REASONING_CAP)
+        setup_shim_context(ctx, shim)
+        assert ctx.options["reasoning_cap"] is _REASONING_CAP
+
+    def test_model_level_override(self):
+        ctx = ConversionContext()
+        shim = _make_shim(
+            reasoning=_REASONING_CAP,
+            model_reasoning={"gpt-4": _MODEL_REASONING_CAP},
+        )
+        setup_shim_context(ctx, shim, model="gpt-4")
+        assert ctx.options["reasoning_cap"] is _MODEL_REASONING_CAP
+
+    def test_model_not_in_overrides_falls_back(self):
+        ctx = ConversionContext()
+        shim = _make_shim(
+            reasoning=_REASONING_CAP,
+            model_reasoning={"gpt-4": _MODEL_REASONING_CAP},
+        )
+        setup_shim_context(ctx, shim, model="gpt-3.5")
+        assert ctx.options["reasoning_cap"] is _REASONING_CAP
+
+    def test_config_override_highest_priority(self):
+        ctx = ConversionContext()
+        shim = _make_shim(reasoning=_REASONING_CAP)
+        setup_shim_context(ctx, shim, config_override={"thinking_type": "adaptive"})
+        cap = ctx.options["reasoning_cap"]
+        assert cap.thinking_type == "adaptive"
+        # Other fields inherited from base
+        assert cap.disabled == _REASONING_CAP.disabled
+        assert cap.effort_field == _REASONING_CAP.effort_field
+
+    def test_config_override_on_model_override(self):
+        """Config override should apply on top of model-level override."""
+        ctx = ConversionContext()
+        shim = _make_shim(
+            reasoning=_REASONING_CAP,
+            model_reasoning={"gpt-4": _MODEL_REASONING_CAP},
+        )
+        setup_shim_context(
+            ctx, shim, model="gpt-4", config_override={"disabled": "block"}
+        )
+        cap = ctx.options["reasoning_cap"]
+        assert cap.disabled == "block"
+        # Rest inherited from model-level
+        assert cap.thinking_type == _MODEL_REASONING_CAP.thinking_type
+
+    def test_accepts_registered_name(self):
+        ctx = ConversionContext()
+        shim = _make_shim(reasoning=_REASONING_CAP)
+        register_shim(shim)
+        setup_shim_context(ctx, "test-shim")
+        assert ctx.options["reasoning_cap"] is _REASONING_CAP
+
+    def test_unknown_name_is_noop(self):
+        ctx = ConversionContext()
+        setup_shim_context(ctx, "nonexistent")
+        assert "reasoning_cap" not in ctx.options
+
+
+# ---------------------------------------------------------------------------
+# apply_shim_to_ir
+# ---------------------------------------------------------------------------
+
+
+class TestApplyShimToIr:
+    def test_none_shim_passthrough(self):
+        ir = _simple_ir_request()
+        original = copy.deepcopy(ir)
+        result = apply_shim_to_ir(ir, None)
+        assert result == original
+
+    def test_shim_no_features_passthrough(self):
+        ir = _simple_ir_request()
+        original = copy.deepcopy(ir)
+        shim = _make_shim()
+        result = apply_shim_to_ir(ir, shim)
+        assert result == original
+
+    def test_strip_non_vision_when_no_vision_cap(self):
+        """Images should be stripped when model lacks vision capability."""
+        ir = _simple_ir_request(n_images=3)
+        result = apply_shim_to_ir(
+            ir, None, model_capabilities=["text"], upstream_model="deepseek-chat"
+        )
+        # Images should be replaced with text placeholders
+        content = result["messages"][0]["content"]
+        image_parts = [p for p in content if p.get("type") == "image"]
+        assert len(image_parts) == 0
+
+    def test_no_strip_when_vision_cap(self):
+        """Images should NOT be stripped when model has vision capability."""
+        ir = _simple_ir_request(n_images=3)
+        original = copy.deepcopy(ir)
+        result = apply_shim_to_ir(
+            ir, None, model_capabilities=["text", "vision"], upstream_model="gpt-4o"
+        )
+        assert result == original
+
+    def test_no_strip_when_caps_none(self):
+        """Images should NOT be stripped when model_capabilities is None."""
+        ir = _simple_ir_request(n_images=3)
+        original = copy.deepcopy(ir)
+        result = apply_shim_to_ir(ir, None, model_capabilities=None)
+        assert result == original
+
+    def test_image_limit_enforced(self):
+        """Shim with max_images should truncate excess images."""
+        ir = _simple_ir_request(n_images=5)
+        shim = _make_shim(name="test-shim-img", max_images=2)
+        result = apply_shim_to_ir(ir, shim)
+        content = result["messages"][0]["content"]
+        image_parts = [p for p in content if p.get("type") == "image"]
+        assert len(image_parts) <= 2
+
+    def test_image_limit_pattern_match(self):
+        """Image limit should only fire when model matches pattern."""
+        ir = _simple_ir_request(n_images=5)
+        shim = _make_shim(name="test-shim-img", max_images=2, max_images_pattern="^gpt")
+        # Matching model
+        result = apply_shim_to_ir(copy.deepcopy(ir), shim, upstream_model="gpt-4o")
+        content = result["messages"][0]["content"]
+        image_parts = [p for p in content if p.get("type") == "image"]
+        assert len(image_parts) <= 2
+
+    def test_image_limit_pattern_no_match(self):
+        """Image limit should NOT fire when model doesn't match pattern."""
+        ir = _simple_ir_request(n_images=5)
+        shim = _make_shim(name="test-shim-img", max_images=2, max_images_pattern="^gpt")
+        result = apply_shim_to_ir(copy.deepcopy(ir), shim, upstream_model="gemini-pro")
+        content = result["messages"][0]["content"]
+        image_parts = [p for p in content if p.get("type") == "image"]
+        assert len(image_parts) == 5  # untouched
+
+    def test_unwind_parallel_tool_calls(self):
+        """Shim with unwind should split parallel tool calls."""
+        ir = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_call",
+                            "tool_call_id": "call_1",
+                            "tool_name": "fn_a",
+                            "tool_input": {},
+                            "tool_type": "function",
+                        },
+                        {
+                            "type": "tool_call",
+                            "tool_call_id": "call_2",
+                            "tool_name": "fn_b",
+                            "tool_input": {},
+                            "tool_type": "function",
+                        },
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_call_id": "call_1",
+                            "result": "a",
+                        },
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_call_id": "call_2",
+                            "result": "b",
+                        },
+                    ],
+                },
+            ],
+            "tools": [],
+        }
+        shim = _make_shim(name="test-shim-unwind", unwind_parallel_tool_calls=True)
+        result = apply_shim_to_ir(ir, shim)
+        # After unwind: user + (assistant+tool) + (assistant+tool) = 5
+        assert len(result["messages"]) == 5
+
+    def test_unwind_pattern_no_match(self):
+        """Unwind should NOT fire when model doesn't match pattern."""
+        ir = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_call",
+                            "tool_call_id": "call_1",
+                            "tool_name": "fn_a",
+                            "tool_input": {},
+                            "tool_type": "function",
+                        },
+                        {
+                            "type": "tool_call",
+                            "tool_call_id": "call_2",
+                            "tool_name": "fn_b",
+                            "tool_input": {},
+                            "tool_type": "function",
+                        },
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_call_id": "call_1",
+                            "result": "a",
+                        },
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_call_id": "call_2",
+                            "result": "b",
+                        },
+                    ],
+                },
+            ],
+            "tools": [],
+        }
+        shim = _make_shim(
+            name="test-shim-unwind",
+            unwind_parallel_tool_calls=True,
+            unwind_parallel_tool_calls_pattern="^gemini",
+        )
+        result = apply_shim_to_ir(ir, shim, upstream_model="gpt-4o")
+        assert len(result["messages"]) == 4  # untouched
+
+    def test_accepts_registered_name(self):
+        ir = _simple_ir_request(n_images=5)
+        shim = _make_shim(name="test-shim-img", max_images=2)
+        register_shim(shim)
+        result = apply_shim_to_ir(ir, "test-shim-img")
+        content = result["messages"][0]["content"]
+        image_parts = [p for p in content if p.get("type") == "image"]
+        assert len(image_parts) <= 2
+
+
+# ---------------------------------------------------------------------------
+# _apply_config_reasoning_override
+# ---------------------------------------------------------------------------
+
+
+class TestApplyConfigReasoningOverride:
+    def test_partial_override(self):
+        result = _apply_config_reasoning_override(
+            _REASONING_CAP, {"thinking_type": "adaptive"}
+        )
+        assert result.thinking_type == "adaptive"
+        assert result.disabled == _REASONING_CAP.disabled
+        assert result.effort_field == _REASONING_CAP.effort_field
+        assert result.effort_map == _REASONING_CAP.effort_map
+
+    def test_full_override(self):
+        override = {
+            "disabled": "block",
+            "effort_field": "custom_effort",
+            "max_effort": "high",
+            "thinking_type": "enabled",
+            "unsigned_reasoning_blocks": "drop",
+            "effort_map": {"a": "b"},
+            "budget_tokens_default_ratio": 0.5,
+        }
+        result = _apply_config_reasoning_override(_REASONING_CAP, override)
+        assert result.disabled == "block"
+        assert result.effort_field == "custom_effort"
+        assert result.thinking_type == "enabled"
+        assert result.budget_tokens_default_ratio == 0.5
+
+    def test_empty_override_preserves_base(self):
+        result = _apply_config_reasoning_override(_REASONING_CAP, {})
+        assert result.disabled == _REASONING_CAP.disabled
+        assert result.effort_field == _REASONING_CAP.effort_field
+        assert result.effort_map == _REASONING_CAP.effort_map


### PR DESCRIPTION
Closes #319

## Summary

- New `shims/pipeline.py` with two public entry points: `setup_shim_context()` and `apply_shim_to_ir()`
- Gateway `proxy.py` refactored to use them — 5 private functions deleted, both handlers use identical one-liner calls
- External consumers (e.g. argo-proxy) can now `from llm_rosetta.shims import apply_shim_to_ir, setup_shim_context` to get all shim-driven behavior

## Changes

| File | Change |
|---|---|
| `src/llm_rosetta/shims/pipeline.py` | **New** — unified shim pipeline |
| `src/llm_rosetta/shims/__init__.py` | Re-export the two public functions |
| `src/llm_rosetta/gateway/proxy.py` | Delete 5 private functions, replace with pipeline calls |
| `tests/test_shim_pipeline.py` | **New** — 27 unit tests |

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1932 passed (27 new + 1905 existing), 0 failures
- [ ] Integration: gateway behavior unchanged (same upstream requests, same responses)

AI was used to assist with implementation.