### PR TITLE
refactor(gateway): extract transport layer (#321)

### DIFF
--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -10,7 +10,8 @@ from typing import Any
 
 from llm_rosetta.auto_detect import ProviderType
 
-from .providers import ProviderInfo, build_provider_info
+from .providers import build_provider_info
+from .transport import ProviderInfo
 
 logger = logging.getLogger("llm-rosetta-gateway")
 

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -16,7 +16,7 @@ from llm_rosetta._vendor.httpserver import JSONResponse, Response
 from .auth import api_key_label_var
 from .config import GatewayConfig
 from .logging import get_logger
-from .proxy import get_client
+from .transport import get_client
 
 logger = get_logger()
 

--- a/src/llm_rosetta/gateway/providers.py
+++ b/src/llm_rosetta/gateway/providers.py
@@ -1,114 +1,28 @@
-"""Gateway provider definitions — auth, URLs, defaults, and key rotation."""
+"""Gateway provider definitions — registry, factory, and defaults.
+
+Transport-level classes (:class:`ProviderInfo`, :class:`KeyRing`) and auth
+header builders live in :mod:`gateway.transport.provider_info`.  This module
+keeps the provider *registry* and *factory* that resolve shim config into
+runtime :class:`ProviderInfo` instances.
+"""
 
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
 from typing import Any
 
+from .transport.provider_info import (
+    ProviderInfo,
+    _anthropic_auth,
+    _google_auth,
+    _openai_auth,
+)
+
+# Re-export ProviderInfo so existing ``from .providers import ProviderInfo``
+# continues to work without changes across the codebase.
+__all__ = ["ProviderInfo", "build_provider_info"]
+
 logger = logging.getLogger("llm-rosetta-gateway")
-
-# Type alias for auth-header builder callables
-AuthHeaderFn = Callable[[str], dict[str, str]]
-
-
-# ---------------------------------------------------------------------------
-# API key rotation (round-robin)
-# ---------------------------------------------------------------------------
-
-
-class KeyRing:
-    """Round-robin API key selector.
-
-    Accepts a single key string **or** a comma-separated list of keys.
-    Each call to :meth:`next` returns the next key in rotation.
-    """
-
-    def __init__(self, keys_csv: str) -> None:
-        self._keys = [k.strip() for k in keys_csv.split(",") if k.strip()]
-        self._idx = 0
-
-    def next(self) -> str:
-        """Return the next API key."""
-        if not self._keys:
-            raise ValueError("No API keys configured")
-        key = self._keys[self._idx]
-        self._idx = (self._idx + 1) % len(self._keys)
-        return key
-
-    def __len__(self) -> int:
-        return len(self._keys)
-
-
-# ---------------------------------------------------------------------------
-# Provider descriptor
-# ---------------------------------------------------------------------------
-
-
-class ProviderInfo:
-    """Runtime representation of a single configured provider.
-
-    Encapsulates base_url, key rotation, auth-header construction,
-    and upstream URL building.
-    """
-
-    def __init__(
-        self,
-        name: str,
-        *,
-        api_key: str,
-        base_url: str,
-        auth_header_fn: AuthHeaderFn,
-        url_template: str,
-        stream_url_template: str | None = None,
-        proxy_url: str | None = None,
-    ) -> None:
-        if not base_url.startswith(("http://", "https://")):
-            raise ValueError(
-                f"Provider '{name}': base_url must start with http:// or https://, "
-                f"got '{base_url}'"
-            )
-        self.name = name
-        self.base_url = base_url.rstrip("/")
-        self.key_ring = KeyRing(api_key)
-        self._auth_header_fn = auth_header_fn
-        self._url_template = url_template
-        self._stream_url_template = stream_url_template
-        self.proxy_url = proxy_url
-
-    # -- public helpers used by the proxy -----------------------------------
-
-    def auth_headers(self) -> dict[str, str]:
-        """Return auth headers using the next rotated key."""
-        return self._auth_header_fn(self.key_ring.next())
-
-    def upstream_url(self, model: str, *, stream: bool = False) -> str:
-        tpl = (
-            self._stream_url_template
-            if (stream and self._stream_url_template)
-            else self._url_template
-        )
-        return tpl.format(base_url=self.base_url, model=model)
-
-
-# ---------------------------------------------------------------------------
-# Per-provider auth header builders
-# ---------------------------------------------------------------------------
-
-
-def _openai_auth(api_key: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {api_key}"}
-
-
-def _anthropic_auth(api_key: str) -> dict[str, str]:
-    return {
-        "x-api-key": api_key,
-        "anthropic-version": "2023-06-01",
-    }
-
-
-def _google_auth(api_key: str) -> dict[str, str]:
-    return {"x-goog-api-key": api_key}
 
 
 # ---------------------------------------------------------------------------

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -1,13 +1,14 @@
-"""Proxy engine — upstream request building, SSE handling, and response conversion.
+"""Proxy engine — response conversion, metadata caching, and pipeline handlers.
 
-This module contains the core proxy logic extracted from ``app.py``:
-- Upstream request preparation (including Google body fixups)
-- SSE parsing and formatting
+This module contains the core proxy logic:
 - Provider metadata caching (e.g. Google ``thought_signature``)
-- HTTP client pool management
+- Shim transform resolution (image limits, tool call unwind, reasoning)
 - Non-streaming and streaming request handlers
 - Error response helpers
 - Request body helpers
+
+Transport-level concerns (SSE, HTTP client, provider connection info)
+live in :mod:`gateway.transport`.
 """
 
 from __future__ import annotations
@@ -19,7 +20,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from llm_rosetta._vendor.httpclient import (
-    AsyncClient,
     HttpClientError,
     Response as HttpResponse,
     StreamingResponse as HttpStreamingResponse,
@@ -33,7 +33,6 @@ from llm_rosetta.shims import get_shim
 from llm_rosetta.shims.provider_shim import ReasoningCapability
 from llm_rosetta.shims.transforms import Transform, apply_transforms
 
-
 from .logging import (
     get_logger,
     log_converted_request,
@@ -42,112 +41,16 @@ from .logging import (
     log_stream_summary,
     log_upstream_error,
 )
-from .providers import ProviderInfo
+from .transport import ProviderInfo, get_client, prepare_upstream
+from .transport.client import close_clients
+from .transport.sse import (
+    SENTINEL_DONE,
+    SSE_FORMATTERS,
+    _format_sse_openai_chat_done,
+    parse_sse_data,
+)
 
 logger = get_logger()
-
-# ---------------------------------------------------------------------------
-# Upstream request building
-# ---------------------------------------------------------------------------
-
-
-def prepare_upstream(
-    target_provider: ProviderType,
-    provider_info: ProviderInfo,
-    provider_request: dict[str, Any],
-    model: str,
-    *,
-    stream: bool,
-    extra_headers: dict[str, str] | None = None,
-) -> tuple[str, dict[str, str], dict[str, Any]]:
-    """Return (url, headers, body) ready for the upstream HTTP call."""
-    url = provider_info.upstream_url(model, stream=stream)
-    headers = {
-        "Content-Type": "application/json",
-        **provider_info.auth_headers(),
-    }
-    if extra_headers:
-        headers.update(extra_headers)
-
-    body = dict(provider_request)
-
-    # Inject stream flag into the body for providers that use it
-    if stream:
-        if target_provider in ("openai_chat",):
-            body["stream"] = True
-            body["stream_options"] = {"include_usage": True}
-        elif target_provider in ("openai_responses", "open_responses", "anthropic"):
-            body["stream"] = True
-        # Google streaming is signaled via URL, not body
-
-    return url, headers, body
-
-
-# ---------------------------------------------------------------------------
-# SSE parsing (upstream → IR events)
-# ---------------------------------------------------------------------------
-
-
-def _iter_sse_lines(line: str) -> tuple[str | None, str | None] | None:
-    """Parse a single SSE line into (field, value) or None if not relevant.
-
-    Returns:
-        ("data", <value>)  for data lines
-        ("event", <value>) for event lines
-        None               for empty/irrelevant lines
-    """
-    if not line:
-        return None
-    if line.startswith("data: "):
-        return ("data", line[6:])
-    if line.startswith("event: "):
-        return ("event", line[7:])
-    return None
-
-
-def _is_openai_done(data: str) -> bool:
-    """Check if the SSE data payload signals end-of-stream (OpenAI [DONE])."""
-    return data.strip() == "[DONE]"
-
-
-# ---------------------------------------------------------------------------
-# SSE emission (IR events → source-format SSE text)
-# ---------------------------------------------------------------------------
-
-
-def _format_sse_openai_chat(chunk: dict[str, Any]) -> str:
-    """Format a chunk as OpenAI Chat SSE line."""
-    return f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-
-
-def _format_sse_openai_chat_done() -> str:
-    return "data: [DONE]\n\n"
-
-
-def _format_sse_anthropic(chunk: dict[str, Any]) -> str:
-    """Format a chunk as Anthropic SSE (event: type\\ndata: json)."""
-    event_type = chunk.get("type", "unknown")
-    return f"event: {event_type}\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-
-
-def _format_sse_openai_responses(chunk: dict[str, Any]) -> str:
-    """Format a chunk as OpenAI Responses SSE (event: type\\ndata: json)."""
-    event_type = chunk.get("type", "unknown")
-    return f"event: {event_type}\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-
-
-def _format_sse_google(chunk: dict[str, Any]) -> str:
-    """Format a chunk as Google SSE line."""
-    return f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-
-
-SSE_FORMATTERS: dict[str, Any] = {
-    "openai_chat": _format_sse_openai_chat,
-    "openai_responses": _format_sse_openai_responses,
-    "open_responses": _format_sse_openai_responses,
-    "anthropic": _format_sse_anthropic,
-    "google": _format_sse_google,
-}
 
 
 # ---------------------------------------------------------------------------
@@ -218,30 +121,15 @@ def extract_model(source_provider: ProviderType, body: dict[str, Any]) -> str | 
 
 
 # ---------------------------------------------------------------------------
-# HTTP client pool
+# Resource cleanup
 # ---------------------------------------------------------------------------
-
-# Shared HTTP clients keyed by proxy URL (None = direct connection)
-_http_clients: dict[str | None, AsyncClient] = {}
-
-
-def get_client(proxy_url: str | None = None) -> AsyncClient:
-    """Get or create an ``AsyncClient`` for the given proxy URL."""
-    if proxy_url not in _http_clients:
-        _http_clients[proxy_url] = AsyncClient(
-            timeout=300.0,
-            proxy=proxy_url,
-        )
-    return _http_clients[proxy_url]
 
 
 async def close_resources(
     *, metadata_store: ProviderMetadataStore | None = None
 ) -> None:
     """Close all pooled HTTP clients and clear metadata store (called on app shutdown)."""
-    for client in _http_clients.values():
-        await client.aclose()
-    _http_clients.clear()
+    await close_clients()
     store = metadata_store or _default_metadata_store
     store.clear()
 
@@ -681,29 +569,6 @@ async def handle_non_streaming(
     return JSONResponse(source_response)
 
 
-_SENTINEL_DONE = object()
-
-
-def _parse_sse_data(line: str) -> Any:
-    """Parse a single SSE line and return the JSON chunk, or None to skip.
-
-    Returns ``_SENTINEL_DONE`` when the stream signals completion.
-    """
-    parsed = _iter_sse_lines(line)
-    if parsed is None:
-        return None
-    field, value = parsed
-    if field == "event" or field != "data" or value is None:
-        return None
-    if _is_openai_done(value):
-        return _SENTINEL_DONE
-    try:
-        return json.loads(value)
-    except json.JSONDecodeError:
-        logger.warning("Skipping malformed SSE data: %s", value[:200])
-        return None
-
-
 async def _format_upstream_error(upstream_resp: Any, endpoint: str) -> str:
     """Read an error response from upstream and format it as an SSE data line."""
     raw = await upstream_resp.aread()
@@ -804,8 +669,8 @@ async def _stream_event_generator(
             return
 
         async for line in upstream_resp.aiter_lines():
-            chunk = _parse_sse_data(line)
-            if chunk is _SENTINEL_DONE:
+            chunk = parse_sse_data(line)
+            if chunk is SENTINEL_DONE:
                 break
             if chunk is None:
                 continue

--- a/src/llm_rosetta/gateway/transport/__init__.py
+++ b/src/llm_rosetta/gateway/transport/__init__.py
@@ -1,0 +1,33 @@
+"""Transport layer — SSE, HTTP client, and provider connection primitives.
+
+This package isolates all protocol-specific code (HTTP, SSE) from the
+higher-level proxy pipeline.  Future protocol backends (gRPC, WebSocket)
+can be added as sibling modules.
+"""
+
+from .client import close_clients, get_client, prepare_upstream
+from .provider_info import AuthHeaderFn, KeyRing, ProviderInfo
+from .sse import (
+    SENTINEL_DONE,
+    SSE_FORMATTERS,
+    is_openai_done,
+    parse_sse_data,
+    parse_sse_line,
+)
+
+__all__ = [
+    # client
+    "close_clients",
+    "get_client",
+    "prepare_upstream",
+    # provider_info
+    "AuthHeaderFn",
+    "KeyRing",
+    "ProviderInfo",
+    # sse
+    "SENTINEL_DONE",
+    "SSE_FORMATTERS",
+    "is_openai_done",
+    "parse_sse_data",
+    "parse_sse_line",
+]

--- a/src/llm_rosetta/gateway/transport/client.py
+++ b/src/llm_rosetta/gateway/transport/client.py
@@ -1,0 +1,67 @@
+"""HTTP client pool and upstream request construction.
+
+Manages a shared pool of :class:`AsyncClient` instances (keyed by proxy
+URL) and provides :func:`prepare_upstream` to assemble the URL, headers,
+and body for an upstream provider call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta._vendor.httpclient import AsyncClient
+from llm_rosetta.auto_detect import ProviderType
+
+from .provider_info import ProviderInfo
+
+# Shared HTTP clients keyed by proxy URL (None = direct connection)
+_http_clients: dict[str | None, AsyncClient] = {}
+
+
+def get_client(proxy_url: str | None = None) -> AsyncClient:
+    """Get or create an ``AsyncClient`` for the given proxy URL."""
+    if proxy_url not in _http_clients:
+        _http_clients[proxy_url] = AsyncClient(
+            timeout=300.0,
+            proxy=proxy_url,
+        )
+    return _http_clients[proxy_url]
+
+
+async def close_clients() -> None:
+    """Close all pooled HTTP clients."""
+    for client in _http_clients.values():
+        await client.aclose()
+    _http_clients.clear()
+
+
+def prepare_upstream(
+    target_provider: ProviderType,
+    provider_info: ProviderInfo,
+    provider_request: dict[str, Any],
+    model: str,
+    *,
+    stream: bool,
+    extra_headers: dict[str, str] | None = None,
+) -> tuple[str, dict[str, str], dict[str, Any]]:
+    """Return ``(url, headers, body)`` ready for the upstream HTTP call."""
+    url = provider_info.upstream_url(model, stream=stream)
+    headers = {
+        "Content-Type": "application/json",
+        **provider_info.auth_headers(),
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+
+    body = dict(provider_request)
+
+    # Inject stream flag into the body for providers that use it
+    if stream:
+        if target_provider in ("openai_chat",):
+            body["stream"] = True
+            body["stream_options"] = {"include_usage": True}
+        elif target_provider in ("openai_responses", "open_responses", "anthropic"):
+            body["stream"] = True
+        # Google streaming is signaled via URL, not body
+
+    return url, headers, body

--- a/src/llm_rosetta/gateway/transport/provider_info.py
+++ b/src/llm_rosetta/gateway/transport/provider_info.py
@@ -1,0 +1,120 @@
+"""Provider runtime configuration — connection info, auth, and key rotation.
+
+This module contains the data classes that describe *how* to talk to an
+upstream provider at the transport level:
+
+* :class:`KeyRing` — round-robin API key selector.
+* :class:`ProviderInfo` — base URL, auth headers, URL templates.
+* Auth header builder functions (``_openai_auth``, ``_anthropic_auth``,
+  ``_google_auth``).
+
+Higher-level factory logic (shim resolution, config parsing) stays in
+``gateway.providers``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+# Type alias for auth-header builder callables
+AuthHeaderFn = Callable[[str], dict[str, str]]
+
+
+# ---------------------------------------------------------------------------
+# API key rotation (round-robin)
+# ---------------------------------------------------------------------------
+
+
+class KeyRing:
+    """Round-robin API key selector.
+
+    Accepts a single key string **or** a comma-separated list of keys.
+    Each call to :meth:`next` returns the next key in rotation.
+    """
+
+    def __init__(self, keys_csv: str) -> None:
+        self._keys = [k.strip() for k in keys_csv.split(",") if k.strip()]
+        self._idx = 0
+
+    def next(self) -> str:
+        """Return the next API key."""
+        if not self._keys:
+            raise ValueError("No API keys configured")
+        key = self._keys[self._idx]
+        self._idx = (self._idx + 1) % len(self._keys)
+        return key
+
+    def __len__(self) -> int:
+        return len(self._keys)
+
+
+# ---------------------------------------------------------------------------
+# Provider descriptor
+# ---------------------------------------------------------------------------
+
+
+class ProviderInfo:
+    """Runtime representation of a single configured provider.
+
+    Encapsulates base_url, key rotation, auth-header construction,
+    and upstream URL building.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        api_key: str,
+        base_url: str,
+        auth_header_fn: AuthHeaderFn,
+        url_template: str,
+        stream_url_template: str | None = None,
+        proxy_url: str | None = None,
+    ) -> None:
+        if not base_url.startswith(("http://", "https://")):
+            raise ValueError(
+                f"Provider '{name}': base_url must start with http:// or https://, "
+                f"got '{base_url}'"
+            )
+        self.name = name
+        self.base_url = base_url.rstrip("/")
+        self.key_ring = KeyRing(api_key)
+        self._auth_header_fn = auth_header_fn
+        self._url_template = url_template
+        self._stream_url_template = stream_url_template
+        self.proxy_url = proxy_url
+
+    # -- public helpers used by the proxy -----------------------------------
+
+    def auth_headers(self) -> dict[str, str]:
+        """Return auth headers using the next rotated key."""
+        return self._auth_header_fn(self.key_ring.next())
+
+    def upstream_url(self, model: str, *, stream: bool = False) -> str:
+        """Build the upstream URL for the given model."""
+        tpl = (
+            self._stream_url_template
+            if (stream and self._stream_url_template)
+            else self._url_template
+        )
+        return tpl.format(base_url=self.base_url, model=model)
+
+
+# ---------------------------------------------------------------------------
+# Per-provider auth header builders
+# ---------------------------------------------------------------------------
+
+
+def _openai_auth(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _anthropic_auth(api_key: str) -> dict[str, str]:
+    return {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+    }
+
+
+def _google_auth(api_key: str) -> dict[str, str]:
+    return {"x-goog-api-key": api_key}

--- a/src/llm_rosetta/gateway/transport/sse.py
+++ b/src/llm_rosetta/gateway/transport/sse.py
@@ -1,0 +1,108 @@
+"""SSE (Server-Sent Events) parsing and formatting.
+
+Handles two directions:
+
+* **Parsing** — upstream SSE lines → structured data (``parse_sse_line``,
+  ``parse_sse_data``, ``is_openai_done``).
+* **Formatting** — IR/provider chunks → downstream SSE text, keyed by
+  provider type in ``SSE_FORMATTERS``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger("llm-rosetta-gateway")
+
+# Sentinel returned by :func:`parse_sse_data` when the stream signals
+# completion (e.g. OpenAI ``[DONE]``).
+SENTINEL_DONE = object()
+
+
+# ---------------------------------------------------------------------------
+# SSE parsing (upstream → structured data)
+# ---------------------------------------------------------------------------
+
+
+def parse_sse_line(line: str) -> tuple[str, str] | None:
+    """Parse a single SSE line into ``(field, value)`` or ``None``.
+
+    Returns:
+        ``("data", <value>)`` for data lines, ``("event", <value>)`` for
+        event lines, or ``None`` for empty / irrelevant lines.
+    """
+    if not line:
+        return None
+    if line.startswith("data: "):
+        return ("data", line[6:])
+    if line.startswith("event: "):
+        return ("event", line[7:])
+    return None
+
+
+def is_openai_done(data: str) -> bool:
+    """Check if the SSE data payload signals end-of-stream (OpenAI ``[DONE]``)."""
+    return data.strip() == "[DONE]"
+
+
+def parse_sse_data(line: str) -> Any:
+    """Parse a single SSE line and return the JSON chunk, or ``None`` to skip.
+
+    Returns :data:`SENTINEL_DONE` when the stream signals completion.
+    """
+    parsed = parse_sse_line(line)
+    if parsed is None:
+        return None
+    field, value = parsed
+    if field == "event" or field != "data" or value is None:
+        return None
+    if is_openai_done(value):
+        return SENTINEL_DONE
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        logger.warning("Skipping malformed SSE data: %s", value[:200])
+        return None
+
+
+# ---------------------------------------------------------------------------
+# SSE formatting (IR events → source-format SSE text)
+# ---------------------------------------------------------------------------
+
+
+def _format_sse_openai_chat(chunk: dict[str, Any]) -> str:
+    """Format a chunk as OpenAI Chat SSE line."""
+    return f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+
+
+def _format_sse_openai_chat_done() -> str:
+    """Emit the OpenAI Chat ``[DONE]`` marker."""
+    return "data: [DONE]\n\n"
+
+
+def _format_sse_anthropic(chunk: dict[str, Any]) -> str:
+    """Format a chunk as Anthropic SSE (``event: type\\ndata: json``)."""
+    event_type = chunk.get("type", "unknown")
+    return f"event: {event_type}\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+
+
+def _format_sse_openai_responses(chunk: dict[str, Any]) -> str:
+    """Format a chunk as OpenAI Responses SSE (``event: type\\ndata: json``)."""
+    event_type = chunk.get("type", "unknown")
+    return f"event: {event_type}\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+
+
+def _format_sse_google(chunk: dict[str, Any]) -> str:
+    """Format a chunk as Google SSE line."""
+    return f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+
+
+SSE_FORMATTERS: dict[str, Any] = {
+    "openai_chat": _format_sse_openai_chat,
+    "openai_responses": _format_sse_openai_responses,
+    "open_responses": _format_sse_openai_responses,
+    "anthropic": _format_sse_anthropic,
+    "google": _format_sse_google,
+}

--- a/tests/gateway/test_embeddings.py
+++ b/tests/gateway/test_embeddings.py
@@ -13,7 +13,7 @@ import pytest
 
 from llm_rosetta.gateway.config import GatewayConfig
 from llm_rosetta.gateway.embeddings import handle_embeddings
-from llm_rosetta.gateway.proxy import _http_clients
+from llm_rosetta.gateway.transport.client import _http_clients
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extract all protocol-specific code from `proxy.py` and `providers.py` into a dedicated `gateway/transport/` subpackage
- New modules: `transport/sse.py` (SSE parsing/formatting), `transport/provider_info.py` (ProviderInfo, KeyRing, auth builders), `transport/client.py` (HTTP client pool, prepare_upstream)
- Pure structural refactor — no behavior changes, all 1905 tests pass

## Test plan

- [x] `make lint` passes (ruff check + format)
- [x] `make test` passes (1905 passed, 4 skipped)
- [x] No circular imports verified
- [x] All existing consumer imports still resolve

Closes #321