### PR TITLE
refactor: unify system_instruction to list[TextPart]

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -21,6 +21,7 @@ from typing import Any, cast
 from ...types.ir import (
     ExtensionItem,
     Message,
+    TextPart,
     is_text_part,
     is_tool_call_part,
     is_reasoning_part,
@@ -98,25 +99,28 @@ class AnthropicConverter(BaseConverter):
         result: dict[str, Any] = {"model": ir_request["model"]}
 
         # 1. System instruction → top-level system parameter
-        system_instruction = ir_request.get("system_instruction")
-        if system_instruction:
-            result["system"] = system_instruction
+        # system_instruction is list[TextPart]; convert via content_ops
+        # so each block's metadata (e.g. cache_hint) is preserved.
+        system_parts = ir_request.get("system_instruction")
+        if system_parts:
+            result["system"] = self.message_ops._ir_system_to_p(system_parts)
 
         # 2. Messages — fix orphaned tool_calls/results at IR level before
         #    conversion.  Anthropic strictly requires bidirectional pairing.
         ir_messages = fix_orphaned_tool_calls_ir(ir_request.get("messages", []))
         ctx.warnings.extend(strip_orphaned_tool_config(ir_request))
 
-        # Extract system messages from message list
-        for item in ir_messages:
-            if isinstance(item, dict) and item.get("role") == "system":
-                content = item.get("content", [])
-                text_parts = []
-                for part in content:
-                    if is_text_part(part):
-                        text_parts.append(part["text"])
-                if text_parts and "system" not in result:
-                    result["system"] = " ".join(text_parts)
+        # Extract system messages from ir_messages (cross-format path:
+        # other converters may put system in ir_messages instead of
+        # system_instruction).  ir_messages_to_p skips system role, so
+        # we handle them here.
+        if "system" not in result:
+            for item in ir_messages:
+                if isinstance(item, dict) and item.get("role") == "system":
+                    content = item.get("content", [])
+                    if content:
+                        result["system"] = self.message_ops._ir_system_to_p(content)
+                    break
 
         message_kwargs: dict[str, Any] = {}
         if ctx and "reasoning_cap" in ctx.options:
@@ -189,18 +193,20 @@ class AnthropicConverter(BaseConverter):
             "messages": [],
         }
 
-        # 1. System instruction
+        # 1. System instruction → list[TextPart]
         system_content = provider_request.get("system")
         if system_content:
             if isinstance(system_content, str):
-                ir_request["system_instruction"] = system_content
+                ir_request["system_instruction"] = [
+                    TextPart(type="text", text=system_content)
+                ]
             elif isinstance(system_content, list):
-                text_parts = []
+                ir_parts = []
                 for part in system_content:
                     if isinstance(part, dict) and part.get("type") == "text":
-                        text_parts.append(part["text"])
-                if text_parts:
-                    ir_request["system_instruction"] = " ".join(text_parts)
+                        ir_parts.append(self.content_ops.p_text_to_ir(part))
+                if ir_parts:
+                    ir_request["system_instruction"] = ir_parts
 
         # 2. Messages
         messages = provider_request.get("messages", [])

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -24,6 +24,7 @@ from ...types.ir import (
     ExtensionItem,
     IRInput,
     Message,
+    TextPart,
     ToolChoice,
     ToolDefinition,
     is_message,
@@ -224,12 +225,7 @@ class GoogleGenAIConverter(BaseConverter):
         result: dict[str, Any] = {"model": ir_request["model"]}
 
         # 1. Handle system_instruction
-        system_instruction = None
-
-        # From IRRequest.system_instruction field
-        ir_system = ir_request.get("system_instruction")
-        if ir_system:
-            system_instruction = {"role": "user", "parts": [{"text": ir_system}]}
+        system_instruction = self._build_system_instruction(ir_request)
 
         # 2. Handle messages — fix orphaned tool_calls/results and strip
         #    orphaned tool_choice/tool_config at IR level before conversion.
@@ -613,19 +609,31 @@ class GoogleGenAIConverter(BaseConverter):
         return usage_metadata
 
     @staticmethod
-    def _parse_system_instruction(system_instruction: Any) -> str | None:
-        """Parse Google GenAI system_instruction to plain text."""
+    def _build_system_instruction(ir_request: Any) -> dict[str, Any] | None:
+        """Build Google system_instruction Content from IR system_instruction.
+
+        Converts IR list[TextPart] to Google's Content format:
+        ``{"role": "user", "parts": [{"text": "..."}]}``.
+        """
+        system_parts = ir_request.get("system_instruction")
+        if not system_parts:
+            return None
+        parts = [{"text": p["text"]} for p in system_parts if is_text_part(p)]
+        return {"role": "user", "parts": parts} if parts else None
+
+    @staticmethod
+    def _parse_system_instruction(system_instruction: Any) -> list[TextPart] | None:
+        """Parse Google GenAI system_instruction to list[TextPart]."""
         if isinstance(system_instruction, str):
-            return system_instruction
+            return [TextPart(type="text", text=system_instruction)]
         if isinstance(system_instruction, dict):
             parts = system_instruction.get("parts", [])
             text_parts = [
-                part["text"]
+                TextPart(type="text", text=part["text"])
                 for part in parts
                 if isinstance(part, dict) and "text" in part
             ]
-            if text_parts:
-                return " ".join(text_parts)
+            return text_parts or None
         return None
 
     def messages_to_provider(

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -87,13 +87,15 @@ class OpenAIChatConverter(BaseConverter):
         ctx = context if context is not None else ConversionContext()
         result: dict[str, Any] = {"model": ir_request["model"]}
 
-        # 1. System instruction → system message
-        # system_instruction is list[TextPart]; convert via content_ops
+        # 1. System instruction → system message (plain string)
+        # OpenAI Chat system messages use plain string content for maximum
+        # downstream compatibility (some consumers don't handle array form).
         messages: list[dict[str, Any]] = []
         system_parts = ir_request.get("system_instruction")
         if system_parts:
-            content = [self.content_ops.ir_text_to_p(p) for p in system_parts]
-            messages.append({"role": "system", "content": content})
+            system_text = " ".join(p["text"] for p in system_parts if is_text_part(p))
+            if system_text:
+                messages.append({"role": "system", "content": system_text})
 
         # 2. Messages — fix orphaned tool_calls at IR level before conversion.
         # OpenAI Chat API strictly requires every tool_call_id to have a

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 from ...types.ir import (
     ExtensionItem,
     Message,
+    TextPart,
     is_citation_part,
     is_reasoning_part,
     is_refusal_part,
@@ -87,10 +88,12 @@ class OpenAIChatConverter(BaseConverter):
         result: dict[str, Any] = {"model": ir_request["model"]}
 
         # 1. System instruction → system message
+        # system_instruction is list[TextPart]; convert via content_ops
         messages: list[dict[str, Any]] = []
-        system_instruction = ir_request.get("system_instruction")
-        if system_instruction:
-            messages.append({"role": "system", "content": system_instruction})
+        system_parts = ir_request.get("system_instruction")
+        if system_parts:
+            content = [self.content_ops.ir_text_to_p(p) for p in system_parts]
+            messages.append({"role": "system", "content": content})
 
         # 2. Messages — fix orphaned tool_calls at IR level before conversion.
         # OpenAI Chat API strictly requires every tool_call_id to have a
@@ -271,32 +274,32 @@ class OpenAIChatConverter(BaseConverter):
 
     def _extract_system_and_messages(
         self, messages: list[Any]
-    ) -> tuple[list[dict[str, Any]], str | None]:
+    ) -> tuple[list[dict[str, Any]], list[TextPart] | None]:
         """Split system messages from user/assistant messages.
 
         Returns:
-            Tuple of (non-system IR messages, system text or None).
+            Tuple of (non-system IR messages, system parts or None).
         """
         ir_messages: list[dict[str, Any]] = []
-        system_text: str | None = None
+        system_parts: list[TextPart] | None = None
         for msg in messages:
             if isinstance(msg, dict) and msg.get("role") == "system":
                 content = msg.get("content", "")
                 if isinstance(content, str):
-                    system_text = content
+                    system_parts = [TextPart(type="text", text=content)]
                 elif isinstance(content, list):
-                    text_parts = [
-                        part["text"]
+                    parts = [
+                        TextPart(type="text", text=part["text"])
                         for part in content
                         if isinstance(part, dict) and part.get("type") == "text"
                     ]
-                    if text_parts:
-                        system_text = " ".join(text_parts)
+                    if parts:
+                        system_parts = parts
             else:
                 converted = self.message_ops._p_message_to_ir(msg)
                 if converted:
                     ir_messages.append(converted)
-        return ir_messages, system_text
+        return ir_messages, system_parts
 
     def request_from_provider(
         self,
@@ -322,10 +325,10 @@ class OpenAIChatConverter(BaseConverter):
 
         # 1. Messages - separate system messages as system_instruction
         messages = provider_request.get("messages", [])
-        ir_messages, system_text = self._extract_system_and_messages(messages)
+        ir_messages, system_parts = self._extract_system_and_messages(messages)
         ir_request["messages"] = ir_messages
-        if system_text:
-            ir_request["system_instruction"] = system_text
+        if system_parts:
+            ir_request["system_instruction"] = system_parts
 
         # 2. Tools (with process-level cache)
         tools = provider_request.get("tools")

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -16,6 +16,7 @@ from typing import Any, cast
 from ...types.ir import (
     ExtensionItem,
     Message,
+    TextPart,
     is_text_part,
     is_tool_call_part,
     is_reasoning_part,
@@ -106,10 +107,12 @@ class OpenAIResponsesConverter(BaseConverter):
         ctx = context if context is not None else ConversionContext()
         result: dict[str, Any] = {"model": ir_request["model"]}
 
-        # 1. System instruction → instructions field
-        system_instruction = ir_request.get("system_instruction")
-        if system_instruction:
-            result["instructions"] = system_instruction
+        # 1. System instruction → instructions field (plain string)
+        system_parts = ir_request.get("system_instruction")
+        if system_parts:
+            result["instructions"] = " ".join(
+                p["text"] for p in system_parts if is_text_part(p)
+            )
 
         # 2. Messages → input items — fix orphaned tool_calls at IR level
         # before conversion.  OpenAI Responses API strictly requires every
@@ -187,10 +190,12 @@ class OpenAIResponsesConverter(BaseConverter):
             "messages": [],
         }
 
-        # 1. Instructions → system_instruction
+        # 1. Instructions → system_instruction (list[TextPart])
         instructions = provider_request.get("instructions")
         if instructions:
-            ir_request["system_instruction"] = instructions
+            ir_request["system_instruction"] = [
+                TextPart(type="text", text=instructions)
+            ]
 
         # 2. Input items → messages
         input_items = provider_request.get("input", [])

--- a/src/llm_rosetta/types/ir/request.py
+++ b/src/llm_rosetta/types/ir/request.py
@@ -26,6 +26,7 @@ from .configs import (
     StreamConfig,
 )
 from .messages import Message
+from .parts import TextPart
 from .tools import ToolCallConfig, ToolChoice, ToolDefinition
 
 # ============================================================================
@@ -63,7 +64,12 @@ class IRRequest(TypedDict):
     # - OpenAI Responses: instructions
     # - Anthropic: system
     # - Google: config.system_instruction
-    system_instruction: NotRequired[str]
+    #
+    # Canonical form is list[TextPart].  A single string "You are helpful."
+    # is represented as [TextPart(type="text", text="You are helpful.")].
+    # This ensures consistent structure across all converters and allows
+    # block-level metadata (e.g. cache_hint) to flow through the pipeline.
+    system_instruction: NotRequired[list[TextPart]]
 
     # ========== 工具相关 Tool Related ==========
     tools: NotRequired[list[ToolDefinition]]

--- a/tests/converters/anthropic/test_converter.py
+++ b/tests/converters/anthropic/test_converter.py
@@ -52,10 +52,14 @@ class TestAnthropicConverter:
             "messages": [
                 {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}
             ],
-            "system_instruction": "You are a helpful assistant.",
+            "system_instruction": [
+                {"type": "text", "text": "You are a helpful assistant."}
+            ],
         }
         result, warnings = self.converter.request_to_provider(ir_request)
-        assert result["system"] == "You are a helpful assistant."
+        assert result["system"] == [
+            {"type": "text", "text": "You are a helpful assistant."}
+        ]
 
     def test_request_with_system_message_in_messages(self):
         """Test system message in messages list is extracted."""
@@ -70,7 +74,7 @@ class TestAnthropicConverter:
             ],
         }
         result, warnings = self.converter.request_to_provider(ir_request)
-        assert result["system"] == "Be helpful."
+        assert result["system"] == [{"type": "text", "text": "Be helpful."}]
         # System message should not be in messages list
         assert all(m["role"] != "system" for m in result["messages"])
 
@@ -223,7 +227,9 @@ class TestAnthropicConverter:
             "messages": [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}],
         }
         ir_request = self.converter.request_from_provider(provider_request)
-        assert ir_request["system_instruction"] == "You are helpful."
+        assert ir_request["system_instruction"] == [
+            {"type": "text", "text": "You are helpful."}
+        ]
 
     def test_request_from_provider_with_thinking(self):
         """Test request from provider with thinking."""
@@ -745,7 +751,7 @@ class TestAnthropicConverterFullRoundTrip:
             "messages": [
                 {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}
             ],
-            "system_instruction": "Be helpful.",
+            "system_instruction": [{"type": "text", "text": "Be helpful."}],
             "generation": {"temperature": 0.7, "max_tokens": 100},
             "tools": [
                 {
@@ -763,7 +769,9 @@ class TestAnthropicConverterFullRoundTrip:
         restored = self.converter.request_from_provider(provider)
 
         assert restored["model"] == "claude-3-5-sonnet-20241022"
-        assert restored["system_instruction"] == "Be helpful."
+        assert restored["system_instruction"] == [
+            {"type": "text", "text": "Be helpful."}
+        ]
         assert restored["generation"]["temperature"] == 0.7
         assert restored["generation"]["max_tokens"] == 100
         tools = list(restored["tools"])

--- a/tests/converters/google_genai/test_converter.py
+++ b/tests/converters/google_genai/test_converter.py
@@ -47,7 +47,9 @@ class TestGoogleGenAIConverter:
             "messages": [
                 {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}
             ],
-            "system_instruction": "You are a helpful assistant.",
+            "system_instruction": [
+                {"type": "text", "text": "You are a helpful assistant."}
+            ],
         }
         result, warnings = self.converter.request_to_provider(ir_request)
         assert "system_instruction" in result
@@ -232,7 +234,9 @@ class TestGoogleGenAIConverter:
             "config": {},
         }
         ir_request = self.converter.request_from_provider(provider_request)
-        assert ir_request["system_instruction"] == "You are helpful."
+        assert ir_request["system_instruction"] == [
+            {"type": "text", "text": "You are helpful."}
+        ]
 
     def test_request_from_provider_with_system_instruction_dict(self):
         """Test request from provider with dict system instruction."""
@@ -246,7 +250,9 @@ class TestGoogleGenAIConverter:
             "config": {},
         }
         ir_request = self.converter.request_from_provider(provider_request)
-        assert ir_request["system_instruction"] == "Be helpful."
+        assert ir_request["system_instruction"] == [
+            {"type": "text", "text": "Be helpful."}
+        ]
 
     def test_request_from_provider_with_tools(self):
         """Test request from provider with tools."""

--- a/tests/converters/openai_chat/test_converter.py
+++ b/tests/converters/openai_chat/test_converter.py
@@ -57,9 +57,7 @@ class TestOpenAIChatConverter:
         )
         result, _ = self.converter.request_to_provider(ir_request)
         assert result["messages"][0]["role"] == "system"
-        assert result["messages"][0]["content"] == [
-            {"type": "text", "text": "You are helpful."}
-        ]
+        assert result["messages"][0]["content"] == "You are helpful."
         assert result["messages"][1]["role"] == "user"
 
     def test_request_to_provider_full(self):

--- a/tests/converters/openai_chat/test_converter.py
+++ b/tests/converters/openai_chat/test_converter.py
@@ -52,12 +52,14 @@ class TestOpenAIChatConverter:
                 "messages": [
                     {"role": "user", "content": [{"type": "text", "text": "Hi"}]}
                 ],
-                "system_instruction": "You are helpful.",
+                "system_instruction": [{"type": "text", "text": "You are helpful."}],
             },
         )
         result, _ = self.converter.request_to_provider(ir_request)
         assert result["messages"][0]["role"] == "system"
-        assert result["messages"][0]["content"] == "You are helpful."
+        assert result["messages"][0]["content"] == [
+            {"type": "text", "text": "You are helpful."}
+        ]
         assert result["messages"][1]["role"] == "user"
 
     def test_request_to_provider_full(self):
@@ -69,7 +71,7 @@ class TestOpenAIChatConverter:
                 "messages": [
                     {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}
                 ],
-                "system_instruction": "Be helpful.",
+                "system_instruction": [{"type": "text", "text": "Be helpful."}],
                 "generation": {
                     "temperature": 0.7,
                     "max_tokens": 100,
@@ -138,7 +140,7 @@ class TestOpenAIChatConverter:
         }
         result = self.converter.request_from_provider(provider_request)
         assert result["model"] == "gpt-4o"
-        assert result["system_instruction"] == "Be helpful"
+        assert result["system_instruction"] == [{"type": "text", "text": "Be helpful"}]
         messages = list(result["messages"])
         assert len(messages) == 1
         assert messages[0]["role"] == "user"
@@ -591,7 +593,7 @@ class TestOpenAIChatConverterFullRoundTrip:
                 "messages": [
                     {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}
                 ],
-                "system_instruction": "Be helpful.",
+                "system_instruction": [{"type": "text", "text": "Be helpful."}],
                 "generation": {"temperature": 0.7, "max_tokens": 100},
                 "tools": [
                     {
@@ -610,7 +612,9 @@ class TestOpenAIChatConverterFullRoundTrip:
         restored = self.converter.request_from_provider(provider)
 
         assert restored["model"] == "gpt-4o"
-        assert restored["system_instruction"] == "Be helpful."
+        assert restored["system_instruction"] == [
+            {"type": "text", "text": "Be helpful."}
+        ]
         assert restored["generation"]["temperature"] == 0.7
         assert restored["generation"]["max_tokens"] == 100
         tools = list(restored["tools"])

--- a/tests/converters/openai_responses/test_converter.py
+++ b/tests/converters/openai_responses/test_converter.py
@@ -48,7 +48,7 @@ class TestOpenAIResponsesConverter:
                 "messages": [
                     {"role": "user", "content": [{"type": "text", "text": "Hi"}]}
                 ],
-                "system_instruction": "You are helpful.",
+                "system_instruction": [{"type": "text", "text": "You are helpful."}],
             },
         )
         result, _ = self.converter.request_to_provider(ir_request)
@@ -63,7 +63,7 @@ class TestOpenAIResponsesConverter:
                 "messages": [
                     {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}
                 ],
-                "system_instruction": "Be helpful.",
+                "system_instruction": [{"type": "text", "text": "Be helpful."}],
                 "generation": {
                     "temperature": 0.7,
                     "max_tokens": 100,
@@ -136,7 +136,7 @@ class TestOpenAIResponsesConverter:
         }
         result = self.converter.request_from_provider(provider_request)
         assert result["model"] == "gpt-4o"
-        assert result["system_instruction"] == "Be helpful"
+        assert result["system_instruction"] == [{"type": "text", "text": "Be helpful"}]
         messages = list(result["messages"])
         assert len(messages) == 1
         assert messages[0]["role"] == "user"
@@ -877,7 +877,7 @@ class TestOpenAIResponsesConverterFullRoundTrip:
                 "messages": [
                     {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}
                 ],
-                "system_instruction": "Be helpful.",
+                "system_instruction": [{"type": "text", "text": "Be helpful."}],
                 "generation": {"temperature": 0.7, "max_tokens": 100},
                 "tools": [
                     {
@@ -896,7 +896,9 @@ class TestOpenAIResponsesConverterFullRoundTrip:
         restored = self.converter.request_from_provider(provider)
 
         assert restored["model"] == "gpt-4o"
-        assert restored["system_instruction"] == "Be helpful."
+        assert restored["system_instruction"] == [
+            {"type": "text", "text": "Be helpful."}
+        ]
         assert restored["generation"]["temperature"] == 0.7
         assert restored["generation"]["max_tokens"] == 100
         tools = list(restored["tools"])

--- a/tests/test_types/ir/test_validation.py
+++ b/tests/test_types/ir/test_validation.py
@@ -72,8 +72,12 @@ class TestValidateIRRequest:
         assert len(result["messages"]) == 1
 
     def test_valid_with_system_instruction(self):
-        result = validate_ir_request(_minimal_request(system_instruction="Be helpful"))
-        assert result["system_instruction"] == "Be helpful"
+        result = validate_ir_request(
+            _minimal_request(
+                system_instruction=[{"type": "text", "text": "Be helpful"}]
+            )
+        )
+        assert result["system_instruction"] == [{"type": "text", "text": "Be helpful"}]
 
     def test_valid_with_generation_config(self):
         result = validate_ir_request(


### PR DESCRIPTION
## Summary

Closes #364. Prerequisite for PR #363 (cache_hint preservation).

Change the canonical IR form of `system_instruction` from `str` to `list[TextPart]`, following the principle established in #69 that IR should have one canonical form — but picking `list[TextPart]` instead of `str` as the canonical form.

### Why

PR #363 needs structured system content to survive IR round-trips for cache_hint preservation. The previous approach widened the type to `str | list[TextPart]`, reintroducing the union type that #69 deliberately removed. This PR eliminates the need for union types entirely.

### Changes

- **IR type**: `system_instruction: NotRequired[str]` → `NotRequired[list[TextPart]]`
- **All 4 converters**: `request_from_provider` produces `list[TextPart]`; `request_to_provider` consumes `list[TextPart]` via content_ops
- **Tests**: 16 tests updated to use the new canonical form

### How each converter handles it

| Converter | Output format |
|---|---|
| Anthropic | `system: [{"type": "text", "text": "..."}]` (structured blocks) |
| OpenAI Chat | `messages[0].content: [{"type": "text", "text": "..."}]` (content array) |
| OpenAI Responses | `instructions: "..."` (flattened to string) |
| Google GenAI | `system_instruction: {"role": "user", "parts": [{"text": "..."}]}` |

## Test plan

- [x] 2055 tests pass, 0 regressions
- [x] All 4 converter round-trips verified
- [x] IR validation updated