### PR TITLE
feat(shim): add message-level and model-conditional transform primitives

### DIFF
--- a/src/llm_rosetta/shims/__init__.py
+++ b/src/llm_rosetta/shims/__init__.py
@@ -23,9 +23,12 @@ from .provider_shim import (
 from .transforms import (
     Transform,
     apply_transforms,
+    default_message_field,
     rename_field,
+    replace_message_field,
     set_defaults,
     strip_fields,
+    strip_fields_for_model,
 )
 
 # Scan provider directories and register shims from YAML + transforms.py.
@@ -48,5 +51,8 @@ __all__ = [
     "strip_fields",
     "rename_field",
     "set_defaults",
+    "replace_message_field",
+    "default_message_field",
+    "strip_fields_for_model",
     "load_providers_from_dir",
 ]

--- a/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
@@ -2,12 +2,29 @@
 
 Request-side (to_transforms)
 -----------------------------
-``rename_field("max_tokens", "max_completion_tokens")`` converts the deprecated
-``max_tokens`` parameter to ``max_completion_tokens`` for newer OpenAI models
-(GPT-4o, o1, etc.) that reject the old name.
+- ``rename_field("max_tokens", "max_completion_tokens")``: converts the
+  deprecated ``max_tokens`` parameter for newer OpenAI models.
+- ``replace_message_field("role", "developer", "system")``: downgrades
+  the ``developer`` role (OpenAI 2024-12-17+) to ``system`` for upstream
+  gateways that don't support it.
+- ``default_message_field("content", "")``: replaces ``content: null``
+  with an empty string — upstream gateways (e.g. Argo Gemini) crash on
+  null content when iterating message bodies.
+- ``strip_fields_for_model(r"^claudeopus47", "temperature")``: strips
+  ``temperature`` for reasoning models that reject it (e.g. Claude Opus 4.7).
 """
 
-from llm_rosetta.shims.transforms import rename_field
+from llm_rosetta.shims.transforms import (
+    default_message_field,
+    rename_field,
+    replace_message_field,
+    strip_fields_for_model,
+)
 
-to_transforms = (rename_field("max_tokens", "max_completion_tokens"),)
+to_transforms = (
+    rename_field("max_tokens", "max_completion_tokens"),
+    replace_message_field("role", "developer", "system"),
+    default_message_field("content", ""),
+    strip_fields_for_model(r"^claudeopus47", "temperature"),
+)
 from_transforms = ()

--- a/src/llm_rosetta/shims/transforms.py
+++ b/src/llm_rosetta/shims/transforms.py
@@ -131,10 +131,10 @@ def replace_message_field(field: str, old_value: Any, new_value: Any) -> Transfo
 
 def default_message_field(field: str, default: Any) -> Transform:
     """Return a transform that sets a default for ``messages[].field``
-    when its current value is ``None``.
+    when the field is absent or its value is ``None``.
 
-    No-op if ``messages`` is absent or no entry has a ``None`` value
-    for *field* (idempotent).
+    No-op if ``messages`` is absent or no entry needs defaulting
+    (idempotent).
 
     Example::
 

--- a/src/llm_rosetta/shims/transforms.py
+++ b/src/llm_rosetta/shims/transforms.py
@@ -17,8 +17,9 @@ Design principles:
 
 from __future__ import annotations
 
-from typing import Any
+import re
 from collections.abc import Callable
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # Core type
@@ -92,6 +93,96 @@ def set_defaults(**defaults: Any) -> Transform:
     return _NamedTransform(
         _defaults,
         f"set_defaults({', '.join(f'{k}={v!r}' for k, v in defaults.items())})",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Message-level factory functions
+# ---------------------------------------------------------------------------
+
+
+def replace_message_field(field: str, old_value: Any, new_value: Any) -> Transform:
+    """Return a transform that replaces *old_value* with *new_value* in
+    ``messages[].field``.
+
+    Iterates all entries in ``body["messages"]`` and replaces the field
+    value where it matches *old_value*.  No-op if ``messages`` is absent
+    or no entry has the matching value (idempotent).
+
+    Example::
+
+        replace_message_field("role", "developer", "system")
+    """
+
+    def _replace(body: dict[str, Any]) -> dict[str, Any]:
+        messages = body.get("messages")
+        if not messages or not isinstance(messages, list):
+            return body
+        for msg in messages:
+            if isinstance(msg, dict) and msg.get(field) == old_value:
+                msg[field] = new_value
+        return body
+
+    return _NamedTransform(
+        _replace,
+        f"replace_message_field({field!r}, {old_value!r}, {new_value!r})",
+    )
+
+
+def default_message_field(field: str, default: Any) -> Transform:
+    """Return a transform that sets a default for ``messages[].field``
+    when its current value is ``None``.
+
+    No-op if ``messages`` is absent or no entry has a ``None`` value
+    for *field* (idempotent).
+
+    Example::
+
+        default_message_field("content", "")
+    """
+
+    def _default(body: dict[str, Any]) -> dict[str, Any]:
+        messages = body.get("messages")
+        if not messages or not isinstance(messages, list):
+            return body
+        for msg in messages:
+            if isinstance(msg, dict) and msg.get(field) is None:
+                msg[field] = default
+        return body
+
+    return _NamedTransform(
+        _default,
+        f"default_message_field({field!r}, {default!r})",
+    )
+
+
+def strip_fields_for_model(pattern: str, *keys: str) -> Transform:
+    """Return a transform that removes *keys* from the body only when
+    ``body["model"]`` matches *pattern* (regex search).
+
+    No-op if ``model`` is absent or doesn't match (idempotent).
+
+    Example::
+
+        strip_fields_for_model(r"^claudeopus47", "temperature")
+    """
+    compiled = re.compile(pattern)
+
+    def _strip(body: dict[str, Any]) -> dict[str, Any]:
+        model = body.get("model")
+        if not model or not isinstance(model, str):
+            return body
+        # Normalise for matching: strip non-alphanumeric, lowercase
+        normalised = re.sub(r"[^a-z0-9]", "", model.lower())
+        if not compiled.search(normalised):
+            return body
+        for k in keys:
+            body.pop(k, None)
+        return body
+
+    return _NamedTransform(
+        _strip,
+        f"strip_fields_for_model({pattern!r}, {', '.join(repr(k) for k in keys)})",
     )
 
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -482,11 +482,11 @@ class TestDefaultMessageField:
         result = t(body)
         assert result["messages"][0]["content"] == "hello"
 
-    def test_noop_on_missing_field(self):
+    def test_sets_default_on_missing_field(self):
         t = default_message_field("content", "")
         body = {"messages": [{"role": "user"}]}
         result = t(body)
-        # field not present, get() returns None → sets default
+        # field absent, get() returns None → sets default
         assert result["messages"][0]["content"] == ""
 
     def test_noop_on_no_messages(self):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -12,9 +12,12 @@ from llm_rosetta.shims.provider_shim import (
 )
 from llm_rosetta.shims.transforms import (
     apply_transforms,
+    default_message_field,
     rename_field,
+    replace_message_field,
     set_defaults,
     strip_fields,
+    strip_fields_for_model,
 )
 
 
@@ -414,3 +417,206 @@ class TestConvertWithTransforms:
             source_provider="openai_chat",
         )
         assert "logprobs" not in result
+
+
+# ---------------------------------------------------------------------------
+# Message-level transforms
+# ---------------------------------------------------------------------------
+
+
+class TestReplaceMessageField:
+    def test_replaces_matching_value(self):
+        t = replace_message_field("role", "developer", "system")
+        body = {"messages": [{"role": "developer", "content": "hi"}]}
+        result = t(body)
+        assert result["messages"][0]["role"] == "system"
+
+    def test_noop_on_non_matching_value(self):
+        t = replace_message_field("role", "developer", "system")
+        body = {"messages": [{"role": "user", "content": "hi"}]}
+        result = t(body)
+        assert result["messages"][0]["role"] == "user"
+
+    def test_noop_on_no_messages(self):
+        t = replace_message_field("role", "developer", "system")
+        body = {"model": "gpt-4"}
+        result = t(body)
+        assert result == {"model": "gpt-4"}
+
+    def test_multiple_messages(self):
+        t = replace_message_field("role", "developer", "system")
+        body = {
+            "messages": [
+                {"role": "developer", "content": "sys"},
+                {"role": "user", "content": "hi"},
+                {"role": "developer", "content": "more"},
+            ]
+        }
+        result = t(body)
+        assert result["messages"][0]["role"] == "system"
+        assert result["messages"][1]["role"] == "user"
+        assert result["messages"][2]["role"] == "system"
+
+    def test_idempotent(self):
+        t = replace_message_field("role", "developer", "system")
+        body = {"messages": [{"role": "developer", "content": "hi"}]}
+        result1 = t(body)
+        result2 = t(result1)
+        assert result1 == result2
+
+    def test_repr(self):
+        t = replace_message_field("role", "developer", "system")
+        assert repr(t) == "replace_message_field('role', 'developer', 'system')"
+
+
+class TestDefaultMessageField:
+    def test_sets_none_to_default(self):
+        t = default_message_field("content", "")
+        body = {"messages": [{"role": "assistant", "content": None}]}
+        result = t(body)
+        assert result["messages"][0]["content"] == ""
+
+    def test_noop_on_existing_value(self):
+        t = default_message_field("content", "")
+        body = {"messages": [{"role": "user", "content": "hello"}]}
+        result = t(body)
+        assert result["messages"][0]["content"] == "hello"
+
+    def test_noop_on_missing_field(self):
+        t = default_message_field("content", "")
+        body = {"messages": [{"role": "user"}]}
+        result = t(body)
+        # field not present, get() returns None → sets default
+        assert result["messages"][0]["content"] == ""
+
+    def test_noop_on_no_messages(self):
+        t = default_message_field("content", "")
+        body = {"model": "gpt-4"}
+        result = t(body)
+        assert result == {"model": "gpt-4"}
+
+    def test_idempotent(self):
+        t = default_message_field("content", "")
+        body = {"messages": [{"role": "assistant", "content": None}]}
+        result1 = t(body)
+        result2 = t(result1)
+        assert result1 == result2
+
+    def test_repr(self):
+        t = default_message_field("content", "")
+        assert repr(t) == "default_message_field('content', '')"
+
+
+class TestStripFieldsForModel:
+    def test_strips_when_model_matches(self):
+        t = strip_fields_for_model(r"^claudeopus47", "temperature")
+        body = {"model": "claudeopus47", "temperature": 0.7, "messages": []}
+        result = t(body)
+        assert "temperature" not in result
+        assert result["model"] == "claudeopus47"
+
+    def test_strips_with_normalised_model(self):
+        """Model name is normalised (lowercase, non-alnum stripped)."""
+        t = strip_fields_for_model(r"^claudeopus47", "temperature")
+        body = {"model": "Claude-Opus-4.7", "temperature": 0.7, "messages": []}
+        result = t(body)
+        assert "temperature" not in result
+
+    def test_noop_when_model_no_match(self):
+        t = strip_fields_for_model(r"^claudeopus47", "temperature")
+        body = {"model": "gpt-4o", "temperature": 0.7, "messages": []}
+        result = t(body)
+        assert result["temperature"] == 0.7
+
+    def test_noop_when_no_model(self):
+        t = strip_fields_for_model(r"^claudeopus47", "temperature")
+        body = {"temperature": 0.7, "messages": []}
+        result = t(body)
+        assert result["temperature"] == 0.7
+
+    def test_multiple_keys(self):
+        t = strip_fields_for_model(r"^claudeopus47", "temperature", "top_p")
+        body = {"model": "claudeopus47", "temperature": 0.7, "top_p": 0.9}
+        result = t(body)
+        assert "temperature" not in result
+        assert "top_p" not in result
+
+    def test_idempotent(self):
+        t = strip_fields_for_model(r"^claudeopus47", "temperature")
+        body = {"model": "claudeopus47", "temperature": 0.7}
+        result1 = t(body)
+        result2 = t(result1)
+        assert result1 == result2
+
+    def test_repr(self):
+        t = strip_fields_for_model(r"^claudeopus47", "temperature")
+        assert repr(t) == "strip_fields_for_model('^claudeopus47', 'temperature')"
+
+
+# ---------------------------------------------------------------------------
+# Argo OpenAI Chat shim integration
+# ---------------------------------------------------------------------------
+
+
+class TestArgoOpenaiChatTransforms:
+    @pytest.fixture(autouse=True)
+    def _load_builtins(self):
+        from llm_rosetta.shims.providers import load_providers
+
+        load_providers()
+
+    def test_argo_downgrades_developer_role(self):
+        shim = get_shim("argo--openai_chat")
+        assert shim is not None
+        body = {
+            "model": "gpt-4",
+            "messages": [{"role": "developer", "content": "system prompt"}],
+        }
+        result = apply_transforms(shim.to_transforms, body)
+        assert result["messages"][0]["role"] == "system"
+
+    def test_argo_normalizes_null_content(self):
+        shim = get_shim("argo--openai_chat")
+        assert shim is not None
+        body = {
+            "model": "gpt-4",
+            "messages": [
+                {"role": "assistant", "content": None, "tool_calls": []},
+            ],
+        }
+        result = apply_transforms(shim.to_transforms, body)
+        assert result["messages"][0]["content"] == ""
+
+    def test_argo_strips_temperature_for_opus47(self):
+        shim = get_shim("argo--openai_chat")
+        assert shim is not None
+        body = {
+            "model": "claudeopus47",
+            "temperature": 0.7,
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        result = apply_transforms(shim.to_transforms, body)
+        assert "temperature" not in result
+
+    def test_argo_keeps_temperature_for_other_models(self):
+        shim = get_shim("argo--openai_chat")
+        assert shim is not None
+        body = {
+            "model": "gpt-4o",
+            "temperature": 0.7,
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        result = apply_transforms(shim.to_transforms, body)
+        assert result["temperature"] == 0.7
+
+    def test_argo_renames_max_tokens(self):
+        shim = get_shim("argo--openai_chat")
+        assert shim is not None
+        body = {
+            "model": "gpt-4",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        result = apply_transforms(shim.to_transforms, body)
+        assert "max_tokens" not in result
+        assert result["max_completion_tokens"] == 100


### PR DESCRIPTION
Closes #328

## Summary

Three new Transform factory functions for nested field operations:

- `replace_message_field("role", "developer", "system")` — replace field value in all `messages[]`
- `default_message_field("content", "")` — set default when `messages[].field` is `None`
- `strip_fields_for_model(r"^claudeopus47", "temperature")` — conditionally strip by model regex

All follow existing design: idempotent, `_NamedTransform` wrapper, no-op on missing preconditions.

## Argo shim usage

Argo OpenAI Chat `to_transforms` now includes all three, making previously hardcoded argo-proxy functions (`_downgrade_developer_role`, `_normalize_null_content`, `_strip_temperature_for_reasoning_models`) declarative through the shim.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1968 passed (24 new transform tests + 5 argo integration tests)
- [ ] Follow-up: argo-proxy removes hardcoded functions and relies on shim transforms

AI was used to assist with implementation.