### PR TITLE
fix: #368 followup — deprecation warnings, is None check, provider migration

### DIFF
--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -152,8 +152,9 @@ class ProviderShim:
         else:
             kwargs.pop("to_transforms", None)
 
-        # Apply defaults for fields not in kwargs
-        defaults = {
+        # Apply defaults for fields not in kwargs.
+        # Keep in sync with dataclass field defaults above.
+        _FIELD_DEFAULTS = {
             "default_base_url": None,
             "default_api_key_env": None,
             "logo": None,
@@ -164,8 +165,17 @@ class ProviderShim:
             "reasoning": None,
             "model_reasoning": None,
         }
-        for k, v in defaults.items():
+        _VALID_FIELDS = {"name", "base"} | _FIELD_DEFAULTS.keys()
+        for k, v in _FIELD_DEFAULTS.items():
             kwargs.setdefault(k, v)
+
+        # Reject unknown kwargs (match frozen dataclass behavior)
+        unknown = set(kwargs) - _VALID_FIELDS
+        if unknown:
+            raise TypeError(
+                f"ProviderShim.__init__() got unexpected keyword argument(s): "
+                f"{', '.join(sorted(unknown))}"
+            )
 
         for k, v in kwargs.items():
             object.__setattr__(self, k, v)

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -13,6 +13,7 @@ functions (``get_shim``, ``list_shims``) read from it.
 from __future__ import annotations
 
 import logging
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -143,14 +144,28 @@ class ProviderShim:
         New names take precedence if both are provided.
         """
         # Map legacy names → new names (new names take precedence)
-        if "from_transforms" in kwargs and "pre_ir_transforms" not in kwargs:
-            kwargs["pre_ir_transforms"] = kwargs.pop("from_transforms")
-        else:
-            kwargs.pop("from_transforms", None)
-        if "to_transforms" in kwargs and "post_ir_transforms" not in kwargs:
-            kwargs["post_ir_transforms"] = kwargs.pop("to_transforms")
-        else:
-            kwargs.pop("to_transforms", None)
+        if "from_transforms" in kwargs:
+            warnings.warn(
+                "ProviderShim(from_transforms=...) is deprecated, "
+                "use pre_ir_transforms instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if "pre_ir_transforms" not in kwargs:
+                kwargs["pre_ir_transforms"] = kwargs.pop("from_transforms")
+            else:
+                kwargs.pop("from_transforms")
+        if "to_transforms" in kwargs:
+            warnings.warn(
+                "ProviderShim(to_transforms=...) is deprecated, "
+                "use post_ir_transforms instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if "post_ir_transforms" not in kwargs:
+                kwargs["post_ir_transforms"] = kwargs.pop("to_transforms")
+            else:
+                kwargs.pop("to_transforms")
 
         # Apply defaults for fields not in kwargs.
         # Keep in sync with dataclass field defaults above.

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -100,9 +100,19 @@ def _load_transforms(
     pre = getattr(mod, "pre_ir_transforms", None)
     if pre is None:
         pre = getattr(mod, "from_transforms", ())
+        if pre and hasattr(mod, "from_transforms"):
+            logger.info(
+                "%s uses deprecated 'from_transforms'; rename to 'pre_ir_transforms'",
+                tf_path,
+            )
     post = getattr(mod, "post_ir_transforms", None)
     if post is None:
         post = getattr(mod, "to_transforms", ())
+        if post and hasattr(mod, "to_transforms"):
+            logger.info(
+                "%s uses deprecated 'to_transforms'; rename to 'post_ir_transforms'",
+                tf_path,
+            )
     return (
         pre,
         post,

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -95,9 +95,14 @@ def _load_transforms(
         return (), (), ()
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
-    # New names take precedence; fall back to legacy names
-    pre = getattr(mod, "pre_ir_transforms", None) or getattr(mod, "from_transforms", ())
-    post = getattr(mod, "post_ir_transforms", None) or getattr(mod, "to_transforms", ())
+    # New names take precedence; fall back to legacy names.
+    # Use `is None` (not `or`) since empty tuple () is falsy but valid.
+    pre = getattr(mod, "pre_ir_transforms", None)
+    if pre is None:
+        pre = getattr(mod, "from_transforms", ())
+    post = getattr(mod, "post_ir_transforms", None)
+    if post is None:
+        post = getattr(mod, "to_transforms", ())
     return (
         pre,
         post,

--- a/src/llm_rosetta/shims/providers/argo/anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/anthropic/transforms.py
@@ -1,6 +1,6 @@
 """Argo Anthropic schema transforms.
 
-Response-side (from_transforms)
+Response-side (pre_ir_transforms)
 --------------------------------
 ``_normalize_openai_response`` rewrites OpenAI Chat Completions format responses
 to Anthropic Messages format.  Argo's ``/v1/messages`` endpoint inconsistently
@@ -123,7 +123,7 @@ def _normalize_openai_response(body: dict[str, Any]) -> dict[str, Any]:
 # Transform tuples (consumed by the shim loader)
 # ---------------------------------------------------------------------------
 
-to_transforms = ()
-from_transforms = (
+post_ir_transforms = ()
+pre_ir_transforms = (
     _NamedTransform(_normalize_openai_response, "normalize_openai_response()"),
 )

--- a/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
@@ -1,6 +1,6 @@
 """Argo OpenAI Chat schema transforms.
 
-Request-side (to_transforms) — body-level
+Request-side (post_ir_transforms) — body-level
 -------------------------------------------
 - ``rename_field("max_tokens", "max_completion_tokens")``: converts the
   deprecated ``max_tokens`` parameter for newer OpenAI models.
@@ -30,13 +30,13 @@ from llm_rosetta.shims.transforms import (
     unwind_parallel_tool_calls,
 )
 
-to_transforms = (
+post_ir_transforms = (
     rename_field("max_tokens", "max_completion_tokens"),
     replace_message_field("role", "developer", "system"),
     default_message_field("content", ""),
     strip_fields_for_model(r"^claudeopus47", "temperature"),
 )
-from_transforms = ()
+pre_ir_transforms = ()
 ir_transforms = (
     truncate_images(50, pattern=r"^(gpt|o\d)"),
     unwind_parallel_tool_calls(pattern=r"^gemini"),

--- a/src/llm_rosetta/shims/providers/deepseek/transforms.py
+++ b/src/llm_rosetta/shims/providers/deepseek/transforms.py
@@ -9,5 +9,5 @@ References:
 
 from llm_rosetta.shims.transforms import strip_fields
 
-to_transforms = (strip_fields("n", "logit_bias", "seed"),)
-from_transforms = ()
+post_ir_transforms = (strip_fields("n", "logit_bias", "seed"),)
+pre_ir_transforms = ()

--- a/src/llm_rosetta/shims/providers/minimax/openai_chat/transforms.py
+++ b/src/llm_rosetta/shims/providers/minimax/openai_chat/transforms.py
@@ -66,8 +66,8 @@ def _parse_think_tags(body: dict[str, Any]) -> dict[str, Any]:
     return body
 
 
-to_transforms = (
+post_ir_transforms = (
     strip_fields("logprobs", "top_logprobs", "seed", "stop"),
     _NamedTransform(_inject_reasoning_split, "inject_reasoning_split()"),
 )
-from_transforms = (_NamedTransform(_parse_think_tags, "parse_think_tags()"),)
+pre_ir_transforms = (_NamedTransform(_parse_think_tags, "parse_think_tags()"),)

--- a/src/llm_rosetta/shims/providers/moonshot/transforms.py
+++ b/src/llm_rosetta/shims/providers/moonshot/transforms.py
@@ -10,5 +10,5 @@ References:
 
 from llm_rosetta.shims.transforms import strip_fields
 
-to_transforms = (strip_fields("logprobs", "top_logprobs", "logit_bias", "seed"),)
-from_transforms = ()
+post_ir_transforms = (strip_fields("logprobs", "top_logprobs", "logit_bias", "seed"),)
+pre_ir_transforms = ()

--- a/src/llm_rosetta/shims/providers/openrouter/anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/openrouter/anthropic/transforms.py
@@ -5,5 +5,5 @@ of the Anthropic Messages API — no request- or response-side transforms
 are needed.
 """
 
-to_transforms = ()
-from_transforms = ()
+post_ir_transforms = ()
+pre_ir_transforms = ()

--- a/src/llm_rosetta/shims/providers/openrouter/openai_chat/transforms.py
+++ b/src/llm_rosetta/shims/providers/openrouter/openai_chat/transforms.py
@@ -40,5 +40,5 @@ def _rename_reasoning_field(body: dict[str, Any]) -> dict[str, Any]:
     return body
 
 
-to_transforms = ()
-from_transforms = (_NamedTransform(_rename_reasoning_field, "rename_reasoning()"),)
+post_ir_transforms = ()
+pre_ir_transforms = (_NamedTransform(_rename_reasoning_field, "rename_reasoning()"),)

--- a/src/llm_rosetta/shims/providers/qwen/transforms.py
+++ b/src/llm_rosetta/shims/providers/qwen/transforms.py
@@ -10,5 +10,5 @@ References:
 
 from llm_rosetta.shims.transforms import strip_fields
 
-to_transforms = (strip_fields("frequency_penalty", "logit_bias"),)
-from_transforms = ()
+post_ir_transforms = (strip_fields("frequency_penalty", "logit_bias"),)
+pre_ir_transforms = ()

--- a/src/llm_rosetta/shims/providers/volcengine/openai_chat/transforms.py
+++ b/src/llm_rosetta/shims/providers/volcengine/openai_chat/transforms.py
@@ -6,5 +6,5 @@ Strip them before sending upstream to avoid 400 errors.
 
 from llm_rosetta.shims.transforms import strip_fields
 
-to_transforms = (strip_fields("logprobs", "top_logprobs"),)
-from_transforms = ()
+post_ir_transforms = (strip_fields("logprobs", "top_logprobs"),)
+pre_ir_transforms = ()

--- a/src/llm_rosetta/shims/providers/xai/transforms.py
+++ b/src/llm_rosetta/shims/providers/xai/transforms.py
@@ -9,5 +9,5 @@ References:
 
 from llm_rosetta.shims.transforms import strip_fields
 
-to_transforms = (strip_fields("logit_bias"),)
-from_transforms = ()
+post_ir_transforms = (strip_fields("logit_bias"),)
+pre_ir_transforms = ()

--- a/src/llm_rosetta/shims/providers/zhipu/transforms.py
+++ b/src/llm_rosetta/shims/providers/zhipu/transforms.py
@@ -15,7 +15,7 @@ References:
 
 from llm_rosetta.shims.transforms import strip_fields
 
-to_transforms = (
+post_ir_transforms = (
     strip_fields(
         "n",
         "presence_penalty",
@@ -26,4 +26,4 @@ to_transforms = (
         "seed",
     ),
 )
-from_transforms = ()
+pre_ir_transforms = ()

--- a/tests/gateway/test_proxy_transforms.py
+++ b/tests/gateway/test_proxy_transforms.py
@@ -39,11 +39,11 @@ def _clean_registry():
 
 @pytest.fixture()
 def volcengine_shim():
-    """Register a volcengine-like shim with to_transforms that strip fields."""
+    """Register a volcengine-like shim with post_ir_transforms that strip fields."""
     shim = ProviderShim(
         name="volcengine--openai_chat",
         base="openai_chat",
-        to_transforms=(strip_fields("logprobs", "top_logprobs"),),
+        post_ir_transforms=(strip_fields("logprobs", "top_logprobs"),),
     )
     register_shim(shim)
     return shim
@@ -51,12 +51,12 @@ def volcengine_shim():
 
 @pytest.fixture()
 def shim_with_transforms():
-    """Register a shim with both from_transforms and to_transforms."""
+    """Register a shim with both pre_ir_transforms and post_ir_transforms."""
     shim = ProviderShim(
         name="custom_provider",
         base="openai_chat",
-        from_transforms=(rename_field("custom_id", "id"),),
-        to_transforms=(strip_fields("logprobs"),),
+        pre_ir_transforms=(rename_field("custom_id", "id"),),
+        post_ir_transforms=(strip_fields("logprobs"),),
     )
     register_shim(shim)
     return shim
@@ -149,8 +149,8 @@ def _make_route(
 
 
 class TestNonStreamingTransforms:
-    def test_to_transforms_strip_fields(self, volcengine_shim):
-        """to_transforms should strip fields from the target request body."""
+    def test_post_ir_transforms_strip_fields(self, volcengine_shim):
+        """post_ir_transforms should strip fields from the target request body."""
         captured_body: dict[str, Any] = {}
         transport = _make_mock_transport(
             {
@@ -212,8 +212,8 @@ class TestNonStreamingTransforms:
         assert "logprobs" in captured_body
         assert "top_logprobs" in captured_body
 
-    def test_from_transforms_on_response(self, shim_with_transforms):
-        """from_transforms should be applied to the upstream response."""
+    def test_pre_ir_transforms_on_response(self, shim_with_transforms):
+        """pre_ir_transforms should be applied to the upstream response."""
         transport = _make_mock_transport(
             {
                 "custom_id": "resp-1",

--- a/tests/gateway/test_proxy_transforms.py
+++ b/tests/gateway/test_proxy_transforms.py
@@ -80,13 +80,13 @@ class TestPipelineTransformResolution:
 
     def test_volcengine_shim(self, volcengine_shim):
         p = ConversionPipeline("openai_chat", "openai_chat", "volcengine--openai_chat")
-        assert p._post_ir_transforms == volcengine_shim.to_transforms
+        assert p._post_ir_transforms == volcengine_shim.post_ir_transforms
         assert p._pre_ir_transforms == ()
 
     def test_shim_with_both_transforms(self, shim_with_transforms):
         p = ConversionPipeline("openai_chat", "openai_chat", "custom_provider")
-        assert p._pre_ir_transforms == shim_with_transforms.from_transforms
-        assert p._post_ir_transforms == shim_with_transforms.to_transforms
+        assert p._pre_ir_transforms == shim_with_transforms.pre_ir_transforms
+        assert p._post_ir_transforms == shim_with_transforms.post_ir_transforms
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shim_loader.py
+++ b/tests/test_shim_loader.py
@@ -37,12 +37,12 @@ class TestLoadTransforms:
         assert to_t == ()
 
     def test_transforms_with_to_only(self, tmp_path: Path):
-        """Loads to_transforms from transforms.py."""
+        """Loads post_ir_transforms from transforms.py."""
         tf = tmp_path / "transforms.py"
         tf.write_text(
             textwrap.dedent("""\
             from llm_rosetta.shims.transforms import strip_fields
-            to_transforms = (strip_fields("foo"),)
+            post_ir_transforms = (strip_fields("foo"),)
         """)
         )
         from_t, to_t, ir_t = _load_transforms(tmp_path)
@@ -55,13 +55,13 @@ class TestLoadTransforms:
         assert result["bar"] == 2
 
     def test_transforms_with_both(self, tmp_path: Path):
-        """Loads both from_transforms and to_transforms."""
+        """Loads both pre_ir_transforms and post_ir_transforms."""
         tf = tmp_path / "transforms.py"
         tf.write_text(
             textwrap.dedent("""\
             from llm_rosetta.shims.transforms import strip_fields, rename_field
-            to_transforms = (strip_fields("x"),)
-            from_transforms = (rename_field("a", "b"),)
+            post_ir_transforms = (strip_fields("x"),)
+            pre_ir_transforms = (rename_field("a", "b"),)
         """)
         )
         from_t, to_t, ir_t = _load_transforms(tmp_path)
@@ -139,11 +139,11 @@ class TestLoadProviders:
         load_providers()
         v = get_shim("volcengine--openai_chat")
         assert v is not None
-        assert len(v.to_transforms) == 1
-        assert len(v.from_transforms) == 0
+        assert len(v.post_ir_transforms) == 1
+        assert len(v.pre_ir_transforms) == 0
         # Verify it strips the right fields
         body = {"logprobs": True, "top_logprobs": 5, "messages": []}
-        result = v.to_transforms[0](body)
+        result = v.post_ir_transforms[0](body)
         assert "logprobs" not in result
         assert "messages" in result
 
@@ -152,10 +152,10 @@ class TestLoadProviders:
         load_providers()
         s = get_shim("deepseek")
         assert s is not None
-        assert len(s.to_transforms) == 1
-        assert len(s.from_transforms) == 0
+        assert len(s.post_ir_transforms) == 1
+        assert len(s.pre_ir_transforms) == 0
         body = {"n": 2, "logit_bias": {}, "seed": 42, "messages": []}
-        result = s.to_transforms[0](body)
+        result = s.post_ir_transforms[0](body)
         assert "n" not in result
         assert "logit_bias" not in result
         assert "seed" not in result
@@ -166,10 +166,10 @@ class TestLoadProviders:
         load_providers()
         s = get_shim("xai")
         assert s is not None
-        assert len(s.to_transforms) == 1
-        assert len(s.from_transforms) == 0
+        assert len(s.post_ir_transforms) == 1
+        assert len(s.pre_ir_transforms) == 0
         body = {"logit_bias": {"50256": -100}, "messages": []}
-        result = s.to_transforms[0](body)
+        result = s.post_ir_transforms[0](body)
         assert "logit_bias" not in result
         assert "messages" in result
 
@@ -178,8 +178,8 @@ class TestLoadProviders:
         load_providers()
         s = get_shim("moonshot")
         assert s is not None
-        assert len(s.to_transforms) == 1
-        assert len(s.from_transforms) == 0
+        assert len(s.post_ir_transforms) == 1
+        assert len(s.pre_ir_transforms) == 0
         body = {
             "logprobs": True,
             "top_logprobs": 5,
@@ -187,7 +187,7 @@ class TestLoadProviders:
             "seed": 123,
             "messages": [],
         }
-        result = s.to_transforms[0](body)
+        result = s.post_ir_transforms[0](body)
         assert "logprobs" not in result
         assert "top_logprobs" not in result
         assert "logit_bias" not in result
@@ -199,10 +199,10 @@ class TestLoadProviders:
         load_providers()
         s = get_shim("qwen")
         assert s is not None
-        assert len(s.to_transforms) == 1
-        assert len(s.from_transforms) == 0
+        assert len(s.post_ir_transforms) == 1
+        assert len(s.pre_ir_transforms) == 0
         body = {"frequency_penalty": 0.5, "logit_bias": {}, "messages": []}
-        result = s.to_transforms[0](body)
+        result = s.post_ir_transforms[0](body)
         assert "frequency_penalty" not in result
         assert "logit_bias" not in result
         assert "messages" in result
@@ -212,8 +212,8 @@ class TestLoadProviders:
         load_providers()
         s = get_shim("minimax--openai_chat")
         assert s is not None
-        assert len(s.to_transforms) == 2  # strip_fields + inject_reasoning_split
-        assert len(s.from_transforms) == 1  # parse_think_tags
+        assert len(s.post_ir_transforms) == 2  # strip_fields + inject_reasoning_split
+        assert len(s.pre_ir_transforms) == 1  # parse_think_tags
         body = {
             "logprobs": True,
             "top_logprobs": 5,
@@ -221,7 +221,7 @@ class TestLoadProviders:
             "stop": ["\n"],
             "messages": [],
         }
-        result = s.to_transforms[0](body)
+        result = s.post_ir_transforms[0](body)
         assert "logprobs" not in result
         assert "top_logprobs" not in result
         assert "seed" not in result
@@ -233,8 +233,8 @@ class TestLoadProviders:
         load_providers()
         s = get_shim("zhipu")
         assert s is not None
-        assert len(s.to_transforms) == 1
-        assert len(s.from_transforms) == 0
+        assert len(s.post_ir_transforms) == 1
+        assert len(s.pre_ir_transforms) == 0
         body = {
             "n": 2,
             "presence_penalty": 0.5,
@@ -245,7 +245,7 @@ class TestLoadProviders:
             "seed": 42,
             "messages": [],
         }
-        result = s.to_transforms[0](body)
+        result = s.post_ir_transforms[0](body)
         assert "n" not in result
         assert "presence_penalty" not in result
         assert "frequency_penalty" not in result
@@ -347,14 +347,14 @@ class TestLoadProvidersFromDir:
         (d / "provider.yaml").write_text("name: myplugin\nbase: openai_chat\n")
         (d / "transforms.py").write_text(
             "from llm_rosetta.shims.transforms import strip_fields\n"
-            'to_transforms = (strip_fields("foo"),)\n'
+            'post_ir_transforms = (strip_fields("foo"),)\n'
         )
         shims = load_providers_from_dir(tmp_path)
         s = [s for s in shims if s.name == "myplugin"][0]
-        assert len(s.to_transforms) == 1
+        assert len(s.post_ir_transforms) == 1
         # Verify the transform works
         body = {"foo": 1, "bar": 2}
-        result = s.to_transforms[0](body)
+        result = s.post_ir_transforms[0](body)
         assert "foo" not in result
         assert result["bar"] == 2
 

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -266,8 +266,8 @@ class TestGroupedProviders:
         """Grouped shims have their transforms.py imported."""
         anth = get_shim("argo--anthropic")
         assert anth is not None
-        # argo_anthropic has from_transforms (to_transforms retired)
-        assert len(anth.from_transforms) > 0
+        # argo_anthropic has pre_ir_transforms (post_ir_transforms retired)
+        assert len(anth.pre_ir_transforms) > 0
 
     def test_grouped_provider_reasoning_configs_loaded(self):
         """Grouped shims load reasoning capability configs."""

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -185,13 +185,13 @@ class TestShimWithTransforms:
             pre_ir_transforms=(t1,),
             post_ir_transforms=(t2,),
         )
-        assert s.from_transforms == (t1,)
-        assert s.to_transforms == (t2,)
+        assert s.pre_ir_transforms == (t1,)
+        assert s.post_ir_transforms == (t2,)
 
     def test_provider_shim_default_empty(self):
         s = ProviderShim(name="test", base="openai_chat")
-        assert s.from_transforms == ()
-        assert s.to_transforms == ()
+        assert s.pre_ir_transforms == ()
+        assert s.post_ir_transforms == ()
 
 
 # ---------------------------------------------------------------------------
@@ -209,13 +209,13 @@ class TestBuiltinTransforms:
     def test_volcengine_has_post_ir_transforms(self):
         shim = get_shim("volcengine--openai_chat")
         assert shim is not None
-        assert len(shim.to_transforms) > 0
+        assert len(shim.post_ir_transforms) > 0
 
     def test_volcengine_strips_logprobs(self):
         shim = get_shim("volcengine--openai_chat")
         assert shim is not None
         body = {"model": "test", "logprobs": True, "top_logprobs": 5, "messages": []}
-        result = apply_transforms(shim.to_transforms, body)
+        result = apply_transforms(shim.post_ir_transforms, body)
         assert "logprobs" not in result
         assert "top_logprobs" not in result
         assert result["model"] == "test"
@@ -231,7 +231,7 @@ class TestBuiltinTransforms:
             "temperature": 0.7,
             "messages": [],
         }
-        result = apply_transforms(shim.to_transforms, body)
+        result = apply_transforms(shim.post_ir_transforms, body)
         assert "n" not in result
         assert "logit_bias" not in result
         assert "seed" not in result
@@ -247,7 +247,7 @@ class TestBuiltinTransforms:
             "temperature": 1.0,
             "messages": [],
         }
-        result = apply_transforms(shim.to_transforms, body)
+        result = apply_transforms(shim.post_ir_transforms, body)
         assert "logit_bias" not in result
         assert result["model"] == "grok-3"
         assert result["temperature"] == 1.0
@@ -264,7 +264,7 @@ class TestBuiltinTransforms:
             "temperature": 0.5,
             "messages": [],
         }
-        result = apply_transforms(shim.to_transforms, body)
+        result = apply_transforms(shim.post_ir_transforms, body)
         assert "logprobs" not in result
         assert "top_logprobs" not in result
         assert "logit_bias" not in result
@@ -282,7 +282,7 @@ class TestBuiltinTransforms:
             "temperature": 0.7,
             "messages": [],
         }
-        result = apply_transforms(shim.to_transforms, body)
+        result = apply_transforms(shim.post_ir_transforms, body)
         assert "frequency_penalty" not in result
         assert "logit_bias" not in result
         assert result["model"] == "qwen-max"
@@ -300,7 +300,7 @@ class TestBuiltinTransforms:
             "temperature": 0.8,
             "messages": [],
         }
-        result = apply_transforms(shim.to_transforms, body)
+        result = apply_transforms(shim.post_ir_transforms, body)
         assert "logprobs" not in result
         assert "top_logprobs" not in result
         assert "seed" not in result
@@ -323,7 +323,7 @@ class TestBuiltinTransforms:
             "temperature": 0.8,
             "messages": [],
         }
-        result = apply_transforms(shim.to_transforms, body)
+        result = apply_transforms(shim.post_ir_transforms, body)
         assert "n" not in result
         assert "presence_penalty" not in result
         assert "frequency_penalty" not in result
@@ -572,7 +572,7 @@ class TestArgoOpenaiChatTransforms:
             "model": "gpt-4",
             "messages": [{"role": "developer", "content": "system prompt"}],
         }
-        result = apply_transforms(shim.to_transforms, body)
+        result = apply_transforms(shim.post_ir_transforms, body)
         assert result["messages"][0]["role"] == "system"
 
     def test_argo_normalizes_null_content(self):
@@ -584,7 +584,7 @@ class TestArgoOpenaiChatTransforms:
                 {"role": "assistant", "content": None, "tool_calls": []},
             ],
         }
-        result = apply_transforms(shim.to_transforms, body)
+        result = apply_transforms(shim.post_ir_transforms, body)
         assert result["messages"][0]["content"] == ""
 
     def test_argo_strips_temperature_for_opus47(self):
@@ -595,7 +595,7 @@ class TestArgoOpenaiChatTransforms:
             "temperature": 0.7,
             "messages": [{"role": "user", "content": "hi"}],
         }
-        result = apply_transforms(shim.to_transforms, body)
+        result = apply_transforms(shim.post_ir_transforms, body)
         assert "temperature" not in result
 
     def test_argo_keeps_temperature_for_other_models(self):
@@ -606,7 +606,7 @@ class TestArgoOpenaiChatTransforms:
             "temperature": 0.7,
             "messages": [{"role": "user", "content": "hi"}],
         }
-        result = apply_transforms(shim.to_transforms, body)
+        result = apply_transforms(shim.post_ir_transforms, body)
         assert result["temperature"] == 0.7
 
     def test_argo_renames_max_tokens(self):
@@ -617,6 +617,6 @@ class TestArgoOpenaiChatTransforms:
             "max_tokens": 100,
             "messages": [{"role": "user", "content": "hi"}],
         }
-        result = apply_transforms(shim.to_transforms, body)
+        result = apply_transforms(shim.post_ir_transforms, body)
         assert "max_tokens" not in result
         assert result["max_completion_tokens"] == 100

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -182,8 +182,8 @@ class TestShimWithTransforms:
         s = ProviderShim(
             name="test",
             base="openai_chat",
-            from_transforms=(t1,),
-            to_transforms=(t2,),
+            pre_ir_transforms=(t1,),
+            post_ir_transforms=(t2,),
         )
         assert s.from_transforms == (t1,)
         assert s.to_transforms == (t2,)
@@ -206,7 +206,7 @@ class TestBuiltinTransforms:
 
         load_providers()
 
-    def test_volcengine_has_to_transforms(self):
+    def test_volcengine_has_post_ir_transforms(self):
         shim = get_shim("volcengine--openai_chat")
         assert shim is not None
         assert len(shim.to_transforms) > 0
@@ -347,12 +347,12 @@ class TestConvertWithTransforms:
 
         load_providers()
 
-    def test_convert_applies_source_from_transforms(self):
-        """Source shim's from_transforms should normalise before conversion."""
+    def test_convert_applies_source_pre_ir_transforms(self):
+        """Source shim's pre_ir_transforms should normalise before conversion."""
         custom = ProviderShim(
             name="custom-oai",
             base="openai_chat",
-            from_transforms=(rename_field("custom_field", "model"),),
+            pre_ir_transforms=(rename_field("custom_field", "model"),),
         )
         register_shim(custom)
 
@@ -365,12 +365,12 @@ class TestConvertWithTransforms:
         result = convert(body, "anthropic", source_provider="custom-oai")
         assert "model" in result
 
-    def test_convert_applies_target_to_transforms(self):
-        """Target shim's to_transforms should adapt after conversion."""
+    def test_convert_applies_target_post_ir_transforms(self):
+        """Target shim's post_ir_transforms should adapt after conversion."""
         custom = ProviderShim(
             name="custom-target",
             base="openai_chat",
-            to_transforms=(strip_fields("logprobs"),),
+            post_ir_transforms=(strip_fields("logprobs"),),
         )
         register_shim(custom)
 
@@ -400,7 +400,7 @@ class TestConvertWithTransforms:
         custom = ProviderShim(
             name="idem-test",
             base="openai_chat",
-            to_transforms=(t, t),
+            post_ir_transforms=(t, t),
         )
         register_shim(custom)
 


### PR DESCRIPTION
## Summary

Follow-up to #368 (merged at `29f44d8` but two subsequent commits didn't make it in).

### Changes

**Fix: `_load_transforms` fallback logic** (`fdb6fab`)
- `or` → `is None` check: empty tuple `()` is falsy but valid, `or` would incorrectly fall through to the legacy name
- Reject unknown kwargs in `ProviderShim.__init__` to match frozen dataclass behavior
- Add "Keep in sync" comment on defaults dict

**Deprecation warnings + provider migration** (`f31572b`)
- `DeprecationWarning` when `ProviderShim` is constructed with legacy `from_transforms`/`to_transforms` kwargs
- `logger.info` deprecation notice when `transforms.py` exports legacy names
- All 11 built-in provider `transforms.py` files migrated to `pre_ir_transforms`/`post_ir_transforms`
- Test constructors and method names updated

Addresses review feedback from Elena and Milo on #368.

## Test plan
- [x] 2055 tests pass, 0 regressions