### PR TITLE
feat: enhanced settings popup — password, token, log level, retention

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -68,6 +68,28 @@ a { color: var(--accent); text-decoration: none; }
   background: var(--bg); color: var(--text);
   border: 1px solid var(--border); border-radius: 4px;
 }
+.settings-popup-item input[type="number"],
+.settings-popup-item input[type="password"] {
+  flex: 1; min-width: 0; padding: 4px 8px; font-size: 12px;
+  background: var(--bg); color: var(--text);
+  border: 1px solid var(--border); border-radius: 4px;
+  font-family: var(--mono);
+}
+.settings-popup-item input[type="number"] { max-width: 90px; }
+.settings-popup-item .toggle-label {
+  display: flex; align-items: center; gap: 6px; cursor: pointer; font-size: 12px;
+}
+.settings-popup-item .toggle-label input[type="checkbox"] { accent-color: var(--accent); }
+.settings-token-row {
+  display: flex; align-items: center; gap: 6px; font-size: 11px;
+  font-family: var(--mono); color: var(--text-dim); word-break: break-all;
+}
+.countdown { color: var(--accent); font-size: 12px; white-space: nowrap; }
+.countdown .cd-time { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.settings-section-title {
+  font-size: 11px; font-weight: 600; color: var(--text-dim);
+  text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 2px;
+}
 .settings-divider { border-top: 1px solid var(--border); margin: 6px 0; }
 .about-link {
   display: inline-flex; align-items: center; gap: 6px;
@@ -661,8 +683,9 @@ body { padding-bottom: 26px; }
 
 <!-- Settings Popup (tinyleaf-style) -->
 <div class="settings-popup" id="settingsPopup" onclick="this.classList.remove('open')">
-  <div class="settings-popup-panel" onclick="event.stopPropagation()">
+  <div class="settings-popup-panel" onclick="event.stopPropagation()" style="max-height:85vh;overflow-y:auto">
     <h3 data-i18n="modal.settings">Settings</h3>
+    <!-- Theme & Language -->
     <div class="settings-popup-item">
       <label data-i18n="label.theme">Theme</label>
       <select id="settingsThemeSelect" onchange="setTheme(this.value)">
@@ -678,6 +701,81 @@ body { padding-bottom: 26px; }
       </select>
     </div>
     <div class="settings-divider"></div>
+    <!-- Log Level & Auto-Refresh -->
+    <div class="settings-popup-item">
+      <label data-i18n="label.logLevel">Log Level</label>
+      <select id="settingsLogLevel" onchange="saveSettingsField('logLevel',this.value)">
+        <option value="normal" data-i18n="logLevel.normal">Normal</option>
+        <option value="verbose" data-i18n="logLevel.verbose">Verbose</option>
+        <option value="debug" data-i18n="logLevel.debug">Debug (bodies)</option>
+      </select>
+    </div>
+    <div class="settings-popup-item">
+      <label data-i18n="label.autoRefresh">Auto-Refresh</label>
+      <select id="settingsAutoRefresh" onchange="saveAutoRefresh(this.value)">
+        <option value="1000">1s</option>
+        <option value="3000" selected>3s</option>
+        <option value="5000">5s</option>
+        <option value="10000">10s</option>
+        <option value="30000">30s</option>
+        <option value="0" data-i18n="label.off">Off</option>
+      </select>
+    </div>
+    <div class="settings-popup-item">
+      <label data-i18n="label.credentialReveal">Credential Reveal</label>
+      <label class="toggle-label">
+        <input type="checkbox" id="settingsCredentialVisible" onchange="saveSettingsField('credentialVisible',this.checked)">
+        <span data-i18n="label.enabled">Enabled</span>
+      </label>
+    </div>
+    <div class="settings-divider"></div>
+    <!-- Log Retention -->
+    <div class="settings-section-title" data-i18n="label.logRetention">Log Retention</div>
+    <div class="settings-popup-item">
+      <label data-i18n="label.successMax">Success</label>
+      <input type="number" id="settingsSuccessMax" min="50000" step="10000" value="50000">
+    </div>
+    <div class="settings-popup-item">
+      <label data-i18n="label.errorMax">Error</label>
+      <input type="number" id="settingsErrorMax" min="5000" step="5000" value="10000">
+      <button class="btn btn-sm" onclick="saveLogRetention()" data-i18n="btn.save">Save</button>
+    </div>
+    <div class="settings-divider"></div>
+    <!-- Admin Token -->
+    <div class="settings-section-title" data-i18n="label.adminToken">Admin Token</div>
+    <div class="settings-token-row">
+      <span id="settingsTokenDisplay" style="flex:1">—</span>
+      <button class="btn btn-sm" onclick="copyAdminToken()" data-i18n="btn.copy">Copy</button>
+      <button class="btn btn-sm" onclick="_doTokenRotate()" data-i18n="btn.rotate">Rotate</button>
+    </div>
+    <div style="display:flex;align-items:center;gap:8px;margin-top:4px">
+      <span class="countdown" id="tokenCountdown"></span>
+      <select id="settingsRotateInterval" style="font-size:11px;padding:2px 4px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:3px" onchange="localStorage.setItem('tokenRotateMinutes',this.value)">
+        <option value="5">5 min</option>
+        <option value="15" selected>15 min</option>
+        <option value="30">30 min</option>
+        <option value="60">60 min</option>
+      </select>
+    </div>
+    <div class="settings-divider"></div>
+    <!-- Change Password -->
+    <div class="settings-section-title" data-i18n="label.changePassword">Change Password</div>
+    <div class="settings-popup-item">
+      <label data-i18n="label.currentPw">Current</label>
+      <input type="password" id="settingsCurrentPw" autocomplete="current-password">
+    </div>
+    <div class="settings-popup-item">
+      <label data-i18n="label.newPw">New</label>
+      <input type="password" id="settingsNewPw" autocomplete="new-password">
+    </div>
+    <div class="settings-popup-item">
+      <label data-i18n="label.confirmPw">Confirm</label>
+      <input type="password" id="settingsConfirmPw" autocomplete="new-password">
+      <button class="btn btn-sm" onclick="changeAdminPassword()" data-i18n="btn.change">Change</button>
+    </div>
+    <div id="settingsPwError" style="font-size:11px;color:var(--error);margin-top:2px"></div>
+    <div class="settings-divider"></div>
+    <!-- Version & Links -->
     <div style="text-align:center;padding:4px 0 2px">
       <div style="font-size:15px;font-weight:600;margin-bottom:2px">llm-rosetta</div>
       <div id="settingsVersion" style="font-size:11px;color:var(--text-dim);margin-bottom:8px"></div>
@@ -968,7 +1066,14 @@ const I18N = {
     'section.server':'Server Settings', 'section.providers':'Providers', 'section.models':'Model Routing',
     'label.globalProxy':'Global Proxy URL',
     'label.globalProxy.hint':'Applies to all providers unless overridden per-provider.',
-    'btn.save':'Save', 'modal.settings':'Settings', 'label.theme':'Theme', 'label.language':'Language', 'theme.light':'Light', 'theme.dark':'Dark', 'btn.cancel':'Cancel', 'btn.close':'Close',
+    'btn.save':'Save', 'btn.copy':'Copy', 'btn.change':'Change', 'modal.settings':'Settings', 'label.theme':'Theme', 'label.language':'Language', 'theme.light':'Light', 'theme.dark':'Dark', 'btn.cancel':'Cancel', 'btn.close':'Close',
+    'label.logLevel':'Log Level', 'logLevel.normal':'Normal', 'logLevel.verbose':'Verbose', 'logLevel.debug':'Debug (bodies)',
+    'label.autoRefresh':'Auto-Refresh', 'label.off':'Off', 'label.credentialReveal':'Credential Reveal', 'label.enabled':'Enabled',
+    'label.logRetention':'Log Retention', 'label.successMax':'Success', 'label.errorMax':'Error',
+    'label.adminToken':'Admin Token', 'label.rotatingIn':'Rotating in <span class="cd-time">{time}</span>',
+    'label.changePassword':'Change Password', 'label.currentPw':'Current', 'label.newPw':'New', 'label.confirmPw':'Confirm',
+    'pw.required':'Both current and new password required', 'pw.mismatch':'Passwords do not match', 'pw.tooShort':'Password too short (min 4)', 'pw.changed':'Password changed',
+    'toast.saved':'Saved', 'toast.error':'Error', 'toast.copied':'Copied to clipboard', 'toast.copyFailed':'Copy failed', 'toast.tokenRotated':'Token rotated', 'toast.retentionMin':'Minimum: success 50,000 / error 5,000',
     'btn.addProvider':'+ Add Provider', 'btn.addModel':'+ Add Model',
     'btn.edit':'Edit', 'btn.delete':'Delete', 'btn.rotate':'Rotate', 'btn.resetFilters':'Reset Filters',
     'btn.prev':'Prev', 'btn.next':'Next', 'btn.test':'Test',
@@ -1085,7 +1190,14 @@ const I18N = {
     'label.globalProxy':'\u5168\u5c40\u4ee3\u7406 URL',
     'label.globalProxy.hint':'\u9002\u7528\u4e8e\u6240\u6709\u670d\u52a1\u65b9\uff0c\u9664\u975e\u5355\u72ec\u8bbe\u7f6e\u4e86\u4ee3\u7406\u3002',
     'modal.settings':'\u8bbe\u7f6e', 'label.theme':'\u4e3b\u9898', 'label.language':'\u8bed\u8a00', 'theme.light':'\u6d45\u8272', 'theme.dark':'\u6df1\u8272',
-    'btn.save':'\u4fdd\u5b58', 'btn.cancel':'\u53d6\u6d88', 'btn.close':'\u5173\u95ed',
+    'btn.save':'\u4fdd\u5b58', 'btn.copy':'\u590d\u5236', 'btn.change':'\u4fee\u6539', 'btn.cancel':'\u53d6\u6d88', 'btn.close':'\u5173\u95ed',
+    'label.logLevel':'\u65e5\u5fd7\u7ea7\u522b', 'logLevel.normal':'\u6b63\u5e38', 'logLevel.verbose':'\u8be6\u7ec6', 'logLevel.debug':'\u8c03\u8bd5 (\u542b\u8bf7\u6c42\u4f53)',
+    'label.autoRefresh':'\u81ea\u52a8\u5237\u65b0', 'label.off':'\u5173\u95ed', 'label.credentialReveal':'\u51ed\u8bc1\u53ef\u89c1', 'label.enabled':'\u5df2\u542f\u7528',
+    'label.logRetention':'\u65e5\u5fd7\u4fdd\u7559', 'label.successMax':'\u6210\u529f', 'label.errorMax':'\u5931\u8d25',
+    'label.adminToken':'\u7ba1\u7406 Token', 'label.rotatingIn':'<span class="cd-time">{time}</span> \u540e\u8f6e\u6362',
+    'label.changePassword':'\u4fee\u6539\u5bc6\u7801', 'label.currentPw':'\u5f53\u524d\u5bc6\u7801', 'label.newPw':'\u65b0\u5bc6\u7801', 'label.confirmPw':'\u786e\u8ba4\u5bc6\u7801',
+    'pw.required':'\u8bf7\u586b\u5199\u5f53\u524d\u5bc6\u7801\u548c\u65b0\u5bc6\u7801', 'pw.mismatch':'\u4e24\u6b21\u8f93\u5165\u4e0d\u4e00\u81f4', 'pw.tooShort':'\u5bc6\u7801\u592a\u77ed\uff08\u81f3\u5c114\u4f4d\uff09', 'pw.changed':'\u5bc6\u7801\u5df2\u4fee\u6539',
+    'toast.saved':'\u5df2\u4fdd\u5b58', 'toast.error':'\u64cd\u4f5c\u5931\u8d25', 'toast.copied':'\u5df2\u590d\u5236\u5230\u526a\u8d34\u677f', 'toast.copyFailed':'\u590d\u5236\u5931\u8d25', 'toast.tokenRotated':'Token \u5df2\u8f6e\u6362', 'toast.retentionMin':'\u6700\u4f4e\uff1a\u6210\u529f 50,000 / \u5931\u8d25 5,000',
     'btn.addProvider':'+ \u6dfb\u52a0\u670d\u52a1\u65b9', 'btn.addModel':'+ \u6dfb\u52a0\u6a21\u578b',
     'btn.edit':'\u7f16\u8f91', 'btn.delete':'\u5220\u9664', 'btn.rotate':'\u8f6e\u6362', 'btn.resetFilters':'\u91cd\u7f6e\u8fc7\u6ee4\u5668',
     'btn.prev':'\u4e0a\u4e00\u9875', 'btn.next':'\u4e0b\u4e00\u9875', 'btn.test':'\u6d4b\u8bd5',
@@ -1314,15 +1426,172 @@ function doLogout() {
 
 function openSettings() {
   const popup = document.getElementById('settingsPopup');
-  // Sync dropdowns with current state
+  // Sync theme & language
   const ts = document.getElementById('settingsThemeSelect');
   if (ts) ts.value = currentTheme;
   const ls = document.getElementById('settingsLangSelect');
   if (ls) ls.value = currentLang;
-  // Show version
+  // Version
   const ver = document.getElementById('settingsVersion');
   if (ver) ver.textContent = configData?.version ? 'v' + configData.version : '';
+  // Sync log level
+  const ll = document.getElementById('settingsLogLevel');
+  if (ll && configData?.server) {
+    const dbg = configData.debug || {};
+    if (dbg.log_bodies) ll.value = 'debug';
+    else if (dbg.verbose) ll.value = 'verbose';
+    else ll.value = 'normal';
+  }
+  // Sync auto-refresh
+  const ar = document.getElementById('settingsAutoRefresh');
+  if (ar) ar.value = localStorage.getItem('dashboardRefreshMs') || '3000';
+  // Sync credential visibility
+  const cv = document.getElementById('settingsCredentialVisible');
+  if (cv) cv.checked = _credentialVisible;
+  // Sync log retention
+  if (configData?.server?.request_log) {
+    const sm = document.getElementById('settingsSuccessMax');
+    const em = document.getElementById('settingsErrorMax');
+    if (sm) sm.value = configData.server.request_log.success_max || 50000;
+    if (em) em.value = configData.server.request_log.error_max || 10000;
+  }
+  // Sync token
+  _refreshTokenDisplay();
+  // Sync rotate interval
+  const ri = document.getElementById('settingsRotateInterval');
+  if (ri) ri.value = localStorage.getItem('tokenRotateMinutes') || '15';
+  // Clear password fields
+  ['settingsCurrentPw','settingsNewPw','settingsConfirmPw'].forEach(id => {
+    const el = document.getElementById(id); if (el) el.value = '';
+  });
+  document.getElementById('settingsPwError').textContent = '';
   popup.classList.toggle('open');
+}
+
+// --- Settings save helpers ---
+let _dashboardRefreshMs = parseInt(localStorage.getItem('dashboardRefreshMs') || '3000', 10);
+
+async function saveSettingsField(field, value) {
+  const body = {};
+  if (field === 'logLevel') {
+    body.verbose = (value === 'verbose' || value === 'debug');
+    body.log_bodies = (value === 'debug');
+  } else if (field === 'credentialVisible') {
+    body.credential_visible = value;
+  }
+  try {
+    await api.put('/admin/api/config/server', body);
+    await loadConfig(); showToast(t('toast.saved'));
+  } catch { showToast(t('toast.error'), 'error'); }
+}
+
+function saveAutoRefresh(val) {
+  _dashboardRefreshMs = parseInt(val, 10);
+  localStorage.setItem('dashboardRefreshMs', val);
+  // Restart dashboard timer if active
+  if (dashboardTimer) {
+    clearInterval(dashboardTimer);
+    dashboardTimer = _dashboardRefreshMs > 0
+      ? setInterval(loadMetrics, _dashboardRefreshMs)
+      : null;
+  }
+}
+
+async function saveLogRetention() {
+  const sm = parseInt(document.getElementById('settingsSuccessMax')?.value || '50000', 10);
+  const em = parseInt(document.getElementById('settingsErrorMax')?.value || '10000', 10);
+  if (sm < 50000 || em < 5000) { showToast(t('toast.retentionMin'), 'error'); return; }
+  try {
+    await api.put('/admin/api/config/server', { request_log: { success_max: sm, error_max: em } });
+    await loadConfig(); showToast(t('toast.saved'));
+  } catch { showToast(t('toast.error'), 'error'); }
+}
+
+// --- Admin Token ---
+let _tokenRotateTimer = null;
+let _tokenRotateEnd = 0;
+let _tokenCountdownTimer = null;
+
+function _refreshTokenDisplay() {
+  const el = document.getElementById('settingsTokenDisplay');
+  if (!el || !internalToken) { if (el) el.textContent = '—'; return; }
+  // Mask: show first 14 chars + ... + last 4
+  const masked = internalToken.length > 20
+    ? internalToken.slice(0, 14) + '...' + internalToken.slice(-4)
+    : internalToken;
+  el.textContent = masked;
+}
+
+async function copyAdminToken() {
+  if (!internalToken) return;
+  try {
+    await navigator.clipboard.writeText(internalToken);
+    showToast(t('toast.copied'));
+  } catch { showToast(t('toast.copyFailed'), 'error'); return; }
+  // Start auto-rotate countdown
+  const minutes = parseInt(localStorage.getItem('tokenRotateMinutes') || '15', 10);
+  _tokenRotateEnd = Date.now() + minutes * 60 * 1000;
+  if (_tokenRotateTimer) clearTimeout(_tokenRotateTimer);
+  if (_tokenCountdownTimer) clearInterval(_tokenCountdownTimer);
+  _tokenRotateTimer = setTimeout(_doTokenRotate, minutes * 60 * 1000);
+  _tokenCountdownTimer = setInterval(_updateTokenCountdown, 1000);
+  _updateTokenCountdown();
+}
+
+function _updateTokenCountdown() {
+  const el = document.getElementById('tokenCountdown');
+  if (!el) return;
+  const remaining = Math.max(0, _tokenRotateEnd - Date.now());
+  if (remaining <= 0) {
+    el.textContent = '';
+    if (_tokenCountdownTimer) { clearInterval(_tokenCountdownTimer); _tokenCountdownTimer = null; }
+    return;
+  }
+  const mins = Math.floor(remaining / 60000);
+  const secs = Math.floor((remaining % 60000) / 1000);
+  el.innerHTML = t('label.rotatingIn', { time: `${mins}:${String(secs).padStart(2,'0')}` });
+}
+
+async function _doTokenRotate() {
+  _tokenRotateTimer = null;
+  if (_tokenCountdownTimer) { clearInterval(_tokenCountdownTimer); _tokenCountdownTimer = null; }
+  document.getElementById('tokenCountdown').textContent = '';
+  try {
+    const data = await api.post('/admin/api/token/rotate');
+    // api.post returns parsed JSON directly, not a Response
+    if (data.token) {
+      localStorage.setItem('admin_token', data.token);
+    }
+    // Refresh internal token display
+    const td = await api.get('/admin/api/internal-token');
+    internalToken = td.token;
+    _refreshTokenDisplay();
+    showToast(t('toast.tokenRotated'));
+  } catch (e) {
+    showToast(t('toast.error'), 'error');
+  }
+}
+
+// --- Change Password ---
+async function changeAdminPassword() {
+  const current = document.getElementById('settingsCurrentPw')?.value || '';
+  const newPw = document.getElementById('settingsNewPw')?.value || '';
+  const confirm = document.getElementById('settingsConfirmPw')?.value || '';
+  const errEl = document.getElementById('settingsPwError');
+  errEl.textContent = '';
+  if (!current || !newPw) { errEl.textContent = t('pw.required'); return; }
+  if (newPw !== confirm) { errEl.textContent = t('pw.mismatch'); return; }
+  if (newPw.length < 4) { errEl.textContent = t('pw.tooShort'); return; }
+  try {
+    const data = await api.put('/admin/api/config/password', { current_password: current, new_password: newPw });
+    if (data.token) localStorage.setItem('admin_token', data.token);
+    ['settingsCurrentPw','settingsNewPw','settingsConfirmPw'].forEach(id => {
+      const el = document.getElementById(id); if (el) el.value = '';
+    });
+    showToast(t('pw.changed'));
+  } catch (e) {
+    errEl.textContent = e.message || t('toast.error');
+  }
 }
 
 function showLoginOverlay() {
@@ -2891,7 +3160,7 @@ document.querySelectorAll('.tab').forEach(tab => {
     currentTab = id;
     localStorage.setItem('llm-rosetta-tab', id);
     stopTimers();
-    if (id === 'dashboard') { loadMetrics(); dashboardTimer = setInterval(loadMetrics, 3000); }
+    if (id === 'dashboard') { loadMetrics(); dashboardTimer = (_dashboardRefreshMs > 0 ? setInterval(loadMetrics, _dashboardRefreshMs) : null); }
     if (id === 'logs') { logOffset = 0; loadLogs(); logTimer = setInterval(loadLogs, 5000); }
     if (id === 'providers' || id === 'models') { loadConfig(); }
     if (id === 'keys') { loadKeys(); }
@@ -3261,7 +3530,7 @@ function initApp() {
   // the tab restore (savedTab.click()) runs before auth completes, so
   // its fetch calls fail with 401.  Re-trigger here after successful auth.
   stopTimers();
-  if (currentTab === 'dashboard') { loadMetrics(); dashboardTimer = setInterval(loadMetrics, 3000); }
+  if (currentTab === 'dashboard') { loadMetrics(); dashboardTimer = (_dashboardRefreshMs > 0 ? setInterval(loadMetrics, _dashboardRefreshMs) : null); }
   if (currentTab === 'logs') { logOffset = 0; loadLogs(); logTimer = setInterval(loadLogs, 5000); }
 }
 // ===================== System Clock =====================

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -27,6 +27,8 @@ from ._shared import (  # noqa: F401  (re-exported for backward compat)
 from .auth import (
     admin_check,
     admin_login,
+    change_password,
+    rotate_token,
     serve_admin_html,
 )
 from .config import (
@@ -88,6 +90,8 @@ def register_admin_routes(app: Any) -> None:
     # Admin auth
     app.route("/admin/api/login", methods=["POST"])(admin_login)
     app.route("/admin/api/auth-check", methods=["GET"])(admin_check)
+    app.route("/admin/api/config/password", methods=["PUT"])(change_password)
+    app.route("/admin/api/token/rotate", methods=["POST"])(rotate_token)
     # Config CRUD
     app.route("/admin/api/config", methods=["GET"])(get_config)
     app.route("/admin/api/config/providers/<name>", methods=["PUT"])(put_provider)

--- a/src/llm_rosetta/gateway/admin/routes/_shared.py
+++ b/src/llm_rosetta/gateway/admin/routes/_shared.py
@@ -53,6 +53,20 @@ def _reload_gateway_config(request: Any, config_path: str) -> GatewayConfig:
 
     _sync_auth_middleware(request.app, new_config)
 
+    # Hot-reload log level
+    from llm_rosetta.gateway.logging import setup_logging as _setup_logging
+
+    _setup_logging(verbose=new_config.verbose, log_bodies=new_config.log_bodies)
+
+    # Hot-reload log retention caps
+    persistence = getattr(request.app, "persistence", None)
+    if persistence is not None:
+        rl_cfg = new_config.request_log or {}
+        if "success_max" in rl_cfg:
+            persistence.success_max = int(rl_cfg["success_max"])
+        if "error_max" in rl_cfg:
+            persistence.error_max = int(rl_cfg["error_max"])
+
     return new_config
 
 
@@ -62,6 +76,9 @@ def _sync_auth_middleware(app: Any, config: GatewayConfig) -> None:
     if auth_state is not None:
         auth_state.key_set = config.api_key_set
         auth_state.labels = dict(config.api_key_labels)
+        # Sync admin password (e.g. changed via CLI or config edit)
+        if config.admin_password != auth_state.admin_password:
+            auth_state.change_password(config.admin_password or "")
 
 
 def _build_provider_entry(

--- a/src/llm_rosetta/gateway/admin/routes/auth.py
+++ b/src/llm_rosetta/gateway/admin/routes/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import time
 from typing import Any
 
@@ -101,7 +102,7 @@ async def admin_login(request: Any) -> Response:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
     password = body.get("password", "")
-    if password != auth_state.admin_password:
+    if not hmac.compare_digest(password, auth_state.admin_password):
         _record_login_failure(ip)
         blocked, retry_after = _check_login_rate_limit(ip)
         resp: dict[str, Any] = {"error": "Invalid password"}
@@ -120,3 +121,91 @@ async def admin_check(request: Any) -> Response:
     auth_state = request.app.auth_state
     requires_auth = bool(auth_state.admin_password)
     return JSONResponse({"requires_auth": requires_auth})
+
+
+async def change_password(request: Any) -> Response:
+    """Change the admin password (requires current password)."""
+    from ._shared import _get_config_path, _reload_gateway_config
+    from ...config import load_config_raw, write_config
+
+    auth_state = request.app.auth_state
+    if not auth_state.admin_password:
+        return JSONResponse({"error": "Admin password not configured"}, status_code=400)
+
+    # Rate-limit password change attempts the same way as login
+    ip = _get_client_ip(request)
+    blocked, retry_after = _check_login_rate_limit(ip)
+    if blocked:
+        return JSONResponse(
+            {
+                "error": f"Too many failed attempts. Try again in {int(retry_after) + 1}s."
+            },
+            status_code=429,
+        )
+
+    try:
+        body = request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    current = body.get("current_password", "")
+    new_pw = body.get("new_password", "")
+
+    if not current or not new_pw:
+        return JSONResponse(
+            {"error": "Both current_password and new_password are required"},
+            status_code=400,
+        )
+
+    if len(new_pw) < 4:
+        return JSONResponse(
+            {"error": "New password must be at least 4 characters"},
+            status_code=400,
+        )
+
+    if not hmac.compare_digest(current, auth_state.admin_password):
+        _record_login_failure(ip)
+        return JSONResponse({"error": "Current password is incorrect"}, status_code=401)
+
+    _clear_login_failures(ip)
+
+    # Persist to config file
+    config_path = _get_config_path(request)
+    if not config_path:
+        return JSONResponse({"error": "No config file path available"}, status_code=500)
+
+    try:
+        data = load_config_raw(config_path)
+    except Exception as exc:
+        return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
+
+    data.setdefault("server", {})["admin_password"] = new_pw
+
+    try:
+        write_config(config_path, data)
+    except Exception as exc:
+        return JSONResponse(
+            {"error": f"Failed to write config: {exc}"}, status_code=500
+        )
+
+    # Hot-reload config (syncs auth state via _sync_auth_middleware)
+    _reload_gateway_config(request, config_path)
+
+    # Return the new admin token so frontend can swap immediately
+    return JSONResponse({"ok": True, "token": auth_state.admin_token})
+
+
+async def rotate_token(request: Any) -> Response:
+    """Rotate the internal proxy token and recalculate admin token.
+
+    The new token is in-memory only — not persisted to config.  A restart
+    regenerates a fresh token regardless, so persistence is unnecessary.
+    The copied token stops working after restart by design.
+    """
+    auth_state = request.app.auth_state
+    new_admin_token = auth_state.rotate_internal_token()
+
+    # Also update the app-level internal_token reference
+    request.app.internal_token = auth_state.internal_token
+
+    return JSONResponse({"ok": True, "token": new_admin_token})

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -152,6 +152,7 @@ async def get_config(request: Any) -> Response:
             "providers": masked_providers,
             "models": models_normalized,
             "server": server,
+            "debug": raw.get("debug", {}),
             "credential_visible": config.credential_visible,
             "version": _get_version(),
             "known_provider_types": known_provider_types(),
@@ -531,6 +532,26 @@ async def put_server_settings(request: Any) -> Response:
             server["proxy"] = proxy
         else:
             server.pop("proxy", None)
+
+    # Credential visibility toggle
+    if "credential_visible" in body:
+        server["credential_visible"] = bool(body["credential_visible"])
+
+    # Log retention caps (floor prevents accidental wipe)
+    if "request_log" in body:
+        rl = body["request_log"]
+        rl_cfg = server.setdefault("request_log", {})
+        if "success_max" in rl:
+            rl_cfg["success_max"] = max(50000, int(rl["success_max"]))
+        if "error_max" in rl:
+            rl_cfg["error_max"] = max(5000, int(rl["error_max"]))
+
+    # Debug / log level
+    debug = data.setdefault("debug", {})
+    if "verbose" in body:
+        debug["verbose"] = bool(body["verbose"])
+    if "log_bodies" in body:
+        debug["log_bodies"] = bool(body["log_bodies"])
 
     try:
         write_config(config_path, data)

--- a/src/llm_rosetta/gateway/auth.py
+++ b/src/llm_rosetta/gateway/auth.py
@@ -14,6 +14,7 @@ configured, all requests pass through (backward compatible).
 from __future__ import annotations
 
 import contextvars
+import hmac
 from typing import Any
 
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
@@ -120,7 +121,7 @@ def check_admin_auth(request: Any, auth_state: AuthState) -> Response | None:
 
     # Check X-Admin-Token header
     admin_token = request.headers.get("x-admin-token", "")
-    if admin_token and admin_token == auth_state.admin_token:
+    if admin_token and hmac.compare_digest(admin_token, auth_state.admin_token or ""):
         return None
 
     # Block unauthenticated API calls
@@ -147,15 +148,49 @@ class AuthState:
         self.admin_password = admin_password
         # Derive admin token from password + internal_token via HMAC
         self.admin_token: str | None = None
-        if admin_password and internal_token:
+        self._recalculate_admin_token()
+
+    def _recalculate_admin_token(self) -> None:
+        """Derive ``admin_token`` from ``admin_password`` + ``internal_token``.
+
+        Called on init and after password or internal_token changes.
+        """
+        if self.admin_password and self.internal_token:
             import hashlib
             import hmac as _hmac
 
             self.admin_token = _hmac.new(
-                internal_token.encode(),
-                admin_password.encode(),
+                self.internal_token.encode(),
+                self.admin_password.encode(),
                 hashlib.sha256,
             ).hexdigest()
+        else:
+            self.admin_token = None
+
+    def rotate_internal_token(self) -> str:
+        """Generate a new internal token and recalculate admin_token.
+
+        Returns:
+            The new admin_token (or empty string if no password is set).
+        """
+        import secrets
+
+        self.internal_token = f"rsk-internal-{secrets.token_hex(16)}"
+        self._recalculate_admin_token()
+        return self.admin_token or ""
+
+    def change_password(self, new_password: str) -> str:
+        """Update the admin password and recalculate admin_token.
+
+        Args:
+            new_password: The new plaintext password.
+
+        Returns:
+            The new admin_token.
+        """
+        self.admin_password = new_password
+        self._recalculate_admin_token()
+        return self.admin_token or ""
 
 
 def create_auth_hook(auth_state: AuthState) -> Any:

--- a/src/llm_rosetta/gateway/cli.py
+++ b/src/llm_rosetta/gateway/cli.py
@@ -202,6 +202,51 @@ def _cmd_add_model(args: argparse.Namespace) -> None:
 # CLI entry point
 # ---------------------------------------------------------------------------
 
+
+def _cmd_set_password(args: argparse.Namespace) -> None:
+    """Set or change the admin password directly in the config file.
+
+    Intended for forgot-password recovery — does not require the current
+    password.  The gateway must be restarted for the change to take effect
+    (unless it happens to hot-reload the config).
+    """
+    import getpass
+
+    config_path = discover_config(args.config)
+    if config_path is None or not os.path.isfile(config_path):
+        print(f"Config file not found: {config_path or '(auto-detect failed)'}")
+        sys.exit(1)
+
+    new_pw = getpass.getpass("New admin password: ")
+    if not new_pw:
+        print("Password cannot be empty.")
+        sys.exit(1)
+    if len(new_pw) < 4:
+        print("Password must be at least 4 characters.")
+        sys.exit(1)
+    confirm = getpass.getpass("Confirm password: ")
+    if new_pw != confirm:
+        print("Passwords do not match.")
+        sys.exit(1)
+
+    try:
+        data = load_config_raw(config_path)
+    except Exception as exc:
+        print(f"Failed to read config: {exc}")
+        sys.exit(1)
+
+    data.setdefault("server", {})["admin_password"] = new_pw
+
+    try:
+        write_config(config_path, data)
+    except Exception as exc:
+        print(f"Failed to write config: {exc}")
+        sys.exit(1)
+
+    print(f"Admin password updated in {config_path}")
+    print("Restart the gateway for changes to take effect.")
+
+
 _KNOWN_PROVIDERS = known_provider_types()
 
 
@@ -286,6 +331,15 @@ def main() -> None:
     model_parser.add_argument("name", help="Model name (e.g. gpt-4o)")
     model_parser.add_argument("--provider", default=None, help="Target provider name")
 
+    # ``set-password`` subcommand
+    pw_parser = sub.add_parser(
+        "set-password",
+        help="Set or change admin password (for forgot-password recovery)",
+    )
+    pw_parser.add_argument(
+        "config", nargs="?", default=None, help="Path to config file"
+    )
+
     args = parser.parse_args()
 
     # --- edit mode ---
@@ -306,6 +360,11 @@ def main() -> None:
             _cmd_add_model(args)
         else:
             sub.choices["add"].print_help()
+        return
+
+    # --- set-password subcommand ---
+    if args.command == "set-password":
+        _cmd_set_password(args)
         return
 
     # --- normal server startup ---

--- a/src/llm_rosetta/observability/persistence.py
+++ b/src/llm_rosetta/observability/persistence.py
@@ -91,10 +91,18 @@ class PersistenceManager:
         """Cap on retained successful request log entries."""
         return self._success_max
 
+    @success_max.setter
+    def success_max(self, value: int) -> None:
+        self._success_max = value
+
     @property
     def error_max(self) -> int:
         """Cap on retained error request log entries (status_code >= 400)."""
         return self._error_max
+
+    @error_max.setter
+    def error_max(self, value: int) -> None:
+        self._error_max = value
 
     @property
     def db_path(self) -> Path:


### PR DESCRIPTION
## Summary

Expanded the Settings popup from 2 items (theme/language) to 7 operational controls, plus admin token management and password change.

## New features

| Feature | UI | Backend | i18n |
|---------|-----|---------|------|
| Admin password change | 3 inputs (current/new/confirm) | `PUT /admin/api/config/password` — rate-limited, hot-reloads | ✅ |
| Admin token copy + auto-rotate | Masked display, copy button, configurable countdown (5/15/30/60 min) | `POST /admin/api/token/rotate` — new internal_token + recalculated admin_token | ✅ |
| Log level | 3-option select (Normal/Verbose/Debug) | Extends `PUT /admin/api/config/server`, hot-reloads `setup_logging()` | ✅ |
| Auto-refresh interval | Select (1s–30s, off) | Pure frontend, `localStorage` | ✅ |
| Credential visibility | Toggle checkbox | Extends `PUT /admin/api/config/server` | ✅ |
| Log retention | Two number inputs (success/error caps) | Extends `PUT /admin/api/config/server`, hot-reloads `PersistenceManager` caps | ✅ |
| CLI set-password | `llm-rosetta-gateway set-password` | Direct config file edit, no current password (recovery) | N/A |

## Backend changes

- `AuthState`: added `_recalculate_admin_token()`, `rotate_internal_token()`, `change_password()` methods (refactored from inline HMAC)
- `_sync_auth_middleware()`: now syncs admin password on config hot-reload
- `_reload_gateway_config()`: hot-reloads log level + retention caps
- `PersistenceManager`: added `success_max`/`error_max` setters
- `GET /admin/api/config`: now includes `debug` section in response

## Test plan

- [x] `ruff check` + `ruff format` + `ty check` all pass
- [x] 2062 tests pass
- [ ] Playwright: settings popup renders all controls
- [ ] Password change: login → change → logout → login with new
- [ ] Token copy + countdown + auto-rotate
- [ ] Log retention save + verify caps update
- [ ] CLI: `llm-rosetta-gateway set-password`