### PR TITLE
refactor(gateway): extract layered transport abstraction (#321)

### DIFF
--- a/src/llm_rosetta/_vendor/sse.py
+++ b/src/llm_rosetta/_vendor/sse.py
@@ -1,0 +1,694 @@
+# /// zerodep
+# version = "0.3.1"
+# deps = ["httpclient"]
+# tier = "subsystem"
+# category = "network"
+# note = "Install/update via: https://zerodep.readthedocs.io/en/latest/guide/cli/"
+# ///
+"""Zero-dependency SSE (Server-Sent Events) client.
+
+Part of zerodep: https://github.com/Oaklight/zerodep
+Copyright (c) 2026 Peng Ding. MIT License.
+
+Provides three abstraction layers:
+
+1. **Low-level parser** (``EventSource`` / ``AsyncEventSource``):
+   Parse any ``Iterable[str]`` or ``AsyncIterable[str]`` of lines into
+   ``SSEEvent`` objects. No network dependency.
+
+2. **High-level client** (``SSEClient`` / ``AsyncSSEClient``):
+   Open a streaming HTTP GET, parse SSE events, and auto-reconnect
+   on connection loss. Requires sibling ``httpclient`` module.
+
+3. **Convenience functions** (``connect`` / ``async_connect``):
+   Shorthand for creating ``SSEClient`` / ``AsyncSSEClient``.
+
+Usage::
+
+    # High-level (auto-connect + reconnect)
+    from sse import connect, async_connect
+
+    with connect("https://api.example.com/events") as events:
+        for event in events:
+            print(event.event, event.data)
+
+    async with async_connect("https://api.example.com/events") as events:
+        async for event in events:
+            print(event.data)
+
+    # Low-level (parse from any line source)
+    from sse import EventSource
+
+    for event in EventSource(["data: hello", "", "data: world", ""]):
+        print(event.data)  # "hello", then "world"
+
+Requires Python 3.10+.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import os
+import sys
+import time
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
+from typing import Any, Callable
+
+__all__ = [
+    # Constants
+    "DEFAULT_RETRY_INTERVAL",
+    "DEFAULT_TIMEOUT",
+    # Data classes
+    "SSEEvent",
+    # Low-level parsers
+    "EventSource",
+    "AsyncEventSource",
+    # Exceptions
+    "SSEError",
+    "SSEConnectionError",
+    "SSEHTTPError",
+    # High-level clients
+    "SSEClient",
+    "AsyncSSEClient",
+    # Convenience functions
+    "connect",
+    "async_connect",
+]
+
+
+def _ensure_sibling_path(name: str) -> str:
+    """Return the sibling module directory and prepend it to ``sys.path``."""
+    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
+    if sibling_dir not in sys.path:
+        sys.path.insert(0, sibling_dir)
+    return sibling_dir
+
+
+# ── Sibling httpclient import (guarded) ──
+
+try:
+    from llm_rosetta._vendor.httpclient import HttpConnectionError as _HttpConnectionError
+    from llm_rosetta._vendor.httpclient import HttpTimeoutError as _HttpTimeoutError
+    from llm_rosetta._vendor.httpclient import async_get as _http_async_get
+    from llm_rosetta._vendor.httpclient import get as _http_get
+
+    _HAS_HTTPCLIENT = True
+except (ImportError, AttributeError):
+    _HAS_HTTPCLIENT = False
+
+# ── Sentinel for injection parameters ──────────────────────────────────────
+
+
+class _Unset:
+    """Sentinel indicating 'use default sibling auto-discovery'."""
+
+    _instance: _Unset | None = None
+
+    def __new__(cls) -> _Unset:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "UNSET"
+
+
+_UNSET = _Unset()
+
+# ── Constants ──
+
+DEFAULT_RETRY_INTERVAL = 3000  # ms, per W3C spec
+DEFAULT_TIMEOUT = 30.0
+
+
+# ── Data classes ──
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SSEEvent:
+    """A single Server-Sent Event.
+
+    Attributes:
+        event: Event type (default ``"message"``).
+        data: Event payload. Multiple ``data:`` lines are joined with ``\\n``.
+        id: Last event ID. Persists across events until changed by the server.
+        retry: Reconnection interval in milliseconds, or ``None``.
+    """
+
+    event: str = "message"
+    data: str = ""
+    id: str = ""
+    retry: int | None = None
+
+    def __repr__(self) -> str:
+        d = self.data[:50] + "..." if len(self.data) > 50 else self.data
+        return f"<SSEEvent event={self.event!r} data={d!r} id={self.id!r}>"
+
+
+# ── Core parser ──
+
+
+class _SSEParser:
+    """Stateful W3C SSE line parser.
+
+    Feed individual lines via ``feed_line()``; it returns an ``SSEEvent``
+    when an empty line triggers dispatch.
+    """
+
+    __slots__ = ("_event_type", "_data_buf", "_last_id", "_retry", "_first_line")
+
+    def __init__(self) -> None:
+        self._event_type: str = ""
+        self._data_buf: list[str] = []
+        self._last_id: str = ""
+        self._retry: int | None = None
+        self._first_line: bool = True
+
+    @property
+    def last_event_id(self) -> str:
+        """Current last-event-id (persists across events)."""
+        return self._last_id
+
+    @property
+    def retry_interval(self) -> int | None:
+        """Current retry interval in ms (persists across events)."""
+        return self._retry
+
+    def feed_line(self, line: str) -> SSEEvent | None:
+        """Process one line and return an event if dispatched.
+
+        Args:
+            line: A single line from the event stream (already stripped of
+                trailing CR/LF by the transport).
+
+        Returns:
+            An ``SSEEvent`` if an empty line triggers dispatch, else ``None``.
+        """
+        # Strip BOM from the very first line of the stream
+        if self._first_line:
+            self._first_line = False
+            if line.startswith("\ufeff"):
+                line = line[1:]
+
+        # Empty line -> dispatch
+        if not line:
+            return self._dispatch()
+
+        # Comment
+        if line.startswith(":"):
+            return None
+
+        # Split field:value
+        if ":" in line:
+            field, _, value = line.partition(":")
+            # Strip exactly one leading space from value (per W3C spec)
+            if value.startswith(" "):
+                value = value[1:]
+        else:
+            field = line
+            value = ""
+
+        # Process field
+        if field == "event":
+            self._event_type = value
+        elif field == "data":
+            self._data_buf.append(value)
+        elif field == "id":
+            if "\0" not in value:
+                self._last_id = value
+        elif field == "retry":
+            if value.isdigit() and value:
+                self._retry = int(value)
+
+        return None
+
+    def _dispatch(self) -> SSEEvent | None:
+        """Dispatch the accumulated event and reset per-event state."""
+        if not self._data_buf:
+            return None
+        event = SSEEvent(
+            event=self._event_type or "message",
+            data="\n".join(self._data_buf),
+            id=self._last_id,
+            retry=self._retry,
+        )
+        # Reset per-event state (id and retry persist)
+        self._event_type = ""
+        self._data_buf = []
+        return event
+
+
+# ── Iterator wrappers (no httpclient dependency) ──
+
+
+class EventSource:
+    """Sync SSE parser wrapping any line iterable.
+
+    Example::
+
+        lines = ["event: greeting", "data: hello", "", "data: world", ""]
+        for event in EventSource(lines):
+            print(event.event, event.data)
+    """
+
+    def __init__(self, lines: Iterable[str]) -> None:
+        self._lines = lines
+
+    def __iter__(self) -> Iterator[SSEEvent]:
+        parser = _SSEParser()
+        for line in self._lines:
+            event = parser.feed_line(line)
+            if event is not None:
+                yield event
+
+
+class AsyncEventSource:
+    """Async SSE parser wrapping any async line iterable.
+
+    Example::
+
+        async for event in AsyncEventSource(async_line_source):
+            print(event.data)
+    """
+
+    def __init__(self, lines: AsyncIterable[str]) -> None:
+        self._lines = lines
+
+    async def __aiter__(self) -> AsyncIterator[SSEEvent]:
+        parser = _SSEParser()
+        async for line in self._lines:
+            event = parser.feed_line(line)
+            if event is not None:
+                yield event
+
+
+# ── Exceptions ──
+
+
+class SSEError(Exception):
+    """Base exception for SSE errors."""
+
+
+class SSEConnectionError(SSEError):
+    """Raised when max retries exhausted."""
+
+    def __init__(
+        self, url: str, retries: int, last_error: Exception | None = None
+    ) -> None:
+        self.url = url
+        self.retries = retries
+        self.last_error = last_error
+        super().__init__(
+            f"SSE connection to {url} failed after {retries} retries"
+            + (f": {last_error}" if last_error else "")
+        )
+
+
+class SSEHTTPError(SSEError):
+    """Raised on non-2xx HTTP response (other than 204)."""
+
+    def __init__(self, status_code: int, url: str) -> None:
+        self.status_code = status_code
+        self.url = url
+        super().__init__(f"SSE request to {url} returned HTTP {status_code}")
+
+
+# ── High-level clients (require httpclient) ──
+
+
+def _require_httpclient() -> None:
+    if not _HAS_HTTPCLIENT:
+        raise ImportError(
+            "SSEClient requires the sibling httpclient module. "
+            "Place httpclient.py in a sibling directory or on sys.path."
+        )
+
+
+class _SSEClientMixin:
+    """Shared helpers for sync and async SSE clients."""
+
+    _last_event_id: str
+    _retry_interval: int
+    _max_retries: int
+    _url: str
+
+    def _init_parser(self) -> _SSEParser:
+        """Create a parser with restored persistent state."""
+        parser = _SSEParser()
+        parser._last_id = self._last_event_id
+        if self._retry_interval != DEFAULT_RETRY_INTERVAL:
+            parser._retry = self._retry_interval
+        return parser
+
+    def _handle_event(self, event: SSEEvent) -> None:
+        """Update reconnection state from a received event."""
+        if event.id:
+            self._last_event_id = event.id
+        if event.retry is not None:
+            self._retry_interval = event.retry
+
+    def _check_reconnect(self, retries: int, last_error: Exception | None) -> None:
+        """Raise ``SSEConnectionError`` if max retries exceeded."""
+        if self._max_retries >= 0 and retries > self._max_retries:
+            raise SSEConnectionError(self._url, retries, last_error)
+
+
+class SSEClient(_SSEClientMixin):
+    """Synchronous SSE client with auto-reconnection.
+
+    Opens a streaming HTTP GET, parses ``text/event-stream``, and
+    automatically reconnects when the connection drops.
+
+    Args:
+        url: SSE endpoint URL.
+        headers: Extra HTTP headers to send.
+        timeout: Connection/read timeout in seconds.
+        retry_interval: Initial reconnection delay in milliseconds.
+        max_retries: Maximum reconnection attempts (``-1`` = unlimited).
+        verify: Whether to verify TLS certificates.
+        last_event_id: Initial ``Last-Event-ID`` header value.
+        transport: Sync HTTP GET callable. Defaults to ``_UNSET``
+            (auto-discover sibling ``httpclient.get``). Must accept
+            ``(url, *, headers, stream, timeout, verify)`` and return
+            a response with ``.status_code``, ``.ok``, ``.close()``,
+            and ``.iter_lines()`` attributes.
+
+    Example::
+
+        with SSEClient("https://api.example.com/events") as client:
+            for event in client:
+                print(event.data)
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        retry_interval: int = DEFAULT_RETRY_INTERVAL,
+        max_retries: int = -1,
+        verify: bool = True,
+        last_event_id: str = "",
+        transport: Callable[..., Any] | None | _Unset = _UNSET,
+    ) -> None:
+        self._transport: Callable[..., Any]
+        if isinstance(transport, _Unset):
+            _require_httpclient()
+            self._transport = _http_get
+            self._reconnect_errors: tuple[type[Exception], ...] = (
+                _HttpConnectionError,
+                _HttpTimeoutError,
+                ConnectionError,
+                OSError,
+            )
+        elif transport is None:
+            raise ValueError(
+                "SSEClient requires a transport; pass a callable "
+                "or omit to use sibling httpclient"
+            )
+        else:
+            self._transport = transport
+            self._reconnect_errors = (ConnectionError, OSError)
+        self._url = url
+        self._user_headers = headers or {}
+        self._timeout = timeout
+        self._retry_interval = retry_interval
+        self._max_retries = max_retries
+        self._verify = verify
+        self._last_event_id = last_event_id
+        self._response: Any = None
+        self._closed = False
+
+    def __enter__(self) -> SSEClient:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    def __iter__(self) -> Iterator[SSEEvent]:
+        retries = 0
+        last_error: Exception | None = None
+
+        while not self._closed:
+            try:
+                self._response = self._connect()
+                parser = self._init_parser()
+
+                for line in self._response.iter_lines():
+                    if self._closed:
+                        return
+                    event = parser.feed_line(line)
+                    if event is not None:
+                        self._handle_event(event)
+                        retries = 0
+                        yield event
+
+                # Stream ended normally — attempt reconnect
+                if self._closed:
+                    return
+
+            except self._reconnect_errors as exc:
+                last_error = exc
+            finally:
+                self._close_response()
+
+            retries += 1
+            self._check_reconnect(retries, last_error)
+            time.sleep(self._retry_interval / 1000)
+
+    def _connect(self) -> Any:
+        """Open a streaming GET request."""
+        headers = {
+            "Accept": "text/event-stream",
+            "Cache-Control": "no-cache",
+            **self._user_headers,
+        }
+        if self._last_event_id:
+            headers["Last-Event-ID"] = self._last_event_id
+
+        resp = self._transport(
+            self._url,
+            headers=headers,
+            stream=True,
+            timeout=self._timeout,
+            verify=self._verify,
+        )
+
+        if resp.status_code == 204:
+            resp.close()
+            self._closed = True
+            return resp
+
+        if not resp.ok:
+            status = resp.status_code
+            resp.close()
+            raise SSEHTTPError(status, self._url)
+
+        return resp
+
+    def _close_response(self) -> None:
+        if self._response is not None:
+            # Tier 3: best-effort silent — reconnect cleanup
+            try:
+                self._response.close()
+            except Exception:
+                pass
+            self._response = None
+
+    def close(self) -> None:
+        """Close the SSE connection."""
+        self._closed = True
+        self._close_response()
+
+
+class AsyncSSEClient(_SSEClientMixin):
+    """Asynchronous SSE client with auto-reconnection.
+
+    Opens a streaming HTTP GET, parses ``text/event-stream``, and
+    automatically reconnects when the connection drops.
+
+    Args:
+        url: SSE endpoint URL.
+        headers: Extra HTTP headers to send.
+        timeout: Connection/read timeout in seconds.
+        retry_interval: Initial reconnection delay in milliseconds.
+        max_retries: Maximum reconnection attempts (``-1`` = unlimited).
+        verify: Whether to verify TLS certificates.
+        last_event_id: Initial ``Last-Event-ID`` header value.
+        transport: Async HTTP GET callable. Defaults to ``_UNSET``
+            (auto-discover sibling ``httpclient.async_get``). Must accept
+            ``(url, *, headers, stream, timeout, verify)`` and return
+            a response with ``.status_code``, ``.ok``, ``.aclose()``,
+            and ``.aiter_lines()`` attributes.
+
+    Example::
+
+        async with AsyncSSEClient("https://api.example.com/events") as client:
+            async for event in client:
+                print(event.data)
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        retry_interval: int = DEFAULT_RETRY_INTERVAL,
+        max_retries: int = -1,
+        verify: bool = True,
+        last_event_id: str = "",
+        transport: Callable[..., Any] | None | _Unset = _UNSET,
+    ) -> None:
+        self._transport: Callable[..., Any]
+        if isinstance(transport, _Unset):
+            _require_httpclient()
+            self._transport = _http_async_get
+            self._reconnect_errors: tuple[type[Exception], ...] = (
+                _HttpConnectionError,
+                _HttpTimeoutError,
+                ConnectionError,
+                OSError,
+            )
+        elif transport is None:
+            raise ValueError(
+                "AsyncSSEClient requires a transport; pass a callable "
+                "or omit to use sibling httpclient"
+            )
+        else:
+            self._transport = transport
+            self._reconnect_errors = (ConnectionError, OSError)
+        self._url = url
+        self._user_headers = headers or {}
+        self._timeout = timeout
+        self._retry_interval = retry_interval
+        self._max_retries = max_retries
+        self._verify = verify
+        self._last_event_id = last_event_id
+        self._response: Any = None
+        self._closed = False
+
+    async def __aenter__(self) -> AsyncSSEClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()
+
+    async def __aiter__(self) -> AsyncIterator[SSEEvent]:
+        retries = 0
+        last_error: Exception | None = None
+
+        while not self._closed:
+            try:
+                self._response = await self._connect()
+                parser = self._init_parser()
+
+                async for line in self._response.aiter_lines():
+                    if self._closed:
+                        return
+                    event = parser.feed_line(line)
+                    if event is not None:
+                        self._handle_event(event)
+                        retries = 0
+                        yield event
+
+                if self._closed:
+                    return
+
+            except self._reconnect_errors as exc:
+                last_error = exc
+            finally:
+                await self._close_response()
+
+            retries += 1
+            self._check_reconnect(retries, last_error)
+            await asyncio.sleep(self._retry_interval / 1000)
+
+    async def _connect(self) -> Any:
+        """Open a streaming async GET request."""
+        headers = {
+            "Accept": "text/event-stream",
+            "Cache-Control": "no-cache",
+            **self._user_headers,
+        }
+        if self._last_event_id:
+            headers["Last-Event-ID"] = self._last_event_id
+
+        resp = await self._transport(
+            self._url,
+            headers=headers,
+            stream=True,
+            timeout=self._timeout,
+            verify=self._verify,
+        )
+
+        if resp.status_code == 204:
+            await resp.aclose()
+            self._closed = True
+            return resp
+
+        if not resp.ok:
+            status = resp.status_code
+            await resp.aclose()
+            raise SSEHTTPError(status, self._url)
+
+        return resp
+
+    async def _close_response(self) -> None:
+        if self._response is not None:
+            # Tier 3: best-effort silent — reconnect cleanup
+            try:
+                await self._response.aclose()
+            except Exception:
+                pass
+            self._response = None
+
+    async def close(self) -> None:
+        """Close the SSE connection."""
+        self._closed = True
+        await self._close_response()
+
+
+# ── Convenience functions ──
+
+
+def connect(url: str, **kwargs: Any) -> SSEClient:
+    """Open a synchronous SSE connection.
+
+    Shorthand for ``SSEClient(url, **kwargs)``.
+    Use as a context manager::
+
+        with connect("https://example.com/events") as events:
+            for event in events:
+                print(event.data)
+
+    Args:
+        url: SSE endpoint URL.
+        **kwargs: Passed to ``SSEClient``.
+
+    Returns:
+        An ``SSEClient`` instance.
+    """
+    return SSEClient(url, **kwargs)
+
+
+def async_connect(url: str, **kwargs: Any) -> AsyncSSEClient:
+    """Open an asynchronous SSE connection.
+
+    Shorthand for ``AsyncSSEClient(url, **kwargs)``.
+    Use as an async context manager::
+
+        async with async_connect("https://example.com/events") as events:
+            async for event in events:
+                print(event.data)
+
+    Args:
+        url: SSE endpoint URL.
+        **kwargs: Passed to ``AsyncSSEClient``.
+
+    Returns:
+        An ``AsyncSSEClient`` instance.
+    """
+    return AsyncSSEClient(url, **kwargs)

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -207,6 +207,7 @@ async def _proxy_handler(
             provider_info,
             body,
             model,
+            transport=request.app.transport,  # type: ignore
             metadata_store=store,
             extra_headers=extra_headers,
             target_shim_name=target_shim_name,
@@ -446,7 +447,10 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
         os.environ.setdefault("HTTP_PROXY", config.proxy)
         os.environ.setdefault("HTTPS_PROXY", config.proxy)
 
+    from .transport import HttpTransport
+
     metadata_store = ProviderMetadataStore()
+    transport = HttpTransport()
 
     app = App(max_body_size=50_000_000, read_timeout=300.0)
 
@@ -548,6 +552,7 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
     register_admin_routes(app)
 
     # --- App-level state ---
+    app.transport = transport  # type: ignore
     app.metadata_store = metadata_store  # type: ignore
     app.internal_token = internal_token  # type: ignore
     app.auth_state = auth_state  # type: ignore
@@ -574,4 +579,7 @@ async def run_gateway(
         except asyncio.CancelledError:
             pass
         _flush_now(app)
-        await close_resources(metadata_store=app.metadata_store)  # type: ignore
+        await close_resources(
+            transport=app.transport,  # type: ignore
+            metadata_store=app.metadata_store,  # type: ignore
+        )

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -10,7 +10,8 @@ from typing import Any
 
 from llm_rosetta.auto_detect import ProviderType
 
-from .providers import ProviderInfo, build_provider_info
+from .providers import build_provider_info
+from .transport import ProviderInfo
 
 logger = logging.getLogger("llm-rosetta-gateway")
 

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -10,13 +10,12 @@ from __future__ import annotations
 import time
 from typing import Any
 
-from llm_rosetta._vendor.httpclient import HttpClientError, Response as HttpResponse
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
 from .auth import api_key_label_var
 from .config import GatewayConfig
 from .logging import get_logger
-from .proxy import get_client
+from .transport import UpstreamConnectionError
 
 logger = get_logger()
 
@@ -97,8 +96,19 @@ async def handle_embeddings(
     status_code = 500
     error_detail: str | None = None
 
+    # Use the transport's client pool for connection reuse
+    from .transport.http import HttpTransport
+
+    transport = request.app.transport
+    assert isinstance(transport, HttpTransport)
+    client = transport._pool.get(provider_info.proxy_url)
+
     try:
-        client = get_client(provider_info.proxy_url)
+        from llm_rosetta._vendor.httpclient import (
+            HttpClientError,
+            Response as HttpResponse,
+        )
+
         upstream_resp = await client.post(upstream_url, json=body, headers=headers)
         assert isinstance(upstream_resp, HttpResponse)
 
@@ -117,7 +127,7 @@ async def handle_embeddings(
             status_code=200,
             content_type="application/json",
         )
-    except HttpClientError as exc:
+    except (HttpClientError, UpstreamConnectionError) as exc:
         error_detail = str(exc)
         status_code = 502
         return JSONResponse(

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -3,6 +3,9 @@
 Proxies ``/v1/embeddings`` requests to the upstream provider without
 format conversion — the OpenAI embeddings API format is universal
 across providers that support it.
+
+Uses the :class:`~transport.UpstreamTransport` interface so the handler
+is transport-agnostic (works with HTTP, and future gRPC/WebSocket).
 """
 
 from __future__ import annotations
@@ -15,7 +18,7 @@ from llm_rosetta._vendor.httpserver import JSONResponse, Response
 from .auth import api_key_label_var
 from .config import GatewayConfig
 from .logging import get_logger
-from .transport import UpstreamConnectionError
+from .transport import UpstreamConnectionError, UpstreamTransport
 
 logger = get_logger()
 
@@ -82,13 +85,9 @@ async def handle_embeddings(
     if upstream_model:
         body["model"] = upstream_model
 
-    # --- Build upstream URL ---
-    base_url = provider_info.base_url
-    upstream_url = f"{base_url}/embeddings"
-
-    # --- Forward request ---
-    headers = provider_info.auth_headers()
-    headers["Content-Type"] = "application/json"
+    # --- Forward via transport ---
+    upstream_url = f"{provider_info.base_url}/embeddings"
+    transport: UpstreamTransport = request.app.transport
 
     metrics = getattr(request.app, "metrics", None)
     request_log = getattr(request.app, "request_log", None)
@@ -96,38 +95,24 @@ async def handle_embeddings(
     status_code = 500
     error_detail: str | None = None
 
-    # Use the transport's client pool for connection reuse
-    from .transport.http import HttpTransport
-
-    transport = request.app.transport
-    assert isinstance(transport, HttpTransport)
-    client = transport._pool.get(provider_info.proxy_url)
-
     try:
-        from llm_rosetta._vendor.httpclient import (
-            HttpClientError,
-            Response as HttpResponse,
-        )
+        resp = await transport.send_passthrough(provider_info, upstream_url, body)
+        status_code = resp.status_code
 
-        upstream_resp = await client.post(upstream_url, json=body, headers=headers)
-        assert isinstance(upstream_resp, HttpResponse)
-
-        status_code = upstream_resp.status_code
-
-        if upstream_resp.status_code >= 400:
-            error_detail = upstream_resp.text
+        if resp.is_error:
+            error_detail = resp.error_text
             return Response(
-                body=upstream_resp.content,
-                status_code=upstream_resp.status_code,
+                body=resp.raw_content,
+                status_code=resp.status_code,
                 content_type="application/json",
             )
 
         return Response(
-            body=upstream_resp.content,
+            body=resp.raw_content,
             status_code=200,
             content_type="application/json",
         )
-    except (HttpClientError, UpstreamConnectionError) as exc:
+    except UpstreamConnectionError as exc:
         error_detail = str(exc)
         status_code = 502
         return JSONResponse(

--- a/src/llm_rosetta/gateway/providers.py
+++ b/src/llm_rosetta/gateway/providers.py
@@ -1,114 +1,28 @@
-"""Gateway provider definitions — auth, URLs, defaults, and key rotation."""
+"""Gateway provider definitions — registry, factory, and defaults.
+
+Transport-level classes (:class:`ProviderInfo`, :class:`KeyRing`) and auth
+header builders live in :mod:`gateway.transport.provider_info`.  This module
+keeps the provider *registry* and *factory* that resolve shim config into
+runtime :class:`ProviderInfo` instances.
+"""
 
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
 from typing import Any
 
+from .transport.provider_info import (
+    ProviderInfo,
+    _anthropic_auth,
+    _google_auth,
+    _openai_auth,
+)
+
+# Re-export ProviderInfo so existing ``from .providers import ProviderInfo``
+# continues to work without changes across the codebase.
+__all__ = ["ProviderInfo", "build_provider_info"]
+
 logger = logging.getLogger("llm-rosetta-gateway")
-
-# Type alias for auth-header builder callables
-AuthHeaderFn = Callable[[str], dict[str, str]]
-
-
-# ---------------------------------------------------------------------------
-# API key rotation (round-robin)
-# ---------------------------------------------------------------------------
-
-
-class KeyRing:
-    """Round-robin API key selector.
-
-    Accepts a single key string **or** a comma-separated list of keys.
-    Each call to :meth:`next` returns the next key in rotation.
-    """
-
-    def __init__(self, keys_csv: str) -> None:
-        self._keys = [k.strip() for k in keys_csv.split(",") if k.strip()]
-        self._idx = 0
-
-    def next(self) -> str:
-        """Return the next API key."""
-        if not self._keys:
-            raise ValueError("No API keys configured")
-        key = self._keys[self._idx]
-        self._idx = (self._idx + 1) % len(self._keys)
-        return key
-
-    def __len__(self) -> int:
-        return len(self._keys)
-
-
-# ---------------------------------------------------------------------------
-# Provider descriptor
-# ---------------------------------------------------------------------------
-
-
-class ProviderInfo:
-    """Runtime representation of a single configured provider.
-
-    Encapsulates base_url, key rotation, auth-header construction,
-    and upstream URL building.
-    """
-
-    def __init__(
-        self,
-        name: str,
-        *,
-        api_key: str,
-        base_url: str,
-        auth_header_fn: AuthHeaderFn,
-        url_template: str,
-        stream_url_template: str | None = None,
-        proxy_url: str | None = None,
-    ) -> None:
-        if not base_url.startswith(("http://", "https://")):
-            raise ValueError(
-                f"Provider '{name}': base_url must start with http:// or https://, "
-                f"got '{base_url}'"
-            )
-        self.name = name
-        self.base_url = base_url.rstrip("/")
-        self.key_ring = KeyRing(api_key)
-        self._auth_header_fn = auth_header_fn
-        self._url_template = url_template
-        self._stream_url_template = stream_url_template
-        self.proxy_url = proxy_url
-
-    # -- public helpers used by the proxy -----------------------------------
-
-    def auth_headers(self) -> dict[str, str]:
-        """Return auth headers using the next rotated key."""
-        return self._auth_header_fn(self.key_ring.next())
-
-    def upstream_url(self, model: str, *, stream: bool = False) -> str:
-        tpl = (
-            self._stream_url_template
-            if (stream and self._stream_url_template)
-            else self._url_template
-        )
-        return tpl.format(base_url=self.base_url, model=model)
-
-
-# ---------------------------------------------------------------------------
-# Per-provider auth header builders
-# ---------------------------------------------------------------------------
-
-
-def _openai_auth(api_key: str) -> dict[str, str]:
-    return {"Authorization": f"Bearer {api_key}"}
-
-
-def _anthropic_auth(api_key: str) -> dict[str, str]:
-    return {
-        "x-api-key": api_key,
-        "anthropic-version": "2023-06-01",
-    }
-
-
-def _google_auth(api_key: str) -> dict[str, str]:
-    return {"x-goog-api-key": api_key}
 
 
 # ---------------------------------------------------------------------------

--- a/src/llm_rosetta/gateway/providers.py
+++ b/src/llm_rosetta/gateway/providers.py
@@ -13,9 +13,9 @@ from typing import Any
 
 from .transport.provider_info import (
     ProviderInfo,
-    _anthropic_auth,
-    _google_auth,
-    _openai_auth,
+    anthropic_auth,
+    google_auth,
+    openai_auth,
 )
 
 # Re-export ProviderInfo so existing ``from .providers import ProviderInfo``
@@ -33,31 +33,31 @@ _PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
     "openai_chat": {
         "default_base_url": "https://api.openai.com/v1",
         "default_api_key_env": "OPENAI_API_KEY",
-        "auth_header_fn": _openai_auth,
+        "auth_header_fn": openai_auth,
         "url_template": "{base_url}/chat/completions",
     },
     "openai_responses": {
         "default_base_url": "https://api.openai.com/v1",
         "default_api_key_env": "OPENAI_API_KEY",
-        "auth_header_fn": _openai_auth,
+        "auth_header_fn": openai_auth,
         "url_template": "{base_url}/responses",
     },
     "open_responses": {
         "default_base_url": "https://api.openai.com/v1",
         "default_api_key_env": "OPENAI_API_KEY",
-        "auth_header_fn": _openai_auth,
+        "auth_header_fn": openai_auth,
         "url_template": "{base_url}/responses",
     },
     "anthropic": {
         "default_base_url": "https://api.anthropic.com",
         "default_api_key_env": "ANTHROPIC_API_KEY",
-        "auth_header_fn": _anthropic_auth,
+        "auth_header_fn": anthropic_auth,
         "url_template": "{base_url}/v1/messages",
     },
     "google": {
         "default_base_url": "https://generativelanguage.googleapis.com",
         "default_api_key_env": "GOOGLE_API_KEY",
-        "auth_header_fn": _google_auth,
+        "auth_header_fn": google_auth,
         "url_template": "{base_url}/v1beta/models/{model}:generateContent",
         "stream_url_template": "{base_url}/v1beta/models/{model}:streamGenerateContent?alt=sse",
     },
@@ -135,7 +135,7 @@ def build_provider_info(
         stream_tpl = reg.get("stream_url_template")
     else:
         # Unknown / custom provider — best-effort defaults
-        auth_fn = _openai_auth
+        auth_fn = openai_auth
         url_tpl = "{base_url}/"
         stream_tpl = None
         logger.warning(

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -1,13 +1,15 @@
-"""Proxy engine — upstream request building, SSE handling, and response conversion.
+"""Proxy engine — response conversion, metadata caching, and pipeline handlers.
 
-This module contains the core proxy logic extracted from ``app.py``:
-- Upstream request preparation (including Google body fixups)
-- SSE parsing and formatting
+This module contains the core proxy logic:
 - Provider metadata caching (e.g. Google ``thought_signature``)
-- HTTP client pool management
+- Shim transform resolution
 - Non-streaming and streaming request handlers
 - Error response helpers
 - Request body helpers
+
+Transport-level concerns (HTTP client, SSE parsing, upstream request assembly)
+are delegated to the :class:`~transport.UpstreamTransport` interface.
+Downstream SSE formatting lives in :mod:`transport.sse_format`.
 """
 
 from __future__ import annotations
@@ -18,12 +20,6 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any
 
-from llm_rosetta._vendor.httpclient import (
-    AsyncClient,
-    HttpClientError,
-    Response as HttpResponse,
-    StreamingResponse as HttpStreamingResponse,
-)
 from llm_rosetta._vendor.httpserver import JSONResponse, Response, StreamingResponse
 
 from llm_rosetta import get_converter_for_provider
@@ -33,7 +29,6 @@ from llm_rosetta.shims import get_shim
 from llm_rosetta.pipeline import apply_shim_to_ir, setup_shim_context
 from llm_rosetta.shims.transforms import Transform, apply_transforms
 
-
 from .logging import (
     get_logger,
     log_converted_request,
@@ -42,112 +37,14 @@ from .logging import (
     log_stream_summary,
     log_upstream_error,
 )
-from .providers import ProviderInfo
+from .transport import (
+    ProviderInfo,
+    UpstreamConnectionError,
+    UpstreamTransport,
+)
+from .transport.sse_format import SSE_FORMATTERS, format_sse_done
 
 logger = get_logger()
-
-# ---------------------------------------------------------------------------
-# Upstream request building
-# ---------------------------------------------------------------------------
-
-
-def prepare_upstream(
-    target_provider: ProviderType,
-    provider_info: ProviderInfo,
-    provider_request: dict[str, Any],
-    model: str,
-    *,
-    stream: bool,
-    extra_headers: dict[str, str] | None = None,
-) -> tuple[str, dict[str, str], dict[str, Any]]:
-    """Return (url, headers, body) ready for the upstream HTTP call."""
-    url = provider_info.upstream_url(model, stream=stream)
-    headers = {
-        "Content-Type": "application/json",
-        **provider_info.auth_headers(),
-    }
-    if extra_headers:
-        headers.update(extra_headers)
-
-    body = dict(provider_request)
-
-    # Inject stream flag into the body for providers that use it
-    if stream:
-        if target_provider in ("openai_chat",):
-            body["stream"] = True
-            body["stream_options"] = {"include_usage": True}
-        elif target_provider in ("openai_responses", "open_responses", "anthropic"):
-            body["stream"] = True
-        # Google streaming is signaled via URL, not body
-
-    return url, headers, body
-
-
-# ---------------------------------------------------------------------------
-# SSE parsing (upstream → IR events)
-# ---------------------------------------------------------------------------
-
-
-def _iter_sse_lines(line: str) -> tuple[str | None, str | None] | None:
-    """Parse a single SSE line into (field, value) or None if not relevant.
-
-    Returns:
-        ("data", <value>)  for data lines
-        ("event", <value>) for event lines
-        None               for empty/irrelevant lines
-    """
-    if not line:
-        return None
-    if line.startswith("data: "):
-        return ("data", line[6:])
-    if line.startswith("event: "):
-        return ("event", line[7:])
-    return None
-
-
-def _is_openai_done(data: str) -> bool:
-    """Check if the SSE data payload signals end-of-stream (OpenAI [DONE])."""
-    return data.strip() == "[DONE]"
-
-
-# ---------------------------------------------------------------------------
-# SSE emission (IR events → source-format SSE text)
-# ---------------------------------------------------------------------------
-
-
-def _format_sse_openai_chat(chunk: dict[str, Any]) -> str:
-    """Format a chunk as OpenAI Chat SSE line."""
-    return f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-
-
-def _format_sse_openai_chat_done() -> str:
-    return "data: [DONE]\n\n"
-
-
-def _format_sse_anthropic(chunk: dict[str, Any]) -> str:
-    """Format a chunk as Anthropic SSE (event: type\\ndata: json)."""
-    event_type = chunk.get("type", "unknown")
-    return f"event: {event_type}\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-
-
-def _format_sse_openai_responses(chunk: dict[str, Any]) -> str:
-    """Format a chunk as OpenAI Responses SSE (event: type\\ndata: json)."""
-    event_type = chunk.get("type", "unknown")
-    return f"event: {event_type}\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-
-
-def _format_sse_google(chunk: dict[str, Any]) -> str:
-    """Format a chunk as Google SSE line."""
-    return f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
-
-
-SSE_FORMATTERS: dict[str, Any] = {
-    "openai_chat": _format_sse_openai_chat,
-    "openai_responses": _format_sse_openai_responses,
-    "open_responses": _format_sse_openai_responses,
-    "anthropic": _format_sse_anthropic,
-    "google": _format_sse_google,
-}
 
 
 # ---------------------------------------------------------------------------
@@ -218,30 +115,18 @@ def extract_model(source_provider: ProviderType, body: dict[str, Any]) -> str | 
 
 
 # ---------------------------------------------------------------------------
-# HTTP client pool
+# Resource cleanup
 # ---------------------------------------------------------------------------
-
-# Shared HTTP clients keyed by proxy URL (None = direct connection)
-_http_clients: dict[str | None, AsyncClient] = {}
-
-
-def get_client(proxy_url: str | None = None) -> AsyncClient:
-    """Get or create an ``AsyncClient`` for the given proxy URL."""
-    if proxy_url not in _http_clients:
-        _http_clients[proxy_url] = AsyncClient(
-            timeout=300.0,
-            proxy=proxy_url,
-        )
-    return _http_clients[proxy_url]
 
 
 async def close_resources(
-    *, metadata_store: ProviderMetadataStore | None = None
+    *,
+    transport: UpstreamTransport | None = None,
+    metadata_store: ProviderMetadataStore | None = None,
 ) -> None:
-    """Close all pooled HTTP clients and clear metadata store (called on app shutdown)."""
-    for client in _http_clients.values():
-        await client.aclose()
-    _http_clients.clear()
+    """Close transport and clear metadata store (called on app shutdown)."""
+    if transport is not None:
+        await transport.close()
     store = metadata_store or _default_metadata_store
     store.clear()
 
@@ -390,6 +275,7 @@ async def handle_non_streaming(
     body: dict[str, Any],
     model: str,
     *,
+    transport: UpstreamTransport,
     metadata_store: ProviderMetadataStore | None = None,
     extra_headers: dict[str, str] | None = None,
     target_shim_name: str | None = None,
@@ -457,46 +343,41 @@ async def handle_non_streaming(
     if target_to_t:
         target_body = apply_transforms(target_to_t, target_body)
 
-    # 3. Build upstream request
-    url, headers, upstream_body = prepare_upstream(
-        target_provider,
-        provider_info,
-        target_body,
-        model,
-        stream=False,
-        extra_headers=extra_headers,
-    )
-
     # -- body log: target request body --
-    log_converted_request(upstream_body)
+    log_converted_request(target_body)
 
-    # 4. Forward to upstream
-    client = get_client(provider_info.proxy_url)
+    # 3. Forward to upstream via transport
     try:
-        upstream_resp = await client.post(url, json=upstream_body, headers=headers)
-    except HttpClientError as exc:
+        resp = await transport.send_request(
+            provider_info,
+            target_provider,
+            target_body,
+            model,
+            extra_headers=extra_headers,
+        )
+    except UpstreamConnectionError as exc:
         return error_response_for_source(
             source_provider, 502, f"Upstream request failed: {exc}"
         )
-    assert isinstance(upstream_resp, HttpResponse)
 
-    # 5. Pass through upstream errors
-    if upstream_resp.status_code >= 400:
+    # 4. Pass through upstream errors
+    if resp.is_error:
         log_upstream_error(
-            upstream_resp.status_code,
-            upstream_resp.text,
+            resp.status_code,
+            resp.error_text,
             endpoint=str(target_provider),
         )
         return Response(
-            body=upstream_resp.content,
-            status_code=upstream_resp.status_code,
+            body=resp.raw_content,
+            status_code=resp.status_code,
             content_type="application/json",
         )
 
-    # 6. Target response -> IR
+    # 5. Target response -> IR
+    upstream_json = resp.body
+    assert upstream_json is not None
     try:
-        upstream_json = upstream_resp.json()
-        # 6a. Apply target shim from_transforms (normalise response dialect)
+        # 5a. Apply target shim from_transforms (normalise response dialect)
         if target_from_t:
             upstream_json = apply_transforms(target_from_t, upstream_json)
         ir_response = target_converter.response_from_provider(
@@ -510,10 +391,10 @@ async def handle_non_streaming(
     # -- body log: upstream response --
     log_response(upstream_json, label="UPSTREAM RESPONSE")
 
-    # 6b. Cache provider_metadata from tool calls for follow-up requests
+    # 5b. Cache provider_metadata from tool calls for follow-up requests
     store.cache_from_response(ir_response)
 
-    # 7. IR -> Source response
+    # 6. IR -> Source response
     try:
         source_response = source_converter.response_to_provider(
             ir_response, context=ctx
@@ -524,49 +405,6 @@ async def handle_non_streaming(
         )
 
     return JSONResponse(source_response)
-
-
-_SENTINEL_DONE = object()
-
-
-def _parse_sse_data(line: str) -> Any:
-    """Parse a single SSE line and return the JSON chunk, or None to skip.
-
-    Returns ``_SENTINEL_DONE`` when the stream signals completion.
-    """
-    parsed = _iter_sse_lines(line)
-    if parsed is None:
-        return None
-    field, value = parsed
-    if field == "event" or field != "data" or value is None:
-        return None
-    if _is_openai_done(value):
-        return _SENTINEL_DONE
-    try:
-        return json.loads(value)
-    except json.JSONDecodeError:
-        logger.warning("Skipping malformed SSE data: %s", value[:200])
-        return None
-
-
-async def _format_upstream_error(upstream_resp: Any, endpoint: str) -> str:
-    """Read an error response from upstream and format it as an SSE data line."""
-    raw = await upstream_resp.aread()
-    error_text = (
-        raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
-    )
-    log_upstream_error(
-        upstream_resp.status_code,
-        error_text,
-        endpoint=endpoint,
-        is_streaming=True,
-    )
-    try:
-        error_body = json.loads(error_text)
-        error_msg = json.dumps(error_body)
-    except json.JSONDecodeError:
-        error_msg = error_text
-    return f"data: {error_msg}\n\n"
 
 
 def process_stream_chunk(
@@ -613,14 +451,14 @@ async def _stream_event_generator(
     source_converter: Any,
     target_converter: Any,
     ctx: ConversionContext,
+    transport: UpstreamTransport,
     provider_info: ProviderInfo,
-    url: str,
-    upstream_body: dict[str, Any],
-    headers: dict[str, str],
+    target_body: dict[str, Any],
+    model: str,
     format_sse: Any,
     store: ProviderMetadataStore,
-    model: str,
     target_from_transforms: tuple[Transform, ...] = (),
+    extra_headers: dict[str, str] | None = None,
 ) -> AsyncIterator[str]:
     """Stream SSE events from upstream, converting each chunk."""
     from_ctx = target_converter.create_stream_context()  # upstream -> IR
@@ -635,26 +473,35 @@ async def _stream_event_generator(
     chunk_count = 0
     t0 = time.monotonic()
 
-    client = get_client(provider_info.proxy_url)
-    upstream_resp = await client.post(
-        url, json=upstream_body, headers=headers, stream=True
-    )
-    assert isinstance(upstream_resp, HttpStreamingResponse)
-    async with upstream_resp:
-        if upstream_resp.status_code >= 400:
-            error_sse = await _format_upstream_error(
-                upstream_resp, str(target_provider)
+    try:
+        stream = await transport.send_streaming(
+            provider_info,
+            target_provider,
+            target_body,
+            model,
+            extra_headers=extra_headers,
+        )
+    except UpstreamConnectionError as exc:
+        yield f"data: {json.dumps({'error': {'message': str(exc)}})}\n\n"
+        return
+
+    async with stream:
+        if stream.is_error:
+            error_text = await stream.read_error()
+            log_upstream_error(
+                stream.status_code,
+                error_text,
+                endpoint=str(target_provider),
+                is_streaming=True,
             )
-            yield error_sse
+            try:
+                error_msg = json.dumps(json.loads(error_text))
+            except json.JSONDecodeError:
+                error_msg = error_text
+            yield f"data: {error_msg}\n\n"
             return
 
-        async for line in upstream_resp.aiter_lines():
-            chunk = _parse_sse_data(line)
-            if chunk is _SENTINEL_DONE:
-                break
-            if chunk is None:
-                continue
-
+        async for chunk in stream:
             chunk_count += 1
             for sse_line in process_stream_chunk(
                 chunk,
@@ -669,7 +516,7 @@ async def _stream_event_generator(
                 yield sse_line
 
     if source_provider == "openai_chat":
-        yield _format_sse_openai_chat_done()
+        yield format_sse_done()
 
     log_stream_summary(
         model=model,
@@ -685,6 +532,7 @@ async def handle_streaming(
     body: dict[str, Any],
     model: str,
     *,
+    transport: UpstreamTransport,
     metadata_store: ProviderMetadataStore | None = None,
     extra_headers: dict[str, str] | None = None,
     target_shim_name: str | None = None,
@@ -752,18 +600,8 @@ async def handle_streaming(
     if target_to_t:
         target_body = apply_transforms(target_to_t, target_body)
 
-    # 3. Build upstream request (with stream=True)
-    url, headers, upstream_body = prepare_upstream(
-        target_provider,
-        provider_info,
-        target_body,
-        model,
-        stream=True,
-        extra_headers=extra_headers,
-    )
-
     # -- body log: target request body --
-    log_converted_request(upstream_body)
+    log_converted_request(target_body)
 
     format_sse = SSE_FORMATTERS[source_provider]
 
@@ -774,14 +612,14 @@ async def handle_streaming(
             source_converter=source_converter,
             target_converter=target_converter,
             ctx=ctx,
+            transport=transport,
             provider_info=provider_info,
-            url=url,
-            upstream_body=upstream_body,
-            headers=headers,
+            target_body=target_body,
+            model=model,
             format_sse=format_sse,
             store=store,
-            model=model,
             target_from_transforms=target_from_t,
+            extra_headers=extra_headers,
         ),
         content_type="text/event-stream",
     )

--- a/src/llm_rosetta/gateway/transport/__init__.py
+++ b/src/llm_rosetta/gateway/transport/__init__.py
@@ -1,0 +1,38 @@
+"""Transport layer — protocol-agnostic interface and implementations.
+
+This package provides a clean boundary between the proxy pipeline and
+the underlying communication protocol.  The proxy programs against the
+:class:`UpstreamTransport` protocol; concrete implementations live in
+sub-packages:
+
+* :mod:`transport.http` — HTTP REST + SSE streaming (current).
+* ``transport.grpc`` — gRPC (future).
+* ``transport.websocket`` — WebSocket (future).
+"""
+
+from ._base import (
+    UpstreamConnectionError,
+    UpstreamResponse,
+    UpstreamStream,
+    UpstreamTransport,
+)
+from .http import HttpTransport
+from .provider_info import AuthHeaderFn, KeyRing, ProviderInfo
+from .sse_format import SSE_FORMATTERS, format_sse_done
+
+__all__ = [
+    # Protocol + response types
+    "UpstreamConnectionError",
+    "UpstreamResponse",
+    "UpstreamStream",
+    "UpstreamTransport",
+    # HTTP implementation
+    "HttpTransport",
+    # Provider config
+    "AuthHeaderFn",
+    "KeyRing",
+    "ProviderInfo",
+    # Downstream SSE formatting
+    "SSE_FORMATTERS",
+    "format_sse_done",
+]

--- a/src/llm_rosetta/gateway/transport/__init__.py
+++ b/src/llm_rosetta/gateway/transport/__init__.py
@@ -17,7 +17,14 @@ from ._base import (
     UpstreamTransport,
 )
 from .http import HttpTransport
-from .provider_info import AuthHeaderFn, KeyRing, ProviderInfo
+from .provider_info import (
+    AuthHeaderFn,
+    KeyRing,
+    ProviderInfo,
+    anthropic_auth,
+    google_auth,
+    openai_auth,
+)
 from .sse_format import SSE_FORMATTERS, format_sse_done
 
 __all__ = [
@@ -32,6 +39,9 @@ __all__ = [
     "AuthHeaderFn",
     "KeyRing",
     "ProviderInfo",
+    "openai_auth",
+    "anthropic_auth",
+    "google_auth",
     # Downstream SSE formatting
     "SSE_FORMATTERS",
     "format_sse_done",

--- a/src/llm_rosetta/gateway/transport/_base.py
+++ b/src/llm_rosetta/gateway/transport/_base.py
@@ -1,0 +1,153 @@
+"""Transport layer abstractions — protocol-agnostic interface.
+
+Defines the :class:`UpstreamTransport` protocol and response types that
+the proxy pipeline programs against.  Concrete implementations (HTTP/SSE,
+gRPC, WebSocket) live in sub-packages (e.g. ``transport.http``).
+"""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from llm_rosetta.auto_detect import ProviderType
+
+from .provider_info import ProviderInfo
+
+
+# ---------------------------------------------------------------------------
+# Response types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class UpstreamResponse:
+    """Result from a non-streaming upstream call.
+
+    Attributes:
+        status_code: HTTP status code (or equivalent for other transports).
+        body: Parsed JSON response body, or ``None`` on error.
+        raw_content: Raw response bytes for error passthrough.
+    """
+
+    status_code: int
+    body: dict[str, Any] | None
+    raw_content: bytes
+
+    @property
+    def is_error(self) -> bool:
+        """True if the upstream returned an error status."""
+        return self.status_code >= 400
+
+    @property
+    def error_text(self) -> str:
+        """Decode *raw_content* as UTF-8 for logging/passthrough."""
+        return self.raw_content.decode("utf-8", errors="replace")
+
+    @property
+    def error_json(self) -> str:
+        """Best-effort JSON string of the error body for SSE passthrough."""
+        try:
+            return json.dumps(json.loads(self.error_text))
+        except (json.JSONDecodeError, ValueError):
+            return self.error_text
+
+
+class UpstreamStream(ABC):
+    """Async context manager + iterator for a streaming upstream response.
+
+    Usage::
+
+        stream = await transport.send_streaming(...)
+        async with stream:
+            if stream.is_error:
+                error_text = await stream.read_error()
+                ...
+                return
+            async for chunk in stream:
+                process(chunk)   # chunk is a parsed dict
+
+    Subclasses must implement :meth:`read_error`, :meth:`__aiter__`,
+    and :meth:`close`.
+    """
+
+    status_code: int
+
+    @property
+    def is_error(self) -> bool:
+        """True if the upstream returned an error status."""
+        return self.status_code >= 400
+
+    @abstractmethod
+    async def read_error(self) -> str:
+        """Read the error body as a string.
+
+        Only valid when :attr:`is_error` is ``True``.
+        """
+
+    @abstractmethod
+    def __aiter__(self) -> AsyncIterator[dict[str, Any]]:
+        """Yield parsed response chunks (e.g. JSON objects from SSE data)."""
+
+    async def __aenter__(self) -> UpstreamStream:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Release underlying transport resources."""
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class UpstreamConnectionError(Exception):
+    """Raised when the transport cannot reach the upstream provider."""
+
+
+# ---------------------------------------------------------------------------
+# Transport protocol
+# ---------------------------------------------------------------------------
+
+
+class UpstreamTransport(Protocol):
+    """Interface for sending requests to an upstream LLM provider.
+
+    The proxy pipeline programs against this protocol.  Concrete
+    implementations live in sub-packages (``transport.http``, etc.).
+    """
+
+    async def send_request(
+        self,
+        provider_info: ProviderInfo,
+        target_provider: ProviderType,
+        body: dict[str, Any],
+        model: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> UpstreamResponse:
+        """Send a non-streaming request and return the full response."""
+        ...
+
+    async def send_streaming(
+        self,
+        provider_info: ProviderInfo,
+        target_provider: ProviderType,
+        body: dict[str, Any],
+        model: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> UpstreamStream:
+        """Send a streaming request and return an async chunk iterator."""
+        ...
+
+    async def close(self) -> None:
+        """Release all transport resources (connection pools, etc.)."""
+        ...

--- a/src/llm_rosetta/gateway/transport/_base.py
+++ b/src/llm_rosetta/gateway/transport/_base.py
@@ -148,6 +148,23 @@ class UpstreamTransport(Protocol):
         """Send a streaming request and return an async chunk iterator."""
         ...
 
+    async def send_passthrough(
+        self,
+        provider_info: ProviderInfo,
+        url: str,
+        body: dict[str, Any],
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> UpstreamResponse:
+        """Send a raw passthrough request (no format-specific URL or flags).
+
+        Used for endpoints that don't go through IR conversion (e.g.
+        embeddings, reranking) — the URL is caller-provided, auth
+        headers come from *provider_info*, and the body is forwarded
+        as-is.
+        """
+        ...
+
     async def close(self) -> None:
         """Release all transport resources (connection pools, etc.)."""
         ...

--- a/src/llm_rosetta/gateway/transport/http/__init__.py
+++ b/src/llm_rosetta/gateway/transport/http/__init__.py
@@ -1,0 +1,10 @@
+"""HTTP/SSE transport implementation."""
+
+from .client_pool import HttpClientPool
+from .transport import HttpTransport, HttpUpstreamStream
+
+__all__ = [
+    "HttpClientPool",
+    "HttpTransport",
+    "HttpUpstreamStream",
+]

--- a/src/llm_rosetta/gateway/transport/http/client_pool.py
+++ b/src/llm_rosetta/gateway/transport/http/client_pool.py
@@ -1,0 +1,37 @@
+"""HTTP client pool — manages :class:`AsyncClient` instances.
+
+Thin wrapper over :mod:`llm_rosetta._vendor.httpclient` that pools
+``AsyncClient`` instances by proxy URL so multiple requests to the
+same upstream reuse the same connection pool.
+"""
+
+from __future__ import annotations
+
+from llm_rosetta._vendor.httpclient import AsyncClient
+
+
+class HttpClientPool:
+    """Manages :class:`AsyncClient` instances keyed by proxy URL.
+
+    Each unique ``proxy_url`` (including ``None`` for direct connections)
+    gets its own ``AsyncClient`` with connection pooling.
+    """
+
+    def __init__(self, *, timeout: float = 300.0) -> None:
+        self._clients: dict[str | None, AsyncClient] = {}
+        self._timeout = timeout
+
+    def get(self, proxy_url: str | None = None) -> AsyncClient:
+        """Get or create an ``AsyncClient`` for the given proxy URL."""
+        if proxy_url not in self._clients:
+            self._clients[proxy_url] = AsyncClient(
+                timeout=self._timeout,
+                proxy=proxy_url,
+            )
+        return self._clients[proxy_url]
+
+    async def close_all(self) -> None:
+        """Close all pooled HTTP clients."""
+        for client in self._clients.values():
+            await client.aclose()
+        self._clients.clear()

--- a/src/llm_rosetta/gateway/transport/http/transport.py
+++ b/src/llm_rosetta/gateway/transport/http/transport.py
@@ -1,0 +1,181 @@
+"""HTTP/SSE transport implementation.
+
+Implements the :class:`~transport._base.UpstreamTransport` protocol for
+HTTP REST + SSE streaming, backed by the vendored ``httpclient`` and ``sse``
+modules.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+from llm_rosetta._vendor.httpclient import (
+    HttpClientError,
+    Response as HttpResponse,
+    StreamingResponse as HttpStreamingResponse,
+)
+from llm_rosetta._vendor.sse import AsyncEventSource
+from llm_rosetta.auto_detect import ProviderType
+
+from .._base import UpstreamConnectionError, UpstreamResponse, UpstreamStream
+from ..provider_info import ProviderInfo
+from .client_pool import HttpClientPool
+
+logger = logging.getLogger("llm-rosetta-gateway")
+
+
+# ---------------------------------------------------------------------------
+# Upstream request assembly
+# ---------------------------------------------------------------------------
+
+
+def _prepare_upstream(
+    target_provider: ProviderType,
+    provider_info: ProviderInfo,
+    provider_request: dict[str, Any],
+    model: str,
+    *,
+    stream: bool,
+    extra_headers: dict[str, str] | None = None,
+) -> tuple[str, dict[str, str], dict[str, Any]]:
+    """Return ``(url, headers, body)`` ready for the upstream HTTP call."""
+    url = provider_info.upstream_url(model, stream=stream)
+    headers = {
+        "Content-Type": "application/json",
+        **provider_info.auth_headers(),
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+
+    body = dict(provider_request)
+
+    # Inject stream flag into the body for providers that use it
+    if stream:
+        if target_provider in ("openai_chat",):
+            body["stream"] = True
+            body["stream_options"] = {"include_usage": True}
+        elif target_provider in ("openai_responses", "open_responses", "anthropic"):
+            body["stream"] = True
+        # Google streaming is signaled via URL, not body
+
+    return url, headers, body
+
+
+# ---------------------------------------------------------------------------
+# Streaming response wrapper
+# ---------------------------------------------------------------------------
+
+
+class HttpUpstreamStream(UpstreamStream):
+    """Streaming response backed by HTTP/SSE.
+
+    Wraps a :class:`~httpclient.StreamingResponse` and uses the vendored
+    :class:`~sse.AsyncEventSource` to parse SSE events into JSON chunks.
+    """
+
+    def __init__(self, resp: HttpStreamingResponse) -> None:
+        self.status_code = resp.status_code
+        self._resp = resp
+
+    async def read_error(self) -> str:
+        """Read the error body as a string."""
+        raw = await self._resp.aread()
+        return raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else raw
+
+    async def __aiter__(self) -> AsyncIterator[dict[str, Any]]:  # type: ignore[override]
+        """Yield parsed JSON chunks from the upstream SSE stream.
+
+        Uses the vendored W3C-compliant SSE parser.  Detects OpenAI's
+        ``[DONE]`` marker and stops iteration.
+        """
+        async for event in AsyncEventSource(self._resp.aiter_lines()):
+            if event.data == "[DONE]":
+                break
+            try:
+                yield json.loads(event.data)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed SSE data: %s", event.data[:200])
+
+    async def close(self) -> None:
+        """Close the underlying HTTP streaming response."""
+        await self._resp.aclose()
+
+
+# ---------------------------------------------------------------------------
+# HttpTransport
+# ---------------------------------------------------------------------------
+
+
+class HttpTransport:
+    """Upstream transport implementation for HTTP REST + SSE streaming.
+
+    Implements the :class:`~transport._base.UpstreamTransport` protocol.
+    """
+
+    def __init__(self, *, timeout: float = 300.0) -> None:
+        self._pool = HttpClientPool(timeout=timeout)
+
+    async def send_request(
+        self,
+        provider_info: ProviderInfo,
+        target_provider: ProviderType,
+        body: dict[str, Any],
+        model: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> UpstreamResponse:
+        """Send a non-streaming request and return the full response."""
+        url, headers, req_body = _prepare_upstream(
+            target_provider,
+            provider_info,
+            body,
+            model,
+            stream=False,
+            extra_headers=extra_headers,
+        )
+        client = self._pool.get(provider_info.proxy_url)
+        try:
+            resp = await client.post(url, json=req_body, headers=headers)
+        except HttpClientError as exc:
+            raise UpstreamConnectionError(str(exc)) from exc
+
+        assert isinstance(resp, HttpResponse)
+        return UpstreamResponse(
+            status_code=resp.status_code,
+            body=resp.json() if resp.status_code < 400 else None,
+            raw_content=resp.content,
+        )
+
+    async def send_streaming(
+        self,
+        provider_info: ProviderInfo,
+        target_provider: ProviderType,
+        body: dict[str, Any],
+        model: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> HttpUpstreamStream:
+        """Send a streaming request and return an async chunk iterator."""
+        url, headers, req_body = _prepare_upstream(
+            target_provider,
+            provider_info,
+            body,
+            model,
+            stream=True,
+            extra_headers=extra_headers,
+        )
+        client = self._pool.get(provider_info.proxy_url)
+        try:
+            resp = await client.post(url, json=req_body, headers=headers, stream=True)
+        except HttpClientError as exc:
+            raise UpstreamConnectionError(str(exc)) from exc
+
+        assert isinstance(resp, HttpStreamingResponse)
+        return HttpUpstreamStream(resp)
+
+    async def close(self) -> None:
+        """Close all pooled HTTP clients."""
+        await self._pool.close_all()

--- a/src/llm_rosetta/gateway/transport/http/transport.py
+++ b/src/llm_rosetta/gateway/transport/http/transport.py
@@ -176,6 +176,38 @@ class HttpTransport:
         assert isinstance(resp, HttpStreamingResponse)
         return HttpUpstreamStream(resp)
 
+    async def send_passthrough(
+        self,
+        provider_info: ProviderInfo,
+        url: str,
+        body: dict[str, Any],
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> UpstreamResponse:
+        """Send a raw passthrough request — no URL template or stream flags.
+
+        Used for non-conversion endpoints (embeddings, reranking, etc.).
+        """
+        headers = {
+            "Content-Type": "application/json",
+            **provider_info.auth_headers(),
+        }
+        if extra_headers:
+            headers.update(extra_headers)
+
+        client = self._pool.get(provider_info.proxy_url)
+        try:
+            resp = await client.post(url, json=body, headers=headers)
+        except HttpClientError as exc:
+            raise UpstreamConnectionError(str(exc)) from exc
+
+        assert isinstance(resp, HttpResponse)
+        return UpstreamResponse(
+            status_code=resp.status_code,
+            body=resp.json() if resp.status_code < 400 else None,
+            raw_content=resp.content,
+        )
+
     async def close(self) -> None:
         """Close all pooled HTTP clients."""
         await self._pool.close_all()

--- a/src/llm_rosetta/gateway/transport/provider_info.py
+++ b/src/llm_rosetta/gateway/transport/provider_info.py
@@ -1,0 +1,120 @@
+"""Provider runtime configuration — connection info, auth, and key rotation.
+
+This module contains the data classes that describe *how* to talk to an
+upstream provider at the transport level:
+
+* :class:`KeyRing` — round-robin API key selector.
+* :class:`ProviderInfo` — base URL, auth headers, URL templates.
+* Auth header builder functions (``_openai_auth``, ``_anthropic_auth``,
+  ``_google_auth``).
+
+Higher-level factory logic (shim resolution, config parsing) stays in
+``gateway.providers``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+# Type alias for auth-header builder callables
+AuthHeaderFn = Callable[[str], dict[str, str]]
+
+
+# ---------------------------------------------------------------------------
+# API key rotation (round-robin)
+# ---------------------------------------------------------------------------
+
+
+class KeyRing:
+    """Round-robin API key selector.
+
+    Accepts a single key string **or** a comma-separated list of keys.
+    Each call to :meth:`next` returns the next key in rotation.
+    """
+
+    def __init__(self, keys_csv: str) -> None:
+        self._keys = [k.strip() for k in keys_csv.split(",") if k.strip()]
+        self._idx = 0
+
+    def next(self) -> str:
+        """Return the next API key."""
+        if not self._keys:
+            raise ValueError("No API keys configured")
+        key = self._keys[self._idx]
+        self._idx = (self._idx + 1) % len(self._keys)
+        return key
+
+    def __len__(self) -> int:
+        return len(self._keys)
+
+
+# ---------------------------------------------------------------------------
+# Provider descriptor
+# ---------------------------------------------------------------------------
+
+
+class ProviderInfo:
+    """Runtime representation of a single configured provider.
+
+    Encapsulates base_url, key rotation, auth-header construction,
+    and upstream URL building.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        api_key: str,
+        base_url: str,
+        auth_header_fn: AuthHeaderFn,
+        url_template: str,
+        stream_url_template: str | None = None,
+        proxy_url: str | None = None,
+    ) -> None:
+        if not base_url.startswith(("http://", "https://")):
+            raise ValueError(
+                f"Provider '{name}': base_url must start with http:// or https://, "
+                f"got '{base_url}'"
+            )
+        self.name = name
+        self.base_url = base_url.rstrip("/")
+        self.key_ring = KeyRing(api_key)
+        self._auth_header_fn = auth_header_fn
+        self._url_template = url_template
+        self._stream_url_template = stream_url_template
+        self.proxy_url = proxy_url
+
+    # -- public helpers used by the proxy -----------------------------------
+
+    def auth_headers(self) -> dict[str, str]:
+        """Return auth headers using the next rotated key."""
+        return self._auth_header_fn(self.key_ring.next())
+
+    def upstream_url(self, model: str, *, stream: bool = False) -> str:
+        """Build the upstream URL for the given model."""
+        tpl = (
+            self._stream_url_template
+            if (stream and self._stream_url_template)
+            else self._url_template
+        )
+        return tpl.format(base_url=self.base_url, model=model)
+
+
+# ---------------------------------------------------------------------------
+# Per-provider auth header builders
+# ---------------------------------------------------------------------------
+
+
+def _openai_auth(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _anthropic_auth(api_key: str) -> dict[str, str]:
+    return {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+    }
+
+
+def _google_auth(api_key: str) -> dict[str, str]:
+    return {"x-goog-api-key": api_key}

--- a/src/llm_rosetta/gateway/transport/provider_info.py
+++ b/src/llm_rosetta/gateway/transport/provider_info.py
@@ -5,8 +5,8 @@ upstream provider at the transport level:
 
 * :class:`KeyRing` — round-robin API key selector.
 * :class:`ProviderInfo` — base URL, auth headers, URL templates.
-* Auth header builder functions (``_openai_auth``, ``_anthropic_auth``,
-  ``_google_auth``).
+* Auth header builder functions (``openai_auth``, ``anthropic_auth``,
+  ``google_auth``).
 
 Higher-level factory logic (shim resolution, config parsing) stays in
 ``gateway.providers``.
@@ -105,16 +105,16 @@ class ProviderInfo:
 # ---------------------------------------------------------------------------
 
 
-def _openai_auth(api_key: str) -> dict[str, str]:
+def openai_auth(api_key: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {api_key}"}
 
 
-def _anthropic_auth(api_key: str) -> dict[str, str]:
+def anthropic_auth(api_key: str) -> dict[str, str]:
     return {
         "x-api-key": api_key,
         "anthropic-version": "2023-06-01",
     }
 
 
-def _google_auth(api_key: str) -> dict[str, str]:
+def google_auth(api_key: str) -> dict[str, str]:
     return {"x-goog-api-key": api_key}

--- a/src/llm_rosetta/gateway/transport/sse_format.py
+++ b/src/llm_rosetta/gateway/transport/sse_format.py
@@ -1,0 +1,52 @@
+"""Downstream SSE formatters — IR/provider chunks → SSE text for clients.
+
+The gateway always speaks HTTP/SSE to downstream clients, regardless of
+the upstream transport protocol.  These formatters produce the SSE text
+lines that are written to the client response stream.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Per-provider SSE formatters
+# ---------------------------------------------------------------------------
+
+
+def _format_sse_openai_chat(chunk: dict[str, Any]) -> str:
+    """Format a chunk as OpenAI Chat SSE line."""
+    return f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+
+
+def format_sse_done() -> str:
+    """Emit the OpenAI Chat ``[DONE]`` marker."""
+    return "data: [DONE]\n\n"
+
+
+def _format_sse_anthropic(chunk: dict[str, Any]) -> str:
+    """Format a chunk as Anthropic SSE (``event: type\\ndata: json``)."""
+    event_type = chunk.get("type", "unknown")
+    return f"event: {event_type}\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+
+
+def _format_sse_openai_responses(chunk: dict[str, Any]) -> str:
+    """Format a chunk as OpenAI Responses SSE (``event: type\\ndata: json``)."""
+    event_type = chunk.get("type", "unknown")
+    return f"event: {event_type}\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+
+
+def _format_sse_google(chunk: dict[str, Any]) -> str:
+    """Format a chunk as Google SSE line."""
+    return f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+
+
+SSE_FORMATTERS: dict[str, Any] = {
+    "openai_chat": _format_sse_openai_chat,
+    "openai_responses": _format_sse_openai_responses,
+    "open_responses": _format_sse_openai_responses,
+    "anthropic": _format_sse_anthropic,
+    "google": _format_sse_google,
+}

--- a/tests/gateway/test_embeddings.py
+++ b/tests/gateway/test_embeddings.py
@@ -13,7 +13,7 @@ import pytest
 
 from llm_rosetta.gateway.config import GatewayConfig
 from llm_rosetta.gateway.embeddings import handle_embeddings
-from llm_rosetta.gateway.proxy import _http_clients
+from llm_rosetta.gateway.transport.http import HttpTransport
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +101,7 @@ def _make_request(body: dict[str, Any]) -> MagicMock:
     app = MagicMock()
     app.metrics = None
     app.request_log = None
+    app.transport = HttpTransport()
     req.app = app
     return req
 
@@ -114,10 +115,9 @@ class TestEmbeddingUpstreamModel:
     """Tests for upstream_model substitution in embedding requests."""
 
     @pytest.fixture(autouse=True)
-    def _clear_http_clients(self):
-        """Clear the shared HTTP client pool between tests to avoid stale
-        connections across ``asyncio.run()`` calls."""
-        _http_clients.clear()
+    def _clear_transport(self):
+        """Ensure fresh transport state between tests."""
+        yield
 
     def test_upstream_model_substituted(self, echo_embedding_server: str):
         """When upstream_model is configured, the body sent to upstream should

--- a/tests/gateway/test_proxy_transforms.py
+++ b/tests/gateway/test_proxy_transforms.py
@@ -3,22 +3,24 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from llm_rosetta._vendor.httpclient import Response as HttpResponse
 from llm_rosetta.gateway.proxy import (
+    ProviderMetadataStore,
     _resolve_target_transforms,
     handle_non_streaming,
-    ProviderMetadataStore,
 )
+from llm_rosetta.gateway.transport._base import UpstreamResponse
 from llm_rosetta.shims.provider_shim import (
     ProviderShim,
     _reset_registry,
     register_shim,
 )
-from llm_rosetta.shims.transforms import strip_fields, rename_field
+from llm_rosetta.shims.transforms import rename_field, strip_fields
 
 
 # ---------------------------------------------------------------------------
@@ -28,15 +30,14 @@ from llm_rosetta.shims.transforms import strip_fields, rename_field
 
 @pytest.fixture(autouse=True)
 def _clean_registry():
-    """Reset the shim registry before and after each test."""
-    _reset_registry()
+    """Reset the shim registry before each test."""
     yield
     _reset_registry()
 
 
 @pytest.fixture()
 def volcengine_shim():
-    """Register a volcengine-like shim with to_transforms."""
+    """Register a volcengine-like shim with to_transforms that strip fields."""
     shim = ProviderShim(
         name="volcengine--openai_chat",
         base="openai_chat",
@@ -48,12 +49,12 @@ def volcengine_shim():
 
 @pytest.fixture()
 def shim_with_transforms():
-    """Register a shim with provider-level transforms."""
+    """Register a shim with both from_transforms and to_transforms."""
     shim = ProviderShim(
         name="custom_provider",
         base="openai_chat",
-        to_transforms=(strip_fields("unsupported_field"),),
         from_transforms=(rename_field("custom_id", "id"),),
+        to_transforms=(strip_fields("logprobs"),),
     )
     register_shim(shim)
     return shim
@@ -65,62 +66,54 @@ def shim_with_transforms():
 
 
 class TestResolveTargetTransforms:
-    def test_none_shim_returns_empty(self):
-        from_t, to_t = _resolve_target_transforms(None, "any-model")
+    def test_none_shim(self):
+        from_t, to_t = _resolve_target_transforms(None)
         assert from_t == ()
         assert to_t == ()
 
-    def test_unknown_shim_returns_empty(self):
-        from_t, to_t = _resolve_target_transforms("nonexistent", "any-model")
+    def test_unknown_shim(self):
+        from_t, to_t = _resolve_target_transforms("nonexistent-provider")
         assert from_t == ()
         assert to_t == ()
 
-    def test_shim_without_transforms_returns_empty(self):
-        register_shim(ProviderShim(name="plain", base="openai_chat"))
-        from_t, to_t = _resolve_target_transforms("plain", "any-model")
+    def test_volcengine_shim(self, volcengine_shim):
+        from_t, to_t = _resolve_target_transforms("volcengine--openai_chat")
+        assert to_t == volcengine_shim.to_transforms
         assert from_t == ()
-        assert to_t == ()
 
-    def test_shim_with_to_transforms(self, volcengine_shim):
-        from_t, to_t = _resolve_target_transforms(
-            "volcengine--openai_chat", "some-model"
+    def test_shim_with_both_transforms(self, shim_with_transforms):
+        from_t, to_t = _resolve_target_transforms("custom_provider")
+        assert from_t == shim_with_transforms.from_transforms
+        assert to_t == shim_with_transforms.to_transforms
+
+
+# ---------------------------------------------------------------------------
+# Mock transport helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_transport(
+    response_json: dict[str, Any],
+    *,
+    status_code: int = 200,
+    captured_body: dict[str, Any] | None = None,
+) -> MagicMock:
+    """Create a mock transport that returns an UpstreamResponse."""
+
+    async def mock_send_request(
+        provider_info, target_provider, body, model, *, extra_headers=None
+    ):
+        if captured_body is not None:
+            captured_body.update(body)
+        return UpstreamResponse(
+            status_code=status_code,
+            body=response_json if status_code < 400 else None,
+            raw_content=json.dumps(response_json).encode(),
         )
-        assert from_t == ()
-        assert len(to_t) == 1
-        # Verify the transform actually strips the right fields
-        body = {"logprobs": True, "top_logprobs": 5, "model": "test"}
-        result = to_t[0](body)
-        assert "logprobs" not in result
-        assert "top_logprobs" not in result
-        assert result["model"] == "test"
 
-    def test_shim_provider_level_only(self, shim_with_transforms):
-        """Only provider-level transforms are returned."""
-        from_t, to_t = _resolve_target_transforms("custom_provider", "special-v1")
-        assert len(from_t) == 1
-        assert len(to_t) == 1
-
-    def test_shim_same_regardless_of_model(self, shim_with_transforms):
-        """Transforms are the same no matter which model name is passed."""
-        from_t1, to_t1 = _resolve_target_transforms("custom_provider", "special-v1")
-        from_t2, to_t2 = _resolve_target_transforms("custom_provider", "regular-model")
-        assert from_t1 == from_t2
-        assert to_t1 == to_t2
-
-
-# ---------------------------------------------------------------------------
-# handle_non_streaming — transform integration
-# ---------------------------------------------------------------------------
-
-
-def _make_mock_response(status_code: int, json_data: dict) -> MagicMock:
-    """Create a mock HTTP response that passes isinstance checks."""
-    resp = MagicMock(spec=HttpResponse)
-    resp.status_code = status_code
-    resp.json.return_value = json_data
-    resp.content = b"{}"
-    resp.text = "{}"
-    return resp
+    transport = MagicMock()
+    transport.send_request = AsyncMock(side_effect=mock_send_request)
+    return transport
 
 
 def _make_provider_info() -> MagicMock:
@@ -132,43 +125,39 @@ def _make_provider_info() -> MagicMock:
     return info
 
 
+# ---------------------------------------------------------------------------
+# handle_non_streaming — transform integration
+# ---------------------------------------------------------------------------
+
+
 class TestNonStreamingTransforms:
     def test_to_transforms_strip_fields(self, volcengine_shim):
         """to_transforms should strip fields from the target request body."""
-        captured_body = {}
-
-        async def mock_post(url, json=None, headers=None, **kwargs):
-            captured_body.update(json or {})
-            return _make_mock_response(
-                200,
-                {
-                    "id": "resp-1",
-                    "choices": [{"message": {"role": "assistant", "content": "hi"}}],
-                },
-            )
-
-        mock_client = AsyncMock()
-        mock_client.post = mock_post
+        captured_body: dict[str, Any] = {}
+        transport = _make_mock_transport(
+            {
+                "id": "resp-1",
+                "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+            },
+            captured_body=captured_body,
+        )
 
         async def run():
-            with patch(
-                "llm_rosetta.gateway.proxy.get_client",
-                return_value=mock_client,
-            ):
-                await handle_non_streaming(
-                    source_provider="openai_chat",
-                    target_provider="openai_chat",
-                    provider_info=_make_provider_info(),
-                    body={
-                        "model": "test-model",
-                        "messages": [{"role": "user", "content": "hello"}],
-                        "logprobs": True,
-                        "top_logprobs": 5,
-                    },
-                    model="test-model",
-                    metadata_store=ProviderMetadataStore(),
-                    target_shim_name="volcengine--openai_chat",
-                )
+            await handle_non_streaming(
+                source_provider="openai_chat",
+                target_provider="openai_chat",
+                provider_info=_make_provider_info(),
+                body={
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "logprobs": True,
+                    "top_logprobs": 5,
+                },
+                model="test-model",
+                transport=transport,
+                metadata_store=ProviderMetadataStore(),
+                target_shim_name="volcengine--openai_chat",
+            )
 
         asyncio.run(run())
 
@@ -179,40 +168,31 @@ class TestNonStreamingTransforms:
 
     def test_no_shim_no_transforms(self):
         """Without a shim, no transforms should be applied."""
-        captured_body = {}
-
-        async def mock_post(url, json=None, headers=None, **kwargs):
-            captured_body.update(json or {})
-            return _make_mock_response(
-                200,
-                {
-                    "id": "resp-1",
-                    "choices": [{"message": {"role": "assistant", "content": "hi"}}],
-                },
-            )
-
-        mock_client = AsyncMock()
-        mock_client.post = mock_post
+        captured_body: dict[str, Any] = {}
+        transport = _make_mock_transport(
+            {
+                "id": "resp-1",
+                "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+            },
+            captured_body=captured_body,
+        )
 
         async def run():
-            with patch(
-                "llm_rosetta.gateway.proxy.get_client",
-                return_value=mock_client,
-            ):
-                await handle_non_streaming(
-                    source_provider="openai_chat",
-                    target_provider="openai_chat",
-                    provider_info=_make_provider_info(),
-                    body={
-                        "model": "gpt-4",
-                        "messages": [{"role": "user", "content": "hello"}],
-                        "logprobs": True,
-                        "top_logprobs": 5,
-                    },
-                    model="gpt-4",
-                    metadata_store=ProviderMetadataStore(),
-                    target_shim_name=None,
-                )
+            await handle_non_streaming(
+                source_provider="openai_chat",
+                target_provider="openai_chat",
+                provider_info=_make_provider_info(),
+                body={
+                    "model": "gpt-4",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "logprobs": True,
+                    "top_logprobs": 5,
+                },
+                model="gpt-4",
+                transport=transport,
+                metadata_store=ProviderMetadataStore(),
+                target_shim_name=None,
+            )
 
         asyncio.run(run())
 
@@ -222,37 +202,28 @@ class TestNonStreamingTransforms:
 
     def test_from_transforms_on_response(self, shim_with_transforms):
         """from_transforms should be applied to the upstream response."""
-
-        async def mock_post(url, json=None, headers=None, **kwargs):
-            return _make_mock_response(
-                200,
-                {
-                    "custom_id": "resp-1",
-                    "choices": [{"message": {"role": "assistant", "content": "hi"}}],
-                },
-            )
-
-        mock_client = AsyncMock()
-        mock_client.post = mock_post
+        transport = _make_mock_transport(
+            {
+                "custom_id": "resp-1",
+                "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+            },
+        )
 
         async def run():
-            with patch(
-                "llm_rosetta.gateway.proxy.get_client",
-                return_value=mock_client,
-            ):
-                response = await handle_non_streaming(
-                    source_provider="openai_chat",
-                    target_provider="openai_chat",
-                    provider_info=_make_provider_info(),
-                    body={
-                        "model": "regular-model",
-                        "messages": [{"role": "user", "content": "hello"}],
-                    },
-                    model="regular-model",
-                    metadata_store=ProviderMetadataStore(),
-                    target_shim_name="custom_provider",
-                )
-                return response
+            response = await handle_non_streaming(
+                source_provider="openai_chat",
+                target_provider="openai_chat",
+                provider_info=_make_provider_info(),
+                body={
+                    "model": "regular-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+                model="regular-model",
+                transport=transport,
+                metadata_store=ProviderMetadataStore(),
+                target_shim_name="custom_provider",
+            )
+            return response
 
         response = asyncio.run(run())
         # The handler should complete without error


### PR DESCRIPTION
## Summary

- Introduce `UpstreamTransport` protocol + `UpstreamResponse` / `UpstreamStream` ABC in `transport/_base.py` — proxy.py programs against this interface
- Implement `HttpTransport` (HTTP REST + SSE streaming) under `transport/http/`, backed by vendored `httpclient` + new vendored `sse` module
- Vendor zerodep `sse.py` (v0.3.1) — W3C-compliant SSE parser with `AsyncEventSource`, replaces hand-rolled `parse_sse_line()` / `_parse_sse_data()`
- Move downstream SSE formatters to `transport/sse_format.py` (always HTTP, regardless of upstream protocol)
- proxy.py no longer imports from `_vendor/httpclient` — uses `UpstreamTransport` exclusively
- Future protocol backends (gRPC, WebSocket) can be added as sibling packages

### New structure
```
_vendor/sse.py                          # vendored W3C SSE parser
gateway/transport/
├── __init__.py                         # re-exports
├── _base.py                            # Protocol + response types
├── provider_info.py                    # ProviderInfo, KeyRing, auth
├── sse_format.py                       # downstream SSE formatters
└── http/
    ├── __init__.py
    ├── transport.py                    # HttpTransport + HttpUpstreamStream
    └── client_pool.py                  # AsyncClient pool
```

## Test plan

- [x] `make lint` passes (ruff check + format)
- [x] `make test` passes (1930 passed, 4 skipped)
- [x] No circular imports verified
- [x] proxy.py has zero direct `_vendor/httpclient` imports
- [x] Vendored SSE module importable

Closes #321