### PR TITLE
feat: flatten_system_content transform + per-model gateway toggle

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -87,15 +87,20 @@ class OpenAIChatConverter(BaseConverter):
         ctx = context if context is not None else ConversionContext()
         result: dict[str, Any] = {"model": ir_request["model"]}
 
-        # 1. System instruction → system message (plain string)
-        # OpenAI Chat system messages use plain string content for maximum
-        # downstream compatibility (some consumers don't handle array form).
+        # 1. System instruction → system message (structured content array)
+        # Outputs content as an array of text parts to preserve block
+        # boundaries (e.g. for cache_hint).  Consumers that need a plain
+        # string should use the flatten_system_content() post-IR transform.
         messages: list[dict[str, Any]] = []
         system_parts = ir_request.get("system_instruction")
         if system_parts:
-            system_text = " ".join(p["text"] for p in system_parts if is_text_part(p))
-            if system_text:
-                messages.append({"role": "system", "content": system_text})
+            content = [
+                self.content_ops.ir_text_to_p(p)
+                for p in system_parts
+                if is_text_part(p)
+            ]
+            if content:
+                messages.append({"role": "system", "content": content})
 
         # 2. Messages — fix orphaned tool_calls at IR level before conversion.
         # OpenAI Chat API strictly requires every tool_call_id to have a

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -893,6 +893,10 @@ body { padding-bottom: 26px; }
         <label><input type="checkbox" id="capReasoning" onchange="updateReasoningVisibility()"> reasoning</label>
       </div>
     </div>
+    <div class="form-group">
+      <label><input type="checkbox" id="flattenSystem"> <span data-i18n="label.flattenSystem">Flatten system content</span></label>
+      <div style="font-size:0.8em;color:var(--text-dim);margin-top:4px" data-i18n="label.flattenSystemHint">Flatten system message content arrays to plain strings for upstream compatibility.</div>
+    </div>
     <div class="form-group" id="modelReasoningGroup" style="display:none">
       <label><span data-i18n="label.reasoningConfig">Reasoning Config</span>
         <span class="badge badge-sm" id="reasoningSourceBadge" style="margin-left:6px"></span>
@@ -1112,7 +1116,7 @@ const I18N = {
     'label.baseUrl':'Base URL',
     'label.apiKey':'API Key (or ${ENV_VAR} placeholder)', 'label.keyUnchangedHint':'Leave blank to keep current key',
     'label.proxyUrl':'Proxy URL (optional, overrides global)',
-    'label.modelName':'Model Name', 'label.provider':'Provider', 'label.upstreamModel':'Upstream Model', 'label.capabilities':'Capabilities',
+    'label.modelName':'Model Name', 'label.provider':'Provider', 'label.upstreamModel':'Upstream Model', 'label.capabilities':'Capabilities', 'label.flattenSystem':'Flatten system content', 'label.flattenSystemHint':'Flatten system message content arrays to plain strings for upstream compatibility.',
     'label.reasoningConfig':'Reasoning Config', 'label.thinkingType':'Thinking Type', 'label.budgetRatio':'Budget Tokens Ratio', 'label.disabledStrategy':'Disabled Strategy', 'label.inheritProvider':'(inherit from provider)', 'label.inherited':'inherited',
     'modal.addProvider':'Add Provider', 'modal.editProvider':'Edit Provider',
     'modal.addModel':'Add Model', 'modal.editModel':'Edit Model',
@@ -2432,6 +2436,10 @@ async function saveModel() {
     if (budgetRatioStr !== '') override.budget_tokens_default_ratio = parseFloat(budgetRatioStr);
     if (disabledStrategy) override.disabled = disabledStrategy;
     if (Object.keys(override).length > 0) body.reasoning_override = override;
+  }
+  // flatten_system
+  if (document.getElementById('flattenSystem').checked) {
+    body.flatten_system = true;
   }
   const originalName = document.getElementById('modelName').dataset.originalName;
   if (originalName && originalName !== name) {

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -1862,6 +1862,11 @@ function openModelModal(model, provider, capabilities, upstreamModel, sourceMode
   document.getElementById('capVision').checked = caps.includes('vision');
   document.getElementById('capTools').checked = caps.includes('tools');
   document.getElementById('capReasoning').checked = caps.includes('reasoning');
+  // flatten_system — read from model config, or infer auto-detect for gemini
+  const fsModel = model && configData ? configData.models[model] : null;
+  const fsCfg = fsModel && fsModel.flatten_system;
+  const fsAuto = model && /gemini/i.test(model);
+  document.getElementById('flattenSystem').checked = fsCfg != null ? !!fsCfg : !!fsAuto;
   onModelTypeChange();
 
   // Populate reasoning config section.
@@ -2438,9 +2443,7 @@ async function saveModel() {
     if (Object.keys(override).length > 0) body.reasoning_override = override;
   }
   // flatten_system
-  if (document.getElementById('flattenSystem').checked) {
-    body.flatten_system = true;
-  }
+  body.flatten_system = document.getElementById('flattenSystem').checked;
   const originalName = document.getElementById('modelName').dataset.originalName;
   if (originalName && originalName !== name) {
     body.rename_from = originalName;

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -127,6 +127,8 @@ async def get_config(request: Any) -> Response:
                 entry["upstream_model"] = value["upstream_model"]
             if value.get("reasoning_override"):
                 entry["reasoning_override"] = value["reasoning_override"]
+            if value.get("flatten_system"):
+                entry["flatten_system"] = value["flatten_system"]
             models_normalized[name] = entry
 
     # Resolve effective reasoning config per model
@@ -421,6 +423,11 @@ async def put_model(request: Any, **kwargs: Any) -> Response:
     upstream_model = body.get("upstream_model")
     if upstream_model:
         model_entry["upstream_model"] = upstream_model
+
+    # Persist per-model flatten_system flag (if provided)
+    flatten_system = body.get("flatten_system")
+    if flatten_system is not None:
+        model_entry["flatten_system"] = bool(flatten_system)
 
     # Persist per-model reasoning override (if provided)
     reasoning_override = body.get("reasoning_override")

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -156,6 +156,17 @@ class GatewayConfig:
             if isinstance(value, dict) and value.get("reasoning_override"):
                 self.model_reasoning_overrides[model_name] = value["reasoning_override"]
 
+        # Per-model flatten_system flag (explicit config or auto-detected).
+        # When True, system message content arrays are flattened to plain
+        # strings before sending upstream.
+        self.model_flatten_system: dict[str, bool] = {}
+        for model_name, value in raw.get("models", {}).items():
+            if isinstance(value, dict) and "flatten_system" in value:
+                self.model_flatten_system[model_name] = bool(value["flatten_system"])
+            elif re.search(r"gemini", model_name, re.IGNORECASE):
+                # Auto-detect: gemini models default to flatten_system=True
+                self.model_flatten_system[model_name] = True
+
         _server = raw.get("server", {})
         self.host: str = _server.get("host", "0.0.0.0")
         self.port: int = _server.get("port", 8765)
@@ -348,6 +359,7 @@ class GatewayConfig:
         upstream_model = self.model_upstream_names.get(model)
         caps = self.model_capabilities.get(model, list(self.DEFAULT_CAPABILITIES))
         reasoning = self.model_reasoning_overrides.get(model)
+        flatten_system = self.model_flatten_system.get(model, False)
 
         route = ResolvedRoute(
             source_provider=source_provider,
@@ -357,5 +369,6 @@ class GatewayConfig:
             upstream_model=upstream_model,
             model_capabilities=caps,
             reasoning_override=reasoning,
+            flatten_system=flatten_system,
         )
         return route, self.providers[provider_name]

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -282,6 +282,13 @@ async def handle_non_streaming(
     log_original_request(pipeline.ir_request)
     if pipeline.warnings:
         logger.warning("Conversion warnings: %s", pipeline.warnings)
+
+    # Per-model system message flattening (gateway config override)
+    if route.flatten_system:
+        from llm_rosetta.shims.transforms import flatten_system_content
+
+        target_body = flatten_system_content()(target_body)
+
     log_converted_request(target_body)
 
     # Phase 3: Forward to upstream via transport
@@ -527,6 +534,12 @@ async def handle_streaming(
     log_original_request(pipeline.ir_request)
     if pipeline.warnings:
         logger.warning("Conversion warnings: %s", pipeline.warnings)
+
+    # Per-model system message flattening (gateway config override)
+    if route.flatten_system:
+        from llm_rosetta.shims.transforms import flatten_system_content
+
+        target_body = flatten_system_content()(target_body)
 
     log_converted_request(target_body)
 

--- a/src/llm_rosetta/routing.py
+++ b/src/llm_rosetta/routing.py
@@ -52,6 +52,7 @@ class ResolvedRoute:
     upstream_model: str | None = None
     model_capabilities: list[str] = field(default_factory=lambda: ["text"])
     reasoning_override: dict[str, Any] | None = None
+    flatten_system: bool = False
 
 
 class Router(Protocol):

--- a/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
@@ -12,6 +12,9 @@ Request-side (post_ir_transforms) — body-level
   null content when iterating message bodies.
 - ``strip_fields_for_model(r"^claudeopus47", "temperature")``: strips
   ``temperature`` for reasoning models that reject it (e.g. Claude Opus 4.7).
+- ``flatten_system_content(pattern=r"^gemini")``: flattens system message
+  content arrays to plain strings for Gemini models, which don't handle
+  structured content in system messages.
 
 Request-side (ir_transforms) — IR-level
 -----------------------------------------
@@ -23,6 +26,7 @@ Request-side (ir_transforms) — IR-level
 
 from llm_rosetta.shims.transforms import (
     default_message_field,
+    flatten_system_content,
     rename_field,
     replace_message_field,
     strip_fields_for_model,
@@ -35,6 +39,7 @@ post_ir_transforms = (
     replace_message_field("role", "developer", "system"),
     default_message_field("content", ""),
     strip_fields_for_model(r"^claudeopus47", "temperature"),
+    flatten_system_content(pattern=r"^gemini"),
 )
 pre_ir_transforms = ()
 ir_transforms = (

--- a/src/llm_rosetta/shims/transforms.py
+++ b/src/llm_rosetta/shims/transforms.py
@@ -345,3 +345,56 @@ def unwind_parallel_tool_calls(pattern: str | None = None) -> IRTransform:
         label += f"pattern={pattern!r}"
     label += ")"
     return _NamedIRTransform(_unwind, label)
+
+
+# ---------------------------------------------------------------------------
+# Body-level: system message flattening
+# ---------------------------------------------------------------------------
+
+
+def flatten_system_content(pattern: str | None = None) -> Transform:
+    """Return a body-level transform that flattens system message content
+    arrays to plain strings.
+
+    Converts ``messages[].content`` from
+    ``[{"type": "text", "text": "..."}]`` to a joined string for system
+    messages.  Idempotent — no-op if content is already a string.
+
+    When *pattern* is set, flattening only fires if ``body["model"]``
+    matches the regex (search on raw model string).
+
+    Example::
+
+        flatten_system_content()                     # always flatten
+        flatten_system_content(pattern=r"gemini")    # only for gemini models
+    """
+    compiled = re.compile(pattern) if pattern else None
+
+    def _flatten(body: dict[str, Any]) -> dict[str, Any]:
+        if compiled is not None:
+            model = body.get("model", "")
+            if not compiled.search(model):
+                return body
+
+        messages = body.get("messages")
+        if not messages or not isinstance(messages, list):
+            return body
+
+        for msg in messages:
+            if not isinstance(msg, dict) or msg.get("role") != "system":
+                continue
+            content = msg.get("content")
+            if isinstance(content, list):
+                text = " ".join(
+                    p.get("text", "") if isinstance(p, dict) else str(p)
+                    for p in content
+                )
+                msg["content"] = text
+
+        return body
+
+    label = "flatten_system_content("
+    if pattern:
+        label += f"pattern={pattern!r}"
+    label += ")"
+    return _NamedTransform(_flatten, label)

--- a/tests/converters/anthropic/test_cache_hint.py
+++ b/tests/converters/anthropic/test_cache_hint.py
@@ -631,11 +631,14 @@ class TestCrossFormatSystemCacheHint:
         ir = anthropic_converter.request_from_provider(provider_request)
         result, warnings = openai_converter.request_to_provider(ir)
 
-        # System should be a plain string in the first system message
+        # System should be a structured content array (no cache_control)
         system_msgs = [m for m in result["messages"] if m["role"] == "system"]
         assert len(system_msgs) == 1
         content = system_msgs[0]["content"]
-        assert isinstance(content, str)
+        assert isinstance(content, list)
+        assert len(content) == 2
+        assert content[0]["text"] == "You are helpful."
+        assert content[1]["text"] == "Be concise."
         assert "cache_control" not in str(result)
 
     def test_anthropic_system_cache_to_google_flattens(self):

--- a/tests/converters/openai_chat/test_converter.py
+++ b/tests/converters/openai_chat/test_converter.py
@@ -57,7 +57,9 @@ class TestOpenAIChatConverter:
         )
         result, _ = self.converter.request_to_provider(ir_request)
         assert result["messages"][0]["role"] == "system"
-        assert result["messages"][0]["content"] == "You are helpful."
+        assert result["messages"][0]["content"] == [
+            {"type": "text", "text": "You are helpful."}
+        ]
         assert result["messages"][1]["role"] == "user"
 
     def test_request_to_provider_full(self):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -620,3 +620,147 @@ class TestArgoOpenaiChatTransforms:
         result = apply_transforms(shim.post_ir_transforms, body)
         assert "max_tokens" not in result
         assert result["max_completion_tokens"] == 100
+
+
+# ============================================================================
+# flatten_system_content
+# ============================================================================
+
+
+class TestFlattenSystemContent:
+    """Tests for flatten_system_content() body-level transform."""
+
+    def test_flattens_array_to_string(self):
+        """Content array is joined into a plain string."""
+        from llm_rosetta.shims.transforms import flatten_system_content
+
+        body = {
+            "model": "gemini-3.5-flash",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "Be helpful."},
+                        {"type": "text", "text": "Be concise."},
+                    ],
+                },
+                {"role": "user", "content": "Hi"},
+            ],
+        }
+        result = flatten_system_content()(body)
+        assert result["messages"][0]["content"] == "Be helpful. Be concise."
+
+    def test_idempotent_string_unchanged(self):
+        """Already-string content is left as-is."""
+        from llm_rosetta.shims.transforms import flatten_system_content
+
+        body = {
+            "model": "gpt-4o",
+            "messages": [
+                {"role": "system", "content": "Be helpful."},
+                {"role": "user", "content": "Hi"},
+            ],
+        }
+        result = flatten_system_content()(body)
+        assert result["messages"][0]["content"] == "Be helpful."
+
+    def test_idempotent_double_apply(self):
+        """Applying twice produces the same result."""
+        from llm_rosetta.shims.transforms import flatten_system_content
+
+        body = {
+            "model": "test",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": "Hello"}],
+                },
+            ],
+        }
+        f = flatten_system_content()
+        result1 = f(body)
+        result2 = f(result1)
+        assert result1 == result2
+
+    def test_no_system_message_noop(self):
+        """No system message → no-op."""
+        from llm_rosetta.shims.transforms import flatten_system_content
+
+        body = {
+            "model": "test",
+            "messages": [{"role": "user", "content": "Hi"}],
+        }
+        result = flatten_system_content()(body)
+        assert result == body
+
+    def test_no_messages_noop(self):
+        """Missing messages key → no-op."""
+        from llm_rosetta.shims.transforms import flatten_system_content
+
+        body = {"model": "test"}
+        result = flatten_system_content()(body)
+        assert result == body
+
+    def test_pattern_match(self):
+        """Only flattens when model matches pattern."""
+        from llm_rosetta.shims.transforms import flatten_system_content
+
+        body = {
+            "model": "gemini25flash",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": "Hello"}],
+                },
+            ],
+        }
+        result = flatten_system_content(pattern=r"^gemini")(body)
+        assert result["messages"][0]["content"] == "Hello"
+
+    def test_pattern_no_match(self):
+        """Non-matching model → no-op."""
+        from llm_rosetta.shims.transforms import flatten_system_content
+
+        body = {
+            "model": "gpt5nano",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": "Hello"}],
+                },
+            ],
+        }
+        result = flatten_system_content(pattern=r"^gemini")(body)
+        # Should NOT flatten — content stays as array
+        assert isinstance(result["messages"][0]["content"], list)
+
+    def test_user_messages_untouched(self):
+        """Only system messages are flattened, user messages stay as-is."""
+        from llm_rosetta.shims.transforms import flatten_system_content
+
+        body = {
+            "model": "test",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": "System"}],
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "User"}],
+                },
+            ],
+        }
+        result = flatten_system_content()(body)
+        assert result["messages"][0]["content"] == "System"
+        assert isinstance(result["messages"][1]["content"], list)
+
+    def test_repr(self):
+        """Transform has a readable repr."""
+        from llm_rosetta.shims.transforms import flatten_system_content
+
+        assert repr(flatten_system_content()) == "flatten_system_content()"
+        assert (
+            repr(flatten_system_content(pattern=r"^gemini"))
+            == "flatten_system_content(pattern='^gemini')"
+        )


### PR DESCRIPTION
Closes #370

## Summary

- **OpenAI Chat converter** now outputs structured content arrays for system messages instead of plain strings, preserving block boundaries for `cache_hint` passthrough
- New **`flatten_system_content()`** body-level transform factory that flattens system content arrays to plain strings for upstream compatibility
- **Per-model `flatten_system` config** in gateway with auto-detection for gemini models
- **Admin panel** checkbox toggle for `flatten_system`
- **Argo shim** default: `flatten_system_content(pattern=r"^gemini")` for Gemini models through Argo

## Test plan

- [x] 2108 tests pass (including 9 new `flatten_system_content` tests)
- [x] `ruff check` + `ruff format` + `ty check` clean
- [ ] Deploy to rosetta-dev and verify gemini models get flattened system, claude models preserve structured content with cache_hint