### PR TITLE
refactor: rename from/to_transforms to pre/post_ir_transforms

### DIFF
--- a/src/llm_rosetta/auto_detect.py
+++ b/src/llm_rosetta/auto_detect.py
@@ -240,11 +240,11 @@ def convert(
     source_shim = get_shim(source_provider)
     target_shim = get_shim(target_provider)
 
-    source_from_t = source_shim.from_transforms if source_shim else ()
-    target_to_t = target_shim.to_transforms if target_shim else ()
+    source_pre_t = source_shim.pre_ir_transforms if source_shim else ()
+    target_post_t = target_shim.post_ir_transforms if target_shim else ()
 
-    # --- Apply source from_transforms ---
-    body = apply_transforms(source_from_t, source_body)
+    # --- Apply source pre_ir_transforms ---
+    body = apply_transforms(source_pre_t, source_body)
 
     # --- Core conversion: source → IR → target ---
     source_converter = get_converter_for_provider(source_provider)
@@ -265,7 +265,7 @@ def convert(
         ir_request, context=ctx
     )
 
-    # --- Apply target to_transforms ---
-    target_body = apply_transforms(target_to_t, target_body)
+    # --- Apply target post_ir_transforms ---
+    target_body = apply_transforms(target_post_t, target_body)
 
     return target_body

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -214,11 +214,11 @@ class ConversionPipeline:
         # Resolve body-level transforms from shim
         resolved = resolve_shim(shim)
         if resolved is not None:
-            self._from_transforms = resolved.from_transforms
-            self._to_transforms = resolved.to_transforms
+            self._pre_ir_transforms = resolved.pre_ir_transforms
+            self._post_ir_transforms = resolved.post_ir_transforms
         else:
-            self._from_transforms = _EMPTY_TRANSFORMS
-            self._to_transforms = _EMPTY_TRANSFORMS
+            self._pre_ir_transforms = _EMPTY_TRANSFORMS
+            self._post_ir_transforms = _EMPTY_TRANSFORMS
 
         # Set after convert_request()
         self._ctx: ConversionContext | None = None
@@ -281,7 +281,7 @@ class ConversionPipeline:
             source_to_ir_ms      — Source format → IR parsing
             ir_transforms_ms     — Vision enforcement + shim IR transforms
             ir_to_target_ms      — IR → target format serialization
-            body_transforms_ms   — Shim body-level to_transforms
+            body_transforms_ms   — Shim body-level post_ir_transforms
             request_conversion_ms — Total request conversion time
 
         Keys added by :meth:`convert_response`::
@@ -388,10 +388,10 @@ class ConversionPipeline:
             ) from exc
         self._profile["ir_to_target_ms"] = round((time.perf_counter() - t0) * 1000, 2)
 
-        # Phase 2c: Body-level shim to_transforms
+        # Phase 2c: Body-level shim post_ir_transforms
         t0 = time.perf_counter()
-        if self._to_transforms:
-            target_body = apply_transforms(self._to_transforms, target_body)
+        if self._post_ir_transforms:
+            target_body = apply_transforms(self._post_ir_transforms, target_body)
         self._profile["body_transforms_ms"] = round(
             (time.perf_counter() - t0) * 1000, 2
         )
@@ -409,7 +409,7 @@ class ConversionPipeline:
     ) -> dict[str, Any]:
         """Convert a target-format response body back to source format.
 
-        Executes Phase 4 (from_transforms → Target→IR → IR→Source).
+        Executes Phase 4 (pre_ir_transforms → Target→IR → IR→Source).
 
         Must be called after :meth:`convert_request` (uses the same
         conversion context).
@@ -430,10 +430,10 @@ class ConversionPipeline:
         ctx = self.context  # raises RuntimeError if not ready
         t_total = time.perf_counter()
 
-        # Phase 4a: Body-level shim from_transforms
+        # Phase 4a: Body-level shim pre_ir_transforms
         response = upstream_response
-        if self._from_transforms:
-            response = apply_transforms(self._from_transforms, response)
+        if self._pre_ir_transforms:
+            response = apply_transforms(self._pre_ir_transforms, response)
 
         # Phase 4b: Target response → IR
         t0 = time.perf_counter()
@@ -513,7 +513,7 @@ class ConversionPipeline:
             source_converter=self._source_converter,
             from_ctx=from_ctx,
             to_ctx=to_ctx,
-            from_transforms=self._from_transforms,
+            pre_ir_transforms=self._pre_ir_transforms,
             on_ir_event=on_ir_event,
         )
 
@@ -540,7 +540,7 @@ class StreamProcessor:
         source_converter: The client format converter.
         from_ctx: StreamContext for upstream→IR conversion.
         to_ctx: StreamContext for IR→source conversion.
-        from_transforms: Shim from_transforms to apply before conversion.
+        pre_ir_transforms: Shim pre_ir_transforms to apply before conversion.
         on_ir_event: Optional callback for each IR event.
     """
 
@@ -551,14 +551,14 @@ class StreamProcessor:
         source_converter: Any,
         from_ctx: Any,
         to_ctx: Any,
-        from_transforms: tuple[Transform, ...] = (),
+        pre_ir_transforms: tuple[Transform, ...] = (),
         on_ir_event: Callable[[dict[str, Any]], None] | None = None,
     ) -> None:
         self._target_converter = target_converter
         self._source_converter = source_converter
         self._from_ctx = from_ctx
         self._to_ctx = to_ctx
-        self._from_transforms = from_transforms
+        self._pre_ir_transforms = pre_ir_transforms
         self._on_ir_event = on_ir_event
 
     def process_chunk(self, chunk: dict[str, Any]) -> list[dict[str, Any]]:
@@ -571,9 +571,9 @@ class StreamProcessor:
             List of source-format event dicts.  May be empty (some
             upstream chunks produce no source events), one, or multiple.
         """
-        # Apply shim from_transforms
-        if self._from_transforms:
-            chunk = apply_transforms(self._from_transforms, chunk)
+        # Apply shim pre_ir_transforms
+        if self._pre_ir_transforms:
+            chunk = apply_transforms(self._pre_ir_transforms, chunk)
 
         # Target → IR events
         ir_events = self._target_converter.stream_response_from_provider(

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 from .transforms import IRTransform, Transform
 
@@ -110,10 +110,12 @@ class ProviderShim:
             fetching the upstream model list.  Defaults to ``"id"``
             when ``None``.  Useful for providers like Argo that place
             the actual model identifier in a non-standard field.
-        from_transforms: Transforms applied when data comes FROM this
-            provider (normalise dialect → standard).
-        to_transforms: Transforms applied when data goes TO this
-            provider (standard → dialect).
+        pre_ir_transforms: Body-level transforms applied BEFORE IR
+            conversion (normalise provider dialect → standard).
+            Aliased as ``from_transforms`` for backward compatibility.
+        post_ir_transforms: Body-level transforms applied AFTER IR
+            conversion (standard → provider dialect).
+            Aliased as ``to_transforms`` for backward compatibility.
         reasoning: Reasoning capability config for this provider.
             When ``None``, the converter uses its built-in default.
         model_reasoning: Per-model reasoning overrides keyed by
@@ -127,11 +129,57 @@ class ProviderShim:
     default_api_key_env: str | None = None
     logo: str | None = None
     model_id_field: str | None = None
-    from_transforms: tuple[Transform, ...] = ()
-    to_transforms: tuple[Transform, ...] = ()
+    pre_ir_transforms: tuple[Transform, ...] = ()
+    post_ir_transforms: tuple[Transform, ...] = ()
     ir_transforms: tuple[IRTransform, ...] = ()
     reasoning: ReasoningCapability | None = None
     model_reasoning: dict[str, ReasoningCapability] | None = None
+
+    def __init__(self, **kwargs: Any) -> None:  # type: ignore[override]
+        """Accept both new and legacy kwarg names.
+
+        Legacy ``from_transforms`` maps to ``pre_ir_transforms``;
+        ``to_transforms`` maps to ``post_ir_transforms``.
+        New names take precedence if both are provided.
+        """
+        # Map legacy names → new names (new names take precedence)
+        if "from_transforms" in kwargs and "pre_ir_transforms" not in kwargs:
+            kwargs["pre_ir_transforms"] = kwargs.pop("from_transforms")
+        else:
+            kwargs.pop("from_transforms", None)
+        if "to_transforms" in kwargs and "post_ir_transforms" not in kwargs:
+            kwargs["post_ir_transforms"] = kwargs.pop("to_transforms")
+        else:
+            kwargs.pop("to_transforms", None)
+
+        # Apply defaults for fields not in kwargs
+        defaults = {
+            "default_base_url": None,
+            "default_api_key_env": None,
+            "logo": None,
+            "model_id_field": None,
+            "pre_ir_transforms": (),
+            "post_ir_transforms": (),
+            "ir_transforms": (),
+            "reasoning": None,
+            "model_reasoning": None,
+        }
+        for k, v in defaults.items():
+            kwargs.setdefault(k, v)
+
+        for k, v in kwargs.items():
+            object.__setattr__(self, k, v)
+
+    # Backward-compatible aliases (read-only)
+    @property
+    def from_transforms(self) -> tuple[Transform, ...]:
+        """Alias for ``pre_ir_transforms`` (deprecated)."""
+        return self.pre_ir_transforms
+
+    @property
+    def to_transforms(self) -> tuple[Transform, ...]:
+        """Alias for ``post_ir_transforms`` (deprecated)."""
+        return self.post_ir_transforms
 
 
 # ---------------------------------------------------------------------------

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -19,7 +19,8 @@ Directory layout
 ----------------
 Each subdirectory that contains a ``provider.yaml`` is treated as a leaf
 provider definition.  An optional ``transforms.py`` alongside the YAML
-may export ``to_transforms`` and/or ``from_transforms`` tuples.
+may export ``pre_ir_transforms`` and/or ``post_ir_transforms`` tuples
+(legacy names ``from_transforms`` / ``to_transforms`` are also accepted).
 
 **Grouped directories** are also supported: a child directory that does
 NOT contain ``provider.yaml`` but DOES contain subdirectories with one is
@@ -67,7 +68,11 @@ _PROVIDERS_DIR = Path(__file__).parent
 def _load_transforms(
     provider_dir: Path, *, group: str | None = None, _builtin: bool = True
 ) -> tuple[tuple, tuple, tuple]:
-    """Import transforms.py if present, return (from_transforms, to_transforms, ir_transforms).
+    """Import transforms.py if present, return (pre_ir_transforms, post_ir_transforms, ir_transforms).
+
+    Accepts both new names (``pre_ir_transforms``, ``post_ir_transforms``)
+    and legacy names (``from_transforms``, ``to_transforms``) from the
+    transforms module.  New names take precedence if both are present.
 
     Args:
         provider_dir: Path to the leaf provider directory.
@@ -90,9 +95,12 @@ def _load_transforms(
         return (), (), ()
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
+    # New names take precedence; fall back to legacy names
+    pre = getattr(mod, "pre_ir_transforms", None) or getattr(mod, "from_transforms", ())
+    post = getattr(mod, "post_ir_transforms", None) or getattr(mod, "to_transforms", ())
     return (
-        getattr(mod, "from_transforms", ()),
-        getattr(mod, "to_transforms", ()),
+        pre,
+        post,
         getattr(mod, "ir_transforms", ()),
     )
 
@@ -117,7 +125,7 @@ def _load_single_provider(
         logger.warning("Skipping %s: missing 'name' or 'base'", yaml_path)
         return None
 
-    from_t, to_t, ir_t = _load_transforms(provider_dir, group=group, _builtin=_builtin)
+    pre_t, post_t, ir_t = _load_transforms(provider_dir, group=group, _builtin=_builtin)
 
     # Parse optional reasoning capability config from YAML.
     reasoning_cfg = cfg.get("reasoning")
@@ -172,8 +180,8 @@ def _load_single_provider(
         default_api_key_env=cfg.get("default_api_key_env"),
         logo=cfg.get("logo"),
         model_id_field=cfg.get("model_id_field"),
-        from_transforms=from_t,
-        to_transforms=to_t,
+        pre_ir_transforms=pre_t,
+        post_ir_transforms=post_t,
         ir_transforms=ir_t,
         reasoning=reasoning_cap,
         model_reasoning=model_reasoning,

--- a/tests/gateway/test_proxy_transforms.py
+++ b/tests/gateway/test_proxy_transforms.py
@@ -70,23 +70,23 @@ def shim_with_transforms():
 class TestPipelineTransformResolution:
     def test_none_shim(self):
         p = ConversionPipeline("openai_chat", "openai_chat", None)
-        assert p._from_transforms == ()
-        assert p._to_transforms == ()
+        assert p._pre_ir_transforms == ()
+        assert p._post_ir_transforms == ()
 
     def test_unknown_shim(self):
         p = ConversionPipeline("openai_chat", "openai_chat", "nonexistent-provider")
-        assert p._from_transforms == ()
-        assert p._to_transforms == ()
+        assert p._pre_ir_transforms == ()
+        assert p._post_ir_transforms == ()
 
     def test_volcengine_shim(self, volcengine_shim):
         p = ConversionPipeline("openai_chat", "openai_chat", "volcengine--openai_chat")
-        assert p._to_transforms == volcengine_shim.to_transforms
-        assert p._from_transforms == ()
+        assert p._post_ir_transforms == volcengine_shim.to_transforms
+        assert p._pre_ir_transforms == ()
 
     def test_shim_with_both_transforms(self, shim_with_transforms):
         p = ConversionPipeline("openai_chat", "openai_chat", "custom_provider")
-        assert p._from_transforms == shim_with_transforms.from_transforms
-        assert p._to_transforms == shim_with_transforms.to_transforms
+        assert p._pre_ir_transforms == shim_with_transforms.from_transforms
+        assert p._post_ir_transforms == shim_with_transforms.to_transforms
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Rename body-level transform fields to clarify their position in the conversion pipeline:

| Old name | New name | When it runs |
|---|---|---|
| `from_transforms` | `pre_ir_transforms` | Before source → IR conversion |
| `to_transforms` | `post_ir_transforms` | After IR → target conversion |

The old names described data flow direction ("from provider", "to provider") but were ambiguous about timing relative to the IR conversion step. The new names make the pipeline position explicit.

### Backward compatibility

- `ProviderShim(from_transforms=..., to_transforms=...)` still works (mapped to new names in `__init__`)
- `shim.from_transforms` / `shim.to_transforms` properties remain as read-only aliases
- Provider `transforms.py` files can export either name (new names take precedence)
- Existing provider shim definitions (deepseek, volcengine, argo, etc.) unchanged — they export the old names which the loader accepts

### Files changed

- `provider_shim.py` — field rename + custom `__init__` for compat + property aliases
- `providers/__init__.py` — loader accepts both names
- `pipeline.py` — internal `_from_transforms`/`_to_transforms` → `_pre_ir_transforms`/`_post_ir_transforms`
- `auto_detect.py` — local variable rename
- Tests updated

## Test plan

- [x] 2055 tests pass, 0 regressions
- [x] All existing shims load correctly (old export names accepted)
- [x] Both old and new constructor kwargs work