### PR TITLE
fix: resolve ty 0.0.54 type-check errors

### DIFF
--- a/src/llm_rosetta/converters/base/helpers/reasoning.py
+++ b/src/llm_rosetta/converters/base/helpers/reasoning.py
@@ -363,7 +363,8 @@ def _apply_anthropic_extras(
                     "falling back to 'adaptive'",
                     stacklevel=2,
                 )
-                result["thinking"]: dict[str, Any] = {"type": "adaptive"}
+                thinking_val: dict[str, Any] = {"type": "adaptive"}
+                result["thinking"] = thinking_val
     elif mode == "auto" or effort is not None:
         thinking: dict[str, Any] = {"type": "adaptive"}
         if budget_tokens is not None:

--- a/tests/test_converters_base.py
+++ b/tests/test_converters_base.py
@@ -183,13 +183,11 @@ class MockMessageOps(BaseMessageOps):
         return provider_messages, warnings
 
     @staticmethod
-    def p_messages_to_ir(
-        provider_messages: list[Any], **kwargs: Any
-    ) -> list[Union[Message, ExtensionItem]]:
-        ir_messages = []
+    def p_messages_to_ir(provider_messages: list[Any], **kwargs: Any) -> list[Any]:
+        ir_messages: list[Any] = []
 
         for msg in provider_messages:
-            ir_msg = {"role": msg["role"], "content": []}
+            ir_msg: dict[str, Any] = {"role": msg["role"], "content": []}
 
             for part in msg.get("content", []):
                 if part.get("type") == "text":


### PR DESCRIPTION
## Summary
- Fix 3 ty type-check errors introduced by upgrading ty from 0.0.34 to 0.0.54
- Remove invalid type annotation on subscripted expression (`result["thinking"]: dict[str, Any] = ...`)
- Use explicitly typed local variable to avoid `dict[str, str]` inference causing `invalid-assignment`
- Relax test mock return type to `list[Any]` since it returns plain dicts, not IR types
- Use `conda run -n llm-rosetta` for ty in pre-commit hook so it can find the binary

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (2003 passed)
- [x] `ty check` passes on both changed files
- [x] pre-commit hooks pass