### PR TITLE
refactor: extract routing layer — ResolvedRoute + Router protocol (#323)

### DIFF
--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -197,7 +197,7 @@ async def _proxy_handler(
             route,
             provider_info,
             body,
-            transport=request.app.transport,  # type: ignore
+            transport=request.app.transport,
             metadata_store=store,
             extra_headers=extra_headers,
         )

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-from typing import Any, cast
+from typing import Any
 
 from llm_rosetta._vendor.httpserver import (
     App,
@@ -139,16 +139,9 @@ async def _proxy_handler(
     if model_override and "model" not in body:
         body["model"] = model_override
 
-    # Resolve target provider
+    # Resolve target provider via unified routing
     try:
-        (
-            target_provider_str,
-            provider_info,
-            target_shim_name,
-            upstream_model,
-            provider_name,
-        ) = _config.resolve_model(model)
-        target_provider: ProviderType = cast(ProviderType, target_provider_str)
+        route, provider_info = _config.resolve(source_provider, model)
     except KeyError:
         configured = ", ".join(sorted(_config.models.keys()))
         resp = error_response_for_source(
@@ -162,18 +155,20 @@ async def _proxy_handler(
     # Model alias: replace the model name in the request body with the
     # actual upstream identifier so the converter and upstream provider
     # both see the correct name.
-    if upstream_model:
-        body["model"] = upstream_model
+    if route.upstream_model:
+        body["model"] = route.upstream_model
 
     # Determine streaming
     is_stream = force_stream or detect_stream_request(source_provider, body)
 
-    model_label = f"{model} (upstream={upstream_model})" if upstream_model else model
+    model_label = (
+        f"{model} (upstream={route.upstream_model})" if route.upstream_model else model
+    )
     logger.info(
         "[%s] %s -> %s | model=%s stream=%s",
         request_id,
         source_provider,
-        target_provider,
+        route.target_provider,
         model_label,
         is_stream,
     )
@@ -198,21 +193,13 @@ async def _proxy_handler(
 
     try:
         handler = handle_streaming if is_stream else handle_non_streaming
-        # Resolve config-level reasoning override (keyed by gateway model name)
-        reasoning_override = _config.model_reasoning_overrides.get(model)
-        model_caps = _config.model_capabilities.get(model, ["text"])
         response = await handler(
-            source_provider,
-            target_provider,
+            route,
             provider_info,
             body,
-            model,
             transport=request.app.transport,  # type: ignore
             metadata_store=store,
             extra_headers=extra_headers,
-            target_shim_name=target_shim_name,
-            reasoning_config_override=reasoning_override,
-            model_capabilities=model_caps,
         )
         status_code = response.status_code
         if status_code >= 400 and hasattr(response, "body"):
@@ -236,8 +223,8 @@ async def _proxy_handler(
             request,
             model=model,
             source_provider=source_provider,
-            target_provider=target_provider,
-            provider_name=provider_name,
+            target_provider=route.target_provider,
+            provider_name=route.provider_name,
             is_stream=is_stream,
             status_code=status_code,
             duration_ms=(time.monotonic() - t0) * 1000,

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -9,6 +9,7 @@ import re
 from typing import Any
 
 from llm_rosetta.auto_detect import ProviderType
+from llm_rosetta.routing import ResolvedRoute
 
 from .providers import build_provider_info
 from .transport import ProviderInfo
@@ -336,3 +337,49 @@ class GatewayConfig:
             upstream_model,
             provider_name,
         )
+
+    # Default model capabilities when not explicitly declared.
+    DEFAULT_CAPABILITIES: list[str] = ["text"]
+
+    def resolve(
+        self,
+        source_provider: ProviderType,
+        model: str,
+    ) -> tuple[ResolvedRoute, ProviderInfo]:
+        """Resolve *model* to a :class:`ResolvedRoute` and :class:`ProviderInfo`.
+
+        Consolidates model lookup, provider type resolution, shim binding,
+        capability detection, and reasoning overrides into a single typed
+        result.
+
+        Args:
+            source_provider: API standard of the incoming request.
+            model: Model name as specified by the client.
+
+        Returns:
+            ``(route, provider_info)`` — the route contains all
+            pipeline-relevant fields; ``provider_info`` is the
+            transport-level connection config.
+
+        Raises:
+            KeyError: If the model is not in the routing table.
+        """
+        from typing import cast
+
+        provider_name = self.models[model]
+        provider_type = self.provider_types[provider_name]
+        shim_name = self.provider_shim_names.get(provider_name)
+        upstream_model = self.model_upstream_names.get(model)
+        caps = self.model_capabilities.get(model, list(self.DEFAULT_CAPABILITIES))
+        reasoning = self.model_reasoning_overrides.get(model)
+
+        route = ResolvedRoute(
+            source_provider=source_provider,
+            target_provider=cast(ProviderType, provider_type),
+            provider_name=provider_name,
+            shim_name=shim_name,
+            upstream_model=upstream_model,
+            model_capabilities=caps,
+            reasoning_override=reasoning,
+        )
+        return route, self.providers[provider_name]

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -24,6 +24,7 @@ from llm_rosetta._vendor.httpserver import JSONResponse, Response, StreamingResp
 
 from llm_rosetta.auto_detect import ProviderType
 from llm_rosetta.pipeline import ConversionError, ConversionPipeline
+from llm_rosetta.routing import ResolvedRoute
 
 from .logging import (
     get_logger,
@@ -235,29 +236,26 @@ _default_metadata_store = ProviderMetadataStore()
 
 
 async def handle_non_streaming(
-    source_provider: ProviderType,
-    target_provider: ProviderType,
+    route: ResolvedRoute,
     provider_info: ProviderInfo,
     body: dict[str, Any],
-    model: str,
     *,
     transport: UpstreamTransport,
     metadata_store: ProviderMetadataStore | None = None,
     extra_headers: dict[str, str] | None = None,
-    target_shim_name: str | None = None,
-    reasoning_config_override: dict[str, Any] | None = None,
-    model_capabilities: list[str] | None = None,
 ) -> Response:
     """Non-streaming proxy: convert -> forward -> convert back -> respond."""
     store = metadata_store or _default_metadata_store
+    # model was already injected into body by app.py
+    model = body.get("model", "")
 
     pipeline = ConversionPipeline(
-        source_provider,
-        target_provider,
-        target_shim_name,
-        upstream_model=body.get("model"),
-        model_capabilities=model_capabilities,
-        reasoning_config_override=reasoning_config_override,
+        route.source_provider,
+        route.target_provider,
+        route.shim_name,
+        upstream_model=model,
+        model_capabilities=route.model_capabilities,
+        reasoning_config_override=route.reasoning_override,
     )
 
     # Phase 1+2: Source → IR → Target
@@ -266,7 +264,7 @@ async def handle_non_streaming(
             body, on_ir_ready=store.inject_into_request
         )
     except ConversionError as exc:
-        return error_response_for_source(source_provider, 400, str(exc))
+        return error_response_for_source(route.source_provider, 400, str(exc))
 
     log_original_request(pipeline.ir_request)
     if pipeline.warnings:
@@ -277,21 +275,21 @@ async def handle_non_streaming(
     try:
         resp = await transport.send_request(
             provider_info,
-            target_provider,
+            route.target_provider,
             target_body,
             model,
             extra_headers=extra_headers,
         )
     except UpstreamConnectionError as exc:
         return error_response_for_source(
-            source_provider, 502, f"Upstream request failed: {exc}"
+            route.source_provider, 502, f"Upstream request failed: {exc}"
         )
 
     if resp.is_error:
         log_upstream_error(
             resp.status_code,
             resp.error_text,
-            endpoint=str(target_provider),
+            endpoint=str(route.target_provider),
         )
         return Response(
             body=resp.raw_content,
@@ -307,7 +305,7 @@ async def handle_non_streaming(
             resp.body, on_ir_ready=store.cache_from_response
         )
     except ConversionError as exc:
-        return error_response_for_source(source_provider, 502, str(exc))
+        return error_response_for_source(route.source_provider, 502, str(exc))
 
     return JSONResponse(source_response)
 
@@ -372,29 +370,26 @@ async def _stream_event_generator(
 
 
 async def handle_streaming(
-    source_provider: ProviderType,
-    target_provider: ProviderType,
+    route: ResolvedRoute,
     provider_info: ProviderInfo,
     body: dict[str, Any],
-    model: str,
     *,
     transport: UpstreamTransport,
     metadata_store: ProviderMetadataStore | None = None,
     extra_headers: dict[str, str] | None = None,
-    target_shim_name: str | None = None,
-    reasoning_config_override: dict[str, Any] | None = None,
-    model_capabilities: list[str] | None = None,
 ) -> Response | StreamingResponse:
     """Streaming proxy: convert -> forward -> stream-convert back -> SSE."""
     store = metadata_store or _default_metadata_store
+    # model was already injected into body by app.py
+    model = body.get("model", "")
 
     pipeline = ConversionPipeline(
-        source_provider,
-        target_provider,
-        target_shim_name,
-        upstream_model=body.get("model"),
-        model_capabilities=model_capabilities,
-        reasoning_config_override=reasoning_config_override,
+        route.source_provider,
+        route.target_provider,
+        route.shim_name,
+        upstream_model=model,
+        model_capabilities=route.model_capabilities,
+        reasoning_config_override=route.reasoning_override,
     )
 
     # Phase 1+2: Source → IR → Target
@@ -403,7 +398,7 @@ async def handle_streaming(
             body, on_ir_ready=store.inject_into_request
         )
     except ConversionError as exc:
-        return error_response_for_source(source_provider, 400, str(exc))
+        return error_response_for_source(route.source_provider, 400, str(exc))
 
     log_original_request(pipeline.ir_request)
     if pipeline.warnings:
@@ -415,12 +410,12 @@ async def handle_streaming(
     processor = pipeline.create_stream_processor(
         on_ir_event=store.cache_from_stream_event,
     )
-    format_sse = SSE_FORMATTERS[source_provider]
+    format_sse = SSE_FORMATTERS[route.source_provider]
 
     return StreamingResponse(
         _stream_event_generator(
-            source_provider=source_provider,
-            target_provider=target_provider,
+            source_provider=route.source_provider,
+            target_provider=route.target_provider,
             processor=processor,
             transport=transport,
             provider_info=provider_info,

--- a/src/llm_rosetta/routing.py
+++ b/src/llm_rosetta/routing.py
@@ -1,0 +1,85 @@
+"""Routing layer — model/provider/shim resolution contract.
+
+Defines the :class:`ResolvedRoute` data contract and :class:`Router`
+protocol for resolving a model name into a target provider, shim config,
+capabilities, and reasoning overrides.
+
+This module lives in the core library (no network or gateway deps) so
+any consumer (gateway, argo-proxy, CLI tools) can depend on it.
+
+Transport config (e.g. :class:`~gateway.transport.ProviderInfo`) is
+**not** part of the route — it's transport-specific and returned
+separately by each :class:`Router` implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from llm_rosetta.auto_detect import ProviderType
+
+
+@dataclass(slots=True, frozen=True)
+class ResolvedRoute:
+    """Result of resolving a model name to a target route.
+
+    Contains all the information the pipeline and transport layers need
+    to process a request, except transport-specific config (e.g.
+    ``ProviderInfo``), which is returned alongside by the router.
+
+    Attributes:
+        source_provider: API standard of the incoming request
+            (e.g. ``"openai_chat"``).
+        target_provider: API standard of the upstream provider
+            (e.g. ``"anthropic"``).
+        provider_name: User-configured provider name
+            (e.g. ``"deepseek"``, ``"my-openai"``).
+        shim_name: Shim/type identifier for transform lookup
+            (e.g. ``"volcengine--openai_chat"``), or ``None``.
+        upstream_model: Actual model ID to send upstream, or ``None``
+            when the gateway model name is used as-is.
+        model_capabilities: Declared capabilities of the model
+            (e.g. ``["text", "vision"]``).
+        reasoning_override: Per-model reasoning config override from
+            the admin UI / config, or ``None``.
+    """
+
+    source_provider: ProviderType
+    target_provider: ProviderType
+    provider_name: str
+    shim_name: str | None = None
+    upstream_model: str | None = None
+    model_capabilities: list[str] = field(default_factory=lambda: ["text"])
+    reasoning_override: dict[str, Any] | None = None
+
+
+class Router(Protocol):
+    """Interface for resolving a model name to a target route.
+
+    Each deployment (gateway, argo-proxy, etc.) provides its own
+    implementation backed by its config system.  The pipeline and
+    transport layers consume the resulting :class:`ResolvedRoute`
+    without knowing how it was produced.
+    """
+
+    def resolve(self, source_provider: ProviderType, model: str) -> ResolvedRoute:
+        """Resolve *model* to a :class:`ResolvedRoute`.
+
+        Implementations may return additional transport-specific config
+        (e.g. ``tuple[ResolvedRoute, ProviderInfo]``), but the
+        protocol contract only guarantees ``ResolvedRoute``.  Callers
+        that need transport config should use the concrete type.
+
+        Args:
+            source_provider: API standard of the incoming request.
+            model: Model name as specified by the client.
+
+        Returns:
+            A :class:`ResolvedRoute` with target provider, shim,
+            capabilities, and reasoning config.
+
+        Raises:
+            KeyError: If the model is not in the routing table.
+        """
+        ...

--- a/tests/gateway/test_proxy_transforms.py
+++ b/tests/gateway/test_proxy_transforms.py
@@ -14,6 +14,7 @@ from llm_rosetta.gateway.proxy import (
     handle_non_streaming,
 )
 from llm_rosetta.pipeline import ConversionPipeline
+from llm_rosetta.routing import ResolvedRoute
 from llm_rosetta.gateway.transport._base import UpstreamResponse
 from llm_rosetta.shims.provider_shim import (
     ProviderShim,
@@ -125,6 +126,22 @@ def _make_provider_info() -> MagicMock:
     return info
 
 
+def _make_route(
+    model: str = "test-model",
+    shim_name: str | None = None,
+    source: str = "openai_chat",
+    target: str = "openai_chat",
+) -> ResolvedRoute:
+    """Create a ResolvedRoute for tests."""
+    return ResolvedRoute(
+        source_provider=source,
+        target_provider=target,
+        provider_name="test-provider",
+        shim_name=shim_name,
+        upstream_model=model,
+    )
+
+
 # ---------------------------------------------------------------------------
 # handle_non_streaming — transform integration
 # ---------------------------------------------------------------------------
@@ -144,19 +161,16 @@ class TestNonStreamingTransforms:
 
         async def run():
             await handle_non_streaming(
-                source_provider="openai_chat",
-                target_provider="openai_chat",
-                provider_info=_make_provider_info(),
-                body={
+                _make_route(shim_name="volcengine--openai_chat"),
+                _make_provider_info(),
+                {
                     "model": "test-model",
                     "messages": [{"role": "user", "content": "hello"}],
                     "logprobs": True,
                     "top_logprobs": 5,
                 },
-                model="test-model",
                 transport=transport,
                 metadata_store=ProviderMetadataStore(),
-                target_shim_name="volcengine--openai_chat",
             )
 
         asyncio.run(run())
@@ -179,19 +193,16 @@ class TestNonStreamingTransforms:
 
         async def run():
             await handle_non_streaming(
-                source_provider="openai_chat",
-                target_provider="openai_chat",
-                provider_info=_make_provider_info(),
-                body={
+                _make_route(model="gpt-4"),
+                _make_provider_info(),
+                {
                     "model": "gpt-4",
                     "messages": [{"role": "user", "content": "hello"}],
                     "logprobs": True,
                     "top_logprobs": 5,
                 },
-                model="gpt-4",
                 transport=transport,
                 metadata_store=ProviderMetadataStore(),
-                target_shim_name=None,
             )
 
         asyncio.run(run())
@@ -211,17 +222,14 @@ class TestNonStreamingTransforms:
 
         async def run():
             response = await handle_non_streaming(
-                source_provider="openai_chat",
-                target_provider="openai_chat",
-                provider_info=_make_provider_info(),
-                body={
+                _make_route(model="regular-model", shim_name="custom_provider"),
+                _make_provider_info(),
+                {
                     "model": "regular-model",
                     "messages": [{"role": "user", "content": "hello"}],
                 },
-                model="regular-model",
                 transport=transport,
                 metadata_store=ProviderMetadataStore(),
-                target_shim_name="custom_provider",
             )
             return response
 

--- a/tests/gateway/test_proxy_transforms.py
+++ b/tests/gateway/test_proxy_transforms.py
@@ -13,6 +13,7 @@ from llm_rosetta.gateway.proxy import (
     ProviderMetadataStore,
     handle_non_streaming,
 )
+from llm_rosetta.auto_detect import ProviderType
 from llm_rosetta.pipeline import ConversionPipeline
 from llm_rosetta.routing import ResolvedRoute
 from llm_rosetta.gateway.transport._base import UpstreamResponse
@@ -129,8 +130,8 @@ def _make_provider_info() -> MagicMock:
 def _make_route(
     model: str = "test-model",
     shim_name: str | None = None,
-    source: str = "openai_chat",
-    target: str = "openai_chat",
+    source: ProviderType = "openai_chat",
+    target: ProviderType = "openai_chat",
 ) -> ResolvedRoute:
     """Create a ResolvedRoute for tests."""
     return ResolvedRoute(


### PR DESCRIPTION
## Summary

- New `src/llm_rosetta/routing.py` in the core library (zero deps) with `ResolvedRoute` frozen dataclass and `Router` protocol
- `GatewayConfig.resolve(source, model) → (ResolvedRoute, ProviderInfo)` consolidates 5-tuple unpack + 2 separate dict lookups into one typed call
- `proxy.py` handlers take `route: ResolvedRoute` instead of 6 separate routing params (`source_provider`, `target_provider`, `model`, `target_shim_name`, `reasoning_config_override`, `model_capabilities`)
- `app.py` `_proxy_handler` simplified: one `resolve()` call replaces scattered lookups
- `resolve_model()` retained for backward compat (embeddings, admin)

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (1930 passed, 4 skipped)
- [x] `from llm_rosetta.routing import ResolvedRoute, Router` importable from core

Closes #323