### PR TITLE
fix: preserve upstream user agent

### DIFF
--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -18,6 +18,7 @@ from llm_rosetta.auto_detect import ProviderType
 from .auth import AuthState, api_key_label_var, create_auth_hook
 from .config import GatewayConfig
 from .embeddings import handle_embeddings as _handle_embeddings
+from .headers import build_upstream_extra_headers
 from .logging import get_logger
 from llm_rosetta.observability.error_dump import dump_error
 
@@ -250,11 +251,8 @@ async def _proxy_handler(
 
     store: ProviderMetadataStore = request.app.metadata_store
 
-    # Forward OpenResponses-Version header and request ID to upstream if present
-    extra_headers: dict[str, str] = {"x-request-id": request_id}
-    or_version = request.headers.get("openresponses-version")
-    if or_version:
-        extra_headers["OpenResponses-Version"] = or_version
+    # Forward only explicitly supported client headers to upstream.
+    extra_headers = build_upstream_extra_headers(request, request_id)
 
     # --- Metrics instrumentation ---
     if is_stream:

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -16,6 +16,7 @@ from typing import Any
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
 from .config import GatewayConfig
+from .headers import build_upstream_extra_headers
 from .logging import get_logger
 from .transport import UpstreamConnectionError, UpstreamTransport
 
@@ -87,13 +88,20 @@ async def handle_embeddings(
     # --- Forward via transport ---
     upstream_url = f"{provider_info.base_url}/embeddings"
     transport: UpstreamTransport = request.app.transport
+    request_id = request.headers.get("x-request-id", "")
+    extra_headers = build_upstream_extra_headers(request, request_id)
 
     t0 = time.monotonic()
     status_code = 500
     error_detail: str | None = None
 
     try:
-        resp = await transport.send_passthrough(provider_info, upstream_url, body)
+        resp = await transport.send_passthrough(
+            provider_info,
+            upstream_url,
+            body,
+            extra_headers=extra_headers,
+        )
         status_code = resp.status_code
 
         if resp.is_error:

--- a/src/llm_rosetta/gateway/headers.py
+++ b/src/llm_rosetta/gateway/headers.py
@@ -1,0 +1,23 @@
+"""Helpers for gateway request header forwarding."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_upstream_extra_headers(request: Any, request_id: str) -> dict[str, str]:
+    """Build the explicit request headers that may be forwarded upstream."""
+    extra_headers: dict[str, str] = {}
+
+    if request_id:
+        extra_headers["x-request-id"] = request_id
+
+    user_agent = request.headers.get("user-agent")
+    if user_agent:
+        extra_headers["User-Agent"] = user_agent
+
+    or_version = request.headers.get("openresponses-version")
+    if or_version:
+        extra_headers["OpenResponses-Version"] = or_version
+
+    return extra_headers

--- a/tests/gateway/test_app_headers.py
+++ b/tests/gateway/test_app_headers.py
@@ -1,0 +1,73 @@
+"""Tests for upstream header forwarding from gateway handlers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import llm_rosetta.gateway.app as app_module
+from llm_rosetta._vendor.httpserver import JSONResponse
+from llm_rosetta.gateway.headers import build_upstream_extra_headers
+from llm_rosetta.routing import ResolvedRoute
+
+
+def test_build_upstream_extra_headers_preserves_user_agent_and_responses_version():
+    """Only explicitly supported client headers should be forwarded upstream."""
+    request = MagicMock()
+    request.headers = {
+        "user-agent": "codex-cli/1.2.3",
+        "openresponses-version": "2025-06-18",
+        "authorization": "Bearer client-key",
+    }
+
+    headers = build_upstream_extra_headers(request, "req-123")
+
+    assert headers == {
+        "x-request-id": "req-123",
+        "User-Agent": "codex-cli/1.2.3",
+        "OpenResponses-Version": "2025-06-18",
+    }
+
+
+def test_proxy_handler_forwards_user_agent_to_non_streaming_proxy(monkeypatch):
+    """The main proxy handler should pass client User-Agent to the upstream call."""
+    captured_headers: dict[str, str] = {}
+
+    class _Config:
+        models = {"gpt-test": "test-provider"}
+
+        def resolve(self, source_provider: str, model: str):
+            return (
+                ResolvedRoute(
+                    source_provider=source_provider,
+                    target_provider="openai_chat",
+                    provider_name="test-provider",
+                ),
+                MagicMock(),
+            )
+
+    async def _fake_handle_non_streaming(*args: Any, **kwargs: Any):
+        captured_headers.update(kwargs["extra_headers"])
+        return JSONResponse({"ok": True}), {}
+
+    monkeypatch.setattr(app_module, "_config", _Config())
+    monkeypatch.setattr(app_module, "handle_non_streaming", _fake_handle_non_streaming)
+
+    request = MagicMock()
+    request.headers = {"user-agent": "codex-cli/1.2.3"}
+    request.json.return_value = {
+        "model": "gpt-test",
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    request.app.metadata_store = MagicMock()
+    request.app.metrics = None
+    request.app.request_log = None
+    request.app.persistence = None
+    request.app.profiler_state = None
+
+    response = asyncio.run(app_module._proxy_handler(request, "openai_chat"))
+
+    assert response.status_code == 200
+    assert captured_headers["User-Agent"] == "codex-cli/1.2.3"
+    assert "x-request-id" in captured_headers

--- a/tests/gateway/test_embeddings.py
+++ b/tests/gateway/test_embeddings.py
@@ -7,12 +7,13 @@ import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from llm_rosetta.gateway.config import GatewayConfig
 from llm_rosetta.gateway.embeddings import handle_embeddings
+from llm_rosetta.gateway.transport._base import UpstreamResponse
 from llm_rosetta.gateway.transport.http import HttpTransport
 
 
@@ -91,11 +92,15 @@ def _make_config(base_url: str, upstream_model: str | None = None) -> GatewayCon
     return GatewayConfig(raw)
 
 
-def _make_request(body: dict[str, Any]) -> MagicMock:
+def _make_request(
+    body: dict[str, Any],
+    *,
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
     """Create a mock HTTP request with the given JSON body."""
     req = MagicMock()
     req.json.return_value = body
-    req.headers = {}
+    req.headers = headers or {}
 
     # Provide app-level attributes that handle_embeddings accesses
     app = MagicMock()
@@ -140,3 +145,25 @@ class TestEmbeddingUpstreamModel:
 
         body = json.loads(response.body)
         assert body["model"] == "my-embed"
+
+    def test_user_agent_forwarded_to_passthrough_transport(self):
+        """Embeddings passthrough should preserve the client's User-Agent."""
+        config = _make_config("https://api.example.com/v1")
+        request = _make_request(
+            {"model": "my-embed", "input": "hello"},
+            headers={"user-agent": "codex-cli/1.2.3"},
+        )
+        request.app.transport = MagicMock()
+        request.app.transport.send_passthrough = AsyncMock(
+            return_value=UpstreamResponse(
+                status_code=200,
+                body={"object": "list", "data": [], "model": "my-embed"},
+                raw_content=b'{"object":"list","data":[],"model":"my-embed"}',
+            )
+        )
+
+        response = asyncio.run(handle_embeddings(request, config))
+
+        assert response.status_code == 200
+        _, kwargs = request.app.transport.send_passthrough.call_args
+        assert kwargs["extra_headers"]["User-Agent"] == "codex-cli/1.2.3"


### PR DESCRIPTION
## Summary

- Preserve the client `User-Agent` header when forwarding gateway requests upstream.
- Centralize the small upstream-header whitelist in `gateway.headers` so proxy and passthrough endpoints use the same behavior.
- Apply the same header forwarding to `/v1/embeddings` passthrough requests.

## Context

The gateway already had an `extra_headers` path through the proxy and transport layers, but the application handlers only populated `x-request-id` and `OpenResponses-Version`. As a result, upstream providers saw the transport/client default user agent instead of the SDK or agent user agent from the incoming request.

This keeps the forwarding explicit rather than proxying arbitrary request headers. The whitelist remains limited to `x-request-id`, `User-Agent`, and `OpenResponses-Version`.

## Test plan

- [x] `/Users/ibobby/miniconda3/envs/llm-rosetta/bin/python -m pytest tests/gateway/test_app_headers.py tests/gateway/test_embeddings.py -q` — 5 passed
- [x] `PATH=/Users/ibobby/miniconda3/envs/llm-rosetta/bin:$PATH make lint`
- [ ] `PATH=/Users/ibobby/miniconda3/envs/llm-rosetta/bin:$PATH make test` — currently blocked in this local Python 3.14 environment by existing `tests/gateway/test_auth.py` failures using `asyncio.get_event_loop()` with no current event loop. This was reproduced on the fork point (`origin/master`) as well.

AI was used to assist with implementation and validation; I reviewed the resulting changes and tests.
