### PR TITLE
fix: preserve OpenAI Responses passthrough items

### DIFF
--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -72,6 +72,7 @@ class BaseConverter(ABC):
         "tool_call_delta": "_handle_tool_call_delta_to_p",
         "finish": "_handle_finish_to_p",
         "usage": "_handle_usage_to_p",
+        "provider_passthrough": "_handle_provider_passthrough_to_p",
     }
 
     # ==================== 顶层转换接口 Top-level conversion interface ====================
@@ -305,6 +306,17 @@ class BaseConverter(ABC):
             The (possibly modified) result.
         """
         return result
+
+    @staticmethod
+    def _handle_provider_passthrough_to_p(
+        event: IRStreamEvent,
+        context: StreamContext | None,
+    ) -> dict[str, Any]:
+        """Drop provider-specific opaque events by default.
+
+        Same-format converters can override this to re-emit the native payload.
+        """
+        return {}
 
     # ==================== Provider-specific helpers (abstract) ====================
 

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -34,6 +34,7 @@ from ...types.ir.stream import (
     ToolCallDeltaEvent,
     ToolCallStartEvent,
     UsageEvent,
+    ProviderPassthroughEvent,
 )
 from ..base import BaseConverter
 from ..base.context import ConversionContext, StreamContext
@@ -54,6 +55,14 @@ from .content_ops import OpenAIResponsesContentOps
 from .message_ops import OpenAIResponsesMessageOps
 from .tool_ops import OpenAIResponsesToolOps
 from .utils import build_message_preamble_events, resolve_call_id
+
+
+RESPONSES_PASSTHROUGH_OUTPUT_ITEM_TYPES = frozenset(
+    {
+        "tool_search_call",
+        "tool_search_output",
+    }
+)
 
 
 class OpenAIResponsesConverter(BaseConverter):
@@ -855,6 +864,16 @@ class OpenAIResponsesConverter(BaseConverter):
                 # ``ContentBlockStartEvent`` here would cause duplicate
                 # ``response.content_part.added`` events on round-trip.
                 pass
+            elif item_type in RESPONSES_PASSTHROUGH_OUTPUT_ITEM_TYPES:
+                if isinstance(context, OpenAIResponsesStreamContext):
+                    context.add_passthrough_output_item(item)
+                events.append(
+                    ProviderPassthroughEvent(
+                        type="provider_passthrough",
+                        provider=self._CONVERTER_TAG,
+                        payload=dict(chunk),
+                    )
+                )
 
     def _handle_content_part_added_from_p(
         self,
@@ -916,6 +935,16 @@ class OpenAIResponsesConverter(BaseConverter):
                 call_id = item.get("call_id", "")
                 if call_id:
                     context.set_tool_call_args(call_id, item.get("input", ""))
+        elif item_type in RESPONSES_PASSTHROUGH_OUTPUT_ITEM_TYPES:
+            if isinstance(context, OpenAIResponsesStreamContext):
+                context.add_passthrough_output_item(item)
+            events.append(
+                ProviderPassthroughEvent(
+                    type="provider_passthrough",
+                    provider=self._CONVERTER_TAG,
+                    payload=dict(chunk),
+                )
+            )
 
     def _handle_function_call_args_delta_from_p(
         self,
@@ -1013,7 +1042,17 @@ class OpenAIResponsesConverter(BaseConverter):
         output_items = response.get("output", [])
         if isinstance(output_items, list):
             for item in output_items:
-                if isinstance(item, dict) and item.get("type") == "function_call":
+                if not isinstance(item, dict):
+                    continue
+                item_type = item.get("type")
+                if item_type in RESPONSES_PASSTHROUGH_OUTPUT_ITEM_TYPES and isinstance(
+                    context, OpenAIResponsesStreamContext
+                ):
+                    context.add_passthrough_output_item(item)
+                if (
+                    item_type == "function_call"
+                    or item_type in RESPONSES_PASSTHROUGH_OUTPUT_ITEM_TYPES
+                ):
                     reason = "tool_calls"
                     break
 
@@ -1300,6 +1339,23 @@ class OpenAIResponsesConverter(BaseConverter):
             "delta": event["reasoning"],
         }
 
+    def _handle_provider_passthrough_to_p(
+        self,
+        event: ProviderPassthroughEvent,
+        context: StreamContext | None,
+    ) -> dict[str, Any]:
+        if event.get("provider") != self._CONVERTER_TAG:
+            return {}
+        payload = dict(event.get("payload", {}))
+        item = payload.get("item")
+        if (
+            isinstance(context, OpenAIResponsesStreamContext)
+            and isinstance(item, dict)
+            and item.get("type") in RESPONSES_PASSTHROUGH_OUTPUT_ITEM_TYPES
+        ):
+            context.add_passthrough_output_item(item)
+        return payload
+
     def _handle_tool_call_start_to_p(
         self,
         event: ToolCallStartEvent,
@@ -1512,6 +1568,7 @@ class OpenAIResponsesConverter(BaseConverter):
                         "status": "completed",
                     }
                 )
+        output.extend(context.passthrough_output_items)
         return output
 
     @staticmethod

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -59,6 +59,14 @@ from .utils import build_message_preamble_events, resolve_call_id
 
 RESPONSES_PASSTHROUGH_OUTPUT_ITEM_TYPES = frozenset(
     {
+        "reasoning",
+        "tool_search_call",
+        "tool_search_output",
+    }
+)
+
+RESPONSES_TOOL_LOOP_PASSTHROUGH_OUTPUT_ITEM_TYPES = frozenset(
+    {
         "tool_search_call",
         "tool_search_output",
     }
@@ -261,6 +269,10 @@ class OpenAIResponsesConverter(BaseConverter):
         self._convert_cache_from_p(provider_request, ir_request)
 
         # 11. Provider extensions (passthrough fields like allowed_tools)
+        include = provider_request.get("include")
+        if include is not None:
+            ir_request.setdefault("provider_extensions", {})["include"] = include
+
         allowed_tools = provider_request.get("allowed_tools")
         if allowed_tools is not None:
             ir_request.setdefault("provider_extensions", {})["allowed_tools"] = (
@@ -1058,9 +1070,8 @@ class OpenAIResponsesConverter(BaseConverter):
                     context, OpenAIResponsesStreamContext
                 ):
                     context.add_passthrough_output_item(item)
-                if (
-                    item_type == "function_call"
-                    or item_type in RESPONSES_PASSTHROUGH_OUTPUT_ITEM_TYPES
+                if item_type == "function_call" or (
+                    item_type in RESPONSES_TOOL_LOOP_PASSTHROUGH_OUTPUT_ITEM_TYPES
                 ):
                     reason = "tool_calls"
                     break

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -839,11 +839,18 @@ class OpenAIResponsesConverter(BaseConverter):
                 call_id = item.get("call_id", "")
                 item_id = item.get("id", "")
                 tool_type = "custom" if item_type == "custom_tool_call" else "function"
+                provider_metadata = self._build_tool_call_provider_metadata(item)
 
                 # Register tool call in context
                 if context is not None:
                     context.register_tool_call(call_id, item.get("name", ""), tool_type)
                     context.register_tool_call_item(call_id, item_id)
+                    if provider_metadata and isinstance(
+                        context, OpenAIResponsesStreamContext
+                    ):
+                        context.register_tool_call_provider_metadata(
+                            call_id, provider_metadata
+                        )
 
                 start_event_tc = ToolCallStartEvent(
                     type="tool_call_start",
@@ -851,6 +858,8 @@ class OpenAIResponsesConverter(BaseConverter):
                     tool_name=item.get("name", ""),
                     tool_type=tool_type,
                 )
+                if provider_metadata:
+                    start_event_tc["provider_metadata"] = provider_metadata
                 output_index = chunk.get("output_index")
                 if output_index is not None:
                     start_event_tc["tool_call_index"] = output_index
@@ -1364,12 +1373,15 @@ class OpenAIResponsesConverter(BaseConverter):
         call_id = event["tool_call_id"]
         tool_name = event["tool_name"]
         tool_type = event.get("tool_type", "function")
-        item_id = call_id
+        provider_metadata = event.get("provider_metadata") or {}
+        item_id = provider_metadata.get("responses_item_id") or call_id
 
         # Register in context for later done events
         if context is not None and call_id:
             context.register_tool_call(call_id, tool_name, tool_type)
             context.register_tool_call_item(call_id, item_id)
+            if provider_metadata and isinstance(context, OpenAIResponsesStreamContext):
+                context.register_tool_call_provider_metadata(call_id, provider_metadata)
 
         tc_index = event.get("tool_call_index")
         output_index = tc_index if tc_index is not None else 0
@@ -1398,6 +1410,7 @@ class OpenAIResponsesConverter(BaseConverter):
             "output_index": output_index,
             "item": item,
         }
+        self._apply_tool_call_provider_metadata(item, provider_metadata)
         return result
 
     def _handle_tool_call_delta_to_p(
@@ -1547,29 +1560,51 @@ class OpenAIResponsesConverter(BaseConverter):
             tool_type = context.get_tool_type(call_id)
 
             if tool_type == "custom":
-                output.append(
-                    {
-                        "id": tc_item_id,
-                        "type": "custom_tool_call",
-                        "call_id": call_id,
-                        "name": tool_name,
-                        "input": arguments,
-                        "status": "completed",
-                    }
-                )
+                item = {
+                    "id": tc_item_id,
+                    "type": "custom_tool_call",
+                    "call_id": call_id,
+                    "name": tool_name,
+                    "input": arguments,
+                    "status": "completed",
+                }
             else:
-                output.append(
-                    {
-                        "id": tc_item_id,
-                        "type": "function_call",
-                        "call_id": call_id,
-                        "name": tool_name,
-                        "arguments": arguments,
-                        "status": "completed",
-                    }
-                )
+                item = {
+                    "id": tc_item_id,
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": tool_name,
+                    "arguments": arguments,
+                    "status": "completed",
+                }
+            self._apply_tool_call_provider_metadata(
+                item, context.get_tool_call_provider_metadata(call_id)
+            )
+            output.append(item)
         output.extend(context.passthrough_output_items)
         return output
+
+    @staticmethod
+    def _build_tool_call_provider_metadata(item: dict[str, Any]) -> dict[str, Any]:
+        """Capture Responses-specific tool call fields for same-format streaming."""
+        metadata: dict[str, Any] = {}
+        item_id = item.get("id")
+        call_id = item.get("call_id")
+        if item_id and item_id != call_id:
+            metadata["responses_item_id"] = item_id
+        namespace = item.get("namespace")
+        if namespace:
+            metadata["responses_namespace"] = namespace
+        return metadata
+
+    @staticmethod
+    def _apply_tool_call_provider_metadata(
+        item: dict[str, Any], metadata: dict[str, Any]
+    ) -> None:
+        """Restore Responses-specific tool call fields from provider metadata."""
+        namespace = metadata.get("responses_namespace")
+        if namespace:
+            item["namespace"] = namespace
 
     @staticmethod
     def _build_finish_usage(pending_usage: dict[str, Any]) -> dict[str, Any]:
@@ -1683,6 +1718,7 @@ class OpenAIResponsesConverter(BaseConverter):
             item_id = context.get_tool_call_item_id(call_id) or call_id
             output_index = tc_idx + (1 if context.output_item_emitted else 0)
             tool_type = context.get_tool_type(call_id)
+            provider_metadata = context.get_tool_call_provider_metadata(call_id)
 
             if tool_type == "custom":
                 # response.custom_tool_call_input.done
@@ -1696,18 +1732,20 @@ class OpenAIResponsesConverter(BaseConverter):
                 )
 
                 # response.output_item.done for the custom_tool_call
+                item = {
+                    "id": item_id,
+                    "type": "custom_tool_call",
+                    "call_id": call_id,
+                    "name": tool_name,
+                    "input": arguments,
+                    "status": "completed",
+                }
+                self._apply_tool_call_provider_metadata(item, provider_metadata)
                 results.append(
                     {
                         "type": ResponsesEventType.OUTPUT_ITEM_DONE,
                         "output_index": output_index,
-                        "item": {
-                            "id": item_id,
-                            "type": "custom_tool_call",
-                            "call_id": call_id,
-                            "name": tool_name,
-                            "input": arguments,
-                            "status": "completed",
-                        },
+                        "item": item,
                     }
                 )
             else:
@@ -1722,18 +1760,20 @@ class OpenAIResponsesConverter(BaseConverter):
                 )
 
                 # response.output_item.done for the function_call
+                item = {
+                    "id": item_id,
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": tool_name,
+                    "arguments": arguments,
+                    "status": "completed",
+                }
+                self._apply_tool_call_provider_metadata(item, provider_metadata)
                 results.append(
                     {
                         "type": ResponsesEventType.OUTPUT_ITEM_DONE,
                         "output_index": output_index,
-                        "item": {
-                            "id": item_id,
-                            "type": "function_call",
-                            "call_id": call_id,
-                            "name": tool_name,
-                            "arguments": arguments,
-                            "status": "completed",
-                        },
+                        "item": item,
                     }
                 )
 

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -884,7 +884,15 @@ class OpenAIResponsesConverter(BaseConverter):
                 # own ``ContentBlockStartEvent``.  Emitting a
                 # ``ContentBlockStartEvent`` here would cause duplicate
                 # ``response.content_part.added`` events on round-trip.
-                pass
+                if isinstance(context, OpenAIResponsesStreamContext):
+                    context.register_message_item_metadata(item)
+                    events.append(
+                        ProviderPassthroughEvent(
+                            type="provider_passthrough",
+                            provider=self._CONVERTER_TAG,
+                            payload=dict(chunk),
+                        )
+                    )
             elif item_type in RESPONSES_PASSTHROUGH_OUTPUT_ITEM_TYPES:
                 if isinstance(context, OpenAIResponsesStreamContext):
                     context.add_passthrough_output_item(item)
@@ -1368,12 +1376,12 @@ class OpenAIResponsesConverter(BaseConverter):
             return {}
         payload = dict(event.get("payload", {}))
         item = payload.get("item")
-        if (
-            isinstance(context, OpenAIResponsesStreamContext)
-            and isinstance(item, dict)
-            and item.get("type") in RESPONSES_PASSTHROUGH_OUTPUT_ITEM_TYPES
-        ):
-            context.add_passthrough_output_item(item)
+        if isinstance(context, OpenAIResponsesStreamContext) and isinstance(item, dict):
+            if item.get("type") == "message":
+                context.register_message_item_metadata(item)
+                context.output_item_emitted = True
+            elif item.get("type") in RESPONSES_PASSTHROUGH_OUTPUT_ITEM_TYPES:
+                context.add_passthrough_output_item(item)
         return payload
 
     def _handle_tool_call_start_to_p(
@@ -1557,6 +1565,8 @@ class OpenAIResponsesConverter(BaseConverter):
                 "role": "assistant",
                 "content": [{"type": "output_text", "text": accumulated}],
             }
+            msg_item.update(context.message_item_metadata)
+            msg_item["content"] = [{"type": "output_text", "text": accumulated}]
             if context.metadata_mode == "preserve":
                 msg_item["status"] = "completed"
                 for part in msg_item.get("content", []):

--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -35,6 +35,14 @@ from .content_ops import OpenAIResponsesContentOps
 from .tool_ops import OpenAIResponsesToolOps
 
 
+RESPONSES_PASSTHROUGH_ITEM_TYPES = frozenset(
+    {
+        "tool_search_call",
+        "tool_search_output",
+    }
+)
+
+
 class OpenAIResponsesMessageOps(BaseMessageOps):
     """OpenAI Responses API message conversion operations.
 
@@ -388,15 +396,28 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
                     current_message = None
                 ir_input.append(self._make_system_event(item))
 
+            elif item_type in RESPONSES_PASSTHROUGH_ITEM_TYPES:
+                current_message = self._handle_p_passthrough_item(
+                    item, current_message, ir_input
+                )
+
             elif isinstance(item_type, str) and ":" in item_type:
                 current_message = self._handle_p_extension_item(
                     item, current_message, ir_input
                 )
 
-        if current_message and current_message.get("content"):
+        if current_message and self._message_has_payload(current_message):
             ir_input.append(current_message)
 
         return ir_input
+
+    @staticmethod
+    def _message_has_payload(message: dict[str, Any]) -> bool:
+        """Return whether a buffered IR message contains content or passthrough."""
+        if message.get("content"):
+            return True
+        custom = (message.get("metadata") or {}).get("custom", {})
+        return bool(custom.get("_passthrough_items"))
 
     @staticmethod
     def _make_system_event(item: dict[str, Any]) -> dict[str, Any]:
@@ -421,6 +442,28 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
             custom.setdefault("_passthrough_items", []).append(dict(item))
             return current_message
         if current_message:
+            ir_input.append(current_message)
+        return {
+            "role": "assistant",
+            "content": [],
+            "metadata": {"custom": {"_passthrough_items": [dict(item)]}},
+        }
+
+    @staticmethod
+    def _handle_p_passthrough_item(
+        item: dict[str, Any],
+        current_message: dict[str, Any] | None,
+        ir_input: list[Any],
+    ) -> dict[str, Any]:
+        """Preserve Responses client-executed items opaquely."""
+        if current_message and current_message.get("role") == "assistant":
+            metadata = current_message.setdefault("metadata", {})
+            custom = metadata.setdefault("custom", {})
+            custom.setdefault("_passthrough_items", []).append(dict(item))
+            return current_message
+        if current_message and OpenAIResponsesMessageOps._message_has_payload(
+            current_message
+        ):
             ir_input.append(current_message)
         return {
             "role": "assistant",

--- a/src/llm_rosetta/converters/openai_responses/stream_context.py
+++ b/src/llm_rosetta/converters/openai_responses/stream_context.py
@@ -32,6 +32,7 @@ class OpenAIResponsesStreamContext(StreamContext):
     item_id: str = ""
     accumulated_text: str = ""
     content_part_done_emitted: bool = False
+    passthrough_output_items: list[dict] = field(default_factory=list)
     _sequence_number: int = 0
 
     @classmethod
@@ -63,6 +64,8 @@ class OpenAIResponsesStreamContext(StreamContext):
         ctx._tool_call_args = base._tool_call_args
         ctx._tool_call_order = base._tool_call_order
         ctx._tool_call_types = base._tool_call_types
+        if hasattr(base, "passthrough_output_items"):
+            ctx.passthrough_output_items = base.passthrough_output_items
         return ctx
 
     def register_tool_call_item(self, tool_call_id: str, item_id: str) -> None:
@@ -78,3 +81,16 @@ class OpenAIResponsesStreamContext(StreamContext):
         super().register_tool_call_item(tool_call_id, item_id)
         if tool_call_id and item_id:
             self.item_id_to_call_id[item_id] = tool_call_id
+
+    def add_passthrough_output_item(self, item: dict) -> None:
+        """Remember an opaque Responses output item for response.completed."""
+        item_id = item.get("id")
+        call_id = item.get("call_id")
+        for idx, existing in enumerate(self.passthrough_output_items):
+            if item_id and existing.get("id") == item_id:
+                self.passthrough_output_items[idx] = dict(item)
+                return
+            if call_id and existing.get("call_id") == call_id:
+                self.passthrough_output_items[idx] = dict(item)
+                return
+        self.passthrough_output_items.append(dict(item))

--- a/src/llm_rosetta/converters/openai_responses/stream_context.py
+++ b/src/llm_rosetta/converters/openai_responses/stream_context.py
@@ -32,6 +32,7 @@ class OpenAIResponsesStreamContext(StreamContext):
     item_id: str = ""
     accumulated_text: str = ""
     content_part_done_emitted: bool = False
+    message_item_metadata: dict = field(default_factory=dict)
     passthrough_output_items: list[dict] = field(default_factory=list)
     tool_call_provider_metadata_map: dict[str, dict] = field(default_factory=dict)
     _sequence_number: int = 0
@@ -67,9 +68,19 @@ class OpenAIResponsesStreamContext(StreamContext):
         ctx._tool_call_types = base._tool_call_types
         if hasattr(base, "passthrough_output_items"):
             ctx.passthrough_output_items = base.passthrough_output_items
+        if hasattr(base, "message_item_metadata"):
+            ctx.message_item_metadata = base.message_item_metadata
         if hasattr(base, "tool_call_provider_metadata_map"):
             ctx.tool_call_provider_metadata_map = base.tool_call_provider_metadata_map
         return ctx
+
+    def register_message_item_metadata(self, item: dict) -> None:
+        """Remember Responses message output item metadata for round-trip."""
+        if item_id := item.get("id"):
+            self.item_id = item_id
+        for key, value in item.items():
+            if key not in {"content", "status"}:
+                self.message_item_metadata[key] = value
 
     def register_tool_call_item(self, tool_call_id: str, item_id: str) -> None:
         """Register tool call item with reverse item_id mapping.

--- a/src/llm_rosetta/converters/openai_responses/stream_context.py
+++ b/src/llm_rosetta/converters/openai_responses/stream_context.py
@@ -33,6 +33,7 @@ class OpenAIResponsesStreamContext(StreamContext):
     accumulated_text: str = ""
     content_part_done_emitted: bool = False
     passthrough_output_items: list[dict] = field(default_factory=list)
+    tool_call_provider_metadata_map: dict[str, dict] = field(default_factory=dict)
     _sequence_number: int = 0
 
     @classmethod
@@ -66,6 +67,8 @@ class OpenAIResponsesStreamContext(StreamContext):
         ctx._tool_call_types = base._tool_call_types
         if hasattr(base, "passthrough_output_items"):
             ctx.passthrough_output_items = base.passthrough_output_items
+        if hasattr(base, "tool_call_provider_metadata_map"):
+            ctx.tool_call_provider_metadata_map = base.tool_call_provider_metadata_map
         return ctx
 
     def register_tool_call_item(self, tool_call_id: str, item_id: str) -> None:
@@ -94,3 +97,14 @@ class OpenAIResponsesStreamContext(StreamContext):
                 self.passthrough_output_items[idx] = dict(item)
                 return
         self.passthrough_output_items.append(dict(item))
+
+    def register_tool_call_provider_metadata(
+        self, tool_call_id: str, metadata: dict
+    ) -> None:
+        """Remember provider metadata for a Responses tool call item."""
+        if tool_call_id and metadata:
+            self.tool_call_provider_metadata_map[tool_call_id] = dict(metadata)
+
+    def get_tool_call_provider_metadata(self, tool_call_id: str) -> dict:
+        """Return provider metadata for a Responses tool call item."""
+        return self.tool_call_provider_metadata_map.get(tool_call_id, {})

--- a/src/llm_rosetta/converters/openai_responses/utils.py
+++ b/src/llm_rosetta/converters/openai_responses/utils.py
@@ -51,19 +51,22 @@ def build_message_preamble_events(
         Two-element list of SSE event dicts.
     """
     context.output_item_emitted = True
-    item_id = generate_message_id(context.response_id)
+    item_id = context.item_id or generate_message_id(context.response_id)
     context.item_id = item_id
+    item = {
+        "id": item_id,
+        "type": "message",
+        "role": "assistant",
+        "status": "in_progress",
+        "content": [],
+    }
+    item.update(context.message_item_metadata)
+    item["content"] = []
     return [
         {
             "type": ResponsesEventType.OUTPUT_ITEM_ADDED,
             "output_index": output_index,
-            "item": {
-                "id": item_id,
-                "type": "message",
-                "role": "assistant",
-                "status": "in_progress",
-                "content": [],
-            },
+            "item": item,
         },
         {
             "type": ResponsesEventType.CONTENT_PART_ADDED,

--- a/src/llm_rosetta/types/__init__.py
+++ b/src/llm_rosetta/types/__init__.py
@@ -66,6 +66,7 @@ from .ir import (
     ToolCallDeltaEvent,
     FinishEvent,
     UsageEvent,
+    ProviderPassthroughEvent,
     # Backward compatibility types
     IRInput,
     IRInputSimple,
@@ -131,6 +132,7 @@ __all__ = [
     "ToolCallDeltaEvent",
     "FinishEvent",
     "UsageEvent",
+    "ProviderPassthroughEvent",
     # Backward compatibility types
     "IRInput",
     "IRInputSimple",

--- a/src/llm_rosetta/types/ir/__init__.py
+++ b/src/llm_rosetta/types/ir/__init__.py
@@ -123,6 +123,7 @@ from .stream import (
     ContentBlockStartEvent,
     FinishEvent,
     IRStreamEvent,
+    ProviderPassthroughEvent,
     ReasoningDeltaEvent,
     StreamEndEvent,
     StreamStartEvent,
@@ -238,6 +239,7 @@ __all__ = [
     "ToolCallDeltaEvent",
     "FinishEvent",
     "UsageEvent",
+    "ProviderPassthroughEvent",
     # ========== 向后兼容类型 Backward compatibility types ==========
     "IRInput",
     "IRInputSimple",

--- a/src/llm_rosetta/types/ir/stream.py
+++ b/src/llm_rosetta/types/ir/stream.py
@@ -171,6 +171,19 @@ class UsageEvent(TypedDict):
     usage: Required[UsageInfo]
 
 
+class ProviderPassthroughEvent(TypedDict):
+    """Provider-native stream event that has no portable IR representation.
+
+    This is intentionally opaque. It lets same-format proxy paths preserve
+    provider-specific client-executed items while other providers can ignore
+    the event if they do not know how to render it.
+    """
+
+    type: Required[Literal["provider_passthrough"]]
+    provider: Required[str]
+    payload: Required[dict[str, Any]]
+
+
 # ============================================================================
 # Union type
 # ============================================================================
@@ -186,6 +199,7 @@ IRStreamEvent = Union[
     ToolCallDeltaEvent,
     FinishEvent,
     UsageEvent,
+    ProviderPassthroughEvent,
 ]
 
 # ============================================================================
@@ -203,5 +217,6 @@ __all__ = [
     "ToolCallDeltaEvent",
     "FinishEvent",
     "UsageEvent",
+    "ProviderPassthroughEvent",
     "IRStreamEvent",
 ]

--- a/tests/converters/base/test_conversion_context.py
+++ b/tests/converters/base/test_conversion_context.py
@@ -182,8 +182,8 @@ class TestStreamContextBufferMethods:
 class TestBaseConverterDispatch:
     """Test BaseConverter._TO_P_DISPATCH and dispatch skeleton."""
 
-    def test_dispatch_table_has_10_entries(self):
-        assert len(BaseConverter._TO_P_DISPATCH) == 10
+    def test_dispatch_table_has_11_entries(self):
+        assert len(BaseConverter._TO_P_DISPATCH) == 11
 
     def test_dispatch_table_keys(self):
         expected = {
@@ -197,6 +197,7 @@ class TestBaseConverterDispatch:
             "tool_call_delta",
             "finish",
             "usage",
+            "provider_passthrough",
         }
         assert set(BaseConverter._TO_P_DISPATCH.keys()) == expected
 

--- a/tests/converters/openai_responses/test_converter.py
+++ b/tests/converters/openai_responses/test_converter.py
@@ -191,6 +191,25 @@ class TestOpenAIResponsesConverter:
         result = self.converter.request_from_provider(provider_request)
         assert result["response_format"]["type"] == "json_object"
 
+    def test_request_from_provider_preserves_include_extension(self):
+        """OpenAI Responses include field survives through provider extensions."""
+        provider_request = {
+            "model": "gpt-5.4",
+            "input": "test",
+            "stream": True,
+            "include": ["reasoning.encrypted_content"],
+            "reasoning": {"effort": "low"},
+        }
+
+        ir_request = self.converter.request_from_provider(provider_request)
+        restored, _ = self.converter.request_to_provider(ir_request)
+
+        assert ir_request["provider_extensions"]["include"] == [
+            "reasoning.encrypted_content"
+        ]
+        assert restored["include"] == ["reasoning.encrypted_content"]
+        assert restored["reasoning"] == {"effort": "low"}
+
     def test_request_from_provider_codex_custom_tool_passes_validation(self):
         """End-to-end: a Codex ``"custom"`` apply_patch tool passes IR validation.
 

--- a/tests/converters/openai_responses/test_message_ops.py
+++ b/tests/converters/openai_responses/test_message_ops.py
@@ -480,6 +480,38 @@ class TestOpenAIResponsesMessageOps:
         assert result[0]["type"] == "system_event"
         assert result[0]["event_type"] == "session_start"
 
+    def test_p_tool_search_output_passthrough_round_trip(self):
+        """Codex tool_search_output survives request item conversion."""
+        item = {
+            "type": "tool_search_output",
+            "call_id": "call_123",
+            "status": "completed",
+            "execution": "client",
+            "tools": [
+                {
+                    "type": "namespace",
+                    "name": "multi_agent_v1",
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "spawn_agent",
+                            "parameters": {"type": "object", "properties": {}},
+                        }
+                    ],
+                }
+            ],
+        }
+
+        ir_messages = cast(list[Any], self.message_ops.p_messages_to_ir([item]))
+        assert len(ir_messages) == 1
+        assert ir_messages[0]["role"] == "assistant"
+        assert ir_messages[0]["content"] == []
+        assert ir_messages[0]["metadata"]["custom"]["_passthrough_items"] == [item]
+
+        restored, warnings = self.message_ops.ir_messages_to_p(ir_messages)
+        assert warnings == []
+        assert restored == [item]
+
     def test_p_consecutive_tool_calls_grouped(self):
         """Test consecutive function_call items are grouped into one assistant message."""
         result = cast(

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -666,6 +666,33 @@ class TestStreamResponseFromProviderWithContext:
         assert types[-1] == "stream_end"
         assert ctx.is_ended is True
 
+    def test_response_completed_with_tool_search_sets_tool_calls(self):
+        """tool_search_call in response.completed keeps Codex in the tool loop."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.mark_started()
+        item = {
+            "type": "tool_search_call",
+            "id": "tsc_123",
+            "call_id": "call_123",
+            "status": "completed",
+            "execution": "client",
+            "arguments": {"query": "multi-agent", "limit": 8},
+        }
+        event = {
+            "type": "response.completed",
+            "response": {
+                "status": "completed",
+                "output": [item],
+            },
+        }
+        events = cast(
+            list[Any],
+            self.converter.stream_response_from_provider(event, context=ctx),
+        )
+        finish_events = [e for e in events if e["type"] == "finish"]
+        assert finish_events[0]["finish_reason"]["reason"] == "tool_calls"
+        assert ctx.passthrough_output_items == [item]
+
     def test_response_failed_emits_stream_end(self):
         """response.failed with context emits StreamEndEvent after FinishEvent."""
         ctx = OpenAIResponsesStreamContext()
@@ -741,6 +768,45 @@ class TestStreamResponseFromProviderWithContext:
         }
         events = self.converter.stream_response_from_provider(event)
         assert events == []
+
+    def test_output_item_added_tool_search_passthrough(self):
+        """tool_search_call output items round-trip as provider passthrough."""
+        ctx_from = OpenAIResponsesStreamContext()
+        ctx_to = OpenAIResponsesStreamContext()
+        event = {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "type": "tool_search_call",
+                "id": "tsc_123",
+                "call_id": "call_123",
+                "status": "completed",
+                "execution": "client",
+                "arguments": {
+                    "query": "multi-agent subagent spawn",
+                    "limit": 8,
+                },
+            },
+        }
+
+        events = cast(
+            list[Any],
+            self.converter.stream_response_from_provider(event, context=ctx_from),
+        )
+
+        assert len(events) == 1
+        assert events[0]["type"] == "provider_passthrough"
+        assert events[0]["provider"] == "openai_responses"
+        assert events[0]["payload"] == event
+        assert ctx_from.passthrough_output_items == [event["item"]]
+
+        restored = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(events[0], context=ctx_to),
+        )
+        assert restored["type"] == "response.output_item.added"
+        assert restored["item"]["type"] == "tool_search_call"
+        assert restored["item"]["call_id"] == "call_123"
 
     def test_content_part_added_emits_content_block_start(self):
         """response.content_part.added with context emits ContentBlockStartEvent."""
@@ -1612,3 +1678,69 @@ class TestCustomToolCallStreaming:
         )
         assert restored["type"] == "response.custom_tool_call_input.delta"
         assert restored["delta"] == "search query"
+
+    def test_tool_search_call_stream_round_trip_completed_output(self):
+        """tool_search_call survives streaming provider → IR → provider conversion."""
+        ctx_from = OpenAIResponsesStreamContext()
+        ctx_to = OpenAIResponsesStreamContext()
+
+        tool_search_item = {
+            "type": "tool_search_call",
+            "id": "tsc_123",
+            "call_id": "call_123",
+            "status": "completed",
+            "execution": "client",
+            "arguments": {"query": "multi-agent", "limit": 8},
+        }
+        chunks = [
+            {
+                "type": "response.created",
+                "response": {
+                    "id": "resp_123",
+                    "object": "response",
+                    "model": "gpt-5.5",
+                    "created_at": 123,
+                    "status": "in_progress",
+                    "output": [],
+                },
+            },
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": tool_search_item,
+            },
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_123",
+                    "object": "response",
+                    "model": "gpt-5.5",
+                    "created_at": 123,
+                    "status": "completed",
+                    "output": [tool_search_item],
+                },
+            },
+        ]
+
+        restored_events: list[dict[str, Any]] = []
+        for chunk in chunks:
+            ir_events = cast(
+                list[Any],
+                self.converter.stream_response_from_provider(chunk, context=ctx_from),
+            )
+            for ir_event in ir_events:
+                restored = self.converter.stream_response_to_provider(
+                    ir_event, context=ctx_to
+                )
+                if isinstance(restored, list):
+                    restored_events.extend(cast(list[dict[str, Any]], restored))
+                elif restored:
+                    restored_events.append(cast(dict[str, Any], restored))
+
+        completed = [
+            event
+            for event in restored_events
+            if event.get("type") == "response.completed"
+        ]
+        assert completed
+        assert completed[-1]["response"]["output"] == [tool_search_item]

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -759,8 +759,8 @@ class TestStreamResponseFromProviderWithContext:
         assert events[0]["type"] == "tool_call_start"
         assert ctx.get_tool_name("call_abc") == "get_weather"
 
-    def test_output_item_added_message_emits_no_events(self):
-        """response.output_item.added (message) with context produces no IR events.
+    def test_output_item_added_message_emits_passthrough_with_context(self):
+        """response.output_item.added (message) preserves metadata with context.
 
         The actual content block is signaled by response.content_part.added.
         """
@@ -778,7 +778,10 @@ class TestStreamResponseFromProviderWithContext:
             list[Any],
             self.converter.stream_response_from_provider(event, context=ctx),
         )
-        assert len(events) == 0
+        assert len(events) == 1
+        assert events[0]["type"] == "provider_passthrough"
+        assert ctx.message_item_metadata["type"] == "message"
+        assert ctx.message_item_metadata["role"] == "assistant"
 
     def test_output_item_added_message_without_context_no_events(self):
         """response.output_item.added (message) without context produces no events."""
@@ -1843,6 +1846,112 @@ class TestCustomToolCallStreaming:
         ]
         assert completed
         assert completed[-1]["response"]["output"] == [reasoning_item]
+
+    def test_message_phase_stream_round_trip(self):
+        """Responses message item metadata survives streaming round-trip."""
+        ctx_from = OpenAIResponsesStreamContext()
+        ctx_to = OpenAIResponsesStreamContext()
+
+        chunks = [
+            {
+                "type": "response.created",
+                "response": {
+                    "id": "resp_123",
+                    "object": "response",
+                    "model": "gpt-5.5",
+                    "created_at": 123,
+                    "status": "in_progress",
+                    "output": [],
+                },
+            },
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {
+                    "id": "msg_123",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "phase": "commentary",
+                    "content": [],
+                },
+            },
+            {
+                "type": "response.content_part.added",
+                "item_id": "msg_123",
+                "output_index": 0,
+                "content_index": 0,
+                "part": {"type": "output_text", "text": ""},
+            },
+            {
+                "type": "response.output_text.delta",
+                "item_id": "msg_123",
+                "output_index": 0,
+                "content_index": 0,
+                "delta": "working",
+            },
+            {
+                "type": "response.content_part.done",
+                "item_id": "msg_123",
+                "output_index": 0,
+                "content_index": 0,
+                "part": {"type": "output_text", "text": "working"},
+            },
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_123",
+                    "object": "response",
+                    "model": "gpt-5.5",
+                    "created_at": 123,
+                    "status": "completed",
+                    "output": [
+                        {
+                            "id": "msg_123",
+                            "type": "message",
+                            "role": "assistant",
+                            "phase": "commentary",
+                            "content": [{"type": "output_text", "text": "working"}],
+                        }
+                    ],
+                },
+            },
+        ]
+
+        restored_events: list[dict[str, Any]] = []
+        for chunk in chunks:
+            ir_events = cast(
+                list[Any],
+                self.converter.stream_response_from_provider(chunk, context=ctx_from),
+            )
+            for ir_event in ir_events:
+                restored = self.converter.stream_response_to_provider(
+                    ir_event, context=ctx_to
+                )
+                if isinstance(restored, list):
+                    restored_events.extend(cast(list[dict[str, Any]], restored))
+                elif restored:
+                    restored_events.append(cast(dict[str, Any], restored))
+
+        added = [
+            event
+            for event in restored_events
+            if event.get("type") == "response.output_item.added"
+        ]
+        assert added
+        assert added[0]["item"]["id"] == "msg_123"
+        assert added[0]["item"]["phase"] == "commentary"
+
+        completed = [
+            event
+            for event in restored_events
+            if event.get("type") == "response.completed"
+        ]
+        assert completed
+        output = completed[-1]["response"]["output"]
+        assert output[0]["id"] == "msg_123"
+        assert output[0]["phase"] == "commentary"
+        assert output[0]["content"] == [{"type": "output_text", "text": "working"}]
 
     def test_namespaced_function_call_stream_round_trip(self):
         """Responses namespaced function calls keep namespace and item id."""

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -1744,3 +1744,99 @@ class TestCustomToolCallStreaming:
         ]
         assert completed
         assert completed[-1]["response"]["output"] == [tool_search_item]
+
+    def test_namespaced_function_call_stream_round_trip(self):
+        """Responses namespaced function calls keep namespace and item id."""
+        ctx_from = OpenAIResponsesStreamContext()
+        ctx_to = OpenAIResponsesStreamContext()
+
+        function_item = {
+            "type": "function_call",
+            "id": "fc_123",
+            "call_id": "call_123",
+            "name": "spawn_agent",
+            "namespace": "multi_agent_v1",
+            "arguments": "",
+            "status": "in_progress",
+        }
+        chunks = [
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": function_item,
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_123",
+                "output_index": 0,
+                "delta": '{"agent_type":"default"}',
+            },
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    **function_item,
+                    "arguments": '{"agent_type":"default"}',
+                    "status": "completed",
+                },
+            },
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_123",
+                    "object": "response",
+                    "model": "gpt-5.5",
+                    "created_at": 123,
+                    "status": "completed",
+                    "output": [
+                        {
+                            **function_item,
+                            "arguments": '{"agent_type":"default"}',
+                            "status": "completed",
+                        }
+                    ],
+                },
+            },
+        ]
+
+        restored_events: list[dict[str, Any]] = []
+        for chunk in chunks:
+            ir_events = cast(
+                list[Any],
+                self.converter.stream_response_from_provider(chunk, context=ctx_from),
+            )
+            for ir_event in ir_events:
+                restored = self.converter.stream_response_to_provider(
+                    ir_event, context=ctx_to
+                )
+                if isinstance(restored, list):
+                    restored_events.extend(cast(list[dict[str, Any]], restored))
+                elif restored:
+                    restored_events.append(cast(dict[str, Any], restored))
+
+        added = next(
+            event
+            for event in restored_events
+            if event.get("type") == "response.output_item.added"
+        )
+        assert added["item"]["id"] == "fc_123"
+        assert added["item"]["call_id"] == "call_123"
+        assert added["item"]["namespace"] == "multi_agent_v1"
+
+        done = [
+            event
+            for event in restored_events
+            if event.get("type") == "response.output_item.done"
+        ]
+        assert done
+        assert done[-1]["item"]["id"] == "fc_123"
+        assert done[-1]["item"]["namespace"] == "multi_agent_v1"
+
+        completed = [
+            event
+            for event in restored_events
+            if event.get("type") == "response.completed"
+        ]
+        assert completed
+        assert completed[-1]["response"]["output"][0]["id"] == "fc_123"
+        assert completed[-1]["response"]["output"][0]["namespace"] == "multi_agent_v1"

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -693,6 +693,31 @@ class TestStreamResponseFromProviderWithContext:
         assert finish_events[0]["finish_reason"]["reason"] == "tool_calls"
         assert ctx.passthrough_output_items == [item]
 
+    def test_response_completed_with_reasoning_does_not_set_tool_calls(self):
+        """reasoning output items are preserved without entering tool loop."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.mark_started()
+        item = {
+            "type": "reasoning",
+            "id": "rs_123",
+            "summary": [],
+            "encrypted_content": "encrypted",
+        }
+        event = {
+            "type": "response.completed",
+            "response": {
+                "status": "completed",
+                "output": [item],
+            },
+        }
+        events = cast(
+            list[Any],
+            self.converter.stream_response_from_provider(event, context=ctx),
+        )
+        finish_events = [e for e in events if e["type"] == "finish"]
+        assert finish_events[0]["finish_reason"]["reason"] == "stop"
+        assert ctx.passthrough_output_items == [item]
+
     def test_response_failed_emits_stream_end(self):
         """response.failed with context emits StreamEndEvent after FinishEvent."""
         ctx = OpenAIResponsesStreamContext()
@@ -1744,6 +1769,80 @@ class TestCustomToolCallStreaming:
         ]
         assert completed
         assert completed[-1]["response"]["output"] == [tool_search_item]
+
+    def test_reasoning_stream_round_trip_completed_output(self):
+        """reasoning output items survive streaming provider → IR → provider conversion."""
+        ctx_from = OpenAIResponsesStreamContext()
+        ctx_to = OpenAIResponsesStreamContext()
+
+        reasoning_item = {
+            "type": "reasoning",
+            "id": "rs_123",
+            "summary": [],
+            "encrypted_content": "encrypted",
+        }
+        chunks = [
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": reasoning_item,
+            },
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": reasoning_item,
+            },
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_123",
+                    "object": "response",
+                    "model": "gpt-5.5",
+                    "created_at": 123,
+                    "status": "completed",
+                    "output": [reasoning_item],
+                },
+            },
+        ]
+
+        restored_events: list[dict[str, Any]] = []
+        for chunk in chunks:
+            ir_events = cast(
+                list[Any],
+                self.converter.stream_response_from_provider(chunk, context=ctx_from),
+            )
+            for ir_event in ir_events:
+                restored = self.converter.stream_response_to_provider(
+                    ir_event, context=ctx_to
+                )
+                if isinstance(restored, list):
+                    restored_events.extend(cast(list[dict[str, Any]], restored))
+                elif restored:
+                    restored_events.append(cast(dict[str, Any], restored))
+
+        added = [
+            event
+            for event in restored_events
+            if event.get("type") == "response.output_item.added"
+        ]
+        assert added
+        assert added[0]["item"] == reasoning_item
+
+        done = [
+            event
+            for event in restored_events
+            if event.get("type") == "response.output_item.done"
+        ]
+        assert done
+        assert done[-1]["item"] == reasoning_item
+
+        completed = [
+            event
+            for event in restored_events
+            if event.get("type") == "response.completed"
+        ]
+        assert completed
+        assert completed[-1]["response"]["output"] == [reasoning_item]
 
     def test_namespaced_function_call_stream_round_trip(self):
         """Responses namespaced function calls keep namespace and item id."""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -450,6 +450,24 @@ class TestConversionPipeline:
         assert "messages" in target
         assert target["model"] == "gpt-4"
 
+    def test_convert_request_openai_responses_preserves_include(self):
+        """Responses same-format conversion preserves native include fields."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        pipeline = ConversionPipeline("openai_responses", "openai_responses")
+        target = pipeline.convert_request(
+            {
+                "model": "gpt-5.4",
+                "input": "test",
+                "stream": True,
+                "include": ["reasoning.encrypted_content"],
+                "reasoning": {"effort": "low"},
+            }
+        )
+
+        assert target["include"] == ["reasoning.encrypted_content"]
+        assert target["reasoning"] == {"effort": "low"}
+
     def test_convert_response_openai_to_openai(self):
         """Response round-trip produces valid source response."""
         from llm_rosetta.pipeline import ConversionPipeline


### PR DESCRIPTION
## Summary

- Preserve OpenAI Responses-native passthrough output items (`tool_search_call`, `tool_search_output`, reasoning, and function-call metadata) when converting OpenAI Responses → IR → OpenAI Responses.
- Keep Codex-specific function call identity intact, including namespaced tool names, item IDs, `call_id`, and argument fragments across streaming and request round trips.
- Track the Responses message phase so generated items remain distinguishable from final output, allowing clients to collapse `worked_for`/reasoning-style output correctly.

This PR intentionally does not include the later `User-Agent` passthrough fix; it is scoped to OpenAI Responses conversion behavior.

## Context

Codex drives agent loops through Responses-native stream items that do not always have a portable IR equivalent. Before this change, the same-format gateway path dropped or flattened several of those items:

1. `tool_search_call` / `tool_search_output` items could disappear from the stream and follow-up request history, causing the client to see a completed assistant message instead of continuing the tool loop.
2. Function-call stream items lost Responses-native identity such as item IDs and namespaced names, which broke deferred tool/subagent calls.
3. Reasoning/output phase metadata could be flattened, so intermediate `worked_for`-style content was rendered as normal final output instead of being collapsible.

The fix adds an explicit `provider_passthrough` stream event for provider-native chunks with no portable representation, records passthrough output items in the Responses stream context, and re-emits those items on the same-format Responses path. It also preserves the small amount of metadata needed for request-history round trips.

### Screenshots

Direct symptoms observed through the gateway:

Loop Failure
![Loop stops after one answer](https://raw.githubusercontent.com/iBobbyTS/llm-rosetta/pr-assets/openai-responses-codex-passthrough/.github/pr-assets/openai-responses-codex-passthrough/loop-failure.jpeg)

Tool not passing through
![Tool passthrough issue](https://raw.githubusercontent.com/iBobbyTS/llm-rosetta/pr-assets/openai-responses-codex-passthrough/.github/pr-assets/openai-responses-codex-passthrough/tool-passthrough.jpeg)

"Worked for" section doesn't collapse
![Worked_for output not folded](https://raw.githubusercontent.com/iBobbyTS/llm-rosetta/pr-assets/openai-responses-codex-passthrough/.github/pr-assets/openai-responses-codex-passthrough/worked-for-collapse.jpeg)

## Test plan

- [x] `PATH=/Users/ibobby/miniconda3/envs/llm-rosetta/bin:$PATH make lint`
- [x] `/Users/ibobby/miniconda3/envs/llm-rosetta/bin/python -m pytest tests/converters/openai_responses tests/converters/base/test_conversion_context.py tests/test_pipeline.py -q` — 416 passed
- [ ] `PATH=/Users/ibobby/miniconda3/envs/llm-rosetta/bin:$PATH make test` — currently blocked in this local Python 3.14 environment by existing `tests/gateway/test_auth.py` failures using `asyncio.get_event_loop()` with no current event loop. This was reproduced on the fork point (`origin/master`) as well.

AI was used to assist with implementation and validation; I reviewed the resulting changes and tests.
