### PR TITLE
fix: strip exclusiveMinimum in schema + stop emitting reasoning.type for Responses API

### DIFF
--- a/src/llm_rosetta/converters/base/helpers/reasoning.py
+++ b/src/llm_rosetta/converters/base/helpers/reasoning.py
@@ -325,12 +325,13 @@ def _apply_openai_responses_extras(
     mode: str | None,
     budget_tokens: int | None,
 ) -> None:
-    """OpenAI Responses extras: reasoning.type when mode is set."""
-    if mode:
-        reasoning = result.setdefault("reasoning", {})
-        # auto → enabled for Responses API
-        reasoning["type"] = "enabled" if mode == "auto" else mode
+    """OpenAI Responses extras.
 
+    Note: OpenAI Responses API does **not** accept ``reasoning.type``
+    (returns 400 Unknown parameter).  Reasoning is controlled via
+    ``reasoning.effort`` only, which is already handled by the effort
+    mapping in the caller.
+    """
     if budget_tokens is not None:
         warnings.warn(
             "OpenAI Responses API does not support reasoning budget_tokens, ignored",

--- a/src/llm_rosetta/converters/base/helpers/schema.py
+++ b/src/llm_rosetta/converters/base/helpers/schema.py
@@ -31,6 +31,10 @@ UNSUPPORTED_SCHEMA_KEYS: set[str] = {
     "readOnly",
     "writeOnly",
     "examples",
+    # JSON Schema draft 6+ numeric constraints — not supported by
+    # Google GenAI and some other providers.
+    "exclusiveMinimum",
+    "exclusiveMaximum",
 }
 
 # Keys that hold definition maps (consumed for $ref resolution, then removed).

--- a/tests/converters/openai_responses/test_config_ops.py
+++ b/tests/converters/openai_responses/test_config_ops.py
@@ -272,19 +272,19 @@ class TestOpenAIResponsesConfigOps:
         assert result["reasoning"] == {"effort": "high"}
 
     def test_ir_reasoning_config_with_mode(self):
-        """Test reasoning config with mode field."""
+        """Test reasoning config with mode — type is NOT emitted (OpenAI rejects it)."""
         result = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(
             cast(ReasoningConfig, {"mode": "enabled", "effort": "medium"})
         )
-        assert result["reasoning"]["type"] == "enabled"
+        assert "type" not in result.get("reasoning", {})
         assert result["reasoning"]["effort"] == "medium"
 
     def test_ir_reasoning_config_auto_mode(self):
-        """Test mode: auto maps to reasoning.type: enabled."""
+        """Test mode: auto — only effort is emitted, no reasoning.type."""
         result = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(
             cast(ReasoningConfig, {"mode": "auto", "effort": "high"})
         )
-        assert result["reasoning"]["type"] == "enabled"
+        assert "type" not in result.get("reasoning", {})
         assert result["reasoning"]["effort"] == "high"
 
     def test_ir_reasoning_config_disabled_mode(self):


### PR DESCRIPTION
## Bugs fixed

### 1. `exclusiveMinimum`/`exclusiveMaximum` not stripped by `sanitize_schema`

Google GenAI API rejects JSON Schema draft 6+ numeric constraints in tool definitions. Claude Code sends tool schemas with `exclusiveMinimum`, which passes through `sanitize_schema` unstripped, causing 400 errors on Gemini models.

**Fix:** Add `exclusiveMinimum` and `exclusiveMaximum` to `UNSUPPORTED_SCHEMA_KEYS`.

**Verified:** `claude_code/gemini-3.5-flash` and `claude_code/argo:gemini-2.5-flash` now pass.

### 2. `reasoning.type` emitted for OpenAI Responses API

`_apply_openai_responses_extras` set `reasoning.type = "enabled"` when a thinking mode was present. But **OpenAI Responses API does not accept `reasoning.type`** — it only uses `reasoning.effort`. Volcengine's Responses API also rejects it with `unknown field "type"`.

This was a historical bug from v0.6.8 — incorrectly analogized from Anthropic's `thinking.type` field. Previously unexposed because only Claude Code (Anthropic inbound) sends thinking config that triggers this code path.

**Fix:** Remove `reasoning.type` emission from `_apply_openai_responses_extras`.

**Verified against:**
- OpenAI: `reasoning.type` → 400 Unknown parameter; `reasoning.effort` only → 200
- Volcengine: `reasoning.type` → 400 unknown field; `reasoning.effort` only → 200
- E2E: `claude_code/gpt-5-nano` and `claude_code/o4-mini` now pass

## E2E results after fixes (dev gateway 0.7.0a0)

```
              gpt-5-nano  o4-mini  claude-haiku  opus-4.7  argo:gemini  gemini-direct  deepseek  minimax  doubao
codex            ✅         ✅         ✅           ✅          ✅           ✅            ✅        ✅       ✅
opencode         ✅         ✅         ✅           ✅          ✅           ✅            ✅        ✅       ✅
claude_code      ✅         ✅         ✅           ✅          ✅           ✅            ✅        ✅       ✅
```

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1968 passed
- [x] E2E against dev gateway — all conversion paths verified

AI was used to assist with implementation.