### PR TITLE
fix: preserve upstream user agent header

### DIFF
--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -18,6 +18,7 @@ from llm_rosetta.auto_detect import ProviderType
 from .auth import AuthState, api_key_label_var, create_auth_hook
 from .config import GatewayConfig
 from .embeddings import handle_embeddings as _handle_embeddings
+from .headers import build_upstream_extra_headers
 from .logging import get_logger
 from llm_rosetta.observability.error_dump import dump_error
 
@@ -250,11 +251,8 @@ async def _proxy_handler(
 
     store: ProviderMetadataStore = request.app.metadata_store
 
-    # Forward OpenResponses-Version header and request ID to upstream if present
-    extra_headers: dict[str, str] = {"x-request-id": request_id}
-    or_version = request.headers.get("openresponses-version")
-    if or_version:
-        extra_headers["OpenResponses-Version"] = or_version
+    # Forward only explicitly supported client headers to upstream.
+    extra_headers = build_upstream_extra_headers(request, request_id)
 
     # --- Metrics instrumentation ---
     if is_stream:

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -18,7 +18,7 @@ from llm_rosetta.auto_detect import ProviderType
 from .auth import AuthState, api_key_label_var, create_auth_hook
 from .config import GatewayConfig
 from .embeddings import handle_embeddings as _handle_embeddings
-from .headers import build_upstream_extra_headers
+from .headers import build_upstream_extra_headers, get_request_id
 from .logging import get_logger
 from llm_rosetta.observability.error_dump import dump_error
 
@@ -193,7 +193,7 @@ async def _proxy_handler(
     assert _config is not None
 
     # Generate or honour a request ID for end-to-end traceability.
-    request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
+    request_id = get_request_id(request)
 
     try:
         body: dict[str, Any] = request.json()

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -16,6 +16,7 @@ from typing import Any
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
 from .config import GatewayConfig
+from .headers import build_upstream_extra_headers
 from .logging import get_logger
 from .transport import UpstreamConnectionError, UpstreamTransport
 
@@ -87,13 +88,20 @@ async def handle_embeddings(
     # --- Forward via transport ---
     upstream_url = f"{provider_info.base_url}/embeddings"
     transport: UpstreamTransport = request.app.transport
+    request_id = request.headers.get("x-request-id", "")
+    extra_headers = build_upstream_extra_headers(request, request_id)
 
     t0 = time.monotonic()
     status_code = 500
     error_detail: str | None = None
 
     try:
-        resp = await transport.send_passthrough(provider_info, upstream_url, body)
+        resp = await transport.send_passthrough(
+            provider_info,
+            upstream_url,
+            body,
+            extra_headers=extra_headers,
+        )
         status_code = resp.status_code
 
         if resp.is_error:

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -16,7 +16,7 @@ from typing import Any
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
 from .config import GatewayConfig
-from .headers import build_upstream_extra_headers
+from .headers import build_upstream_extra_headers, get_request_id
 from .logging import get_logger
 from .transport import UpstreamConnectionError, UpstreamTransport
 
@@ -39,30 +39,40 @@ async def handle_embeddings(
     Returns:
         The upstream response, forwarded to the client.
     """
+    request_id = get_request_id(request)
+
+    def with_request_id(response: Response) -> Response:
+        response.headers["x-request-id"] = request_id
+        return response
+
     # --- Parse request ---
     try:
         body: dict[str, Any] = request.json()
     except Exception:
-        return JSONResponse(
-            {
-                "error": {
-                    "message": "Invalid JSON body",
-                    "type": "invalid_request_error",
-                }
-            },
-            status_code=400,
+        return with_request_id(
+            JSONResponse(
+                {
+                    "error": {
+                        "message": "Invalid JSON body",
+                        "type": "invalid_request_error",
+                    }
+                },
+                status_code=400,
+            )
         )
 
     model = body.get("model")
     if not model:
-        return JSONResponse(
-            {
-                "error": {
-                    "message": "Missing 'model' in request body",
-                    "type": "invalid_request_error",
-                }
-            },
-            status_code=400,
+        return with_request_id(
+            JSONResponse(
+                {
+                    "error": {
+                        "message": "Missing 'model' in request body",
+                        "type": "invalid_request_error",
+                    }
+                },
+                status_code=400,
+            )
         )
 
     # --- Resolve provider via unified routing ---
@@ -70,14 +80,16 @@ async def handle_embeddings(
         route, provider_info = config.resolve("openai_chat", model)
     except KeyError:
         configured = ", ".join(sorted(config.models.keys()))
-        return JSONResponse(
-            {
-                "error": {
-                    "message": f"Unknown model: '{model}'. Configured models: {configured}",
-                    "type": "model_not_found",
-                }
-            },
-            status_code=404,
+        return with_request_id(
+            JSONResponse(
+                {
+                    "error": {
+                        "message": f"Unknown model: '{model}'. Configured models: {configured}",
+                        "type": "model_not_found",
+                    }
+                },
+                status_code=404,
+            )
         )
 
     # Model alias: replace the model name in the request body with the
@@ -88,7 +100,6 @@ async def handle_embeddings(
     # --- Forward via transport ---
     upstream_url = f"{provider_info.base_url}/embeddings"
     transport: UpstreamTransport = request.app.transport
-    request_id = request.headers.get("x-request-id", "")
     extra_headers = build_upstream_extra_headers(request, request_id)
 
     t0 = time.monotonic()
@@ -106,28 +117,34 @@ async def handle_embeddings(
 
         if resp.is_error:
             error_detail = resp.error_text
-            return Response(
-                body=resp.raw_content,
-                status_code=resp.status_code,
-                content_type="application/json",
+            return with_request_id(
+                Response(
+                    body=resp.raw_content,
+                    status_code=resp.status_code,
+                    content_type="application/json",
+                )
             )
 
-        return Response(
-            body=resp.raw_content,
-            status_code=200,
-            content_type="application/json",
+        return with_request_id(
+            Response(
+                body=resp.raw_content,
+                status_code=200,
+                content_type="application/json",
+            )
         )
     except UpstreamConnectionError as exc:
         error_detail = str(exc)
         status_code = 502
-        return JSONResponse(
-            {
-                "error": {
-                    "message": f"Upstream request failed: {exc}",
-                    "type": "upstream_error",
-                }
-            },
-            status_code=502,
+        return with_request_id(
+            JSONResponse(
+                {
+                    "error": {
+                        "message": f"Upstream request failed: {exc}",
+                        "type": "upstream_error",
+                    }
+                },
+                status_code=502,
+            )
         )
     except Exception as exc:
         error_detail = str(exc)

--- a/src/llm_rosetta/gateway/headers.py
+++ b/src/llm_rosetta/gateway/headers.py
@@ -1,0 +1,23 @@
+"""Helpers for gateway request header forwarding."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_upstream_extra_headers(request: Any, request_id: str) -> dict[str, str]:
+    """Build the explicit request headers that may be forwarded upstream."""
+    extra_headers: dict[str, str] = {}
+
+    if request_id:
+        extra_headers["x-request-id"] = request_id
+
+    user_agent = request.headers.get("user-agent")
+    if user_agent:
+        extra_headers["User-Agent"] = user_agent
+
+    or_version = request.headers.get("openresponses-version")
+    if or_version:
+        extra_headers["OpenResponses-Version"] = or_version
+
+    return extra_headers

--- a/src/llm_rosetta/gateway/headers.py
+++ b/src/llm_rosetta/gateway/headers.py
@@ -3,6 +3,12 @@
 from __future__ import annotations
 
 from typing import Any
+import uuid
+
+
+def get_request_id(request: Any) -> str:
+    """Return the client request ID or generate one."""
+    return request.headers.get("x-request-id") or str(uuid.uuid4())
 
 
 def build_upstream_extra_headers(request: Any, request_id: str) -> dict[str, str]:

--- a/tests/gateway/test_app_headers.py
+++ b/tests/gateway/test_app_headers.py
@@ -1,0 +1,75 @@
+"""Tests for upstream header forwarding from gateway handlers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import llm_rosetta.gateway.app as app_module
+from llm_rosetta._vendor.httpserver import JSONResponse
+from llm_rosetta.gateway.headers import build_upstream_extra_headers
+from llm_rosetta.routing import ResolvedRoute
+
+
+def test_build_upstream_extra_headers_preserves_user_agent_and_responses_version():
+    """Only explicitly supported client headers should be forwarded upstream."""
+    request = MagicMock()
+    request.headers = {
+        "user-agent": "codex-cli/1.2.3",
+        "openresponses-version": "2025-06-18",
+        "authorization": "Bearer client-key",
+    }
+
+    headers = build_upstream_extra_headers(request, "req-123")
+
+    assert headers == {
+        "x-request-id": "req-123",
+        "User-Agent": "codex-cli/1.2.3",
+        "OpenResponses-Version": "2025-06-18",
+    }
+
+
+def test_proxy_handler_forwards_user_agent_to_non_streaming_proxy(monkeypatch):
+    """The main proxy handler should pass client User-Agent to the upstream call."""
+    captured_headers: dict[str, str] = {}
+
+    class _Config:
+        models = {"gpt-test": "test-provider"}
+        error_dumps_enabled = False
+
+        def resolve(self, source_provider, model):
+            return (
+                ResolvedRoute(
+                    source_provider=source_provider,
+                    target_provider="openai_chat",
+                    provider_name="test-provider",
+                ),
+                MagicMock(),
+            )
+
+    async def _fake_handle_non_streaming(*args: Any, **kwargs: Any):
+        captured_headers.update(kwargs["extra_headers"])
+        return JSONResponse({"ok": True}), {}
+
+    monkeypatch.setattr(app_module, "_config", _Config())
+    monkeypatch.setattr(app_module, "handle_non_streaming", _fake_handle_non_streaming)
+
+    request = MagicMock()
+    request.headers = {"user-agent": "codex-cli/1.2.3"}
+    request.json.return_value = {
+        "model": "gpt-test",
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    request.app.gateway_config = _Config()
+    request.app.metadata_store = MagicMock()
+    request.app.metrics = None
+    request.app.request_log = None
+    request.app.persistence = None
+    request.app.profiler_state = None
+
+    response = asyncio.run(app_module._proxy_handler(request, "openai_chat"))
+
+    assert response.status_code == 200
+    assert captured_headers["User-Agent"] == "codex-cli/1.2.3"
+    assert "x-request-id" in captured_headers

--- a/tests/gateway/test_embeddings.py
+++ b/tests/gateway/test_embeddings.py
@@ -7,12 +7,13 @@ import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from llm_rosetta.gateway.config import GatewayConfig
 from llm_rosetta.gateway.embeddings import handle_embeddings
+from llm_rosetta.gateway.transport._base import UpstreamResponse
 from llm_rosetta.gateway.transport.http import HttpTransport
 
 
@@ -91,11 +92,15 @@ def _make_config(base_url: str, upstream_model: str | None = None) -> GatewayCon
     return GatewayConfig(raw)
 
 
-def _make_request(body: dict[str, Any]) -> MagicMock:
+def _make_request(
+    body: dict[str, Any],
+    *,
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
     """Create a mock HTTP request with the given JSON body."""
     req = MagicMock()
     req.json.return_value = body
-    req.headers = {}
+    req.headers = headers or {}
 
     # Provide app-level attributes that handle_embeddings accesses
     app = MagicMock()
@@ -140,3 +145,25 @@ class TestEmbeddingUpstreamModel:
 
         body = json.loads(response.body)
         assert body["model"] == "my-embed"
+
+    def test_user_agent_forwarded_to_passthrough_transport(self):
+        """Embeddings passthrough should preserve the client's User-Agent."""
+        config = _make_config("https://api.example.com/v1")
+        request = _make_request(
+            {"model": "my-embed", "input": "hello"},
+            headers={"user-agent": "codex-cli/1.2.3"},
+        )
+        request.app.transport = MagicMock()
+        request.app.transport.send_passthrough = AsyncMock(
+            return_value=UpstreamResponse(
+                status_code=200,
+                body={"object": "list", "data": [], "model": "my-embed"},
+                raw_content=b'{"object":"list","data":[],"model":"my-embed"}',
+            )
+        )
+
+        response = asyncio.run(handle_embeddings(request, config))
+
+        assert response.status_code == 200
+        _, kwargs = request.app.transport.send_passthrough.call_args
+        assert kwargs["extra_headers"]["User-Agent"] == "codex-cli/1.2.3"

--- a/tests/gateway/test_embeddings.py
+++ b/tests/gateway/test_embeddings.py
@@ -146,12 +146,27 @@ class TestEmbeddingUpstreamModel:
         body = json.loads(response.body)
         assert body["model"] == "my-embed"
 
-    def test_user_agent_forwarded_to_passthrough_transport(self):
-        """Embeddings passthrough should preserve the client's User-Agent."""
+    def test_validation_error_includes_generated_request_id(self):
         config = _make_config("https://api.example.com/v1")
+        request = _make_request({"input": "hello"})
+
+        response = asyncio.run(handle_embeddings(request, config))
+
+        assert response.status_code == 400
+        assert response.headers["x-request-id"]
+
+    @pytest.mark.parametrize("client_request_id", ["req-123", None])
+    def test_headers_forwarded_to_passthrough_transport(
+        self, client_request_id: str | None
+    ):
+        """Embeddings passthrough should preserve client headers and assign an ID."""
+        config = _make_config("https://api.example.com/v1")
+        headers = {"user-agent": "codex-cli/1.2.3"}
+        if client_request_id:
+            headers["x-request-id"] = client_request_id
         request = _make_request(
             {"model": "my-embed", "input": "hello"},
-            headers={"user-agent": "codex-cli/1.2.3"},
+            headers=headers,
         )
         request.app.transport = MagicMock()
         request.app.transport.send_passthrough = AsyncMock(
@@ -166,4 +181,9 @@ class TestEmbeddingUpstreamModel:
 
         assert response.status_code == 200
         _, kwargs = request.app.transport.send_passthrough.call_args
-        assert kwargs["extra_headers"]["User-Agent"] == "codex-cli/1.2.3"
+        upstream_headers = kwargs["extra_headers"]
+        assert upstream_headers["User-Agent"] == "codex-cli/1.2.3"
+        assert upstream_headers["x-request-id"]
+        assert response.headers["x-request-id"] == upstream_headers["x-request-id"]
+        if client_request_id:
+            assert upstream_headers["x-request-id"] == client_request_id


### PR DESCRIPTION
## Summary

Centralize upstream header forwarding in `gateway.headers` module. Forward `User-Agent`, `x-request-id`, and `OpenResponses-Version` to upstream providers. Apply to both proxy and embeddings passthrough.

Based on @iBobbyTS's PR #355, rebased onto current master with fixes for `_get_gateway_config` app-object lookup and `error_dumps_enabled` test compatibility.

Supersedes #355.

## Test plan

- [x] `test_app_headers.py` — unit test for `build_upstream_extra_headers` + proxy handler integration
- [x] `test_embeddings.py` — verify User-Agent forwarded in embeddings passthrough