### PR TITLE
feat: hybrid profiling — phase timing + on-demand pyinstrument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ openai = ["openai"]
 anthropic = ["anthropic"]
 google = ["google-genai"]
 gateway = []
+profiling = ["pyinstrument>=5.0.0"]
 dev = [
     "python-dotenv",
     "pytest",
@@ -55,7 +56,7 @@ dev = [
     "twine>=6.1.0",
 ]
 
-all = ["llm-rosetta[openai,anthropic,google,gateway,dev]"]
+all = ["llm-rosetta[openai,anthropic,google,gateway,profiling,dev]"]
 
 [project.urls]
 Documentation = "https://llm-rosetta.readthedocs.io"

--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -101,8 +101,14 @@ def setup_admin(
     # Request log delegates to persistence when available
     request_log = RequestLog(persistence=persistence)
 
+    # On-demand deep profiling state
+    from .routes.profiling import ProfilerState
+
+    profiler_state = ProfilerState()
+
     app.metrics = metrics
     app.request_log = request_log
     app.persistence = persistence
     app.gateway_config = config
     app.config_path = config_path
+    app.profiler_state = profiler_state

--- a/src/llm_rosetta/gateway/admin/persistence.py
+++ b/src/llm_rosetta/gateway/admin/persistence.py
@@ -133,7 +133,7 @@ class PersistenceManager:
         cursor = self._conn.execute("PRAGMA table_info(request_log)")
         columns = {row[1] for row in cursor.fetchall()}
         added = False
-        for col in ("target_provider_name", "client_ip"):
+        for col in ("target_provider_name", "client_ip", "profile"):
             if col not in columns:
                 self._conn.execute(f"ALTER TABLE request_log ADD COLUMN {col} TEXT")
                 added = True
@@ -184,6 +184,7 @@ class PersistenceManager:
         "api_key_label",
         "target_provider_name",
         "client_ip",
+        "profile",
     ]
 
     def insert_log_entries(self, entries: list[dict[str, Any]]) -> None:
@@ -194,8 +195,8 @@ class PersistenceManager:
             "INSERT OR IGNORE INTO request_log "
             "(id, timestamp, model, source_provider, target_provider, "
             "is_stream, status_code, duration_ms, error_detail, api_key_label, "
-            "target_provider_name, client_ip) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "target_provider_name, client_ip, profile) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [
                 (
                     e["id"],
@@ -210,6 +211,7 @@ class PersistenceManager:
                     e.get("api_key_label"),
                     e.get("target_provider_name"),
                     e.get("client_ip"),
+                    json.dumps(e["profile"]) if e.get("profile") else None,
                 )
                 for e in entries
             ],
@@ -427,12 +429,50 @@ class PersistenceManager:
         )
         self._conn.commit()
 
+    def update_entry_profile(
+        self, entry_id: str, profile_update: dict[str, Any]
+    ) -> None:
+        """Merge additional profile data into an existing log entry.
+
+        Reads the current profile JSON, merges *profile_update* on top,
+        and writes it back.  Used by the streaming path to write back
+        stream metrics after the stream completes.
+
+        Args:
+            entry_id: The log entry ID to update.
+            profile_update: Profile keys to merge.
+        """
+        row = self._conn.execute(
+            "SELECT profile FROM request_log WHERE id = ?", (entry_id,)
+        ).fetchone()
+        if row is None:
+            return
+        existing: dict[str, Any] = {}
+        if row[0]:
+            try:
+                existing = json.loads(row[0])
+            except (json.JSONDecodeError, TypeError):
+                pass
+        existing.update(profile_update)
+        self._conn.execute(
+            "UPDATE request_log SET profile = ? WHERE id = ?",
+            (json.dumps(existing, ensure_ascii=False), entry_id),
+        )
+        self._conn.commit()
+
     @classmethod
     def _row_to_dict(cls, row: tuple[Any, ...]) -> dict[str, Any]:
         d: dict[str, Any] = {}
         for col, val in zip(cls._LOG_COLUMNS, row):
             if col == "is_stream":
                 d[col] = bool(val)
+            elif col == "profile":
+                if val is not None:
+                    try:
+                        d[col] = json.loads(val)
+                    except (json.JSONDecodeError, TypeError):
+                        d[col] = None
+                # omit if None (match old behavior for optional fields)
             elif col in ("error_detail", "api_key_label", "client_ip") and val is None:
                 continue  # omit None optional fields (match old behavior)
             else:

--- a/src/llm_rosetta/gateway/admin/request_log.py
+++ b/src/llm_rosetta/gateway/admin/request_log.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import uuid
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -32,6 +32,7 @@ class RequestLogEntry:
     api_key_label: str | None = None
     target_provider_name: str | None = None
     client_ip: str | None = None
+    profile: dict[str, Any] | None = None
 
     @classmethod
     def create(
@@ -47,6 +48,7 @@ class RequestLogEntry:
         api_key_label: str | None = None,
         target_provider_name: str | None = None,
         client_ip: str | None = None,
+        profile: dict[str, Any] | None = None,
     ) -> RequestLogEntry:
         """Factory with auto-generated id and timestamp."""
         return cls(
@@ -62,6 +64,7 @@ class RequestLogEntry:
             api_key_label=api_key_label,
             target_provider_name=target_provider_name,
             client_ip=client_ip,
+            profile=profile,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -84,6 +87,8 @@ class RequestLogEntry:
             d["target_provider_name"] = self.target_provider_name
         if self.client_ip is not None:
             d["client_ip"] = self.client_ip
+        if self.profile is not None:
+            d["profile"] = self.profile
         return d
 
 
@@ -206,6 +211,27 @@ class RequestLog:
         entries = [e.to_dict() for e in self._pending]
         self._pending.clear()
         return entries
+
+    def update_profile(self, entry_id: str, profile_update: dict[str, Any]) -> None:
+        """Merge additional profile data into an existing entry.
+
+        Used by the streaming path to write back stream metrics
+        (TTFB, duration, chunk count) after stream completion.
+
+        Args:
+            entry_id: The log entry ID to update.
+            profile_update: Profile keys to merge (e.g.
+                ``{"stream_ttfb_ms": 120.5, "stream_complete": True}``).
+        """
+        if self._persistence is not None:
+            self._persistence.update_entry_profile(entry_id, profile_update)
+        else:
+            # In-memory: find and rebuild the frozen entry
+            for i, entry in enumerate(self._entries):
+                if entry.id == entry_id:
+                    merged = dict(entry.profile or {}, **profile_update)
+                    self._entries[i] = replace(entry, profile=merged)
+                    break
 
     def clear(self) -> None:
         """Remove all entries."""

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -7,6 +7,7 @@ This package splits the admin route handlers into focused modules:
 - keys        — Gateway API key management
 - observability — Metrics, request log, network diagnostics
 - testing     — Async model test tasks
+- profiling   — On-demand pyinstrument profiling
 """
 
 from __future__ import annotations
@@ -57,6 +58,14 @@ from .observability import (
     get_request_key_labels,
     get_requests,
     network_diagnostics,
+)
+from .profiling import (
+    clear_profiling_results,
+    disable_profiling,
+    enable_profiling,
+    get_profiling_result,
+    get_profiling_results,
+    get_profiling_status,
 )
 from .testing import (
     cancel_test,
@@ -113,3 +122,14 @@ def register_admin_routes(app: Any) -> None:
     app.route("/admin/api/test/<task_id>", methods=["GET"])(get_test_result)
     app.route("/admin/api/test/<task_id>/poll", methods=["POST"])(get_test_result)
     app.route("/admin/api/test/<task_id>", methods=["DELETE"])(cancel_test)
+    # Profiling
+    app.route("/admin/api/profiling/status", methods=["GET"])(get_profiling_status)
+    app.route("/admin/api/profiling/enable", methods=["POST"])(enable_profiling)
+    app.route("/admin/api/profiling/disable", methods=["POST"])(disable_profiling)
+    app.route("/admin/api/profiling/results", methods=["GET"])(get_profiling_results)
+    app.route("/admin/api/profiling/results/<index>", methods=["GET"])(
+        get_profiling_result
+    )
+    app.route("/admin/api/profiling/results", methods=["DELETE"])(
+        clear_profiling_results
+    )

--- a/src/llm_rosetta/gateway/admin/routes/profiling.py
+++ b/src/llm_rosetta/gateway/admin/routes/profiling.py
@@ -1,0 +1,223 @@
+"""On-demand deep profiling routes and state management.
+
+Provides :class:`ProfilerState` for managing pyinstrument profiling
+sessions, and admin API handlers for enabling/disabling profiling and
+retrieving results.
+
+The :class:`ProfilerState` is instantiated in :func:`~admin.setup_admin`
+and attached to ``app.profiler_state``.  Route handlers access it via
+``request.app.profiler_state``.  ``app.py`` accesses it the same way
+(never imports :class:`ProfilerState` directly).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from llm_rosetta._vendor.httpserver import JSONResponse, Response
+
+
+# ---------------------------------------------------------------------------
+# Profiler state
+# ---------------------------------------------------------------------------
+
+
+class ProfilerState:
+    """Manages on-demand per-request pyinstrument profiling sessions.
+
+    Each profiled request gets its own
+    :class:`~llm_rosetta.profiling.DeepProfiler` instance to avoid
+    cross-request contamination on the async event loop.
+
+    Attributes:
+        enabled: Whether profiling is currently active.
+        remaining: Number of requests left to profile.
+        results: Collected profiling results (capped at *max_results*).
+    """
+
+    def __init__(self, *, max_results: int = 20) -> None:
+        self.enabled: bool = False
+        self.remaining: int = 0
+        self.results: list[dict[str, Any]] = []
+        self._max_results = max_results
+
+    def enable(self, requests: int = 5) -> dict[str, Any]:
+        """Enable profiling for the next *requests* requests.
+
+        Args:
+            requests: Number of requests to profile.
+
+        Returns:
+            Current status dict.
+        """
+        self.enabled = True
+        self.remaining = max(1, requests)
+        return self.status()
+
+    def disable(self) -> dict[str, Any]:
+        """Manually disable profiling.
+
+        Returns:
+            Current status dict.
+        """
+        self.enabled = False
+        self.remaining = 0
+        return self.status()
+
+    def should_profile(self) -> bool:
+        """Check and consume one profiling slot.
+
+        Returns ``True`` if the current request should be profiled
+        (and decrements the remaining counter).  Auto-disables when
+        the counter reaches zero.
+        """
+        if not self.enabled or self.remaining <= 0:
+            return False
+        self.remaining -= 1
+        if self.remaining <= 0:
+            self.enabled = False
+        return True
+
+    def create_profiler(self) -> Any:
+        """Create a new per-request DeepProfiler instance.
+
+        Returns:
+            A :class:`~llm_rosetta.profiling.DeepProfiler` instance.
+
+        Raises:
+            RuntimeError: If pyinstrument is not installed.
+        """
+        from llm_rosetta.profiling import DeepProfiler
+
+        return DeepProfiler(async_mode=True)
+
+    def store_result(
+        self,
+        profiler: Any,
+        *,
+        request_id: str = "",
+        model: str = "",
+        source: str = "",
+        target: str = "",
+        is_stream: bool = False,
+        duration_ms: float = 0.0,
+    ) -> None:
+        """Store profiling result from a completed request.
+
+        Args:
+            profiler: A stopped DeepProfiler instance.
+            request_id: The request's trace ID.
+            model: Model name.
+            source: Source provider.
+            target: Target provider.
+            is_stream: Whether the request was streaming.
+            duration_ms: End-to-end request duration.
+        """
+        result: dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "request_id": request_id,
+            "model": model,
+            "source": source,
+            "target": target,
+            "is_stream": is_stream,
+            "duration_ms": round(duration_ms, 2),
+            "html": profiler.output_html(),
+            "text": profiler.output_text(),
+        }
+        self.results.append(result)
+        # Trim to max
+        if len(self.results) > self._max_results:
+            self.results = self.results[-self._max_results :]
+
+    def status(self) -> dict[str, Any]:
+        """Return current profiling status."""
+        return {
+            "enabled": self.enabled,
+            "remaining": self.remaining,
+            "results_count": len(self.results),
+            "max_results": self._max_results,
+        }
+
+    def clear_results(self) -> None:
+        """Remove all stored profiling results."""
+        self.results.clear()
+
+
+# ---------------------------------------------------------------------------
+# Route handlers
+# ---------------------------------------------------------------------------
+
+
+async def get_profiling_status(request: Any) -> Response:
+    """Return current profiling status."""
+    state: ProfilerState = request.app.profiler_state
+    return JSONResponse(state.status())
+
+
+async def enable_profiling(request: Any) -> Response:
+    """Enable profiling for the next N requests."""
+    state: ProfilerState = request.app.profiler_state
+    try:
+        body = request.json()
+    except Exception:
+        body = {}
+    requests = int(body.get("requests", 5))
+    requests = max(1, min(requests, 100))  # clamp to [1, 100]
+    return JSONResponse(state.enable(requests))
+
+
+async def disable_profiling(request: Any) -> Response:
+    """Disable profiling."""
+    state: ProfilerState = request.app.profiler_state
+    return JSONResponse(state.disable())
+
+
+async def get_profiling_results(request: Any) -> Response:
+    """Return profiling results (summaries without HTML/text bodies)."""
+    state: ProfilerState = request.app.profiler_state
+    summaries = [
+        {k: v for k, v in r.items() if k not in ("html", "text")} for r in state.results
+    ]
+    return JSONResponse({"results": summaries, "total": len(summaries)})
+
+
+async def get_profiling_result(request: Any, **kwargs: Any) -> Response:
+    """Return a single profiling result by index.
+
+    Query param ``format=html`` returns the flamegraph HTML directly
+    (with ``text/html`` content type).
+    """
+    state: ProfilerState = request.app.profiler_state
+    try:
+        index = int(request.path_params.get("index", kwargs.get("index", 0)))
+    except (ValueError, TypeError):
+        return JSONResponse({"error": "Invalid index"}, status_code=400)
+
+    if index < 0 or index >= len(state.results):
+        return JSONResponse({"error": "Index out of range"}, status_code=404)
+
+    result = state.results[index]
+
+    # Check query param for format
+    fmt = ""
+    if hasattr(request, "query_params"):
+        fmt = request.query_params.get("format", "")
+    elif hasattr(request, "args"):
+        fmt = request.args.get("format", "")
+
+    if fmt == "html":
+        return Response(
+            body=result["html"].encode("utf-8"),
+            status_code=200,
+            content_type="text/html; charset=utf-8",
+        )
+
+    return JSONResponse(result)
+
+
+async def clear_profiling_results(request: Any) -> Response:
+    """Clear all profiling results."""
+    state: ProfilerState = request.app.profiler_state
+    state.clear_results()
+    return JSONResponse({"ok": True})

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -43,8 +43,20 @@ def _record_telemetry(
     status_code: int,
     duration_ms: float,
     error_detail: str | None,
-) -> None:
-    """Record metrics and request log entry after a proxy call completes."""
+    profile: dict[str, Any] | None = None,
+    entry_id_override: str | None = None,
+) -> str | None:
+    """Record metrics and request log entry after a proxy call completes.
+
+    Args:
+        entry_id_override: Pre-generated entry ID for streaming requests.
+            When provided, the entry is created with this ID so the
+            stream generator can write back profile data by ID.
+
+    Returns:
+        The request log entry ID, or ``None`` if no request log is
+        configured.
+    """
     metrics = getattr(request.app, "metrics", None)
     if is_stream and metrics:
         metrics.active_streams -= 1
@@ -62,22 +74,30 @@ def _record_telemetry(
 
     request_log = getattr(request.app, "request_log", None)
     if request_log is not None:
+        from dataclasses import replace as _dc_replace
+
         from .admin.request_log import RequestLogEntry
 
-        request_log.add(
-            RequestLogEntry.create(
-                model=model,
-                source_provider=source_provider,
-                target_provider=target_provider,
-                target_provider_name=provider_name,
-                is_stream=is_stream,
-                status_code=status_code,
-                duration_ms=duration_ms,
-                error_detail=error_detail,
-                api_key_label=api_key_label_var.get(),
-                client_ip=_extract_client_ip(request),
-            )
+        entry = RequestLogEntry.create(
+            model=model,
+            source_provider=source_provider,
+            target_provider=target_provider,
+            target_provider_name=provider_name,
+            is_stream=is_stream,
+            status_code=status_code,
+            duration_ms=duration_ms,
+            error_detail=error_detail,
+            api_key_label=api_key_label_var.get(),
+            client_ip=_extract_client_ip(request),
+            profile=profile,
         )
+        # For streaming, use the pre-generated ID so the stream
+        # generator can write back profile data by this ID.
+        if entry_id_override:
+            entry = _dc_replace(entry, id=entry_id_override)
+        request_log.add(entry)
+        return entry.id
+    return None
 
 
 def _extract_client_ip(request: Any) -> str | None:
@@ -102,6 +122,55 @@ def _extract_client_ip(request: Any) -> str | None:
 # ---------------------------------------------------------------------------
 # Route handlers
 # ---------------------------------------------------------------------------
+
+
+def _try_start_profiler(app: Any) -> Any | None:
+    """Start a per-request deep profiler if profiling is enabled.
+
+    Returns a started DeepProfiler instance, or ``None`` if profiling
+    is disabled or pyinstrument is not installed.
+    """
+    state = getattr(app, "profiler_state", None)
+    if state is None or not state.should_profile():
+        return None
+    try:
+        profiler = state.create_profiler()
+        profiler.start()
+        return profiler
+    except RuntimeError:
+        return None
+
+
+def _try_stop_profiler(
+    profiler: Any,
+    app: Any,
+    *,
+    request_id: str,
+    model: str,
+    source: str,
+    target: str,
+    is_stream: bool,
+    duration_ms: float,
+) -> None:
+    """Stop a running deep profiler and store the result."""
+    if profiler is None:
+        return
+    try:
+        profiler.stop()
+        state = getattr(app, "profiler_state", None)
+        if state is not None:
+            state.store_result(
+                profiler,
+                request_id=request_id,
+                model=model,
+                source=source,
+                target=target,
+                is_stream=is_stream,
+                duration_ms=duration_ms,
+            )
+    except Exception:
+        logger.debug("Failed to store profiling result")
+
 
 # Global config — set at startup
 _config: GatewayConfig | None = None
@@ -190,17 +259,37 @@ async def _proxy_handler(
     t0 = time.monotonic()
     status_code = 500
     error_detail: str | None = None
+    profile: dict[str, Any] | None = None
+    request_log = getattr(request.app, "request_log", None)
+
+    deep_profiler = _try_start_profiler(request.app)
 
     try:
-        handler = handle_streaming if is_stream else handle_non_streaming
-        response = await handler(
-            route,
-            provider_info,
-            body,
-            transport=request.app.transport,
-            metadata_store=store,
-            extra_headers=extra_headers,
-        )
+        if is_stream:
+            # For streaming, we pre-generate the entry_id so the stream
+            # generator can write back stream-phase profile after completion.
+            pre_entry_id = uuid.uuid4().hex
+
+            response, profile = await handle_streaming(
+                route,
+                provider_info,
+                body,
+                transport=request.app.transport,
+                metadata_store=store,
+                extra_headers=extra_headers,
+                entry_id=pre_entry_id,
+                request_log=request_log,
+            )
+        else:
+            pre_entry_id = None
+            response, profile = await handle_non_streaming(
+                route,
+                provider_info,
+                body,
+                transport=request.app.transport,
+                metadata_store=store,
+                extra_headers=extra_headers,
+            )
         status_code = response.status_code
         if status_code >= 400 and hasattr(response, "body"):
             body_bytes = response.body
@@ -213,12 +302,26 @@ async def _proxy_handler(
         error_detail = str(exc)
         logger.exception("[%s] unhandled error in proxy handler", request_id)
         status_code = 500
+        pre_entry_id = None
         resp = error_response_for_source(
             source_provider, 500, f"Internal server error: {exc}"
         )
         resp.headers["x-request-id"] = request_id
         return resp
     finally:
+        duration_ms = (time.monotonic() - t0) * 1000
+
+        _try_stop_profiler(
+            deep_profiler,
+            request.app,
+            request_id=request_id,
+            model=model,
+            source=source_provider,
+            target=route.target_provider,
+            is_stream=is_stream,
+            duration_ms=duration_ms,
+        )
+
         _record_telemetry(
             request,
             model=model,
@@ -227,8 +330,10 @@ async def _proxy_handler(
             provider_name=route.provider_name,
             is_stream=is_stream,
             status_code=status_code,
-            duration_ms=(time.monotonic() - t0) * 1000,
+            duration_ms=duration_ms,
             error_detail=error_detail,
+            profile=profile,
+            entry_id_override=pre_entry_id,
         )
 
 

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -243,9 +243,16 @@ async def handle_non_streaming(
     transport: UpstreamTransport,
     metadata_store: ProviderMetadataStore | None = None,
     extra_headers: dict[str, str] | None = None,
-) -> Response:
-    """Non-streaming proxy: convert -> forward -> convert back -> respond."""
+) -> tuple[Response, dict[str, Any]]:
+    """Non-streaming proxy: convert -> forward -> convert back -> respond.
+
+    Returns:
+        A ``(response, profile)`` tuple.  The profile dict contains
+        per-phase timing data merged from the conversion pipeline and
+        gateway-level measurements (upstream latency).
+    """
     store = metadata_store or _default_metadata_store
+    profile: dict[str, Any] = {}
     # model was already injected into body by app.py
     model = body.get("model", "")
 
@@ -264,7 +271,9 @@ async def handle_non_streaming(
             body, on_ir_ready=store.inject_into_request
         )
     except ConversionError as exc:
-        return error_response_for_source(route.source_provider, 400, str(exc))
+        return error_response_for_source(route.source_provider, 400, str(exc)), profile
+
+    profile.update(pipeline.profile)
 
     log_original_request(pipeline.ir_request)
     if pipeline.warnings:
@@ -272,6 +281,7 @@ async def handle_non_streaming(
     log_converted_request(target_body)
 
     # Phase 3: Forward to upstream via transport
+    t_upstream = time.perf_counter()
     try:
         resp = await transport.send_request(
             provider_info,
@@ -281,9 +291,14 @@ async def handle_non_streaming(
             extra_headers=extra_headers,
         )
     except UpstreamConnectionError as exc:
-        return error_response_for_source(
-            route.source_provider, 502, f"Upstream request failed: {exc}"
+        profile["upstream_ms"] = round((time.perf_counter() - t_upstream) * 1000, 2)
+        return (
+            error_response_for_source(
+                route.source_provider, 502, f"Upstream request failed: {exc}"
+            ),
+            profile,
         )
+    profile["upstream_ms"] = round((time.perf_counter() - t_upstream) * 1000, 2)
 
     if resp.is_error:
         log_upstream_error(
@@ -291,10 +306,13 @@ async def handle_non_streaming(
             resp.error_text,
             endpoint=str(route.target_provider),
         )
-        return Response(
-            body=resp.raw_content,
-            status_code=resp.status_code,
-            content_type="application/json",
+        return (
+            Response(
+                body=resp.raw_content,
+                status_code=resp.status_code,
+                content_type="application/json",
+            ),
+            profile,
         )
 
     # Phase 4: Target response → Source response
@@ -305,9 +323,12 @@ async def handle_non_streaming(
             resp.body, on_ir_ready=store.cache_from_response
         )
     except ConversionError as exc:
-        return error_response_for_source(route.source_provider, 502, str(exc))
+        profile.update(pipeline.profile)
+        return error_response_for_source(route.source_provider, 502, str(exc)), profile
 
-    return JSONResponse(source_response)
+    # Merge response-phase timings from pipeline
+    profile.update(pipeline.profile)
+    return JSONResponse(source_response), profile
 
 
 async def _stream_event_generator(
@@ -321,10 +342,15 @@ async def _stream_event_generator(
     model: str,
     format_sse: Any,
     extra_headers: dict[str, str] | None = None,
+    entry_id: str | None = None,
+    request_log: Any | None = None,
 ) -> AsyncIterator[str]:
     """Stream SSE events from upstream, converting each chunk via Pipeline."""
     chunk_count = 0
     t0 = time.monotonic()
+    stream_error: str | None = None
+    ttfb_ms: float | None = None
+    t_stream_open = time.perf_counter()
 
     try:
         stream = await transport.send_streaming(
@@ -335,38 +361,62 @@ async def _stream_event_generator(
             extra_headers=extra_headers,
         )
     except UpstreamConnectionError as exc:
-        yield f"data: {json.dumps({'error': {'message': str(exc)}})}\n\n"
+        stream_error = str(exc)
+        yield f"data: {json.dumps({'error': {'message': stream_error}})}\n\n"
         return
 
-    async with stream:
-        if stream.is_error:
-            error_text = await stream.read_error()
-            log_upstream_error(
-                stream.status_code,
-                error_text,
-                endpoint=str(target_provider),
-                is_streaming=True,
-            )
+    try:
+        async with stream:
+            if stream.is_error:
+                error_text = await stream.read_error()
+                stream_error = error_text
+                log_upstream_error(
+                    stream.status_code,
+                    error_text,
+                    endpoint=str(target_provider),
+                    is_streaming=True,
+                )
+                try:
+                    error_msg = json.dumps(json.loads(error_text))
+                except json.JSONDecodeError:
+                    error_msg = error_text
+                yield f"data: {error_msg}\n\n"
+                return
+
+            async for chunk in stream:
+                if chunk_count == 0:
+                    ttfb_ms = round((time.perf_counter() - t_stream_open) * 1000, 2)
+                chunk_count += 1
+                for source_event in processor.process_chunk(chunk):
+                    yield format_sse(source_event)
+
+        if source_provider == "openai_chat":
+            yield format_sse_done()
+
+        log_stream_summary(
+            model=model,
+            duration_s=time.monotonic() - t0,
+            chunk_count=chunk_count,
+        )
+    except Exception as exc:
+        stream_error = str(exc)
+        raise
+    finally:
+        # Write back stream profile to request log entry
+        if entry_id and request_log is not None:
+            stream_profile: dict[str, Any] = {
+                "stream_duration_ms": round((time.monotonic() - t0) * 1000, 2),
+                "stream_chunks": chunk_count,
+                "stream_complete": stream_error is None,
+            }
+            if ttfb_ms is not None:
+                stream_profile["stream_ttfb_ms"] = ttfb_ms
+            if stream_error is not None:
+                stream_profile["stream_error"] = stream_error[:500]
             try:
-                error_msg = json.dumps(json.loads(error_text))
-            except json.JSONDecodeError:
-                error_msg = error_text
-            yield f"data: {error_msg}\n\n"
-            return
-
-        async for chunk in stream:
-            chunk_count += 1
-            for source_event in processor.process_chunk(chunk):
-                yield format_sse(source_event)
-
-    if source_provider == "openai_chat":
-        yield format_sse_done()
-
-    log_stream_summary(
-        model=model,
-        duration_s=time.monotonic() - t0,
-        chunk_count=chunk_count,
-    )
+                request_log.update_profile(entry_id, stream_profile)
+            except Exception:
+                logger.debug("Failed to write stream profile for %s", entry_id)
 
 
 async def handle_streaming(
@@ -377,9 +427,19 @@ async def handle_streaming(
     transport: UpstreamTransport,
     metadata_store: ProviderMetadataStore | None = None,
     extra_headers: dict[str, str] | None = None,
-) -> Response | StreamingResponse:
-    """Streaming proxy: convert -> forward -> stream-convert back -> SSE."""
+    entry_id: str | None = None,
+    request_log: Any | None = None,
+) -> tuple[Response | StreamingResponse, dict[str, Any]]:
+    """Streaming proxy: convert -> forward -> stream-convert back -> SSE.
+
+    Returns:
+        A ``(response, profile)`` tuple.  The profile dict contains
+        request-phase timing data.  Stream-phase metrics (TTFB,
+        duration, chunks) are written back to the request log entry
+        after the stream completes.
+    """
     store = metadata_store or _default_metadata_store
+    profile: dict[str, Any] = {}
     # model was already injected into body by app.py
     model = body.get("model", "")
 
@@ -398,7 +458,9 @@ async def handle_streaming(
             body, on_ir_ready=store.inject_into_request
         )
     except ConversionError as exc:
-        return error_response_for_source(route.source_provider, 400, str(exc))
+        return error_response_for_source(route.source_provider, 400, str(exc)), profile
+
+    profile.update(pipeline.profile)
 
     log_original_request(pipeline.ir_request)
     if pipeline.warnings:
@@ -412,17 +474,22 @@ async def handle_streaming(
     )
     format_sse = SSE_FORMATTERS[route.source_provider]
 
-    return StreamingResponse(
-        _stream_event_generator(
-            source_provider=route.source_provider,
-            target_provider=route.target_provider,
-            processor=processor,
-            transport=transport,
-            provider_info=provider_info,
-            target_body=target_body,
-            model=model,
-            format_sse=format_sse,
-            extra_headers=extra_headers,
+    return (
+        StreamingResponse(
+            _stream_event_generator(
+                source_provider=route.source_provider,
+                target_provider=route.target_provider,
+                processor=processor,
+                transport=transport,
+                provider_info=provider_info,
+                target_body=target_body,
+                model=model,
+                format_sse=format_sse,
+                extra_headers=extra_headers,
+                entry_id=entry_id,
+                request_log=request_log,
+            ),
+            content_type="text/event-stream",
         ),
-        content_type="text/event-stream",
+        profile,
     )

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -22,6 +22,7 @@ the caller (gateway, argo-proxy, etc.) owns the transport.
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -223,6 +224,9 @@ class ConversionPipeline:
         self._ctx: ConversionContext | None = None
         self._ir_request: dict[str, Any] | None = None
 
+        # Per-phase timing (always-on, ~30ns per perf_counter call)
+        self._profile: dict[str, float] = {}
+
     @property
     def context(self) -> ConversionContext:
         """The request-phase conversion context.
@@ -262,6 +266,31 @@ class ConversionPipeline:
         if self._ctx is None:
             return []
         return self._ctx.warnings
+
+    @property
+    def profile(self) -> dict[str, float]:
+        """Per-phase timing data collected during conversion.
+
+        Contains millisecond durations for each conversion sub-phase.
+        Populated incrementally by :meth:`convert_request` and
+        :meth:`convert_response`.  Always available (returns ``{}``
+        before any conversion).
+
+        Keys after :meth:`convert_request`::
+
+            source_to_ir_ms      — Source format → IR parsing
+            ir_transforms_ms     — Vision enforcement + shim IR transforms
+            ir_to_target_ms      — IR → target format serialization
+            body_transforms_ms   — Shim body-level to_transforms
+            request_conversion_ms — Total request conversion time
+
+        Keys added by :meth:`convert_response`::
+
+            response_from_target_ms — Target response → IR parsing
+            response_to_source_ms   — IR → source response serialization
+            response_conversion_ms  — Total response conversion time
+        """
+        return self._profile
 
     def convert_request(
         self,
@@ -309,13 +338,17 @@ class ConversionPipeline:
         )
         self._ctx = ctx
 
+        t_total = time.perf_counter()
+
         # Phase 1: Source → IR
+        t0 = time.perf_counter()
         try:
             ir_request = self._source_converter.request_from_provider(body, context=ctx)
         except Exception as exc:
             raise ConversionError(
                 f"Failed to parse request: {exc}", phase="source_to_ir"
             ) from exc
+        self._profile["source_to_ir_ms"] = round((time.perf_counter() - t0) * 1000, 2)
 
         # Hook: let caller inject metadata before IR transforms
         if on_ir_ready is not None:
@@ -323,7 +356,8 @@ class ConversionPipeline:
 
         request_id = ctx.options.get("request_id", "-")
 
-        # Capability enforcement: vision (post-IR)
+        # Capability enforcement: vision (post-IR) + shim IR transforms
+        t0 = time.perf_counter()
         ir_request = enforce_vision(
             ir_request,
             model_capabilities=self._model_capabilities,
@@ -339,9 +373,11 @@ class ConversionPipeline:
             model_capabilities=self._model_capabilities,
             request_id=request_id,
         )
+        self._profile["ir_transforms_ms"] = round((time.perf_counter() - t0) * 1000, 2)
         self._ir_request = ir_request
 
         # Phase 2b: IR → Target
+        t0 = time.perf_counter()
         try:
             target_body, _ = self._target_converter.request_to_provider(
                 ir_request, context=ctx
@@ -350,11 +386,19 @@ class ConversionPipeline:
             raise ConversionError(
                 f"Conversion error: {exc}", phase="ir_to_target"
             ) from exc
+        self._profile["ir_to_target_ms"] = round((time.perf_counter() - t0) * 1000, 2)
 
         # Phase 2c: Body-level shim to_transforms
+        t0 = time.perf_counter()
         if self._to_transforms:
             target_body = apply_transforms(self._to_transforms, target_body)
+        self._profile["body_transforms_ms"] = round(
+            (time.perf_counter() - t0) * 1000, 2
+        )
 
+        self._profile["request_conversion_ms"] = round(
+            (time.perf_counter() - t_total) * 1000, 2
+        )
         return target_body
 
     def convert_response(
@@ -384,6 +428,7 @@ class ConversionPipeline:
             RuntimeError: If called before :meth:`convert_request`.
         """
         ctx = self.context  # raises RuntimeError if not ready
+        t_total = time.perf_counter()
 
         # Phase 4a: Body-level shim from_transforms
         response = upstream_response
@@ -391,6 +436,7 @@ class ConversionPipeline:
             response = apply_transforms(self._from_transforms, response)
 
         # Phase 4b: Target response → IR
+        t0 = time.perf_counter()
         try:
             ir_response = self._target_converter.response_from_provider(
                 response, context=ctx
@@ -400,12 +446,16 @@ class ConversionPipeline:
                 f"Failed to parse upstream response: {exc}",
                 phase="response_to_ir",
             ) from exc
+        self._profile["response_from_target_ms"] = round(
+            (time.perf_counter() - t0) * 1000, 2
+        )
 
         # Hook: let caller cache metadata from IR response
         if on_ir_ready is not None:
             on_ir_ready(ir_response)
 
         # Phase 4c: IR → Source response
+        t0 = time.perf_counter()
         try:
             source_response = self._source_converter.response_to_provider(
                 ir_response, context=ctx
@@ -414,7 +464,13 @@ class ConversionPipeline:
             raise ConversionError(
                 f"Failed to convert response: {exc}", phase="ir_to_source"
             ) from exc
+        self._profile["response_to_source_ms"] = round(
+            (time.perf_counter() - t0) * 1000, 2
+        )
 
+        self._profile["response_conversion_ms"] = round(
+            (time.perf_counter() - t_total) * 1000, 2
+        )
         return source_response
 
     def create_stream_processor(

--- a/src/llm_rosetta/profiling.py
+++ b/src/llm_rosetta/profiling.py
@@ -1,0 +1,182 @@
+"""On-demand deep profiling for llm-rosetta conversions.
+
+Provides :class:`DeepProfiler`, a thin wrapper around **pyinstrument**
+that supports both sync and async context managers.  ``pyinstrument``
+is lazy-imported at :meth:`start` / ``__enter__`` time — the class
+itself is always importable even without ``pyinstrument`` installed.
+
+Install the optional dependency::
+
+    pip install llm-rosetta[profiling]
+
+Usage (sync)::
+
+    from llm_rosetta.profiling import DeepProfiler
+
+    with DeepProfiler() as dp:
+        result = convert(body, "anthropic")
+    print(dp.output_text())
+
+Usage (async)::
+
+    async with DeepProfiler() as dp:
+        target = pipeline.convert_request(body)
+        resp = await transport.send(target)
+    dp.save_html("profile.html")
+
+Note:
+    Under concurrent async workloads, flamegraphs may include minor
+    noise from other coroutines on the same event loop.  Results are
+    best-effort; per-instance isolation minimizes contamination.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+class DeepProfiler:
+    """Thin wrapper around pyinstrument for on-demand profiling.
+
+    Args:
+        async_mode: If ``True`` (default), create the underlying
+            ``Profiler`` with ``async_mode="enabled"`` so that
+            ``await`` boundaries are correctly attributed.  Set to
+            ``False`` for purely synchronous workloads.
+    """
+
+    def __init__(self, *, async_mode: bool = True) -> None:
+        self._async_mode = async_mode
+        self._profiler: Any = None  # lazy — set in start()
+
+    # ------------------------------------------------------------------
+    # Lazy import helper
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _import_pyinstrument() -> Any:
+        """Import and return the ``pyinstrument`` module.
+
+        Raises:
+            RuntimeError: If ``pyinstrument`` is not installed.
+        """
+        try:
+            import pyinstrument
+
+            return pyinstrument
+        except ImportError:
+            raise RuntimeError(
+                "pyinstrument is not installed. "
+                "Install with: pip install llm-rosetta[profiling]"
+            ) from None
+
+    # ------------------------------------------------------------------
+    # Explicit start / stop API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start profiling.
+
+        Creates a fresh ``pyinstrument.Profiler`` instance (one per
+        call, never shared across requests).
+
+        Raises:
+            RuntimeError: If ``pyinstrument`` is not installed, or if
+                the profiler is already running.
+        """
+        if self._profiler is not None:
+            raise RuntimeError("Profiler is already running")
+        pyinstrument = self._import_pyinstrument()
+        kwargs: dict[str, Any] = {}
+        if self._async_mode:
+            kwargs["async_mode"] = "enabled"
+        self._profiler = pyinstrument.Profiler(**kwargs)
+        self._profiler.start()
+
+    def stop(self) -> None:
+        """Stop profiling.
+
+        Raises:
+            RuntimeError: If the profiler is not running.
+        """
+        if self._profiler is None:
+            raise RuntimeError("Profiler is not running")
+        self._profiler.stop()
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the profiler is currently active."""
+        return self._profiler is not None and self._profiler.is_running
+
+    # ------------------------------------------------------------------
+    # Sync context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> DeepProfiler:
+        self.start()
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        if self.is_running:
+            self.stop()
+
+    # ------------------------------------------------------------------
+    # Async context manager
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> DeepProfiler:
+        self.start()
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        if self.is_running:
+            self.stop()
+
+    # ------------------------------------------------------------------
+    # Output methods
+    # ------------------------------------------------------------------
+
+    def output_text(self, **kwargs: Any) -> str:
+        """Return profiling results as a human-readable text tree.
+
+        Raises:
+            RuntimeError: If the profiler was never started or is
+                still running.
+        """
+        self._check_stopped()
+        return self._profiler.output_text(**kwargs)
+
+    def output_html(self, **kwargs: Any) -> str:
+        """Return profiling results as an interactive HTML flamegraph.
+
+        Raises:
+            RuntimeError: If the profiler was never started or is
+                still running.
+        """
+        self._check_stopped()
+        return self._profiler.output_html(**kwargs)
+
+    def save_html(self, path: str | Path, **kwargs: Any) -> None:
+        """Write the HTML flamegraph to a file.
+
+        Args:
+            path: Destination file path.
+
+        Raises:
+            RuntimeError: If the profiler was never started or is
+                still running.
+        """
+        html = self.output_html(**kwargs)
+        Path(path).write_text(html, encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _check_stopped(self) -> None:
+        """Ensure the profiler has been started and stopped."""
+        if self._profiler is None:
+            raise RuntimeError("Profiler was never started")
+        if self._profiler.is_running:
+            raise RuntimeError("Profiler is still running — call stop() first")

--- a/tests/gateway/test_profiling.py
+++ b/tests/gateway/test_profiling.py
@@ -1,0 +1,342 @@
+"""Tests for ProfilerState and profiling admin routes."""
+
+from llm_rosetta.gateway.admin.routes.profiling import ProfilerState
+
+
+class TestProfilerState:
+    """Unit tests for the ProfilerState class."""
+
+    def test_initial_state(self):
+        state = ProfilerState()
+        assert not state.enabled
+        assert state.remaining == 0
+        assert state.results == []
+        status = state.status()
+        assert status["enabled"] is False
+        assert status["remaining"] == 0
+        assert status["results_count"] == 0
+
+    def test_enable(self):
+        state = ProfilerState()
+        result = state.enable(requests=3)
+        assert state.enabled
+        assert state.remaining == 3
+        assert result["enabled"] is True
+        assert result["remaining"] == 3
+
+    def test_enable_clamps_minimum(self):
+        state = ProfilerState()
+        state.enable(requests=0)
+        assert state.remaining == 1  # clamped to >= 1
+
+    def test_disable(self):
+        state = ProfilerState()
+        state.enable(5)
+        result = state.disable()
+        assert not state.enabled
+        assert state.remaining == 0
+        assert result["enabled"] is False
+
+    def test_should_profile_decrements(self):
+        state = ProfilerState()
+        state.enable(requests=2)
+
+        assert state.should_profile()  # remaining: 2 -> 1
+        assert state.remaining == 1
+        assert state.enabled  # still enabled
+
+        assert state.should_profile()  # remaining: 1 -> 0
+        assert state.remaining == 0
+        assert not state.enabled  # auto-disabled
+
+    def test_should_profile_returns_false_when_disabled(self):
+        state = ProfilerState()
+        assert not state.should_profile()
+
+    def test_should_profile_auto_disables(self):
+        state = ProfilerState()
+        state.enable(requests=1)
+        assert state.should_profile()
+        assert not state.enabled
+        assert not state.should_profile()
+
+    def test_store_result(self):
+        state = ProfilerState()
+
+        # Create a mock profiler
+        class MockProfiler:
+            def output_html(self):
+                return "<html>flamegraph</html>"
+
+            def output_text(self):
+                return "call tree text"
+
+        state.store_result(
+            MockProfiler(),
+            request_id="test-123",
+            model="gpt-4o",
+            source="openai_chat",
+            target="anthropic",
+            is_stream=False,
+            duration_ms=150.3,
+        )
+        assert len(state.results) == 1
+        result = state.results[0]
+        assert result["request_id"] == "test-123"
+        assert result["model"] == "gpt-4o"
+        assert result["html"] == "<html>flamegraph</html>"
+        assert result["text"] == "call tree text"
+        assert result["duration_ms"] == 150.3
+
+    def test_store_result_caps_at_max(self):
+        state = ProfilerState(max_results=3)
+
+        class MockProfiler:
+            def output_html(self):
+                return ""
+
+            def output_text(self):
+                return ""
+
+        for i in range(5):
+            state.store_result(MockProfiler(), model=f"model-{i}")
+
+        assert len(state.results) == 3
+        # Should keep the latest 3
+        assert state.results[0]["model"] == "model-2"
+        assert state.results[2]["model"] == "model-4"
+
+    def test_clear_results(self):
+        state = ProfilerState()
+
+        class MockProfiler:
+            def output_html(self):
+                return ""
+
+            def output_text(self):
+                return ""
+
+        state.store_result(MockProfiler())
+        assert len(state.results) == 1
+        state.clear_results()
+        assert len(state.results) == 0
+
+
+class TestRequestLogProfile:
+    """Test profile field in RequestLogEntry."""
+
+    def test_create_with_profile(self):
+        from llm_rosetta.gateway.admin.request_log import RequestLogEntry
+
+        profile = {"request_conversion_ms": 2.45, "upstream_ms": 150.3}
+        entry = RequestLogEntry.create(
+            model="gpt-4o",
+            source_provider="openai_chat",
+            target_provider="anthropic",
+            is_stream=False,
+            status_code=200,
+            duration_ms=155.0,
+            profile=profile,
+        )
+        assert entry.profile == profile
+
+    def test_create_without_profile(self):
+        from llm_rosetta.gateway.admin.request_log import RequestLogEntry
+
+        entry = RequestLogEntry.create(
+            model="gpt-4o",
+            source_provider="openai_chat",
+            target_provider="anthropic",
+            is_stream=False,
+            status_code=200,
+            duration_ms=155.0,
+        )
+        assert entry.profile is None
+
+    def test_to_dict_includes_profile(self):
+        from llm_rosetta.gateway.admin.request_log import RequestLogEntry
+
+        profile = {"request_conversion_ms": 2.45}
+        entry = RequestLogEntry.create(
+            model="gpt-4o",
+            source_provider="openai_chat",
+            target_provider="anthropic",
+            is_stream=False,
+            status_code=200,
+            duration_ms=155.0,
+            profile=profile,
+        )
+        d = entry.to_dict()
+        assert d["profile"] == profile
+
+    def test_to_dict_omits_none_profile(self):
+        from llm_rosetta.gateway.admin.request_log import RequestLogEntry
+
+        entry = RequestLogEntry.create(
+            model="gpt-4o",
+            source_provider="openai_chat",
+            target_provider="anthropic",
+            is_stream=False,
+            status_code=200,
+            duration_ms=155.0,
+        )
+        d = entry.to_dict()
+        assert "profile" not in d
+
+    def test_update_profile_in_memory(self):
+        from llm_rosetta.gateway.admin.request_log import RequestLog, RequestLogEntry
+
+        log = RequestLog()
+        entry = RequestLogEntry.create(
+            model="gpt-4o",
+            source_provider="openai_chat",
+            target_provider="anthropic",
+            is_stream=True,
+            status_code=200,
+            duration_ms=100.0,
+            profile={"request_conversion_ms": 2.0},
+        )
+        log.add(entry)
+
+        # Update with stream metrics
+        log.update_profile(
+            entry.id,
+            {"stream_ttfb_ms": 120.5, "stream_complete": True},
+        )
+
+        # Verify merged
+        result = log.get_entry(entry.id)
+        assert result is not None
+        assert result["profile"]["request_conversion_ms"] == 2.0
+        assert result["profile"]["stream_ttfb_ms"] == 120.5
+        assert result["profile"]["stream_complete"] is True
+
+
+class TestPersistenceProfile:
+    """Test profile column in SQLite persistence."""
+
+    def test_insert_and_query_with_profile(self, tmp_path):
+        from llm_rosetta.gateway.admin.persistence import PersistenceManager
+
+        pm = PersistenceManager(str(tmp_path))
+        profile = {"request_conversion_ms": 2.45, "upstream_ms": 150.3}
+        pm.insert_log_entries(
+            [
+                {
+                    "id": "test-1",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "model": "gpt-4o",
+                    "source_provider": "openai_chat",
+                    "target_provider": "anthropic",
+                    "is_stream": False,
+                    "status_code": 200,
+                    "duration_ms": 155.0,
+                    "profile": profile,
+                }
+            ]
+        )
+
+        entry = pm.get_log_entry("test-1")
+        assert entry is not None
+        assert entry["profile"] == profile
+        pm.close()
+
+    def test_insert_without_profile(self, tmp_path):
+        from llm_rosetta.gateway.admin.persistence import PersistenceManager
+
+        pm = PersistenceManager(str(tmp_path))
+        pm.insert_log_entries(
+            [
+                {
+                    "id": "test-2",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "model": "gpt-4o",
+                    "source_provider": "openai_chat",
+                    "target_provider": "anthropic",
+                    "is_stream": False,
+                    "status_code": 200,
+                    "duration_ms": 155.0,
+                }
+            ]
+        )
+
+        entry = pm.get_log_entry("test-2")
+        assert entry is not None
+        assert "profile" not in entry  # omitted when None
+        pm.close()
+
+    def test_update_entry_profile(self, tmp_path):
+        from llm_rosetta.gateway.admin.persistence import PersistenceManager
+
+        pm = PersistenceManager(str(tmp_path))
+        pm.insert_log_entries(
+            [
+                {
+                    "id": "test-3",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "model": "gpt-4o",
+                    "source_provider": "openai_chat",
+                    "target_provider": "anthropic",
+                    "is_stream": True,
+                    "status_code": 200,
+                    "duration_ms": 155.0,
+                    "profile": {"request_conversion_ms": 2.0},
+                }
+            ]
+        )
+
+        # Update with stream metrics
+        pm.update_entry_profile(
+            "test-3",
+            {"stream_ttfb_ms": 120.5, "stream_complete": True},
+        )
+
+        entry = pm.get_log_entry("test-3")
+        assert entry is not None
+        assert entry["profile"]["request_conversion_ms"] == 2.0
+        assert entry["profile"]["stream_ttfb_ms"] == 120.5
+        assert entry["profile"]["stream_complete"] is True
+        pm.close()
+
+    def test_update_entry_profile_nonexistent(self, tmp_path):
+        """Updating a non-existent entry is a no-op."""
+        from llm_rosetta.gateway.admin.persistence import PersistenceManager
+
+        pm = PersistenceManager(str(tmp_path))
+        pm.update_entry_profile("nonexistent", {"foo": 1})
+        pm.close()
+
+    def test_migration_adds_profile_column(self, tmp_path):
+        """Verify the profile column is added by migration."""
+        import sqlite3
+
+        db_path = tmp_path / "gateway.db"
+        conn = sqlite3.connect(str(db_path))
+        # Create table WITHOUT profile column (old schema)
+        conn.executescript("""
+            CREATE TABLE request_log (
+                id TEXT PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                model TEXT NOT NULL,
+                source_provider TEXT NOT NULL,
+                target_provider TEXT NOT NULL,
+                is_stream INTEGER NOT NULL,
+                status_code INTEGER NOT NULL,
+                duration_ms REAL NOT NULL,
+                error_detail TEXT,
+                api_key_label TEXT,
+                target_provider_name TEXT,
+                client_ip TEXT
+            );
+            CREATE TABLE metrics (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        """)
+        conn.close()
+
+        # PersistenceManager should add the profile column via migration
+        from llm_rosetta.gateway.admin.persistence import PersistenceManager
+
+        pm = PersistenceManager(str(tmp_path))
+        cursor = pm._conn.execute("PRAGMA table_info(request_log)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "profile" in columns
+        pm.close()

--- a/tests/gateway/test_proxy_transforms.py
+++ b/tests/gateway/test_proxy_transforms.py
@@ -222,7 +222,7 @@ class TestNonStreamingTransforms:
         )
 
         async def run():
-            response = await handle_non_streaming(
+            response, profile = await handle_non_streaming(
                 _make_route(model="regular-model", shim_name="custom_provider"),
                 _make_provider_info(),
                 {
@@ -232,8 +232,11 @@ class TestNonStreamingTransforms:
                 transport=transport,
                 metadata_store=ProviderMetadataStore(),
             )
-            return response
+            return response, profile
 
-        response = asyncio.run(run())
+        response, profile = asyncio.run(run())
         # The handler should complete without error
         assert response.status_code == 200
+        # Profile should contain timing data
+        assert "request_conversion_ms" in profile
+        assert "upstream_ms" in profile

--- a/tests/test_pipeline_profile.py
+++ b/tests/test_pipeline_profile.py
@@ -1,0 +1,95 @@
+"""Tests for ConversionPipeline.profile timing data."""
+
+from llm_rosetta.pipeline import ConversionPipeline
+
+
+class TestPipelineProfile:
+    """Verify that pipeline.profile is populated after conversion."""
+
+    def _make_simple_request(self) -> dict:
+        """Create a minimal OpenAI chat request."""
+        return {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+
+    def _make_simple_response(self) -> dict:
+        """Create a minimal Anthropic response."""
+        return {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hi"}],
+            "model": "test-model",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+
+    def test_profile_empty_before_conversion(self):
+        pipeline = ConversionPipeline("openai_chat", "anthropic")
+        assert pipeline.profile == {}
+
+    def test_profile_populated_after_convert_request(self):
+        pipeline = ConversionPipeline("openai_chat", "anthropic")
+        pipeline.convert_request(self._make_simple_request())
+
+        p = pipeline.profile
+        assert "source_to_ir_ms" in p
+        assert "ir_transforms_ms" in p
+        assert "ir_to_target_ms" in p
+        assert "body_transforms_ms" in p
+        assert "request_conversion_ms" in p
+
+        # All values should be non-negative floats
+        for key, val in p.items():
+            assert isinstance(val, float), f"{key} is not float: {type(val)}"
+            assert val >= 0, f"{key} is negative: {val}"
+
+        # Total should be >= sum of parts (due to overhead)
+        parts_sum = (
+            p["source_to_ir_ms"]
+            + p["ir_transforms_ms"]
+            + p["ir_to_target_ms"]
+            + p["body_transforms_ms"]
+        )
+        assert p["request_conversion_ms"] >= parts_sum * 0.9  # allow small float error
+
+    def test_profile_populated_after_convert_response(self):
+        pipeline = ConversionPipeline("openai_chat", "anthropic")
+        pipeline.convert_request(self._make_simple_request())
+        pipeline.convert_response(self._make_simple_response())
+
+        p = pipeline.profile
+        assert "response_from_target_ms" in p
+        assert "response_to_source_ms" in p
+        assert "response_conversion_ms" in p
+
+        # Response conversion total should be >= sum of parts
+        parts_sum = p["response_from_target_ms"] + p["response_to_source_ms"]
+        assert p["response_conversion_ms"] >= parts_sum * 0.9
+
+    def test_profile_has_all_keys_after_full_roundtrip(self):
+        pipeline = ConversionPipeline("openai_chat", "anthropic")
+        pipeline.convert_request(self._make_simple_request())
+        pipeline.convert_response(self._make_simple_response())
+
+        expected_keys = {
+            "source_to_ir_ms",
+            "ir_transforms_ms",
+            "ir_to_target_ms",
+            "body_transforms_ms",
+            "request_conversion_ms",
+            "response_from_target_ms",
+            "response_to_source_ms",
+            "response_conversion_ms",
+        }
+        assert expected_keys == set(pipeline.profile.keys())
+
+    def test_same_format_conversion(self):
+        """Profile is populated even for same-format conversion."""
+        pipeline = ConversionPipeline("openai_chat", "openai_chat")
+        pipeline.convert_request(self._make_simple_request())
+
+        p = pipeline.profile
+        assert "request_conversion_ms" in p
+        assert p["request_conversion_ms"] >= 0

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,0 +1,96 @@
+"""Tests for the core DeepProfiler."""
+
+import pytest
+
+from llm_rosetta.profiling import DeepProfiler
+
+
+class TestDeepProfilerWithoutPyinstrument:
+    """Tests that work regardless of pyinstrument installation."""
+
+    def test_class_importable(self):
+        """DeepProfiler class is always importable."""
+        dp = DeepProfiler()
+        assert dp._profiler is None
+        assert not dp.is_running
+
+    def test_output_before_start_raises(self):
+        dp = DeepProfiler()
+        with pytest.raises(RuntimeError, match="never started"):
+            dp.output_text()
+
+    def test_stop_before_start_raises(self):
+        dp = DeepProfiler()
+        with pytest.raises(RuntimeError, match="not running"):
+            dp.stop()
+
+
+class TestDeepProfilerWithPyinstrument:
+    """Tests requiring pyinstrument."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_without_pyinstrument(self):
+        pytest.importorskip("pyinstrument")
+
+    def test_sync_context_manager(self):
+        with DeepProfiler(async_mode=False) as dp:
+            total = sum(range(1000))
+            assert total == 499500
+        text = dp.output_text()
+        assert isinstance(text, str)
+        assert len(text) > 0
+
+    def test_explicit_start_stop(self):
+        dp = DeepProfiler(async_mode=False)
+        dp.start()
+        assert dp.is_running
+        _ = sum(range(1000))
+        dp.stop()
+        assert not dp.is_running
+        html = dp.output_html()
+        assert "<html" in html.lower() or "pyinstrument" in html.lower()
+
+    def test_double_start_raises(self):
+        dp = DeepProfiler(async_mode=False)
+        dp.start()
+        with pytest.raises(RuntimeError, match="already running"):
+            dp.start()
+        dp.stop()
+
+    def test_output_while_running_raises(self):
+        dp = DeepProfiler(async_mode=False)
+        dp.start()
+        with pytest.raises(RuntimeError, match="still running"):
+            dp.output_text()
+        dp.stop()
+
+    def test_save_html(self, tmp_path):
+        with DeepProfiler(async_mode=False) as dp:
+            _ = sum(range(100))
+        outfile = tmp_path / "profile.html"
+        dp.save_html(str(outfile))
+        assert outfile.exists()
+        content = outfile.read_text()
+        assert len(content) > 0
+
+    def test_async_context_manager(self):
+        import asyncio
+
+        async def _run():
+            async with DeepProfiler(async_mode=True) as dp:
+                await asyncio.sleep(0.01)
+            return dp
+
+        dp = asyncio.run(_run())
+        text = dp.output_text()
+        assert isinstance(text, str)
+
+    def test_context_manager_stops_on_exception(self):
+        dp = DeepProfiler(async_mode=False)
+        with pytest.raises(ValueError):
+            with dp:
+                raise ValueError("test error")
+        # Profiler should be stopped even on exception
+        assert not dp.is_running
+        text = dp.output_text()
+        assert isinstance(text, str)


### PR DESCRIPTION
## Summary

Two-layer profiling system for diagnosing conversion and upstream latency in production:

- **Always-on phase timing** — `ConversionPipeline.profile` records per-phase `perf_counter` durations (source_to_ir, ir_transforms, ir_to_target, etc.). Gateway merges these with `upstream_ms` and stream metrics, persisted to the `profile` column in `request_log`. Zero config, ~30ns overhead per call.

- **On-demand deep profiling** — `DeepProfiler` (core lib) wraps pyinstrument with sync/async context managers. Gateway exposes `ProfilerState` via admin API to enable profiling for the next N requests and retrieve flamegraph HTML. Per-request profiler instances avoid cross-request contamination on the event loop.

- **Streaming write-back** — stream-phase metrics (TTFB, duration, chunk count, `stream_complete` flag) written back to the request log entry after stream completion, including partial profile on failure.

### New admin API endpoints
```
POST   /admin/api/profiling/enable       — enable for N requests
POST   /admin/api/profiling/disable      — disable
GET    /admin/api/profiling/status        — current state
GET    /admin/api/profiling/results       — result summaries
GET    /admin/api/profiling/results/<i>   — single result (?format=html for flamegraph)
DELETE /admin/api/profiling/results       — clear results
```

### Lib-level usage
```python
# Always-on phase timing
pipeline = ConversionPipeline("openai_chat", "anthropic")
target = pipeline.convert_request(body)
print(pipeline.profile)  # {"source_to_ir_ms": 0.8, "ir_to_target_ms": 1.1, ...}

# On-demand deep profiling
from llm_rosetta.profiling import DeepProfiler
with DeepProfiler() as dp:
    result = convert(body, "anthropic")
dp.save_html("profile.html")
```

`pyinstrument` is a new `[profiling]` optional dependency, lazy-imported at runtime.

## Test plan
- [x] `make lint` passes
- [x] 2003 tests pass, 0 failures
- [x] `DeepProfiler` sync/async context managers tested
- [x] `ConversionPipeline.profile` populated with all expected keys
- [x] `ProfilerState` enable/disable/should_profile/store_result tested
- [x] `RequestLogEntry.profile` field + `update_profile()` tested
- [x] SQLite `profile` column migration + `update_entry_profile()` tested
- [ ] E2E: start gateway, send request, verify profile in `/admin/api/requests`
- [ ] E2E: enable profiling, send requests, retrieve flamegraph HTML