### PR TITLE
fix: return correct HTTP status for streaming upstream errors

### DIFF
--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -14,7 +14,6 @@ Downstream SSE formatting lives in :mod:`transport.sse_format`.
 
 from __future__ import annotations
 
-import json
 import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -350,21 +349,21 @@ async def handle_non_streaming(
 async def _stream_event_generator(
     *,
     source_provider: ProviderType,
-    target_provider: ProviderType,
+    stream: Any,
     processor: Any,
-    transport: UpstreamTransport,
-    provider_info: ProviderInfo,
-    target_body: dict[str, Any],
     model: str,
     format_sse: Any,
-    extra_headers: dict[str, str] | None = None,
     entry_id: str | None = None,
     request_log: Any | None = None,
-    persistence: Any | None = None,
-    request_body: dict[str, Any] | None = None,
-    provider_name: str | None = None,
 ) -> AsyncIterator[str]:
-    """Stream SSE events from upstream, converting each chunk via Pipeline."""
+    """Stream SSE events from an already-opened upstream stream.
+
+    The caller (``handle_streaming``) is responsible for opening the upstream
+    connection and checking for immediate errors *before* constructing the
+    ``StreamingResponse``.  This ensures the HTTP status code sent to the
+    client reflects the upstream status (e.g. 400 for token-limit errors)
+    rather than always being 200.
+    """
     chunk_count = 0
     t0 = time.monotonic()
     stream_error: str | None = None
@@ -372,64 +371,7 @@ async def _stream_event_generator(
     t_stream_open = time.perf_counter()
 
     try:
-        stream = await transport.send_streaming(
-            provider_info,
-            target_provider,
-            target_body,
-            model,
-            extra_headers=extra_headers,
-        )
-    except UpstreamConnectionError as exc:
-        stream_error = str(exc)
-        dump_error(
-            persistence,
-            request_body=request_body,
-            response_text=stream_error,
-            converted_body=target_body,
-            model=model,
-            source_provider=source_provider,
-            target_provider=target_provider,
-            provider_name=provider_name,
-            status_code=502,
-            error_phase="stream_header",
-            upstream_url=str(provider_info.base_url),
-            request_log_id=entry_id,
-        )
-        yield f"data: {json.dumps({'error': {'message': stream_error}})}\n\n"
-        return
-
-    try:
         async with stream:
-            if stream.is_error:
-                error_text = await stream.read_error()
-                stream_error = error_text
-                log_upstream_error(
-                    stream.status_code,
-                    error_text,
-                    endpoint=str(target_provider),
-                    is_streaming=True,
-                )
-                dump_error(
-                    persistence,
-                    request_body=request_body,
-                    response_text=error_text,
-                    converted_body=target_body,
-                    model=model,
-                    source_provider=source_provider,
-                    target_provider=target_provider,
-                    provider_name=provider_name,
-                    status_code=stream.status_code,
-                    error_phase="stream_header",
-                    upstream_url=str(provider_info.base_url),
-                    request_log_id=entry_id,
-                )
-                try:
-                    error_msg = json.dumps(json.loads(error_text))
-                except json.JSONDecodeError:
-                    error_msg = error_text
-                yield f"data: {error_msg}\n\n"
-                return
-
             async for chunk in stream:
                 if chunk_count == 0:
                     ttfb_ms = round((time.perf_counter() - t_stream_open) * 1000, 2)
@@ -480,6 +422,11 @@ async def handle_streaming(
 ) -> tuple[Response | StreamingResponse, dict[str, Any]]:
     """Streaming proxy: convert -> forward -> stream-convert back -> SSE.
 
+    Opens the upstream connection *before* constructing the
+    ``StreamingResponse`` so that immediate errors (4xx/5xx from the
+    upstream) are returned with the correct HTTP status code instead of
+    being buried inside an SSE event on an HTTP 200 response.
+
     Returns:
         A ``(response, profile)`` tuple.  The profile dict contains
         request-phase timing data.  Stream-phase metrics (TTFB,
@@ -516,7 +463,77 @@ async def handle_streaming(
 
     log_converted_request(target_body)
 
-    # Create stream processor for per-chunk conversion
+    # Phase 3: Open upstream connection and check for immediate errors
+    # *before* committing to a 200 StreamingResponse.
+    try:
+        stream = await transport.send_streaming(
+            provider_info,
+            route.target_provider,
+            target_body,
+            model,
+            extra_headers=extra_headers,
+        )
+    except UpstreamConnectionError as exc:
+        error_msg = str(exc)
+        dump_error(
+            persistence,
+            request_body=body,
+            response_text=error_msg,
+            converted_body=target_body,
+            model=model,
+            source_provider=route.source_provider,
+            target_provider=route.target_provider,
+            provider_name=route.provider_name,
+            status_code=502,
+            error_phase="stream_header",
+            upstream_url=str(provider_info.base_url),
+            request_log_id=entry_id,
+        )
+        return (
+            error_response_for_source(
+                route.source_provider, 502, f"Upstream request failed: {exc}"
+            ),
+            profile,
+        )
+
+    # If the upstream responded with an error status (e.g. 400 token limit,
+    # 429 rate limit), return a proper error response with the correct HTTP
+    # status code so the client SDK can surface the real error message.
+    if stream.is_error:
+        error_text = await stream.read_error()
+        await stream.close()
+        log_upstream_error(
+            stream.status_code,
+            error_text,
+            endpoint=str(route.target_provider),
+            is_streaming=True,
+        )
+        dump_error(
+            persistence,
+            request_body=body,
+            response_text=error_text,
+            converted_body=target_body,
+            model=model,
+            source_provider=route.source_provider,
+            target_provider=route.target_provider,
+            provider_name=route.provider_name,
+            status_code=stream.status_code,
+            error_phase="stream_header",
+            upstream_url=str(provider_info.base_url),
+            request_log_id=entry_id,
+        )
+        return (
+            Response(
+                body=error_text.encode("utf-8")
+                if isinstance(error_text, str)
+                else error_text,
+                status_code=stream.status_code,
+                content_type="application/json",
+            ),
+            profile,
+        )
+
+    # Phase 4: No error — create stream processor and return SSE response
     processor = pipeline.create_stream_processor(
         on_ir_event=store.cache_from_stream_event,
     )
@@ -526,19 +543,12 @@ async def handle_streaming(
         StreamingResponse(
             _stream_event_generator(
                 source_provider=route.source_provider,
-                target_provider=route.target_provider,
+                stream=stream,
                 processor=processor,
-                transport=transport,
-                provider_info=provider_info,
-                target_body=target_body,
                 model=model,
                 format_sse=format_sse,
-                extra_headers=extra_headers,
                 entry_id=entry_id,
                 request_log=request_log,
-                persistence=persistence,
-                request_body=body,
-                provider_name=route.provider_name,
             ),
             content_type="text/event-stream",
         ),


### PR DESCRIPTION
## Summary

- Move upstream connection opening from `_stream_event_generator` into `handle_streaming`, so HTTP error status codes (400, 429, etc.) are detected **before** the `StreamingResponse` commits to HTTP 200
- When upstream returns an error, return a proper `Response` with the original status code and error body instead of burying it in an SSE data event
- Simplify `_stream_event_generator` — it now receives an already-opened, already-validated stream and only handles the happy path

Fixes #345

## Context

When an upstream provider returns an error during a streaming request (e.g. Argo's 400 `context_length_exceeded`), the old code path was:

1. `handle_streaming` returns `StreamingResponse` (HTTP 200) immediately
2. `_stream_event_generator` opens the upstream connection, discovers the error
3. Error body gets yielded as `data: {...}\n\n` inside the SSE stream
4. Client SDK sees HTTP 200 + non-standard SSE error → reports misleading `400 Invalid JSON body`

Now the flow is:

1. `handle_streaming` opens upstream connection first
2. If `stream.is_error` → return `Response(status_code=stream.status_code, body=error_text)` with correct status
3. If OK → return `StreamingResponse` with the validated stream

## Test plan

- [x] `ruff check` + `ruff format` clean
- [x] `ty check` passes
- [x] 2062 unit tests pass (0 failures)
- [ ] Manual test: trigger a token-limit error through rosetta and verify the client sees the original upstream error message with correct HTTP status