### PR TITLE
refactor: extract ConfigIO protocol for admin panel config I/O

### DIFF
--- a/src/llm_rosetta/gateway/__init__.py
+++ b/src/llm_rosetta/gateway/__init__.py
@@ -19,14 +19,16 @@ Usage::
 
 from .app import create_app
 from .cli import main
-from .config import GatewayConfig, discover_config, load_config
+from .config import ConfigIO, GatewayConfig, JsoncConfigIO, discover_config, load_config
 from .proxy import ProviderMetadataStore
 
 __all__ = [
+    "ConfigIO",
+    "GatewayConfig",
+    "JsoncConfigIO",
     "ProviderMetadataStore",
     "create_app",
-    "main",
-    "GatewayConfig",
     "discover_config",
     "load_config",
+    "main",
 ]

--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -15,7 +15,7 @@ from llm_rosetta.observability import (
 )
 
 if TYPE_CHECKING:
-    from ..config import GatewayConfig
+    from ..config import ConfigIO, GatewayConfig
 
 __all__ = ["setup_admin", "MetricsCollector", "RequestLog", "PersistenceManager"]
 
@@ -66,12 +66,27 @@ def setup_admin(
     app: Any,
     config: GatewayConfig,
     config_path: str | None,
+    config_io: ConfigIO | None = None,
 ) -> None:
     """Initialize admin panel state on the app.
+
+    Args:
+        app: The httpserver application.
+        config: Parsed gateway configuration.
+        config_path: Path to the config file on disk (``None`` disables
+            persistence and config editing).
+        config_io: Optional I/O adapter for reading/writing the config
+            file.  Defaults to :class:`JsoncConfigIO` when ``None``.
+            Supply a custom implementation for non-JSONC formats
+            (e.g. YAML in argo-proxy).
 
     Routes are registered separately via ``register_admin_routes`` before
     calling this function.
     """
+    if config_io is None:
+        from ..config import JsoncConfigIO
+
+        config_io = JsoncConfigIO()
     metrics = MetricsCollector()
 
     # Set up SQLite persistence alongside the config file
@@ -120,5 +135,6 @@ def setup_admin(
     app.persistence = persistence
     app.gateway_config = config
     app.config_path = config_path
+    app.config_io = config_io
     app.profiler_state = profiler_state
     app.capture_state = capture_state

--- a/src/llm_rosetta/gateway/admin/routes/_shared.py
+++ b/src/llm_rosetta/gateway/admin/routes/_shared.py
@@ -7,7 +7,7 @@ from typing import Any, overload
 
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
-from ...config import GatewayConfig, load_config, write_config  # noqa: F401
+from ...config import ConfigIO, GatewayConfig
 
 _ENV_VAR_RE = re.compile(r"^\$\{.+\}$")
 
@@ -42,11 +42,17 @@ def _get_config_path(request: Any) -> str | None:
     return getattr(request.app, "config_path", None)
 
 
+def _get_config_io(request: Any) -> ConfigIO:
+    """Return the :class:`ConfigIO` adapter stored on the app object."""
+    return request.app.config_io  # type: ignore[attr-defined]
+
+
 def _reload_gateway_config(request: Any, config_path: str) -> GatewayConfig:
     """Re-read config from disk, rebuild GatewayConfig, swap into app state."""
     import llm_rosetta.gateway.app as _app_mod
 
-    raw = load_config(config_path)
+    config_io = _get_config_io(request)
+    raw = config_io.load(config_path)
     new_config = GatewayConfig(raw)
     _app_mod._config = new_config
     request.app.gateway_config = new_config

--- a/src/llm_rosetta/gateway/admin/routes/_shared.py
+++ b/src/llm_rosetta/gateway/admin/routes/_shared.py
@@ -37,9 +37,12 @@ def _mask_api_key(value: str) -> str:
     return value[:4] + "***" + value[-4:]
 
 
-def _get_config_path(request: Any) -> str | None:
+def _get_config_path(request: Any) -> str:
     """Return the config file path stored on the app object."""
-    return getattr(request.app, "config_path", None)
+    path = getattr(request.app, "config_path", None)
+    if path is None:
+        raise RuntimeError("No config file path available")
+    return path
 
 
 def _get_config_io(request: Any) -> ConfigIO:

--- a/src/llm_rosetta/gateway/admin/routes/_shared.py
+++ b/src/llm_rosetta/gateway/admin/routes/_shared.py
@@ -44,7 +44,10 @@ def _get_config_path(request: Any) -> str | None:
 
 def _get_config_io(request: Any) -> ConfigIO:
     """Return the :class:`ConfigIO` adapter stored on the app object."""
-    return request.app.config_io  # type: ignore[attr-defined]
+    io = getattr(request.app, "config_io", None)
+    if io is None:
+        raise RuntimeError("No ConfigIO adapter configured on this application")
+    return io
 
 
 def _reload_gateway_config(request: Any, config_path: str) -> GatewayConfig:

--- a/src/llm_rosetta/gateway/admin/routes/auth.py
+++ b/src/llm_rosetta/gateway/admin/routes/auth.py
@@ -171,8 +171,6 @@ async def change_password(request: Any) -> Response:
 
     # Persist to config file
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     try:
         data = _get_config_io(request).load_raw(config_path)

--- a/src/llm_rosetta/gateway/admin/routes/auth.py
+++ b/src/llm_rosetta/gateway/admin/routes/auth.py
@@ -126,7 +126,7 @@ async def admin_check(request: Any) -> Response:
 async def change_password(request: Any) -> Response:
     """Change the admin password (requires current password)."""
     from ._shared import _get_config_path, _reload_gateway_config
-    from ...config import load_config_raw, write_config
+    from ._shared import _get_config_io
 
     auth_state = request.app.auth_state
     if not auth_state.admin_password:
@@ -175,14 +175,14 @@ async def change_password(request: Any) -> Response:
         return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
     data.setdefault("server", {})["admin_password"] = new_pw
 
     try:
-        write_config(config_path, data)
+        _get_config_io(request).save(config_path, data)
     except Exception as exc:
         return JSONResponse(
             {"error": f"Failed to write config: {exc}"}, status_code=500

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -93,8 +93,6 @@ def _resolve_model_reasoning(
 async def get_config(request: Any) -> Response:
     """Return the current (raw) gateway configuration."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     try:
         raw = _get_config_io(request).load_raw(config_path)
@@ -176,8 +174,6 @@ async def get_config(request: Any) -> Response:
 async def put_provider(request: Any, **kwargs: Any) -> Response:
     """Add or update a provider entry."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     name = request.path_params["name"]
 
@@ -250,8 +246,6 @@ async def put_provider(request: Any, **kwargs: Any) -> Response:
 async def delete_provider(request: Any, **kwargs: Any) -> Response:
     """Remove a provider entry."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     name = request.path_params["name"]
 
@@ -324,8 +318,6 @@ async def delete_provider(request: Any, **kwargs: Any) -> Response:
 async def toggle_provider(request: Any, **kwargs: Any) -> Response:
     """Toggle a provider's enabled/disabled state."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     name = request.path_params["name"]
 
@@ -373,8 +365,6 @@ async def toggle_provider(request: Any, **kwargs: Any) -> Response:
 async def put_model(request: Any, **kwargs: Any) -> Response:
     """Add or update a model routing entry."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     name = request.path_params["name"]
 
@@ -471,8 +461,6 @@ async def put_model(request: Any, **kwargs: Any) -> Response:
 async def delete_model(request: Any, **kwargs: Any) -> Response:
     """Remove a model routing entry."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     name = request.path_params["name"]
 
@@ -518,8 +506,6 @@ async def delete_model(request: Any, **kwargs: Any) -> Response:
 async def put_server_settings(request: Any) -> Response:
     """Update server settings (e.g. global proxy)."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     try:
         body = request.json()
@@ -588,8 +574,6 @@ async def put_server_settings(request: Any) -> Response:
 async def reload_config(request: Any) -> Response:
     """Force hot-reload of the config from disk."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     try:
         new_config = _reload_gateway_config(request, config_path)
@@ -720,8 +704,6 @@ async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
 async def bulk_add_models(request: Any) -> Response:
     """Bulk-add multiple models for a given provider."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     try:
         body = request.json()

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -8,10 +8,11 @@ from llm_rosetta._vendor.httpclient import AsyncClient, Response as HttpResponse
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
 from llm_rosetta.shims import get_shim, list_shims
 
-from ...config import GatewayConfig, load_config_raw, write_config
+from ...config import GatewayConfig
 from ...providers import known_provider_types
 from ._shared import (
     _build_provider_entry,
+    _get_config_io,
     _get_config_path,
     _handle_provider_rename,
     _mask_api_key,
@@ -96,7 +97,7 @@ async def get_config(request: Any) -> Response:
         return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     try:
-        raw = load_config_raw(config_path)
+        raw = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -189,7 +190,7 @@ async def put_provider(request: Any, **kwargs: Any) -> Response:
     base_url = body.get("base_url", "")
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -219,7 +220,7 @@ async def put_provider(request: Any, **kwargs: Any) -> Response:
     data.setdefault("providers", {})[name] = provider_entry
 
     try:
-        write_config(config_path, data)
+        _get_config_io(request).save(config_path, data)
     except Exception as exc:
         return JSONResponse(
             {"error": f"Failed to write config: {exc}"}, status_code=500
@@ -255,7 +256,7 @@ async def delete_provider(request: Any, **kwargs: Any) -> Response:
     name = request.path_params["name"]
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -292,7 +293,7 @@ async def delete_provider(request: Any, **kwargs: Any) -> Response:
     del providers[name]
 
     try:
-        write_config(config_path, data)
+        _get_config_io(request).save(config_path, data)
     except Exception as exc:
         return JSONResponse(
             {"error": f"Failed to write config: {exc}"}, status_code=500
@@ -329,7 +330,7 @@ async def toggle_provider(request: Any, **kwargs: Any) -> Response:
     name = request.path_params["name"]
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -348,7 +349,7 @@ async def toggle_provider(request: Any, **kwargs: Any) -> Response:
         providers[name]["enabled"] = False
 
     try:
-        write_config(config_path, data)
+        _get_config_io(request).save(config_path, data)
     except Exception as exc:
         return JSONResponse(
             {"error": f"Failed to write config: {exc}"}, status_code=500
@@ -387,7 +388,7 @@ async def put_model(request: Any, **kwargs: Any) -> Response:
         return JSONResponse({"error": "'provider' is required"}, status_code=400)
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -438,7 +439,7 @@ async def put_model(request: Any, **kwargs: Any) -> Response:
     data.setdefault("models", {})[name] = model_entry
 
     try:
-        write_config(config_path, data)
+        _get_config_io(request).save(config_path, data)
     except Exception as exc:
         return JSONResponse(
             {"error": f"Failed to write config: {exc}"}, status_code=500
@@ -476,7 +477,7 @@ async def delete_model(request: Any, **kwargs: Any) -> Response:
     name = request.path_params["name"]
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -487,7 +488,7 @@ async def delete_model(request: Any, **kwargs: Any) -> Response:
     del models[name]
 
     try:
-        write_config(config_path, data)
+        _get_config_io(request).save(config_path, data)
     except Exception as exc:
         return JSONResponse(
             {"error": f"Failed to write config: {exc}"}, status_code=500
@@ -526,7 +527,7 @@ async def put_server_settings(request: Any) -> Response:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -563,7 +564,7 @@ async def put_server_settings(request: Any) -> Response:
         debug["error_dumps"] = bool(body["error_dumps"])
 
     try:
-        write_config(config_path, data)
+        _get_config_io(request).save(config_path, data)
     except Exception as exc:
         return JSONResponse(
             {"error": f"Failed to write config: {exc}"}, status_code=500
@@ -738,7 +739,7 @@ async def bulk_add_models(request: Any) -> Response:
         )
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -781,7 +782,7 @@ async def bulk_add_models(request: Any) -> Response:
         )
 
     try:
-        write_config(config_path, data)
+        _get_config_io(request).save(config_path, data)
     except Exception as exc:
         return JSONResponse(
             {"error": f"Failed to write config: {exc}"}, status_code=500

--- a/src/llm_rosetta/gateway/admin/routes/keys.py
+++ b/src/llm_rosetta/gateway/admin/routes/keys.py
@@ -21,8 +21,6 @@ from ._shared import (
 async def get_api_keys(request: Any) -> Response:
     """List all gateway API keys (values masked)."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     try:
         data = _get_config_io(request).load_raw(config_path)
@@ -49,8 +47,6 @@ async def get_api_keys(request: Any) -> Response:
 async def create_api_key(request: Any) -> Response:
     """Create a new gateway API key."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     try:
         body = request.json()
@@ -110,8 +106,6 @@ async def create_api_key(request: Any) -> Response:
 async def update_api_key(request: Any, **kwargs: Any) -> Response:
     """Update an API key's label."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     key_id = request.path_params["key_id"]
 
@@ -163,8 +157,6 @@ async def update_api_key(request: Any, **kwargs: Any) -> Response:
 async def delete_api_key(request: Any, **kwargs: Any) -> Response:
     """Delete a gateway API key."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     key_id = request.path_params["key_id"]
 
@@ -205,8 +197,6 @@ async def delete_api_key(request: Any, **kwargs: Any) -> Response:
 async def rotate_api_key(request: Any, **kwargs: Any) -> Response:
     """Rotate an API key: generate a new value, keep the same id and label."""
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     key_id = request.path_params["key_id"]
 
@@ -260,8 +250,6 @@ async def reveal_api_key(request: Any, **kwargs: Any) -> Response:
             {"error": "Credential visibility is disabled"}, status_code=403
         )
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     key_id = request.path_params["key_id"]
 

--- a/src/llm_rosetta/gateway/admin/routes/keys.py
+++ b/src/llm_rosetta/gateway/admin/routes/keys.py
@@ -9,8 +9,13 @@ from typing import Any
 
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
-from ...config import GatewayConfig, load_config_raw, write_config
-from ._shared import _get_config_path, _mask_api_key, _reload_gateway_config
+from ...config import GatewayConfig
+from ._shared import (
+    _get_config_io,
+    _get_config_path,
+    _mask_api_key,
+    _reload_gateway_config,
+)
 
 
 async def get_api_keys(request: Any) -> Response:
@@ -20,7 +25,7 @@ async def get_api_keys(request: Any) -> Response:
         return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -64,7 +69,7 @@ async def create_api_key(request: Any) -> Response:
     }
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -80,7 +85,7 @@ async def create_api_key(request: Any) -> Response:
     server.setdefault("api_keys", []).append(entry)
 
     try:
-        write_config(config_path, data)
+        _get_config_io(request).save(config_path, data)
     except Exception as exc:
         return JSONResponse(
             {"error": f"Failed to write config: {exc}"}, status_code=500
@@ -116,7 +121,7 @@ async def update_api_key(request: Any, **kwargs: Any) -> Response:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -134,7 +139,7 @@ async def update_api_key(request: Any, **kwargs: Any) -> Response:
         target["label"] = body["label"]
 
     try:
-        write_config(config_path, data)
+        _get_config_io(request).save(config_path, data)
     except Exception as exc:
         return JSONResponse(
             {"error": f"Failed to write config: {exc}"}, status_code=500
@@ -164,7 +169,7 @@ async def delete_api_key(request: Any, **kwargs: Any) -> Response:
     key_id = request.path_params["key_id"]
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -176,7 +181,7 @@ async def delete_api_key(request: Any, **kwargs: Any) -> Response:
         return JSONResponse({"error": f"Key '{key_id}' not found"}, status_code=404)
 
     try:
-        write_config(config_path, data)
+        _get_config_io(request).save(config_path, data)
     except Exception as exc:
         return JSONResponse(
             {"error": f"Failed to write config: {exc}"}, status_code=500
@@ -206,7 +211,7 @@ async def rotate_api_key(request: Any, **kwargs: Any) -> Response:
     key_id = request.path_params["key_id"]
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 
@@ -225,7 +230,7 @@ async def rotate_api_key(request: Any, **kwargs: Any) -> Response:
     target["rotated"] = datetime.now(timezone.utc).isoformat()
 
     try:
-        write_config(config_path, data)
+        _get_config_io(request).save(config_path, data)
     except Exception as exc:
         return JSONResponse(
             {"error": f"Failed to write config: {exc}"}, status_code=500
@@ -261,7 +266,7 @@ async def reveal_api_key(request: Any, **kwargs: Any) -> Response:
     key_id = request.path_params["key_id"]
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 

--- a/src/llm_rosetta/gateway/admin/routes/observability.py
+++ b/src/llm_rosetta/gateway/admin/routes/observability.py
@@ -131,12 +131,12 @@ async def get_requests(request: Any) -> Response:
         if provider_type is None:
             # Fallback: read from raw config file (covers disabled providers)
             from ._shared import _get_config_path
-            from ...config import load_config_raw
+            from ._shared import _get_config_io
 
             config_path = _get_config_path(request)
             if config_path:
                 try:
-                    raw = load_config_raw(config_path)
+                    raw = _get_config_io(request).load_raw(config_path)
                     raw_prov = raw.get("providers", {}).get(provider, {})
                     raw_type = raw_prov.get("type") or raw_prov.get("shim")
                     if raw_type:
@@ -173,7 +173,7 @@ async def get_provider_key(request: Any, **kwargs: Any) -> Response:
             {"error": "Credential visibility is disabled"}, status_code=403
         )
     from ._shared import _get_config_path
-    from ...config import load_config_raw
+    from ._shared import _get_config_io
 
     config_path = _get_config_path(request)
     if not config_path:
@@ -182,7 +182,7 @@ async def get_provider_key(request: Any, **kwargs: Any) -> Response:
     name = request.path_params["name"]
 
     try:
-        data = load_config_raw(config_path)
+        data = _get_config_io(request).load_raw(config_path)
     except Exception as exc:
         return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
 

--- a/src/llm_rosetta/gateway/admin/routes/observability.py
+++ b/src/llm_rosetta/gateway/admin/routes/observability.py
@@ -133,18 +133,17 @@ async def get_requests(request: Any) -> Response:
             from ._shared import _get_config_path
             from ._shared import _get_config_io
 
-            config_path = _get_config_path(request)
-            if config_path:
-                try:
-                    raw = _get_config_io(request).load_raw(config_path)
-                    raw_prov = raw.get("providers", {}).get(provider, {})
-                    raw_type = raw_prov.get("type") or raw_prov.get("shim")
-                    if raw_type:
-                        from llm_rosetta.shims import resolve_base
+            try:
+                config_path = _get_config_path(request)
+                raw = _get_config_io(request).load_raw(config_path)
+                raw_prov = raw.get("providers", {}).get(provider, {})
+                raw_type = raw_prov.get("type") or raw_prov.get("shim")
+                if raw_type:
+                    from llm_rosetta.shims import resolve_base
 
-                        provider_type = resolve_base(raw_type)
-                except Exception:
-                    pass
+                    provider_type = resolve_base(raw_type)
+            except Exception:
+                pass
 
     entries, total = log.get_entries(
         limit=limit,
@@ -176,8 +175,6 @@ async def get_provider_key(request: Any, **kwargs: Any) -> Response:
     from ._shared import _get_config_io
 
     config_path = _get_config_path(request)
-    if not config_path:
-        return JSONResponse({"error": "No config file path available"}, status_code=500)
 
     name = request.path_params["name"]
 

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 import re
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from llm_rosetta.auto_detect import ProviderType
 from llm_rosetta.routing import ResolvedRoute
@@ -103,6 +103,41 @@ def load_config_raw(path: str) -> dict[str, Any]:
         raw = f.read()
     stripped = _strip_jsonc_comments(raw)
     return json.loads(stripped)
+
+
+@runtime_checkable
+class ConfigIO(Protocol):
+    """Protocol for reading/writing gateway config files.
+
+    The default :class:`JsoncConfigIO` handles JSONC files.  Downstream
+    projects (e.g. argo-proxy) can supply an alternative implementation
+    for other formats (YAML, TOML, etc.) via ``setup_admin(..., config_io=...)``.
+    """
+
+    def load(self, path: str) -> dict[str, Any]:
+        """Read config with env-var substitution (for runtime use)."""
+        ...
+
+    def load_raw(self, path: str) -> dict[str, Any]:
+        """Read config without env-var substitution (for edit round-trips)."""
+        ...
+
+    def save(self, path: str, data: dict[str, Any]) -> None:
+        """Write config back to disk."""
+        ...
+
+
+class JsoncConfigIO:
+    """Default :class:`ConfigIO` — reads/writes JSONC with env-var substitution."""
+
+    def load(self, path: str) -> dict[str, Any]:
+        return load_config(path)
+
+    def load_raw(self, path: str) -> dict[str, Any]:
+        return load_config_raw(path)
+
+    def save(self, path: str, data: dict[str, Any]) -> None:
+        write_config(path, data)
 
 
 def discover_config(explicit_path: str | None = None) -> str | None:


### PR DESCRIPTION
## Summary

Admin route handlers now use a pluggable `ConfigIO` protocol instead of hard-coded JSONC `load_config_raw`/`write_config` calls. This allows downstream projects (e.g. argo-proxy with YAML configs) to supply their own I/O adapter via `setup_admin(..., config_io=MyConfigIO())`.

## Changes

- **`config.py`**: Added `ConfigIO` protocol (3 methods: `load`, `load_raw`, `save`) and `JsoncConfigIO` default implementation
- **`admin/__init__.py`**: `setup_admin()` accepts optional `config_io` parameter, defaults to `JsoncConfigIO`, attaches as `app.config_io`
- **`admin/routes/_shared.py`**: Added `_get_config_io(request)` helper, updated `_reload_gateway_config` to use it
- **`admin/routes/config.py`**: All `load_config_raw`/`write_config` → `_get_config_io(request).load_raw/save`
- **`admin/routes/keys.py`**: Same
- **`admin/routes/auth.py`**: Same
- **`admin/routes/observability.py`**: Same
- **`gateway/__init__.py`**: Exported `ConfigIO`, `JsoncConfigIO`

## Backward compatible

- Default behavior unchanged — `JsoncConfigIO` is used when `config_io` is not passed
- Existing gateway deployments need zero changes

## Motivation

argo-proxy uses YAML config files. Without this change, the admin panel can't read/write argo-proxy configs because `load_config_raw` hard-codes JSONC parsing.