### PR TITLE
fix: strip nullable and title from tool schemas for Anthropic/Google

### DIFF
--- a/src/llm_rosetta/converters/anthropic/tool_ops.py
+++ b/src/llm_rosetta/converters/anthropic/tool_ops.py
@@ -28,7 +28,12 @@ from ...types.ir import (
 )
 from ...types.ir.tools import ToolCallConfig
 from ..base import BaseToolOps
-from ..base.helpers import extract_part_ids, log_orphan_warnings, sanitize_schema
+from ..base.helpers import (
+    convert_nullable_to_type_array,
+    extract_part_ids,
+    log_orphan_warnings,
+    sanitize_schema,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -175,8 +180,12 @@ class AnthropicToolOps(BaseToolOps):
         }
         raw_schema = ir_tool.get("parameters", {})
         schema = (
-            sanitize_schema(raw_schema) if isinstance(raw_schema, dict) else raw_schema
+            sanitize_schema(raw_schema, extra_strip_keys={"title"})
+            if isinstance(raw_schema, dict)
+            else raw_schema
         )
+        if isinstance(schema, dict):
+            schema = convert_nullable_to_type_array(schema)
         # Anthropic requires input_schema to have "type"; default to object
         if isinstance(schema, dict) and "type" not in schema:
             schema = {"type": "object", **schema}

--- a/src/llm_rosetta/converters/base/helpers/__init__.py
+++ b/src/llm_rosetta/converters/base/helpers/__init__.py
@@ -24,7 +24,7 @@ from .tool_orphan_fix import (
     log_orphan_warnings,
     strip_orphaned_tool_config,
 )
-from .schema import sanitize_schema
+from .schema import convert_nullable_to_type_array, sanitize_schema
 from .reasoning import DEFAULT_REASONING_CAPS, apply_reasoning_config
 from .tool_call_unwind import unwind_parallel_tool_calls_ir
 from .tool_content import convert_content_blocks_to_ir, convert_ir_content_blocks_to_p
@@ -36,6 +36,7 @@ __all__ = [
     "log_orphan_warnings",
     "strip_orphaned_tool_config",
     # schema
+    "convert_nullable_to_type_array",
     "sanitize_schema",
     # reasoning
     "DEFAULT_REASONING_CAPS",

--- a/src/llm_rosetta/converters/base/helpers/schema.py
+++ b/src/llm_rosetta/converters/base/helpers/schema.py
@@ -284,12 +284,21 @@ def _nullable_to_type_array(schema: dict[str, Any]) -> dict[str, Any]:
         else:
             result[key] = value
 
-    if schema.get("nullable") is True and "type" in result:
-        current_type = result["type"]
-        if isinstance(current_type, str):
-            result["type"] = [current_type, "null"]
-        elif isinstance(current_type, list) and "null" not in current_type:
-            result["type"] = [*current_type, "null"]
+    if schema.get("nullable") is True:
+        if "type" in result:
+            current_type = result["type"]
+            if isinstance(current_type, str):
+                result["type"] = [current_type, "null"]
+            elif isinstance(current_type, list) and "null" not in current_type:
+                result["type"] = [*current_type, "null"]
+        else:
+            # No type field — inject null variant into anyOf/oneOf if present
+            for kw in ("anyOf", "oneOf"):
+                if kw in result and isinstance(result[kw], list):
+                    null_variant = {"type": "null"}
+                    if null_variant not in result[kw]:
+                        result[kw] = [*result[kw], null_variant]
+                    break
 
     return result
 

--- a/src/llm_rosetta/converters/base/helpers/schema.py
+++ b/src/llm_rosetta/converters/base/helpers/schema.py
@@ -257,3 +257,54 @@ def sanitize_schema(
     result = _sanitize_schema_impl(schema, defs, extra_strip_keys)
     sanitize_cache.put(key, result)
     return result
+
+
+# ---- nullable → type-array conversion ----
+
+
+def _nullable_to_type_array(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively convert ``"nullable": true`` to standard JSON Schema type arrays.
+
+    Transforms ``{"type": "string", "nullable": true}`` into
+    ``{"type": ["string", "null"]}`` and removes the ``nullable`` key.
+    When ``type`` is already a list, appends ``"null"`` if absent.
+    When ``type`` is missing, only strips the ``nullable`` key.
+    """
+    result: dict[str, Any] = {}
+    for key, value in schema.items():
+        if key == "nullable":
+            continue
+        if isinstance(value, dict):
+            result[key] = _nullable_to_type_array(value)
+        elif isinstance(value, list):
+            result[key] = [
+                _nullable_to_type_array(item) if isinstance(item, dict) else item
+                for item in value
+            ]
+        else:
+            result[key] = value
+
+    if schema.get("nullable") is True and "type" in result:
+        current_type = result["type"]
+        if isinstance(current_type, str):
+            result["type"] = [current_type, "null"]
+        elif isinstance(current_type, list) and "null" not in current_type:
+            result["type"] = [*current_type, "null"]
+
+    return result
+
+
+def convert_nullable_to_type_array(schema: dict[str, Any]) -> dict[str, Any]:
+    """Convert ``"nullable": true`` to standard JSON Schema ``"type": [T, "null"]``.
+
+    Providers like Anthropic do not support the OpenAPI ``nullable`` extension.
+    This function recursively replaces it with the equivalent JSON Schema
+    representation using type arrays.
+
+    Args:
+        schema: A sanitized JSON Schema dict.
+
+    Returns:
+        A new dict with ``nullable`` fields replaced by type arrays.
+    """
+    return _nullable_to_type_array(schema)

--- a/src/llm_rosetta/converters/google_genai/tool_ops.py
+++ b/src/llm_rosetta/converters/google_genai/tool_ops.py
@@ -60,7 +60,7 @@ class GoogleGenAIToolOps(BaseToolOps):
             func_decl["parameters"] = (
                 sanitize_schema(
                     parameters,
-                    extra_strip_keys={"additionalProperties"},
+                    extra_strip_keys={"additionalProperties", "title"},
                 )
                 if isinstance(parameters, dict)
                 else parameters

--- a/tests/converters/anthropic/test_tool_ops.py
+++ b/tests/converters/anthropic/test_tool_ops.py
@@ -341,3 +341,117 @@ class TestAnthropicToolOps:
         """Test empty Anthropic tool config → empty IR."""
         result = AnthropicToolOps.p_tool_config_to_ir({})
         assert result == {}
+
+    # ==================== Schema Sanitization (#372) ====================
+
+    def test_ir_tool_definition_strips_nullable(self):
+        """nullable: true should be converted to type array for Anthropic."""
+        ir_tool: ToolDefinition = {
+            "type": "function",
+            "name": "run_cmd",
+            "description": "Run a command",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "cwd": {
+                        "default": None,
+                        "type": "string",
+                        "nullable": True,
+                    }
+                },
+            },
+            "required_parameters": [],
+            "metadata": {},
+        }
+        result = AnthropicToolOps.ir_tool_definition_to_p(ir_tool)
+        cwd_schema = result["input_schema"]["properties"]["cwd"]
+        assert cwd_schema["type"] == ["string", "null"]
+        assert "nullable" not in cwd_schema
+
+    def test_ir_tool_definition_strips_title(self):
+        """title fields should be stripped for Anthropic."""
+        ir_tool: ToolDefinition = {
+            "type": "function",
+            "name": "run_cmd",
+            "description": "Run a command",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "cwd": {
+                        "title": "Cwd",
+                        "type": "string",
+                    }
+                },
+            },
+            "required_parameters": [],
+            "metadata": {},
+        }
+        result = AnthropicToolOps.ir_tool_definition_to_p(ir_tool)
+        cwd_schema = result["input_schema"]["properties"]["cwd"]
+        assert "title" not in cwd_schema
+
+    def test_ir_tool_definition_pydantic_schema(self):
+        """Full Pydantic-generated schema from issue #372."""
+        ir_tool: ToolDefinition = {
+            "type": "function",
+            "name": "execute",
+            "description": "Execute a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "title": "Command",
+                        "type": "string",
+                    },
+                    "cwd": {
+                        "default": None,
+                        "title": "Cwd",
+                        "type": "string",
+                        "nullable": True,
+                    },
+                    "timeout": {
+                        "default": 120,
+                        "title": "Timeout",
+                        "type": "integer",
+                    },
+                },
+                "required": ["command"],
+            },
+            "required_parameters": ["command"],
+            "metadata": {},
+        }
+        result = AnthropicToolOps.ir_tool_definition_to_p(ir_tool)
+        schema = result["input_schema"]
+        assert "title" not in schema["properties"]["command"]
+        assert "title" not in schema["properties"]["cwd"]
+        assert "title" not in schema["properties"]["timeout"]
+        assert schema["properties"]["cwd"]["type"] == ["string", "null"]
+        assert "nullable" not in schema["properties"]["cwd"]
+        assert schema["properties"]["command"]["type"] == "string"
+        assert schema["properties"]["timeout"]["type"] == "integer"
+
+    def test_ir_tool_definition_anyof_nullable_converted(self):
+        """anyOf nullable pattern should end up as type array, not nullable."""
+        ir_tool: ToolDefinition = {
+            "type": "function",
+            "name": "test",
+            "description": "Test",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "field": {
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "null"},
+                        ]
+                    }
+                },
+            },
+            "required_parameters": [],
+            "metadata": {},
+        }
+        result = AnthropicToolOps.ir_tool_definition_to_p(ir_tool)
+        field_schema = result["input_schema"]["properties"]["field"]
+        assert field_schema["type"] == ["string", "null"]
+        assert "nullable" not in field_schema
+        assert "anyOf" not in field_schema

--- a/tests/converters/base/test_nullable_conversion.py
+++ b/tests/converters/base/test_nullable_conversion.py
@@ -132,3 +132,36 @@ class TestConvertNullableToTypeArray:
         result = convert_nullable_to_type_array(schema)
         assert result["anyOf"][0]["type"] == ["string", "null"]
         assert result["anyOf"][1]["type"] == "integer"
+
+    def test_nullable_with_anyof_no_type(self):
+        """nullable + anyOf without type → inject null variant into anyOf."""
+        schema = {
+            "anyOf": [{"type": "string"}, {"type": "integer"}],
+            "nullable": True,
+        }
+        result = convert_nullable_to_type_array(schema)
+        assert "nullable" not in result
+        assert {"type": "null"} in result["anyOf"]
+        assert len(result["anyOf"]) == 3
+
+    def test_nullable_with_oneof_no_type(self):
+        """nullable + oneOf without type → inject null variant into oneOf."""
+        schema = {
+            "oneOf": [{"type": "string"}, {"type": "integer"}],
+            "nullable": True,
+        }
+        result = convert_nullable_to_type_array(schema)
+        assert "nullable" not in result
+        assert {"type": "null"} in result["oneOf"]
+        assert len(result["oneOf"]) == 3
+
+    def test_nullable_with_anyof_already_has_null(self):
+        """nullable + anyOf that already has null → no duplicate."""
+        schema = {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "nullable": True,
+        }
+        result = convert_nullable_to_type_array(schema)
+        assert "nullable" not in result
+        null_count = sum(1 for v in result["anyOf"] if v == {"type": "null"})
+        assert null_count == 1

--- a/tests/converters/base/test_nullable_conversion.py
+++ b/tests/converters/base/test_nullable_conversion.py
@@ -1,0 +1,134 @@
+"""Tests for convert_nullable_to_type_array in converters/base/schema.py."""
+
+from llm_rosetta.converters.base.helpers.schema import convert_nullable_to_type_array
+
+
+class TestConvertNullableToTypeArray:
+    """Tests for nullable → type array conversion."""
+
+    def test_simple_nullable_string(self):
+        schema = {"type": "string", "nullable": True}
+        result = convert_nullable_to_type_array(schema)
+        assert result["type"] == ["string", "null"]
+        assert "nullable" not in result
+
+    def test_simple_nullable_integer(self):
+        schema = {"type": "integer", "nullable": True}
+        result = convert_nullable_to_type_array(schema)
+        assert result["type"] == ["integer", "null"]
+        assert "nullable" not in result
+
+    def test_non_nullable_unchanged(self):
+        schema = {"type": "string", "description": "a field"}
+        result = convert_nullable_to_type_array(schema)
+        assert result["type"] == "string"
+        assert result["description"] == "a field"
+
+    def test_nullable_false_stripped(self):
+        schema = {"type": "string", "nullable": False}
+        result = convert_nullable_to_type_array(schema)
+        assert result["type"] == "string"
+        assert "nullable" not in result
+
+    def test_type_already_list(self):
+        schema = {"type": ["string", "integer"], "nullable": True}
+        result = convert_nullable_to_type_array(schema)
+        assert result["type"] == ["string", "integer", "null"]
+        assert "nullable" not in result
+
+    def test_type_list_already_has_null(self):
+        schema = {"type": ["string", "null"], "nullable": True}
+        result = convert_nullable_to_type_array(schema)
+        assert result["type"] == ["string", "null"]
+        assert "nullable" not in result
+
+    def test_nullable_without_type_strips_key(self):
+        schema = {"nullable": True, "description": "no type"}
+        result = convert_nullable_to_type_array(schema)
+        assert "nullable" not in result
+        assert "type" not in result
+        assert result["description"] == "no type"
+
+    def test_nested_in_properties(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "cwd": {"type": "string", "nullable": True, "default": None},
+            },
+        }
+        result = convert_nullable_to_type_array(schema)
+        assert result["properties"]["name"]["type"] == "string"
+        assert result["properties"]["cwd"]["type"] == ["string", "null"]
+        assert "nullable" not in result["properties"]["cwd"]
+
+    def test_nested_in_items(self):
+        schema = {
+            "type": "array",
+            "items": {"type": "string", "nullable": True},
+        }
+        result = convert_nullable_to_type_array(schema)
+        assert result["items"]["type"] == ["string", "null"]
+        assert "nullable" not in result["items"]
+
+    def test_deeply_nested(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "outer": {
+                    "type": "object",
+                    "properties": {
+                        "inner": {"type": "integer", "nullable": True},
+                    },
+                }
+            },
+        }
+        result = convert_nullable_to_type_array(schema)
+        inner = result["properties"]["outer"]["properties"]["inner"]
+        assert inner["type"] == ["integer", "null"]
+        assert "nullable" not in inner
+
+    def test_preserves_other_fields(self):
+        schema = {
+            "type": "string",
+            "nullable": True,
+            "description": "Optional field",
+            "default": None,
+            "enum": ["a", "b"],
+        }
+        result = convert_nullable_to_type_array(schema)
+        assert result["type"] == ["string", "null"]
+        assert result["description"] == "Optional field"
+        assert result["default"] is None
+        assert result["enum"] == ["a", "b"]
+        assert "nullable" not in result
+
+    def test_pydantic_style_schema(self):
+        """Reproduce the exact schema from issue #372."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "cwd": {
+                    "default": None,
+                    "title": "Cwd",
+                    "type": "string",
+                    "nullable": True,
+                }
+            },
+        }
+        result = convert_nullable_to_type_array(schema)
+        cwd = result["properties"]["cwd"]
+        assert cwd["type"] == ["string", "null"]
+        assert "nullable" not in cwd
+        assert cwd["title"] == "Cwd"  # title not stripped by this function
+
+    def test_list_of_schemas(self):
+        schema = {
+            "anyOf": [
+                {"type": "string", "nullable": True},
+                {"type": "integer"},
+            ]
+        }
+        result = convert_nullable_to_type_array(schema)
+        assert result["anyOf"][0]["type"] == ["string", "null"]
+        assert result["anyOf"][1]["type"] == "integer"

--- a/tests/converters/google_genai/test_tool_ops.py
+++ b/tests/converters/google_genai/test_tool_ops.py
@@ -441,3 +441,41 @@ class TestGoogleGenAIToolOps:
         """Test Google tool config → IR ToolCallConfig (empty)."""
         result = GoogleGenAIToolOps.p_tool_config_to_ir({})
         assert result == {}
+
+    # ==================== Schema Sanitization (#372) ====================
+
+    def test_ir_tool_definition_strips_title(self):
+        """title fields should be stripped for Google GenAI."""
+        ir_tool: ToolDefinition = {
+            "type": "function",
+            "name": "run_cmd",
+            "description": "Run a command",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {"title": "Command", "type": "string"},
+                    "cwd": {"title": "Cwd", "type": "string", "nullable": True},
+                },
+            },
+        }
+        result = GoogleGenAIToolOps.ir_tool_definition_to_p(ir_tool)
+        params = result["function_declarations"][0]["parameters"]
+        assert "title" not in params["properties"]["command"]
+        assert "title" not in params["properties"]["cwd"]
+
+    def test_ir_tool_definition_preserves_nullable(self):
+        """Google GenAI supports nullable — it should be preserved."""
+        ir_tool: ToolDefinition = {
+            "type": "function",
+            "name": "test",
+            "description": "Test",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "field": {"type": "string", "nullable": True},
+                },
+            },
+        }
+        result = GoogleGenAIToolOps.ir_tool_definition_to_p(ir_tool)
+        params = result["function_declarations"][0]["parameters"]
+        assert params["properties"]["field"]["nullable"] is True


### PR DESCRIPTION
## Summary

Fixes #372.

- Add `convert_nullable_to_type_array()` helper that recursively converts OpenAPI `"nullable": true` to standard JSON Schema `"type": [T, "null"]`
- Anthropic converter: strip `title` fields and convert `nullable` to type arrays before sending to API
- Google GenAI converter: strip `title` fields (`nullable` is kept — Google supports it)
- OpenAI converters: no changes needed (lenient validation)

## Test plan

- [x] Unit tests for `convert_nullable_to_type_array` — simple types, nested properties, lists, deeply nested, edge cases
- [x] Anthropic `ir_tool_definition_to_p` tests — nullable conversion, title stripping, full Pydantic schema, anyOf→type-array pipeline
- [x] Google `ir_tool_definition_to_p` tests — title stripping, nullable preserved
- [x] Full test suite passes (2127 passed)
- [x] Lint clean