### PR TITLE
refactor: extract capabilities.py — enforce_reasoning, enforce_vision

### DIFF
--- a/src/llm_rosetta/capabilities.py
+++ b/src/llm_rosetta/capabilities.py
@@ -1,0 +1,137 @@
+"""Capability enforcement — adapt IR input to model capabilities.
+
+This module handles **platform-level** capability constraints that apply
+regardless of provider dialect.  Every model has capabilities (vision,
+audio, tools, reasoning, etc.) and the pipeline must adapt the IR
+request to match what the model can actually process.
+
+This is distinct from **shim transforms** (provider-specific dialect
+adaptation) and from **converter logic** (API-standard translation).
+
+Functions follow the ``enforce_*`` naming convention:
+
+- :func:`enforce_reasoning` — configure reasoning output mode (pre-IR)
+- :func:`enforce_vision` — strip images for non-vision models (post-IR)
+
+Called by :class:`~llm_rosetta.pipeline.ConversionPipeline` at the
+appropriate pipeline stages.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.shims.provider_shim import (
+    ProviderShim,
+    ReasoningCapability,
+    resolve_shim,
+)
+
+
+def _apply_config_reasoning_override(
+    base: ReasoningCapability,
+    override: dict[str, Any],
+) -> ReasoningCapability:
+    """Merge config-level reasoning overrides onto a base capability.
+
+    Only fields present in *override* are replaced; the rest inherit
+    from *base*.
+    """
+    return ReasoningCapability(
+        disabled=override.get("disabled", base.disabled),
+        effort_field=override.get("effort_field", base.effort_field),
+        max_effort=override.get("max_effort", base.max_effort),
+        thinking_type=override.get("thinking_type", base.thinking_type),
+        unsigned_reasoning_blocks=override.get(
+            "unsigned_reasoning_blocks", base.unsigned_reasoning_blocks
+        ),
+        effort_map=override.get("effort_map", base.effort_map),
+        budget_tokens_default_ratio=override.get(
+            "budget_tokens_default_ratio", base.budget_tokens_default_ratio
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def enforce_reasoning(
+    ctx: ConversionContext,
+    shim: ProviderShim | str | None,
+    *,
+    model: str | None = None,
+    config_override: dict[str, Any] | None = None,
+) -> None:
+    """Configure reasoning capability in the conversion context.
+
+    Injects ``reasoning_cap`` into *ctx* so converters produce the
+    correct thinking/reasoning output for the target provider.
+
+    Must be called **before** source → IR conversion (converters read
+    ``ctx.options["reasoning_cap"]`` during parsing).
+
+    Resolution priority (highest first):
+
+    1. *config_override* — per-model override from external config
+       (e.g. gateway admin UI).
+    2. ``shim.model_reasoning[model]`` — per-model override from the
+       provider YAML.
+    3. ``shim.reasoning`` — provider-level default.
+
+    Args:
+        ctx: Conversion context to mutate.
+        shim: ProviderShim instance, registered name, or None (no-op).
+        model: Upstream model ID (for per-model reasoning overrides).
+        config_override: External reasoning override (highest priority).
+    """
+    resolved = resolve_shim(shim)
+    if resolved is None:
+        return
+
+    cap = resolved.reasoning
+    # Model-level override (keyed by upstream model ID)
+    if model and resolved.model_reasoning and model in resolved.model_reasoning:
+        cap = resolved.model_reasoning[model]
+    # Config-level override (from admin UI, keyed by gateway model name)
+    if cap is not None and config_override:
+        cap = _apply_config_reasoning_override(cap, config_override)
+    if cap is not None:
+        ctx.options["reasoning_cap"] = cap
+
+
+def enforce_vision(
+    ir_request: dict[str, Any],
+    *,
+    model_capabilities: list[str] | None = None,
+    model: str = "",
+    request_id: str = "-",
+) -> dict[str, Any]:
+    """Strip images from the IR request if the model lacks vision capability.
+
+    Must be called **after** source → IR conversion (operates on the IR
+    dict, not the raw provider body).
+
+    No-op when *model_capabilities* is ``None`` (unknown) or includes
+    ``"vision"``.
+
+    Args:
+        ir_request: The IR request dict — **always use the return value**.
+        model_capabilities: Declared capabilities of the model.
+        model: Upstream model identifier (for logging).
+        request_id: Request identifier (for logging).
+
+    Returns:
+        The IR request with images replaced by text placeholders, or
+        the original request if the model has vision capability.
+    """
+    if model_capabilities is None or "vision" in model_capabilities:
+        return ir_request
+
+    from llm_rosetta.converters.base.helpers.image_limit import (
+        strip_images_for_non_vision,
+    )
+
+    return strip_images_for_non_vision(ir_request, model=model, request_id=request_id)

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -11,8 +11,8 @@ request conversion, response conversion, and/or streaming:
     # ... transport sends target_body, receives upstream_response ...
     source_response = pipeline.convert_response(upstream_response)
 
-**Low-level** — :func:`configure_context` and :func:`apply_ir_transforms`
-for consumers that need finer control over individual pipeline stages.
+**Low-level** — :func:`apply_ir_transforms` and the functions in
+:mod:`llm_rosetta.capabilities` for finer control over individual stages.
 
 The pipeline is part of the core library — **no network dependency**.
 It produces a target request body and consumes a target response body;
@@ -25,8 +25,9 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
+from llm_rosetta.capabilities import enforce_reasoning, enforce_vision
 from llm_rosetta.converters.base.context import ConversionContext
-from llm_rosetta.shims.provider_shim import ProviderShim, ReasoningCapability, get_shim
+from llm_rosetta.shims.provider_shim import ProviderShim, resolve_shim
 from llm_rosetta.shims.transforms import (
     Transform,
     TransformContext,
@@ -35,58 +36,6 @@ from llm_rosetta.shims.transforms import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def _resolve_shim(shim: ProviderShim | str | None) -> ProviderShim | None:
-    """Resolve a shim argument to a ProviderShim instance.
-
-    Args:
-        shim: A ProviderShim instance, a registered name, or None.
-
-    Returns:
-        The resolved ProviderShim, or None.
-    """
-    if shim is None:
-        return None
-    if isinstance(shim, ProviderShim):
-        return shim
-    return get_shim(shim)
-
-
-def _apply_config_reasoning_override(
-    base: ReasoningCapability,
-    override: dict[str, Any],
-) -> ReasoningCapability:
-    """Merge config-level reasoning overrides onto a base capability.
-
-    Only fields present in *override* are replaced; the rest inherit
-    from *base*.
-
-    Args:
-        base: The base reasoning capability from the shim.
-        override: A dict of field overrides (e.g. from admin UI).
-
-    Returns:
-        A new ReasoningCapability with merged values.
-    """
-    return ReasoningCapability(
-        disabled=override.get("disabled", base.disabled),
-        effort_field=override.get("effort_field", base.effort_field),
-        max_effort=override.get("max_effort", base.max_effort),
-        thinking_type=override.get("thinking_type", base.thinking_type),
-        unsigned_reasoning_blocks=override.get(
-            "unsigned_reasoning_blocks", base.unsigned_reasoning_blocks
-        ),
-        effort_map=override.get("effort_map", base.effort_map),
-        budget_tokens_default_ratio=override.get(
-            "budget_tokens_default_ratio", base.budget_tokens_default_ratio
-        ),
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -101,38 +50,15 @@ def configure_context(
     model: str | None = None,
     config_override: dict[str, Any] | None = None,
 ) -> None:
-    """Configure a ConversionContext with shim-driven options.
+    """Deprecated: use :func:`llm_rosetta.capabilities.enforce_reasoning`."""
+    import warnings
 
-    Currently injects ``reasoning_cap`` so converters produce the correct
-    thinking/reasoning output for the target provider.
-
-    Resolution priority (highest first):
-
-    1. *config_override* — per-model override from external config
-       (e.g. gateway admin UI).
-    2. ``shim.model_reasoning[model]`` — per-model override from the
-       provider YAML.
-    3. ``shim.reasoning`` — provider-level default.
-
-    Args:
-        ctx: Conversion context to mutate.
-        shim: ProviderShim instance, registered name, or None (no-op).
-        model: Upstream model ID (for per-model reasoning overrides).
-        config_override: External reasoning override (highest priority).
-    """
-    resolved = _resolve_shim(shim)
-    if resolved is None:
-        return
-
-    cap = resolved.reasoning
-    # Model-level override (keyed by upstream model ID)
-    if model and resolved.model_reasoning and model in resolved.model_reasoning:
-        cap = resolved.model_reasoning[model]
-    # Config-level override (from admin UI, keyed by gateway model name)
-    if cap is not None and config_override:
-        cap = _apply_config_reasoning_override(cap, config_override)
-    if cap is not None:
-        ctx.options["reasoning_cap"] = cap
+    warnings.warn(
+        "configure_context is deprecated; use capabilities.enforce_reasoning()",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    enforce_reasoning(ctx, shim, model=model, config_override=config_override)
 
 
 def apply_ir_transforms(
@@ -163,7 +89,7 @@ def apply_ir_transforms(
         The IR request dict after all applicable transforms.  Always
         assign the return value: ``ir = apply_ir_transforms(ir, shim, ...)``.
     """
-    resolved = _resolve_shim(shim)
+    resolved = resolve_shim(shim)
     if resolved is None or not resolved.ir_transforms:
         return ir_request
 
@@ -285,7 +211,7 @@ class ConversionPipeline:
         self._target_converter = get_converter_for_provider(target_provider)
 
         # Resolve body-level transforms from shim
-        resolved = _resolve_shim(shim)
+        resolved = resolve_shim(shim)
         if resolved is not None:
             self._from_transforms = resolved.from_transforms
             self._to_transforms = resolved.to_transforms
@@ -374,7 +300,8 @@ class ConversionPipeline:
         if self._target_provider == "google":
             ctx.options["output_format"] = "rest"
 
-        configure_context(
+        # Capability enforcement: reasoning (pre-IR)
+        enforce_reasoning(
             ctx,
             self._shim,
             model=self._upstream_model or body.get("model"),
@@ -394,8 +321,17 @@ class ConversionPipeline:
         if on_ir_ready is not None:
             on_ir_ready(ir_request)
 
-        # Phase 2a: Shim-driven IR transforms
         request_id = ctx.options.get("request_id", "-")
+
+        # Capability enforcement: vision (post-IR)
+        ir_request = enforce_vision(
+            ir_request,
+            model_capabilities=self._model_capabilities,
+            model=self._upstream_model or body.get("model") or "",
+            request_id=request_id,
+        )
+
+        # Phase 2a: Shim-driven IR transforms
         ir_request = apply_ir_transforms(
             ir_request,
             self._shim,

--- a/src/llm_rosetta/shims/__init__.py
+++ b/src/llm_rosetta/shims/__init__.py
@@ -18,6 +18,7 @@ from .provider_shim import (
     list_shims,
     register_shim,
     resolve_base,
+    resolve_shim,
     unregister_shim,
 )
 from .transforms import (
@@ -48,6 +49,7 @@ __all__ = [
     "get_shim",
     "list_shims",
     "resolve_base",
+    "resolve_shim",
     # Transforms
     "Transform",
     "apply_transforms",

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -168,6 +168,19 @@ def get_shim(name: str) -> ProviderShim | None:
     return _SHIM_REGISTRY.get(name)
 
 
+def resolve_shim(shim: ProviderShim | str | None) -> ProviderShim | None:
+    """Resolve a shim argument to a :class:`ProviderShim` instance.
+
+    Accepts a :class:`ProviderShim` (returned as-is), a registered name
+    (looked up via :func:`get_shim`), or ``None`` (returns ``None``).
+    """
+    if shim is None:
+        return None
+    if isinstance(shim, ProviderShim):
+        return shim
+    return get_shim(shim)
+
+
 def list_shims() -> list[ProviderShim]:
     """Return all registered provider shims."""
     return list(_SHIM_REGISTRY.values())

--- a/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
@@ -15,8 +15,6 @@ Request-side (to_transforms) — body-level
 
 Request-side (ir_transforms) — IR-level
 -----------------------------------------
-- ``strip_non_vision_images()``: replace images with text placeholders
-  for models without ``"vision"`` capability.
 - ``truncate_images(50, pattern=r"^(gpt|o\\d)")``: enforce 50-image limit
   for GPT/o* models; Gemini and Claude pass through untouched.
 - ``unwind_parallel_tool_calls(pattern=r"^gemini")``: split parallel tool
@@ -28,7 +26,6 @@ from llm_rosetta.shims.transforms import (
     rename_field,
     replace_message_field,
     strip_fields_for_model,
-    strip_non_vision_images,
     truncate_images,
     unwind_parallel_tool_calls,
 )
@@ -41,7 +38,6 @@ to_transforms = (
 )
 from_transforms = ()
 ir_transforms = (
-    strip_non_vision_images(),
     truncate_images(50, pattern=r"^(gpt|o\d)"),
     unwind_parallel_tool_calls(pattern=r"^gemini"),
 )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,8 +1,7 @@
-"""Tests for llm_rosetta.pipeline — ConversionPipeline and shim-driven helpers.
+"""Tests for llm_rosetta.pipeline and llm_rosetta.capabilities.
 
-Note: This file imports private helpers (_resolve_shim, _apply_config_reasoning_override)
-directly from llm_rosetta.pipeline for unit-testing internal logic.  These are NOT
-re-exported by the backward-compat shim at llm_rosetta.shims.pipeline.
+Note: This file imports private helpers (resolve_shim, _apply_config_reasoning_override)
+directly from llm_rosetta.capabilities for unit-testing internal logic.
 """
 
 import copy
@@ -10,17 +9,17 @@ from typing import Any
 
 import pytest
 
-from llm_rosetta.converters.base.context import ConversionContext
-from llm_rosetta.pipeline import (
+from llm_rosetta.capabilities import (
     _apply_config_reasoning_override,
-    _resolve_shim,
-    apply_ir_transforms,
-    configure_context,
+    enforce_reasoning,
 )
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.pipeline import apply_ir_transforms
 from llm_rosetta.shims.provider_shim import (
     ProviderShim,
     ReasoningCapability,
     register_shim,
+    resolve_shim,
     unregister_shim,
 )
 from llm_rosetta.shims.transforms import (
@@ -87,48 +86,48 @@ def _simple_ir_request(n_messages: int = 1, n_images: int = 0) -> dict[str, Any]
 
 
 # ---------------------------------------------------------------------------
-# _resolve_shim
+# resolve_shim
 # ---------------------------------------------------------------------------
 
 
 class TestResolveShim:
     def test_none(self):
-        assert _resolve_shim(None) is None
+        assert resolve_shim(None) is None
 
     def test_provider_shim_instance(self):
         shim = _make_shim()
-        assert _resolve_shim(shim) is shim
+        assert resolve_shim(shim) is shim
 
     def test_registered_name(self):
         shim = _make_shim()
         register_shim(shim)
-        assert _resolve_shim("test-shim") is shim
+        assert resolve_shim("test-shim") is shim
 
     def test_unknown_name(self):
-        assert _resolve_shim("nonexistent-shim") is None
+        assert resolve_shim("nonexistent-shim") is None
 
 
 # ---------------------------------------------------------------------------
-# configure_context
+# enforce_reasoning
 # ---------------------------------------------------------------------------
 
 
-class TestConfigureContext:
+class TestEnforceReasoning:
     def test_none_shim_is_noop(self):
         ctx = ConversionContext()
-        configure_context(ctx, None)
+        enforce_reasoning(ctx, None)
         assert "reasoning_cap" not in ctx.options
 
     def test_shim_without_reasoning_is_noop(self):
         ctx = ConversionContext()
         shim = _make_shim(reasoning=None)
-        configure_context(ctx, shim)
+        enforce_reasoning(ctx, shim)
         assert "reasoning_cap" not in ctx.options
 
     def test_provider_level_reasoning(self):
         ctx = ConversionContext()
         shim = _make_shim(reasoning=_REASONING_CAP)
-        configure_context(ctx, shim)
+        enforce_reasoning(ctx, shim)
         assert ctx.options["reasoning_cap"] is _REASONING_CAP
 
     def test_model_level_override(self):
@@ -137,7 +136,7 @@ class TestConfigureContext:
             reasoning=_REASONING_CAP,
             model_reasoning={"gpt-4": _MODEL_REASONING_CAP},
         )
-        configure_context(ctx, shim, model="gpt-4")
+        enforce_reasoning(ctx, shim, model="gpt-4")
         assert ctx.options["reasoning_cap"] is _MODEL_REASONING_CAP
 
     def test_model_not_in_overrides_falls_back(self):
@@ -146,13 +145,13 @@ class TestConfigureContext:
             reasoning=_REASONING_CAP,
             model_reasoning={"gpt-4": _MODEL_REASONING_CAP},
         )
-        configure_context(ctx, shim, model="gpt-3.5")
+        enforce_reasoning(ctx, shim, model="gpt-3.5")
         assert ctx.options["reasoning_cap"] is _REASONING_CAP
 
     def test_config_override_highest_priority(self):
         ctx = ConversionContext()
         shim = _make_shim(reasoning=_REASONING_CAP)
-        configure_context(ctx, shim, config_override={"thinking_type": "adaptive"})
+        enforce_reasoning(ctx, shim, config_override={"thinking_type": "adaptive"})
         cap = ctx.options["reasoning_cap"]
         assert cap.thinking_type == "adaptive"
         # Other fields inherited from base
@@ -166,7 +165,7 @@ class TestConfigureContext:
             reasoning=_REASONING_CAP,
             model_reasoning={"gpt-4": _MODEL_REASONING_CAP},
         )
-        configure_context(
+        enforce_reasoning(
             ctx, shim, model="gpt-4", config_override={"disabled": "block"}
         )
         cap = ctx.options["reasoning_cap"]
@@ -178,12 +177,12 @@ class TestConfigureContext:
         ctx = ConversionContext()
         shim = _make_shim(reasoning=_REASONING_CAP)
         register_shim(shim)
-        configure_context(ctx, "test-shim")
+        enforce_reasoning(ctx, "test-shim")
         assert ctx.options["reasoning_cap"] is _REASONING_CAP
 
     def test_unknown_name_is_noop(self):
         ctx = ConversionContext()
-        configure_context(ctx, "nonexistent")
+        enforce_reasoning(ctx, "nonexistent")
         assert "reasoning_cap" not in ctx.options
 
 


### PR DESCRIPTION
Closes #335

## Summary

New `capabilities.py` module for platform-level capability enforcement, separate from shim transforms (provider dialect) and converters (format translation).

**Capability enforcement** = "this model can/cannot do X" — applies regardless of provider.
**Shim transforms** = "this provider's API dialect needs field Y adjusted" — provider-specific.

## Changes

| File | Change |
|---|---|
| `capabilities.py` | **New** — `enforce_reasoning()` (pre-IR), `enforce_vision()` (post-IR) |
| `pipeline.py` | Delegates to capabilities; `configure_context()` becomes deprecated alias |
| `argo/openai_chat/transforms.py` | Remove `strip_non_vision_images()` from `ir_transforms` — now platform-level |
| `tests/test_pipeline.py` | Import from capabilities, rename test class |

## Pipeline flow

```python
enforce_reasoning(ctx, shim)          # capability: reasoning mode
ir = source→IR(body, ctx)             # converter
ir = enforce_vision(ir, caps)         # capability: strip images for non-vision
ir = apply_ir_transforms(shim, ir)    # shim: provider-specific IR transforms
body = IR→target(ir, ctx)             # converter
body = apply_transforms(to_t, body)   # shim: provider-specific body transforms
```

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1968 passed
- [x] `configure_context()` compat alias emits `DeprecationWarning`

AI was used to assist with implementation.