### PR TITLE
fix: metrics breakdown uses provider name, add counter rebuild

### DIFF
--- a/src/llm_rosetta/gateway/admin/metrics.py
+++ b/src/llm_rosetta/gateway/admin/metrics.py
@@ -7,6 +7,7 @@ on a single asyncio event loop thread, no locks are required.
 from __future__ import annotations
 
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 
@@ -265,7 +266,7 @@ class MetricsCollector:
             int(k): v for k, v in data.get("by_status_code", {}).items()
         }
 
-    def rebuild_counters(self, rows: list[dict]) -> None:
+    def rebuild_counters(self, rows: Iterable[dict]) -> int:
         """Rebuild all counters from request log rows.
 
         Replaces current counter values with aggregates computed from
@@ -273,42 +274,62 @@ class MetricsCollector:
         ``target_provider``, ``target_provider_name``, ``is_stream``,
         and ``status_code`` keys.
 
+        Accepts any iterable (including generators) so the caller can
+        stream rows in batches without loading the entire table into
+        memory at once.
+
         Time-series and per-provider rolling stats are NOT rebuilt
         (they only make sense for recent data).
 
         Args:
-            rows: List of request log entry dicts (as returned by
-                ``PersistenceManager.query_log_entries``).
+            rows: Iterable of request log entry dicts.
+
+        Returns:
+            Number of rows processed.
         """
-        self.total_requests = 0
-        self.total_errors = 0
-        self.total_streams = 0
-        self.by_model = {}
-        self.by_source_provider = {}
-        self.by_target_provider = {}
-        self.by_status_code = {}
+        # Build in temporaries, then swap atomically.  The gateway runs
+        # on a single asyncio thread so there are no true data races,
+        # but building first avoids exposing half-rebuilt counters to
+        # concurrent ``snapshot()`` calls between await points.
+        total_requests = 0
+        total_errors = 0
+        total_streams = 0
+        by_model: dict[str, int] = {}
+        by_source: dict[str, int] = {}
+        by_target: dict[str, int] = {}
+        by_status: dict[int, int] = {}
 
         for r in rows:
-            self.total_requests += 1
+            total_requests += 1
             sc = r.get("status_code", 200)
             if sc >= 400:
-                self.total_errors += 1
+                total_errors += 1
             if r.get("is_stream"):
-                self.total_streams += 1
+                total_streams += 1
 
             model = r.get("model", "unknown")
-            self.by_model[model] = self.by_model.get(model, 0) + 1
+            by_model[model] = by_model.get(model, 0) + 1
 
             source = r.get("source_provider", "unknown")
-            self.by_source_provider[source] = self.by_source_provider.get(source, 0) + 1
+            by_source[source] = by_source.get(source, 0) + 1
 
-            # Prefer provider display name, fall back to API type
             target = r.get("target_provider_name") or r.get(
                 "target_provider", "unknown"
             )
-            self.by_target_provider[target] = self.by_target_provider.get(target, 0) + 1
+            by_target[target] = by_target.get(target, 0) + 1
 
-            self.by_status_code[sc] = self.by_status_code.get(sc, 0) + 1
+            by_status[sc] = by_status.get(sc, 0) + 1
+
+        # Atomic swap — active_streams is live state, not rebuilt.
+        self.total_requests = total_requests
+        self.total_errors = total_errors
+        self.total_streams = total_streams
+        self.by_model = by_model
+        self.by_source_provider = by_source
+        self.by_target_provider = by_target
+        self.by_status_code = by_status
+
+        return total_requests
 
     def snapshot(self, series_seconds: int = 60) -> dict:
         """Return a JSON-serializable metrics snapshot."""

--- a/src/llm_rosetta/gateway/admin/metrics.py
+++ b/src/llm_rosetta/gateway/admin/metrics.py
@@ -208,7 +208,12 @@ class MetricsCollector:
 
         self.by_model[model] = self.by_model.get(model, 0) + 1
         self.by_source_provider[source] = self.by_source_provider.get(source, 0) + 1
-        self.by_target_provider[target] = self.by_target_provider.get(target, 0) + 1
+        # Use provider_name (e.g. "Argo Claude") when available,
+        # fall back to API type (e.g. "anthropic") for backward compat.
+        target_key = provider_name or target
+        self.by_target_provider[target_key] = (
+            self.by_target_provider.get(target_key, 0) + 1
+        )
         self.by_status_code[status_code] = self.by_status_code.get(status_code, 0) + 1
 
         self._window.record(duration_ms, is_error=is_error)
@@ -259,6 +264,51 @@ class MetricsCollector:
         self.by_status_code = {
             int(k): v for k, v in data.get("by_status_code", {}).items()
         }
+
+    def rebuild_counters(self, rows: list[dict]) -> None:
+        """Rebuild all counters from request log rows.
+
+        Replaces current counter values with aggregates computed from
+        *rows*.  Each row must have ``model``, ``source_provider``,
+        ``target_provider``, ``target_provider_name``, ``is_stream``,
+        and ``status_code`` keys.
+
+        Time-series and per-provider rolling stats are NOT rebuilt
+        (they only make sense for recent data).
+
+        Args:
+            rows: List of request log entry dicts (as returned by
+                ``PersistenceManager.query_log_entries``).
+        """
+        self.total_requests = 0
+        self.total_errors = 0
+        self.total_streams = 0
+        self.by_model = {}
+        self.by_source_provider = {}
+        self.by_target_provider = {}
+        self.by_status_code = {}
+
+        for r in rows:
+            self.total_requests += 1
+            sc = r.get("status_code", 200)
+            if sc >= 400:
+                self.total_errors += 1
+            if r.get("is_stream"):
+                self.total_streams += 1
+
+            model = r.get("model", "unknown")
+            self.by_model[model] = self.by_model.get(model, 0) + 1
+
+            source = r.get("source_provider", "unknown")
+            self.by_source_provider[source] = self.by_source_provider.get(source, 0) + 1
+
+            # Prefer provider display name, fall back to API type
+            target = r.get("target_provider_name") or r.get(
+                "target_provider", "unknown"
+            )
+            self.by_target_provider[target] = self.by_target_provider.get(target, 0) + 1
+
+            self.by_status_code[sc] = self.by_status_code.get(sc, 0) + 1
 
     def snapshot(self, series_seconds: int = 60) -> dict:
         """Return a JSON-serializable metrics snapshot."""

--- a/src/llm_rosetta/gateway/admin/persistence.py
+++ b/src/llm_rosetta/gateway/admin/persistence.py
@@ -12,7 +12,7 @@ import json
 import logging
 import sqlite3
 import warnings
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -316,29 +316,34 @@ class PersistenceManager:
         ).fetchall()
         return [row[0] for row in rows]
 
-    def all_log_rows_for_rebuild(self) -> list[dict[str, Any]]:
-        """Return lightweight dicts for every log entry (for counter rebuild).
+    def iter_log_rows_for_rebuild(
+        self, batch_size: int = 5000
+    ) -> Iterator[dict[str, Any]]:
+        """Yield lightweight dicts for every log entry (for counter rebuild).
 
         Only fetches the columns needed by
-        :meth:`~MetricsCollector.rebuild_counters`.  Does NOT load
-        heavy columns like ``profile`` or ``error_detail``.
+        :meth:`~MetricsCollector.rebuild_counters`.  Rows are fetched
+        in batches of *batch_size* to bound memory usage regardless of
+        table size.
         """
-        rows = self._conn.execute(
+        cursor = self._conn.execute(
             "SELECT model, source_provider, target_provider, "
             "target_provider_name, is_stream, status_code "
             "FROM request_log"
-        ).fetchall()
-        return [
-            {
-                "model": r[0],
-                "source_provider": r[1],
-                "target_provider": r[2],
-                "target_provider_name": r[3],
-                "is_stream": bool(r[4]),
-                "status_code": r[5],
-            }
-            for r in rows
-        ]
+        )
+        while True:
+            batch = cursor.fetchmany(batch_size)
+            if not batch:
+                break
+            for r in batch:
+                yield {
+                    "model": r[0],
+                    "source_provider": r[1],
+                    "target_provider": r[2],
+                    "target_provider_name": r[3],
+                    "is_stream": bool(r[4]),
+                    "status_code": r[5],
+                }
 
     def count_log_entries(self) -> int:
         """Return the total number of log entries."""

--- a/src/llm_rosetta/gateway/admin/persistence.py
+++ b/src/llm_rosetta/gateway/admin/persistence.py
@@ -316,6 +316,30 @@ class PersistenceManager:
         ).fetchall()
         return [row[0] for row in rows]
 
+    def all_log_rows_for_rebuild(self) -> list[dict[str, Any]]:
+        """Return lightweight dicts for every log entry (for counter rebuild).
+
+        Only fetches the columns needed by
+        :meth:`~MetricsCollector.rebuild_counters`.  Does NOT load
+        heavy columns like ``profile`` or ``error_detail``.
+        """
+        rows = self._conn.execute(
+            "SELECT model, source_provider, target_provider, "
+            "target_provider_name, is_stream, status_code "
+            "FROM request_log"
+        ).fetchall()
+        return [
+            {
+                "model": r[0],
+                "source_provider": r[1],
+                "target_provider": r[2],
+                "target_provider_name": r[3],
+                "is_stream": bool(r[4]),
+                "status_code": r[5],
+            }
+            for r in rows
+        ]
+
     def count_log_entries(self) -> int:
         """Return the total number of log entries."""
         row = self._conn.execute("SELECT COUNT(*) FROM request_log").fetchone()

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -58,6 +58,7 @@ from .observability import (
     get_request_key_labels,
     get_requests,
     network_diagnostics,
+    rebuild_metrics,
 )
 from .profiling import (
     clear_profiling_results,
@@ -103,6 +104,7 @@ def register_admin_routes(app: Any) -> None:
     app.route("/admin/api/config/reload", methods=["POST"])(reload_config)
     # Metrics
     app.route("/admin/api/metrics", methods=["GET"])(get_metrics)
+    app.route("/admin/api/metrics/rebuild", methods=["POST"])(rebuild_metrics)
     # Request log
     app.route("/admin/api/requests", methods=["GET"])(get_requests)
     app.route("/admin/api/requests/key-labels", methods=["GET"])(get_request_key_labels)

--- a/src/llm_rosetta/gateway/admin/routes/observability.py
+++ b/src/llm_rosetta/gateway/admin/routes/observability.py
@@ -89,8 +89,7 @@ async def rebuild_metrics(request: Any) -> Response:
         )
 
     metrics = request.app.metrics
-    rows = persistence.all_log_rows_for_rebuild()
-    metrics.rebuild_counters(rows)
+    count = metrics.rebuild_counters(persistence.iter_log_rows_for_rebuild())
 
     # Persist the rebuilt counters immediately
     persistence.save_metrics(metrics.export_counters())
@@ -98,7 +97,7 @@ async def rebuild_metrics(request: Any) -> Response:
     return JSONResponse(
         {
             "ok": True,
-            "rebuilt_from": len(rows),
+            "rebuilt_from": count,
             "counters": metrics.export_counters(),
         }
     )

--- a/src/llm_rosetta/gateway/admin/routes/observability.py
+++ b/src/llm_rosetta/gateway/admin/routes/observability.py
@@ -75,6 +75,35 @@ async def get_metrics(request: Any) -> Response:
     return JSONResponse(snap)
 
 
+async def rebuild_metrics(request: Any) -> Response:
+    """Rebuild metrics counters from request log entries.
+
+    Useful after fixing a counter bug or when persisted counters
+    have drifted from the actual request log data.
+    """
+    persistence = getattr(request.app, "persistence", None)
+    if persistence is None:
+        return JSONResponse(
+            {"error": "No persistence configured (in-memory mode)"},
+            status_code=400,
+        )
+
+    metrics = request.app.metrics
+    rows = persistence.all_log_rows_for_rebuild()
+    metrics.rebuild_counters(rows)
+
+    # Persist the rebuilt counters immediately
+    persistence.save_metrics(metrics.export_counters())
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "rebuilt_from": len(rows),
+            "counters": metrics.export_counters(),
+        }
+    )
+
+
 async def get_request_key_labels(request: Any) -> Response:
     """Return API key labels seen in request logs."""
     log = request.app.request_log


### PR DESCRIPTION
## Summary

- **Bug fix**: `by_target_provider` was keyed by API type (e.g. `anthropic`) instead of provider display name (e.g. `Argo Claude`). Multiple providers sharing the same API type were merged in the dashboard "Per-Provider Breakdown". Now uses `provider_name` with fallback to API type.

- **Feature**: `POST /admin/api/metrics/rebuild` reconstructs all counters from request log entries in SQLite. Useful after this bug fix to correct historical counter data without losing request logs.

## Test plan
- [x] 2003 tests pass
- [ ] Deploy to dev, call `POST /admin/api/metrics/rebuild`, verify breakdown shows correct provider names
- [ ] Send new requests, verify new entries increment the correct provider name