### PR TITLE
feat: add error detail log toggle to settings popup

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -728,6 +728,13 @@ body { padding-bottom: 26px; }
         <span data-i18n="label.enabled">Enabled</span>
       </label>
     </div>
+    <div class="settings-popup-item">
+      <label data-i18n="label.errorDumps">Error Detail Log</label>
+      <label class="toggle-label">
+        <input type="checkbox" id="settingsErrorDumps" onchange="saveSettingsField('errorDumps',this.checked)">
+        <span data-i18n="label.enabled">Enabled</span>
+      </label>
+    </div>
     <div class="settings-divider"></div>
     <!-- Log Retention -->
     <div class="settings-section-title" data-i18n="label.logRetention">Log Retention</div>
@@ -1068,7 +1075,7 @@ const I18N = {
     'label.globalProxy.hint':'Applies to all providers unless overridden per-provider.',
     'btn.save':'Save', 'btn.copy':'Copy', 'btn.change':'Change', 'modal.settings':'Settings', 'label.theme':'Theme', 'label.language':'Language', 'theme.light':'Light', 'theme.dark':'Dark', 'btn.cancel':'Cancel', 'btn.close':'Close',
     'label.logLevel':'Log Level', 'logLevel.normal':'Normal', 'logLevel.verbose':'Verbose', 'logLevel.debug':'Debug (bodies)',
-    'label.autoRefresh':'Auto-Refresh', 'label.off':'Off', 'label.credentialReveal':'Credential Reveal', 'label.enabled':'Enabled',
+    'label.autoRefresh':'Auto-Refresh', 'label.off':'Off', 'label.credentialReveal':'Credential Reveal', 'label.errorDumps':'Error Detail Log', 'label.enabled':'Enabled',
     'label.logRetention':'Log Retention', 'label.successMax':'Success', 'label.errorMax':'Error',
     'label.adminToken':'Admin Token', 'label.rotatingIn':'Rotating in <span class="cd-time">{time}</span>',
     'label.changePassword':'Change Password', 'label.currentPw':'Current', 'label.newPw':'New', 'label.confirmPw':'Confirm',
@@ -1192,7 +1199,7 @@ const I18N = {
     'modal.settings':'\u8bbe\u7f6e', 'label.theme':'\u4e3b\u9898', 'label.language':'\u8bed\u8a00', 'theme.light':'\u6d45\u8272', 'theme.dark':'\u6df1\u8272',
     'btn.save':'\u4fdd\u5b58', 'btn.copy':'\u590d\u5236', 'btn.change':'\u4fee\u6539', 'btn.cancel':'\u53d6\u6d88', 'btn.close':'\u5173\u95ed',
     'label.logLevel':'\u65e5\u5fd7\u7ea7\u522b', 'logLevel.normal':'\u6b63\u5e38', 'logLevel.verbose':'\u8be6\u7ec6', 'logLevel.debug':'\u8c03\u8bd5 (\u542b\u8bf7\u6c42\u4f53)',
-    'label.autoRefresh':'\u81ea\u52a8\u5237\u65b0', 'label.off':'\u5173\u95ed', 'label.credentialReveal':'\u51ed\u8bc1\u53ef\u89c1', 'label.enabled':'\u5df2\u542f\u7528',
+    'label.autoRefresh':'\u81ea\u52a8\u5237\u65b0', 'label.off':'\u5173\u95ed', 'label.credentialReveal':'\u51ed\u8bc1\u53ef\u89c1', 'label.errorDumps':'\u9519\u8bef\u8be6\u60c5\u8bb0\u5f55', 'label.enabled':'\u5df2\u542f\u7528',
     'label.logRetention':'\u65e5\u5fd7\u4fdd\u7559', 'label.successMax':'\u6210\u529f', 'label.errorMax':'\u5931\u8d25',
     'label.adminToken':'\u7ba1\u7406 Token', 'label.rotatingIn':'<span class="cd-time">{time}</span> \u540e\u8f6e\u6362',
     'label.changePassword':'\u4fee\u6539\u5bc6\u7801', 'label.currentPw':'\u5f53\u524d\u5bc6\u7801', 'label.newPw':'\u65b0\u5bc6\u7801', 'label.confirmPw':'\u786e\u8ba4\u5bc6\u7801',
@@ -1448,6 +1455,8 @@ function openSettings() {
   // Sync credential visibility
   const cv = document.getElementById('settingsCredentialVisible');
   if (cv) cv.checked = _credentialVisible;
+  const ed = document.getElementById('settingsErrorDumps');
+  if (ed) ed.checked = configData?.debug?.error_dumps !== false;
   // Sync log retention
   if (configData?.server?.request_log) {
     const sm = document.getElementById('settingsSuccessMax');
@@ -1478,6 +1487,8 @@ async function saveSettingsField(field, value) {
     body.log_bodies = (value === 'debug');
   } else if (field === 'credentialVisible') {
     body.credential_visible = value;
+  } else if (field === 'errorDumps') {
+    body.error_dumps = value;
   }
   try {
     await api.put('/admin/api/config/server', body);

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -552,6 +552,8 @@ async def put_server_settings(request: Any) -> Response:
         debug["verbose"] = bool(body["verbose"])
     if "log_bodies" in body:
         debug["log_bodies"] = bool(body["log_bodies"])
+    if "error_dumps" in body:
+        debug["error_dumps"] = bool(body["error_dumps"])
 
     try:
         write_config(config_path, data)

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -268,7 +268,9 @@ async def _proxy_handler(
     profile: dict[str, Any] | None = None
     request_log = getattr(request.app, "request_log", None)
 
-    persistence = getattr(request.app, "persistence", None)
+    # Error dump persistence — pass None to disable dump_error in handlers
+    _raw_persistence = getattr(request.app, "persistence", None)
+    persistence = _raw_persistence if _config.error_dumps_enabled else None
     deep_profiler = _try_start_profiler(request.app)
 
     try:

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -268,9 +268,11 @@ async def _proxy_handler(
     profile: dict[str, Any] | None = None
     request_log = getattr(request.app, "request_log", None)
 
-    # Error dump persistence — pass None to disable dump_error in handlers
-    _raw_persistence = getattr(request.app, "persistence", None)
-    persistence = _raw_persistence if _config.error_dumps_enabled else None
+    persistence = getattr(request.app, "persistence", None)
+    # Only pass persistence to dump_error when error dumps are enabled.
+    # Use a separate local so `persistence` stays available for future uses
+    # in this path without being affected by this toggle.
+    _error_persistence = persistence if _config.error_dumps_enabled else None
     deep_profiler = _try_start_profiler(request.app)
 
     try:
@@ -288,7 +290,7 @@ async def _proxy_handler(
                 extra_headers=extra_headers,
                 entry_id=pre_entry_id,
                 request_log=request_log,
-                persistence=persistence,
+                persistence=_error_persistence,
             )
         else:
             pre_entry_id = None
@@ -299,7 +301,7 @@ async def _proxy_handler(
                 transport=request.app.transport,
                 metadata_store=store,
                 extra_headers=extra_headers,
-                persistence=persistence,
+                persistence=_error_persistence,
             )
         status_code = response.status_code
         if status_code >= 400 and hasattr(response, "body"):
@@ -315,7 +317,7 @@ async def _proxy_handler(
         status_code = 500
         pre_entry_id = None
         dump_error(
-            persistence,
+            _error_persistence,
             request_body=body,
             response_text=error_detail,
             model=model,

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -209,6 +209,7 @@ class GatewayConfig:
         self.log_bodies: bool = _debug.get("log_bodies", False) or os.environ.get(
             "LLM_ROSETTA_LOG_BODIES", ""
         ).lower() in ("1", "true", "yes")
+        self.error_dumps_enabled: bool = _debug.get("error_dumps", True)
 
         self._validate()
 


### PR DESCRIPTION
## Summary

Adds a toggle in Settings → "Error Detail Log" to control whether upstream error details are written to SQLite. Default: enabled (preserves current behavior).

## Changes

| File | Change |
|------|--------|
| `gateway/config.py` | `debug.error_dumps` config field (default `true`) |
| `gateway/app.py` | Pass `persistence=None` to handlers when disabled |
| `gateway/admin/routes/config.py` | `PUT /admin/api/config/server` accepts `error_dumps` |
| `gateway/admin/admin.html` | Toggle checkbox + i18n (en: "Error Detail Log", zh: "错误详情记录") |

4 files, +19/-3 lines. Single commit.

## Test plan

- [x] `ruff check` + `ruff format` + `ty check` pass
- [x] 2062 tests pass
- [x] Local instance: toggle renders in settings popup