### PR TITLE
refactor: rename pipeline API + add IRTransform system (#330)

### DIFF
--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -11,7 +11,7 @@ request conversion, response conversion, and/or streaming:
     # ... transport sends target_body, receives upstream_response ...
     source_response = pipeline.convert_response(upstream_response)
 
-**Low-level** — :func:`setup_shim_context` and :func:`apply_shim_to_ir`
+**Low-level** — :func:`configure_context` and :func:`apply_ir_transforms`
 for consumers that need finer control over individual pipeline stages.
 
 The pipeline is part of the core library — **no network dependency**.
@@ -22,13 +22,17 @@ the caller (gateway, argo-proxy, etc.) owns the transport.
 from __future__ import annotations
 
 import logging
-import re
 from collections.abc import Callable
 from typing import Any
 
 from llm_rosetta.converters.base.context import ConversionContext
 from llm_rosetta.shims.provider_shim import ProviderShim, ReasoningCapability, get_shim
-from llm_rosetta.shims.transforms import Transform, apply_transforms
+from llm_rosetta.shims.transforms import (
+    Transform,
+    TransformContext,
+    apply_ir_transforms as _apply_ir_transforms_exec,
+    apply_transforms,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -90,14 +94,14 @@ def _apply_config_reasoning_override(
 # ---------------------------------------------------------------------------
 
 
-def setup_shim_context(
+def configure_context(
     ctx: ConversionContext,
     shim: ProviderShim | str | None,
     *,
     model: str | None = None,
     config_override: dict[str, Any] | None = None,
 ) -> None:
-    """Inject shim-driven options into a ConversionContext.
+    """Configure a ConversionContext with shim-driven options.
 
     Currently injects ``reasoning_cap`` so converters produce the correct
     thinking/reasoning output for the target provider.
@@ -131,7 +135,7 @@ def setup_shim_context(
         ctx.options["reasoning_cap"] = cap
 
 
-def apply_shim_to_ir(
+def apply_ir_transforms(
     ir_request: dict[str, Any],
     shim: ProviderShim | str | None,
     *,
@@ -139,23 +143,11 @@ def apply_shim_to_ir(
     model_capabilities: list[str] | None = None,
     request_id: str = "-",
 ) -> dict[str, Any]:
-    """Apply all shim-driven IR-level transforms in canonical order.
+    """Apply all shim-driven IR-level transforms.
 
-    Operations applied (in order):
-
-    1. **Strip non-vision images** — if *model_capabilities* is provided
-       and does not include ``"vision"``, replace all images with text
-       placeholders.  Driven by the caller, not by the shim.
-    2. **Enforce image count limit** — if the shim declares
-       ``max_images`` (and the upstream model matches
-       ``max_images_pattern`` when set), truncate excess images.
-    3. **Unwind parallel tool calls** — if the shim declares
-       ``unwind_parallel_tool_calls`` (and the upstream model matches
-       ``unwind_parallel_tool_calls_pattern`` when set), split parallel
-       tool calls into sequential call-result pairs.
-
-    All operations are no-ops when the corresponding shim field is unset
-    or when the pattern guard doesn't match.
+    Builds a :class:`~llm_rosetta.shims.transforms.TransformContext` from
+    the provided parameters and runs the shim's ``ir_transforms`` tuple
+    through :func:`~llm_rosetta.shims.transforms.apply_ir_transforms`.
 
     Args:
         ir_request: The IR request dict.  Some operations mutate in-place,
@@ -163,60 +155,53 @@ def apply_shim_to_ir(
         shim: ProviderShim instance, registered name, or None (no-op).
         upstream_model: The upstream model ID (for pattern matching).
         model_capabilities: Model capability list (e.g. ``["text", "vision"]``).
-            When ``None``, the non-vision image stripping step is skipped.
+            When ``None``, transforms that check capabilities treat the
+            model as unknown and skip capability-dependent operations.
         request_id: Request identifier for logging.
 
     Returns:
         The IR request dict after all applicable transforms.  Always
-        assign the return value: ``ir = apply_shim_to_ir(ir, shim, ...)``.
+        assign the return value: ``ir = apply_ir_transforms(ir, shim, ...)``.
     """
-    # 1. Strip images for non-vision models (caller-driven, not shim-driven)
-    if model_capabilities is not None and "vision" not in model_capabilities:
-        from llm_rosetta.converters.base.helpers.image_limit import (
-            strip_images_for_non_vision,
-        )
-
-        ir_request = strip_images_for_non_vision(
-            ir_request, model=upstream_model or "", request_id=request_id
-        )
-
     resolved = _resolve_shim(shim)
-    if resolved is None:
+    if resolved is None or not resolved.ir_transforms:
         return ir_request
 
-    # 2. Enforce per-shim image count limit
-    if resolved.max_images is not None:
-        apply_limit = True
-        if resolved.max_images_pattern is not None:
-            apply_limit = bool(
-                upstream_model
-                and re.search(resolved.max_images_pattern, upstream_model)
-            )
-        if apply_limit:
-            from llm_rosetta.converters.base.helpers.image_limit import truncate_images
+    ctx = TransformContext(
+        model=upstream_model or "",
+        model_capabilities=model_capabilities,
+        request_id=request_id,
+    )
+    return _apply_ir_transforms_exec(resolved.ir_transforms, ir_request, ctx)
 
-            ir_request = truncate_images(
-                ir_request, resolved.max_images, request_id=request_id
-            )
 
-    # 3. Unwind parallel tool calls
-    if resolved.unwind_parallel_tool_calls:
-        apply_unwind = True
-        if resolved.unwind_parallel_tool_calls_pattern is not None:
-            apply_unwind = bool(
-                upstream_model
-                and re.search(
-                    resolved.unwind_parallel_tool_calls_pattern, upstream_model
-                )
-            )
-        if apply_unwind:
-            from llm_rosetta.converters.base.helpers.tool_call_unwind import (
-                unwind_parallel_tool_calls_ir,
-            )
+# ---------------------------------------------------------------------------
+# Deprecated aliases (backward compatibility with v0.6.x)
+# ---------------------------------------------------------------------------
 
-            ir_request = unwind_parallel_tool_calls_ir(ir_request)
 
-    return ir_request
+def setup_shim_context(*args: Any, **kwargs: Any) -> None:
+    """Deprecated: use :func:`configure_context`."""
+    import warnings
+
+    warnings.warn(
+        "setup_shim_context is deprecated; use configure_context()",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return configure_context(*args, **kwargs)
+
+
+def apply_shim_to_ir(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    """Deprecated: use :func:`apply_ir_transforms`."""
+    import warnings
+
+    warnings.warn(
+        "apply_shim_to_ir is deprecated; use apply_ir_transforms()",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return apply_ir_transforms(*args, **kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -389,7 +374,7 @@ class ConversionPipeline:
         if self._target_provider == "google":
             ctx.options["output_format"] = "rest"
 
-        setup_shim_context(
+        configure_context(
             ctx,
             self._shim,
             model=self._upstream_model or body.get("model"),
@@ -411,7 +396,7 @@ class ConversionPipeline:
 
         # Phase 2a: Shim-driven IR transforms
         request_id = ctx.options.get("request_id", "-")
-        ir_request = apply_shim_to_ir(
+        ir_request = apply_ir_transforms(
             ir_request,
             self._shim,
             upstream_model=self._upstream_model or body.get("model"),

--- a/src/llm_rosetta/shims/__init__.py
+++ b/src/llm_rosetta/shims/__init__.py
@@ -21,7 +21,10 @@ from .provider_shim import (
     unregister_shim,
 )
 from .transforms import (
+    IRTransform,
     Transform,
+    TransformContext,
+    apply_ir_transforms,
     apply_transforms,
     default_message_field,
     rename_field,
@@ -54,5 +57,9 @@ __all__ = [
     "replace_message_field",
     "default_message_field",
     "strip_fields_for_model",
+    # IR transforms
+    "IRTransform",
+    "TransformContext",
+    "apply_ir_transforms",
     "load_providers_from_dir",
 ]

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -16,7 +16,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Literal
 
-from .transforms import Transform
+from .transforms import IRTransform, Transform
 
 logger = logging.getLogger(__name__)
 
@@ -129,16 +129,9 @@ class ProviderShim:
     model_id_field: str | None = None
     from_transforms: tuple[Transform, ...] = ()
     to_transforms: tuple[Transform, ...] = ()
+    ir_transforms: tuple[IRTransform, ...] = ()
     reasoning: ReasoningCapability | None = None
     model_reasoning: dict[str, ReasoningCapability] | None = None
-    max_images: int | None = None
-    max_images_pattern: str | None = (
-        None  # regex; if set, only apply when model matches
-    )
-    unwind_parallel_tool_calls: bool = False
-    unwind_parallel_tool_calls_pattern: str | None = (
-        None  # regex; if set, only apply when upstream model matches
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -66,8 +66,8 @@ _PROVIDERS_DIR = Path(__file__).parent
 
 def _load_transforms(
     provider_dir: Path, *, group: str | None = None, _builtin: bool = True
-) -> tuple[tuple, tuple]:
-    """Import transforms.py if present, return (from_transforms, to_transforms).
+) -> tuple[tuple, tuple, tuple]:
+    """Import transforms.py if present, return (from_transforms, to_transforms, ir_transforms).
 
     Args:
         provider_dir: Path to the leaf provider directory.
@@ -78,7 +78,7 @@ def _load_transforms(
     """
     tf_path = provider_dir / "transforms.py"
     if not tf_path.exists():
-        return (), ()
+        return (), (), ()
     prefix = "llm_rosetta.shims.providers" if _builtin else "_llm_rosetta_plugin_shims"
     if group is not None:
         module_name = f"{prefix}.{group}.{provider_dir.name}.transforms"
@@ -87,12 +87,13 @@ def _load_transforms(
     spec = importlib.util.spec_from_file_location(module_name, tf_path)
     if spec is None or spec.loader is None:
         logger.warning("Could not load %s", tf_path)
-        return (), ()
+        return (), (), ()
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return (
         getattr(mod, "from_transforms", ()),
         getattr(mod, "to_transforms", ()),
+        getattr(mod, "ir_transforms", ()),
     )
 
 
@@ -116,7 +117,7 @@ def _load_single_provider(
         logger.warning("Skipping %s: missing 'name' or 'base'", yaml_path)
         return None
 
-    from_t, to_t = _load_transforms(provider_dir, group=group, _builtin=_builtin)
+    from_t, to_t, ir_t = _load_transforms(provider_dir, group=group, _builtin=_builtin)
 
     # Parse optional reasoning capability config from YAML.
     reasoning_cfg = cfg.get("reasoning")
@@ -173,14 +174,9 @@ def _load_single_provider(
         model_id_field=cfg.get("model_id_field"),
         from_transforms=from_t,
         to_transforms=to_t,
+        ir_transforms=ir_t,
         reasoning=reasoning_cap,
         model_reasoning=model_reasoning,
-        max_images=cfg.get("max_images"),
-        max_images_pattern=cfg.get("max_images_pattern"),
-        unwind_parallel_tool_calls=bool(cfg.get("unwind_parallel_tool_calls", False)),
-        unwind_parallel_tool_calls_pattern=cfg.get(
-            "unwind_parallel_tool_calls_pattern"
-        ),
     )
     register_shim(shim)
     logger.debug("Registered provider shim: %s (base=%s)", shim.name, shim.base)

--- a/src/llm_rosetta/shims/providers/argo/openai_chat/provider.yaml
+++ b/src/llm_rosetta/shims/providers/argo/openai_chat/provider.yaml
@@ -1,9 +1,5 @@
 name: argo--openai_chat
 base: openai_chat
-max_images: 50
-max_images_pattern: "^(gpt|o\\d)"
-unwind_parallel_tool_calls: true
-unwind_parallel_tool_calls_pattern: "^gemini"
 default_base_url: https://apps.inside.anl.gov/argoapi/v1
 default_api_key_env: ARGO_API_KEY
 model_id_field: internal_id

--- a/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
@@ -1,7 +1,7 @@
 """Argo OpenAI Chat schema transforms.
 
-Request-side (to_transforms)
------------------------------
+Request-side (to_transforms) — body-level
+-------------------------------------------
 - ``rename_field("max_tokens", "max_completion_tokens")``: converts the
   deprecated ``max_tokens`` parameter for newer OpenAI models.
 - ``replace_message_field("role", "developer", "system")``: downgrades
@@ -12,6 +12,15 @@ Request-side (to_transforms)
   null content when iterating message bodies.
 - ``strip_fields_for_model(r"^claudeopus47", "temperature")``: strips
   ``temperature`` for reasoning models that reject it (e.g. Claude Opus 4.7).
+
+Request-side (ir_transforms) — IR-level
+-----------------------------------------
+- ``strip_non_vision_images()``: replace images with text placeholders
+  for models without ``"vision"`` capability.
+- ``truncate_images(50, pattern=r"^(gpt|o\\d)")``: enforce 50-image limit
+  for GPT/o* models; Gemini and Claude pass through untouched.
+- ``unwind_parallel_tool_calls(pattern=r"^gemini")``: split parallel tool
+  calls into sequential pairs for Gemini models through Argo.
 """
 
 from llm_rosetta.shims.transforms import (
@@ -19,6 +28,9 @@ from llm_rosetta.shims.transforms import (
     rename_field,
     replace_message_field,
     strip_fields_for_model,
+    strip_non_vision_images,
+    truncate_images,
+    unwind_parallel_tool_calls,
 )
 
 to_transforms = (
@@ -28,3 +40,8 @@ to_transforms = (
     strip_fields_for_model(r"^claudeopus47", "temperature"),
 )
 from_transforms = ()
+ir_transforms = (
+    strip_non_vision_images(),
+    truncate_images(50, pattern=r"^(gpt|o\d)"),
+    unwind_parallel_tool_calls(pattern=r"^gemini"),
+)

--- a/src/llm_rosetta/shims/transforms.py
+++ b/src/llm_rosetta/shims/transforms.py
@@ -1,12 +1,13 @@
 """Transform primitives for the provider shim layer.
 
-A **Transform** is a pure data transformation: ``dict → dict``.  Transforms
-bridge the gap between a real provider's API dialect and the "ideal" standard
-that the corresponding base converter expects.
+Two transform types:
 
-Transforms are NOT a replacement for converter functionality — they handle
-provider-specific field-level quirks (rename, strip, inject defaults),
-while converters handle semantic API-standard translation.
+* **Transform** — body-level: ``dict → dict``.  Handles provider-specific
+  field-level quirks (rename, strip, inject defaults) on the raw provider
+  request/response body.
+* **IRTransform** — IR-level: ``(dict, TransformContext) → dict``.  Operates
+  on the IR request with access to route-level context (model capabilities,
+  upstream model name, etc.).
 
 Design principles:
 
@@ -19,6 +20,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 # ---------------------------------------------------------------------------
@@ -198,3 +200,148 @@ def apply_transforms(
     for t in transforms:
         body = t(body)
     return body
+
+
+# ---------------------------------------------------------------------------
+# IR-level transforms (context-aware)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class TransformContext:
+    """Context available to IR-level transforms.
+
+    Carries route-level information that body-level transforms don't
+    need but IR transforms do (e.g. model capabilities for vision
+    stripping).
+
+    Attributes:
+        model: Upstream model identifier (post-alias).
+        model_capabilities: Declared capabilities of the model
+            (e.g. ``["text", "vision"]``).  ``None`` means unknown.
+        request_id: Request identifier for logging.
+    """
+
+    model: str = ""
+    model_capabilities: list[str] | None = None
+    request_id: str = "-"
+
+
+IRTransform = Callable[[dict[str, Any], TransformContext], dict[str, Any]]
+"""An IR-level data transformation: receives an IR request dict and a
+:class:`TransformContext`, returns the (possibly mutated) IR dict."""
+
+
+class _NamedIRTransform:
+    """Thin wrapper that gives a factory-produced IR transform a readable repr."""
+
+    __slots__ = ("_fn", "_repr")
+
+    def __init__(self, fn: IRTransform, repr_str: str) -> None:
+        self._fn = fn
+        self._repr = repr_str
+
+    def __call__(
+        self, body: dict[str, Any], context: TransformContext
+    ) -> dict[str, Any]:
+        return self._fn(body, context)
+
+    def __repr__(self) -> str:
+        return self._repr
+
+
+def apply_ir_transforms(
+    transforms: tuple[IRTransform, ...],
+    body: dict[str, Any],
+    context: TransformContext,
+) -> dict[str, Any]:
+    """Apply IR-level *transforms* sequentially with *context*."""
+    for t in transforms:
+        body = t(body, context)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# IR-level factory functions
+# ---------------------------------------------------------------------------
+
+
+def strip_non_vision_images() -> IRTransform:
+    """Return an IR transform that replaces all images with text placeholders
+    when the model lacks ``"vision"`` capability.
+
+    No-op if ``model_capabilities`` is ``None`` (unknown) or includes
+    ``"vision"`` (idempotent).
+    """
+
+    def _strip(body: dict[str, Any], context: TransformContext) -> dict[str, Any]:
+        if context.model_capabilities is None or "vision" in context.model_capabilities:
+            return body
+        from llm_rosetta.converters.base.helpers.image_limit import (
+            strip_images_for_non_vision,
+        )
+
+        return strip_images_for_non_vision(
+            body, model=context.model, request_id=context.request_id
+        )
+
+    return _NamedIRTransform(_strip, "strip_non_vision_images()")
+
+
+def truncate_images(max_images: int, pattern: str | None = None) -> IRTransform:
+    """Return an IR transform that truncates images exceeding *max_images*.
+
+    When *pattern* is set, truncation only fires if the upstream model
+    matches the regex (search on raw model string).
+
+    Example::
+
+        truncate_images(50, pattern=r"^(gpt|o\\d)")
+    """
+    compiled = re.compile(pattern) if pattern else None
+
+    def _truncate(body: dict[str, Any], context: TransformContext) -> dict[str, Any]:
+        if compiled is not None:
+            if not context.model or not compiled.search(context.model):
+                return body
+        from llm_rosetta.converters.base.helpers.image_limit import (
+            truncate_images as _truncate_impl,
+        )
+
+        return _truncate_impl(body, max_images, request_id=context.request_id)
+
+    label = f"truncate_images({max_images}"
+    if pattern:
+        label += f", pattern={pattern!r}"
+    label += ")"
+    return _NamedIRTransform(_truncate, label)
+
+
+def unwind_parallel_tool_calls(pattern: str | None = None) -> IRTransform:
+    """Return an IR transform that splits parallel tool calls into
+    sequential call-result pairs.
+
+    When *pattern* is set, unwinding only fires if the upstream model
+    matches the regex (search on raw model string).
+
+    Example::
+
+        unwind_parallel_tool_calls(pattern=r"^gemini")
+    """
+    compiled = re.compile(pattern) if pattern else None
+
+    def _unwind(body: dict[str, Any], context: TransformContext) -> dict[str, Any]:
+        if compiled is not None:
+            if not context.model or not compiled.search(context.model):
+                return body
+        from llm_rosetta.converters.base.helpers.tool_call_unwind import (
+            unwind_parallel_tool_calls_ir,
+        )
+
+        return unwind_parallel_tool_calls_ir(body)
+
+    label = "unwind_parallel_tool_calls("
+    if pattern:
+        label += f"pattern={pattern!r}"
+    label += ")"
+    return _NamedIRTransform(_unwind, label)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,14 +14,19 @@ from llm_rosetta.converters.base.context import ConversionContext
 from llm_rosetta.pipeline import (
     _apply_config_reasoning_override,
     _resolve_shim,
-    apply_shim_to_ir,
-    setup_shim_context,
+    apply_ir_transforms,
+    configure_context,
 )
 from llm_rosetta.shims.provider_shim import (
     ProviderShim,
     ReasoningCapability,
     register_shim,
     unregister_shim,
+)
+from llm_rosetta.shims.transforms import (
+    strip_non_vision_images,
+    truncate_images as truncate_images_transform,
+    unwind_parallel_tool_calls as unwind_transform,
 )
 
 
@@ -104,26 +109,26 @@ class TestResolveShim:
 
 
 # ---------------------------------------------------------------------------
-# setup_shim_context
+# configure_context
 # ---------------------------------------------------------------------------
 
 
-class TestSetupShimContext:
+class TestConfigureContext:
     def test_none_shim_is_noop(self):
         ctx = ConversionContext()
-        setup_shim_context(ctx, None)
+        configure_context(ctx, None)
         assert "reasoning_cap" not in ctx.options
 
     def test_shim_without_reasoning_is_noop(self):
         ctx = ConversionContext()
         shim = _make_shim(reasoning=None)
-        setup_shim_context(ctx, shim)
+        configure_context(ctx, shim)
         assert "reasoning_cap" not in ctx.options
 
     def test_provider_level_reasoning(self):
         ctx = ConversionContext()
         shim = _make_shim(reasoning=_REASONING_CAP)
-        setup_shim_context(ctx, shim)
+        configure_context(ctx, shim)
         assert ctx.options["reasoning_cap"] is _REASONING_CAP
 
     def test_model_level_override(self):
@@ -132,7 +137,7 @@ class TestSetupShimContext:
             reasoning=_REASONING_CAP,
             model_reasoning={"gpt-4": _MODEL_REASONING_CAP},
         )
-        setup_shim_context(ctx, shim, model="gpt-4")
+        configure_context(ctx, shim, model="gpt-4")
         assert ctx.options["reasoning_cap"] is _MODEL_REASONING_CAP
 
     def test_model_not_in_overrides_falls_back(self):
@@ -141,13 +146,13 @@ class TestSetupShimContext:
             reasoning=_REASONING_CAP,
             model_reasoning={"gpt-4": _MODEL_REASONING_CAP},
         )
-        setup_shim_context(ctx, shim, model="gpt-3.5")
+        configure_context(ctx, shim, model="gpt-3.5")
         assert ctx.options["reasoning_cap"] is _REASONING_CAP
 
     def test_config_override_highest_priority(self):
         ctx = ConversionContext()
         shim = _make_shim(reasoning=_REASONING_CAP)
-        setup_shim_context(ctx, shim, config_override={"thinking_type": "adaptive"})
+        configure_context(ctx, shim, config_override={"thinking_type": "adaptive"})
         cap = ctx.options["reasoning_cap"]
         assert cap.thinking_type == "adaptive"
         # Other fields inherited from base
@@ -161,7 +166,7 @@ class TestSetupShimContext:
             reasoning=_REASONING_CAP,
             model_reasoning={"gpt-4": _MODEL_REASONING_CAP},
         )
-        setup_shim_context(
+        configure_context(
             ctx, shim, model="gpt-4", config_override={"disabled": "block"}
         )
         cap = ctx.options["reasoning_cap"]
@@ -173,39 +178,40 @@ class TestSetupShimContext:
         ctx = ConversionContext()
         shim = _make_shim(reasoning=_REASONING_CAP)
         register_shim(shim)
-        setup_shim_context(ctx, "test-shim")
+        configure_context(ctx, "test-shim")
         assert ctx.options["reasoning_cap"] is _REASONING_CAP
 
     def test_unknown_name_is_noop(self):
         ctx = ConversionContext()
-        setup_shim_context(ctx, "nonexistent")
+        configure_context(ctx, "nonexistent")
         assert "reasoning_cap" not in ctx.options
 
 
 # ---------------------------------------------------------------------------
-# apply_shim_to_ir
+# apply_ir_transforms
 # ---------------------------------------------------------------------------
 
 
-class TestApplyShimToIr:
+class TestApplyIrTransforms:
     def test_none_shim_passthrough(self):
         ir = _simple_ir_request()
         original = copy.deepcopy(ir)
-        result = apply_shim_to_ir(ir, None)
+        result = apply_ir_transforms(ir, None)
         assert result == original
 
     def test_shim_no_features_passthrough(self):
         ir = _simple_ir_request()
         original = copy.deepcopy(ir)
         shim = _make_shim()
-        result = apply_shim_to_ir(ir, shim)
+        result = apply_ir_transforms(ir, shim)
         assert result == original
 
     def test_strip_non_vision_when_no_vision_cap(self):
         """Images should be stripped when model lacks vision capability."""
         ir = _simple_ir_request(n_images=3)
-        result = apply_shim_to_ir(
-            ir, None, model_capabilities=["text"], upstream_model="deepseek-chat"
+        shim = _make_shim(ir_transforms=(strip_non_vision_images(),))
+        result = apply_ir_transforms(
+            ir, shim, model_capabilities=["text"], upstream_model="deepseek-chat"
         )
         # Images should be replaced with text placeholders
         content = result["messages"][0]["content"]
@@ -216,8 +222,9 @@ class TestApplyShimToIr:
         """Images should NOT be stripped when model has vision capability."""
         ir = _simple_ir_request(n_images=3)
         original = copy.deepcopy(ir)
-        result = apply_shim_to_ir(
-            ir, None, model_capabilities=["text", "vision"], upstream_model="gpt-4o"
+        shim = _make_shim(ir_transforms=(strip_non_vision_images(),))
+        result = apply_ir_transforms(
+            ir, shim, model_capabilities=["text", "vision"], upstream_model="gpt-4o"
         )
         assert result == original
 
@@ -225,14 +232,17 @@ class TestApplyShimToIr:
         """Images should NOT be stripped when model_capabilities is None."""
         ir = _simple_ir_request(n_images=3)
         original = copy.deepcopy(ir)
-        result = apply_shim_to_ir(ir, None, model_capabilities=None)
+        shim = _make_shim(ir_transforms=(strip_non_vision_images(),))
+        result = apply_ir_transforms(ir, shim, model_capabilities=None)
         assert result == original
 
     def test_image_limit_enforced(self):
         """Shim with max_images should truncate excess images."""
         ir = _simple_ir_request(n_images=5)
-        shim = _make_shim(name="test-shim-img", max_images=2)
-        result = apply_shim_to_ir(ir, shim)
+        shim = _make_shim(
+            name="test-shim-img", ir_transforms=(truncate_images_transform(2),)
+        )
+        result = apply_ir_transforms(ir, shim)
         content = result["messages"][0]["content"]
         image_parts = [p for p in content if p.get("type") == "image"]
         assert len(image_parts) <= 2
@@ -240,9 +250,12 @@ class TestApplyShimToIr:
     def test_image_limit_pattern_match(self):
         """Image limit should only fire when model matches pattern."""
         ir = _simple_ir_request(n_images=5)
-        shim = _make_shim(name="test-shim-img", max_images=2, max_images_pattern="^gpt")
+        shim = _make_shim(
+            name="test-shim-img",
+            ir_transforms=(truncate_images_transform(2, pattern="^gpt"),),
+        )
         # Matching model
-        result = apply_shim_to_ir(copy.deepcopy(ir), shim, upstream_model="gpt-4o")
+        result = apply_ir_transforms(copy.deepcopy(ir), shim, upstream_model="gpt-4o")
         content = result["messages"][0]["content"]
         image_parts = [p for p in content if p.get("type") == "image"]
         assert len(image_parts) <= 2
@@ -250,8 +263,13 @@ class TestApplyShimToIr:
     def test_image_limit_pattern_no_match(self):
         """Image limit should NOT fire when model doesn't match pattern."""
         ir = _simple_ir_request(n_images=5)
-        shim = _make_shim(name="test-shim-img", max_images=2, max_images_pattern="^gpt")
-        result = apply_shim_to_ir(copy.deepcopy(ir), shim, upstream_model="gemini-pro")
+        shim = _make_shim(
+            name="test-shim-img",
+            ir_transforms=(truncate_images_transform(2, pattern="^gpt"),),
+        )
+        result = apply_ir_transforms(
+            copy.deepcopy(ir), shim, upstream_model="gemini-pro"
+        )
         content = result["messages"][0]["content"]
         image_parts = [p for p in content if p.get("type") == "image"]
         assert len(image_parts) == 5  # untouched
@@ -303,8 +321,8 @@ class TestApplyShimToIr:
             ],
             "tools": [],
         }
-        shim = _make_shim(name="test-shim-unwind", unwind_parallel_tool_calls=True)
-        result = apply_shim_to_ir(ir, shim)
+        shim = _make_shim(name="test-shim-unwind", ir_transforms=(unwind_transform(),))
+        result = apply_ir_transforms(ir, shim)
         # After unwind: user + (assistant+tool) + (assistant+tool) = 5
         assert len(result["messages"]) == 5
 
@@ -357,17 +375,18 @@ class TestApplyShimToIr:
         }
         shim = _make_shim(
             name="test-shim-unwind",
-            unwind_parallel_tool_calls=True,
-            unwind_parallel_tool_calls_pattern="^gemini",
+            ir_transforms=(unwind_transform(pattern="^gemini"),),
         )
-        result = apply_shim_to_ir(ir, shim, upstream_model="gpt-4o")
+        result = apply_ir_transforms(ir, shim, upstream_model="gpt-4o")
         assert len(result["messages"]) == 4  # untouched
 
     def test_accepts_registered_name(self):
         ir = _simple_ir_request(n_images=5)
-        shim = _make_shim(name="test-shim-img", max_images=2)
+        shim = _make_shim(
+            name="test-shim-img", ir_transforms=(truncate_images_transform(2),)
+        )
         register_shim(shim)
-        result = apply_shim_to_ir(ir, "test-shim-img")
+        result = apply_ir_transforms(ir, "test-shim-img")
         content = result["messages"][0]["content"]
         image_parts = [p for p in content if p.get("type") == "image"]
         assert len(image_parts) <= 2

--- a/tests/test_shim_loader.py
+++ b/tests/test_shim_loader.py
@@ -32,7 +32,7 @@ class TestLoadTransforms:
 
     def test_no_transforms_file(self, tmp_path: Path):
         """Returns empty tuples when transforms.py does not exist."""
-        from_t, to_t = _load_transforms(tmp_path)
+        from_t, to_t, ir_t = _load_transforms(tmp_path)
         assert from_t == ()
         assert to_t == ()
 
@@ -45,7 +45,7 @@ class TestLoadTransforms:
             to_transforms = (strip_fields("foo"),)
         """)
         )
-        from_t, to_t = _load_transforms(tmp_path)
+        from_t, to_t, ir_t = _load_transforms(tmp_path)
         assert from_t == ()
         assert len(to_t) == 1
         # Verify the transform works
@@ -64,7 +64,7 @@ class TestLoadTransforms:
             from_transforms = (rename_field("a", "b"),)
         """)
         )
-        from_t, to_t = _load_transforms(tmp_path)
+        from_t, to_t, ir_t = _load_transforms(tmp_path)
         assert len(from_t) == 1
         assert len(to_t) == 1
 


### PR DESCRIPTION
Closes #330

## Summary

**Naming cleanup:**
- `apply_shim_to_ir()` → `apply_ir_transforms()` — drops misleading `shim` prefix
- `setup_shim_context()` → `configure_context()` — pipeline configures context, not shim
- Old names kept as compat aliases with `DeprecationWarning`

**New IR transform system:**
- `TransformContext` dataclass — carries route-level info (model, model_capabilities)
- `IRTransform = Callable[[dict, TransformContext], dict]` — 2-arg, context-aware
- `_NamedIRTransform` — mirrors `_NamedTransform` pattern
- `apply_ir_transforms()` — executor for IR transform tuples
- `ProviderShim.ir_transforms` — new field (defaults empty)

**Design decision (Elena's proposal D):** body transforms (1-arg) and IR transforms (2-arg) are separate types. No dispatch magic, no signature inspection, no breakage of existing custom callables.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1968 passed
- [x] Old function names emit `DeprecationWarning` and still work

AI was used to assist with implementation.