### PR TITLE
feat(admin): model enable/disable + table UI restyle

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -1038,6 +1038,21 @@ body { padding-bottom: 26px; }
   </div>
 </div>
 
+<!-- Matryoshka Dimensions Modal -->
+<div class="modal-overlay" id="matryoshkaModal">
+  <div class="modal" style="max-width:360px">
+    <h3 data-i18n="test.matryoshka">Matryoshka</h3>
+    <div class="form-group">
+      <label data-i18n="test.matryoshkaDimPrompt">Enter dimensions for matryoshka embedding:</label>
+      <input id="matryoshkaDim" type="number" min="1" value="256" style="margin-top:6px" onkeydown="if(event.key==='Enter')confirmMatryoshka()">
+    </div>
+    <div class="modal-actions">
+      <button class="btn" onclick="closeModal('matryoshkaModal')" data-i18n="btn.cancel">Cancel</button>
+      <button class="btn btn-primary" onclick="confirmMatryoshka()" data-i18n="btn.ok">OK</button>
+    </div>
+  </div>
+</div>
+
 <!-- Test Result Modal -->
 <div class="modal-overlay" id="testModal">
   <div class="modal modal-wide">
@@ -1157,7 +1172,7 @@ const I18N = {
     'label.selectOne':'— select —',
     'label.baseUrl':'Base URL',
     'label.apiKey':'API Key (or ${ENV_VAR} placeholder)', 'label.keyUnchangedHint':'Leave blank to keep current key',
-    'label.proxyUrl':'Proxy URL (optional, overrides global)', 'label.selected':'selected', 'btn.enable':'Enable', 'btn.disable':'Disable', 'model.enabled':'Enabled', 'model.disabled':'Disabled', 'label.on':'ON', 'label.off':'OFF', 'test.embedding':'Embedding', 'test.embedBatch':'Batch', 'test.matryoshka':'Matryoshka', 'test.embedMultimodal':'Multimodal (image)', 'test.matryoshkaDimPrompt':'Enter dimensions for matryoshka embedding:', 'error.invalidDimension':'Invalid dimension value', 'confirm.bulkDelete':'Delete {count} model(s)?', 'toast.bulkDone':'{action} applied to {count} model(s)', 'label.urlTemplate':'URL Template', 'label.streamUrlTemplate':'Stream URL Template', 'label.urlTemplateHint':'Override the endpoint path. Placeholders: {base_url}, {model}',
+    'label.proxyUrl':'Proxy URL (optional, overrides global)', 'label.selected':'selected', 'btn.enable':'Enable', 'btn.disable':'Disable', 'model.enabled':'Enabled', 'model.disabled':'Disabled', 'label.on':'ON', 'label.off':'OFF', 'test.embedding':'Embedding', 'test.embedBatch':'Batch', 'test.matryoshka':'Matryoshka', 'test.embedMultimodal':'Multimodal (image)', 'test.matryoshkaDimPrompt':'Enter dimensions for matryoshka embedding:', 'btn.ok':'OK', 'error.invalidDimension':'Invalid dimension value', 'confirm.bulkDelete':'Delete {count} model(s)?', 'toast.bulkDone':'{action} applied to {count} model(s)', 'label.urlTemplate':'URL Template', 'label.streamUrlTemplate':'Stream URL Template', 'label.urlTemplateHint':'Override the endpoint path. Placeholders: {base_url}, {model}',
     'label.modelName':'Model Name', 'label.provider':'Provider', 'label.upstreamModel':'Upstream Model', 'label.capabilities':'Capabilities', 'label.systemOptions':'System Options', 'label.flattenSystem':'Flatten system content', 'label.flattenSystemHint':'Flatten system message content arrays to plain strings for upstream compatibility.',
     'label.reasoningConfig':'Reasoning Config', 'label.thinkingType':'Thinking Type', 'label.budgetRatio':'Budget Tokens Ratio', 'label.disabledStrategy':'Disabled Strategy', 'label.inheritProvider':'(inherit from provider)', 'label.inherited':'inherited',
     'modal.addProvider':'Add Provider', 'modal.editProvider':'Edit Provider',
@@ -1287,7 +1302,7 @@ const I18N = {
     'label.selectOne':'\u2014 \u8bf7\u9009\u62e9 \u2014',
     'label.baseUrl':'Base URL',
     'label.apiKey':'API Key\uff08\u6216 ${ENV_VAR} \u5360\u4f4d\u7b26\uff09', 'label.keyUnchangedHint':'\u7559\u7a7a\u4ee5\u4fdd\u7559\u5f53\u524d\u5bc6\u94a5',
-    'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09', 'label.urlTemplate':'URL \u6a21\u677f', 'label.streamUrlTemplate':'\u6d41\u5f0f URL \u6a21\u677f', 'label.urlTemplateHint':'\u8986\u76d6\u7aef\u70b9\u8def\u5f84\u3002\u5360\u4f4d\u7b26\uff1a{base_url}\u3001{model}', 'label.selected':'\u5df2\u9009\u62e9', 'btn.enable':'\u542f\u7528', 'btn.disable':'\u7981\u7528', 'model.enabled':'\u5df2\u542f\u7528', 'model.disabled':'\u5df2\u7981\u7528', 'label.on':'\u5f00', 'label.off':'\u5173', 'test.embedding':'Embedding', 'test.embedBatch':'\u6279\u91cf', 'test.matryoshka':'\u5957\u5a03 (Matryoshka)', 'test.embedMultimodal':'\u591a\u6a21\u6001 (\u56fe\u7247)', 'test.matryoshkaDimPrompt':'\u8f93\u5165 Matryoshka \u7ef4\u5ea6\uff1a', 'error.invalidDimension':'\u65e0\u6548\u7684\u7ef4\u5ea6\u503c', 'confirm.bulkDelete':'\u5220\u9664 {count} \u4e2a\u6a21\u578b\uff1f', 'toast.bulkDone':'{action} \u5df2\u5e94\u7528\u5230 {count} \u4e2a\u6a21\u578b',
+    'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09', 'label.urlTemplate':'URL \u6a21\u677f', 'label.streamUrlTemplate':'\u6d41\u5f0f URL \u6a21\u677f', 'label.urlTemplateHint':'\u8986\u76d6\u7aef\u70b9\u8def\u5f84\u3002\u5360\u4f4d\u7b26\uff1a{base_url}\u3001{model}', 'label.selected':'\u5df2\u9009\u62e9', 'btn.enable':'\u542f\u7528', 'btn.disable':'\u7981\u7528', 'model.enabled':'\u5df2\u542f\u7528', 'model.disabled':'\u5df2\u7981\u7528', 'label.on':'\u5f00', 'label.off':'\u5173', 'test.embedding':'Embedding', 'test.embedBatch':'\u6279\u91cf', 'test.matryoshka':'\u5957\u5a03 (Matryoshka)', 'test.embedMultimodal':'\u591a\u6a21\u6001 (\u56fe\u7247)', 'test.matryoshkaDimPrompt':'\u8f93\u5165 Matryoshka \u7ef4\u5ea6\uff1a', 'error.invalidDimension':'\u65e0\u6548\u7684\u7ef4\u5ea6\u503c', 'btn.ok':'\u786e\u5b9a', 'confirm.bulkDelete':'\u5220\u9664 {count} \u4e2a\u6a21\u578b\uff1f', 'toast.bulkDone':'{action} \u5df2\u5e94\u7528\u5230 {count} \u4e2a\u6a21\u578b',
     'label.modelName':'\u6a21\u578b\u540d\u79f0', 'label.provider':'\u670d\u52a1\u65b9', 'label.upstreamModel':'\u4e0a\u6e38\u6a21\u578b', 'label.capabilities':'\u80fd\u529b', 'label.systemOptions':'\u7cfb\u7edf\u9009\u9879', 'label.flattenSystem':'\u5c55\u5e73\u7cfb\u7edf\u6d88\u606f\u5185\u5bb9', 'label.flattenSystemHint':'\u5c06\u7cfb\u7edf\u6d88\u606f\u5185\u5bb9\u6570\u7ec4\u5c55\u5e73\u4e3a\u7eaf\u6587\u672c\u5b57\u7b26\u4e32\uff0c\u4ee5\u517c\u5bb9\u4e0a\u6e38\u670d\u52a1\u3002',
     'label.reasoningConfig':'\u63a8\u7406\u914d\u7f6e', 'label.thinkingType':'\u601d\u8003\u7c7b\u578b', 'label.budgetRatio':'\u9884\u7b97 Token \u6bd4\u4f8b', 'label.disabledStrategy':'\u7981\u7528\u7b56\u7565', 'label.inheritProvider':'(\u7ee7\u627f\u81ea Provider)', 'label.inherited':'\u7ee7\u627f',
     'modal.addProvider':'\u6dfb\u52a0\u670d\u52a1\u65b9', 'modal.editProvider':'\u7f16\u8f91\u670d\u52a1\u65b9',
@@ -3583,12 +3598,18 @@ function _newTestSignal() {
 }
 
 
+let _matryoshkaModel = '';
 function promptMatryoshka(model) {
-  const dim = prompt(t('test.matryoshkaDimPrompt'), '256');
-  if (dim === null) return;
-  const dimensions = parseInt(dim, 10);
-  if (isNaN(dimensions) || dimensions < 1) { showToast(t('error.invalidDimension'), 'error'); return; }
-  runTest(model, 'matryoshka', dimensions);
+  _matryoshkaModel = model;
+  document.getElementById('matryoshkaDim').value = '256';
+  document.getElementById('matryoshkaModal').classList.add('open');
+  document.getElementById('matryoshkaDim').focus();
+}
+function confirmMatryoshka() {
+  const dim = parseInt(document.getElementById('matryoshkaDim').value, 10);
+  if (isNaN(dim) || dim < 1) { showToast(t('error.invalidDimension'), 'error'); return; }
+  closeModal('matryoshkaModal');
+  runTest(_matryoshkaModel, 'matryoshka', dim);
 }
 
 async function runTest(model, type, extraParam) {

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -183,6 +183,18 @@ tr:hover td { background: var(--bg-hover); }
 }
 .provider-card .field code { overflow: hidden; text-overflow: ellipsis; max-width: 220px; display: inline-block; vertical-align: bottom; }
 .provider-card.disabled { opacity: 0.5; }
+.model-disabled td:not(:first-child):not(:last-child) { opacity: 0.4; }
+.bulk-bar { display:none;align-items:center;gap:10px;padding:8px 14px;margin-bottom:8px;background:#ddf4ff;border:1px solid #a8d4f5;border-radius:8px;font-size:13px; }
+.bulk-bar .bulk-count { font-weight:600;color:var(--accent); }
+.bulk-bar .bulk-actions { margin-left:auto;display:flex;gap:6px; }
+.row-check { width:16px;height:16px;cursor:pointer;accent-color:var(--accent); }
+.pill-toggle { display:inline-flex;border:1px solid var(--border);border-radius:14px;overflow:hidden;font-size:11px;font-weight:600;cursor:pointer;user-select:none;vertical-align:middle;min-width:52px;text-align:center; }
+.pill-toggle span { padding:3px 8px;transition:all 0.15s; }
+.pill-toggle.is-on .pill-on { background:var(--green, #2da44e);color:#fff; }
+.pill-toggle.is-on .pill-off { background:var(--bg-card);color:var(--text-dim); }
+.pill-toggle.is-off .pill-off { background:var(--border);color:var(--text); }
+.pill-toggle.is-off .pill-on { background:var(--bg-card);color:var(--text-dim); }
+.btn-test-embed { color:var(--orange, #d4740a) !important;font-weight:600; }
 .provider-card .card-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
 .provider-card .actions { margin-top: 12px; display: flex; gap: 8px; }
 /* List view — CSS grid for column alignment across rows */
@@ -578,10 +590,19 @@ body { padding-bottom: 26px; }
       </div>
       <div class="table-scroll"><table>
         <thead><tr>
+          <th style="width:30px"><input type="checkbox" class="row-check" onchange="selectAllModels(this)"></th>
           <th class="sortable" onclick="sortModels('name')" id="sortName" data-i18n="col.model">Model</th>
           <th class="sortable" onclick="sortModels('provider')" id="sortProvider" data-i18n="col.provider">Provider</th>
           <th></th>
         </tr></thead>
+        <div class="bulk-bar" id="modelBulkBar">
+          <span class="bulk-count" id="modelBulkCount">0</span> <span data-i18n="label.selected">selected</span>
+          <div class="bulk-actions">
+            <button class="btn btn-sm" onclick="bulkModels('enable')" data-i18n="btn.enable">Enable</button>
+            <button class="btn btn-sm" onclick="bulkModels('disable')" data-i18n="btn.disable">Disable</button>
+            <button class="btn btn-sm btn-danger" onclick="bulkModels('delete')" data-i18n="btn.delete">Delete</button>
+          </div>
+        </div>
         <tbody id="modelTable"></tbody>
       </table></div>
     </div>
@@ -1136,7 +1157,7 @@ const I18N = {
     'label.selectOne':'— select —',
     'label.baseUrl':'Base URL',
     'label.apiKey':'API Key (or ${ENV_VAR} placeholder)', 'label.keyUnchangedHint':'Leave blank to keep current key',
-    'label.proxyUrl':'Proxy URL (optional, overrides global)', 'label.urlTemplate':'URL Template', 'label.streamUrlTemplate':'Stream URL Template', 'label.urlTemplateHint':'Override the endpoint path. Placeholders: {base_url}, {model}',
+    'label.proxyUrl':'Proxy URL (optional, overrides global)', 'label.selected':'selected', 'btn.enable':'Enable', 'btn.disable':'Disable', 'model.enabled':'Enabled', 'model.disabled':'Disabled', 'label.on':'ON', 'label.off':'OFF', 'test.embedding':'Embedding', 'confirm.bulkDelete':'Delete {count} model(s)?', 'toast.bulkDone':'{action} applied to {count} model(s)', 'label.urlTemplate':'URL Template', 'label.streamUrlTemplate':'Stream URL Template', 'label.urlTemplateHint':'Override the endpoint path. Placeholders: {base_url}, {model}',
     'label.modelName':'Model Name', 'label.provider':'Provider', 'label.upstreamModel':'Upstream Model', 'label.capabilities':'Capabilities', 'label.systemOptions':'System Options', 'label.flattenSystem':'Flatten system content', 'label.flattenSystemHint':'Flatten system message content arrays to plain strings for upstream compatibility.',
     'label.reasoningConfig':'Reasoning Config', 'label.thinkingType':'Thinking Type', 'label.budgetRatio':'Budget Tokens Ratio', 'label.disabledStrategy':'Disabled Strategy', 'label.inheritProvider':'(inherit from provider)', 'label.inherited':'inherited',
     'modal.addProvider':'Add Provider', 'modal.editProvider':'Edit Provider',
@@ -1266,7 +1287,7 @@ const I18N = {
     'label.selectOne':'\u2014 \u8bf7\u9009\u62e9 \u2014',
     'label.baseUrl':'Base URL',
     'label.apiKey':'API Key\uff08\u6216 ${ENV_VAR} \u5360\u4f4d\u7b26\uff09', 'label.keyUnchangedHint':'\u7559\u7a7a\u4ee5\u4fdd\u7559\u5f53\u524d\u5bc6\u94a5',
-    'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09', 'label.urlTemplate':'URL \u6a21\u677f', 'label.streamUrlTemplate':'\u6d41\u5f0f URL \u6a21\u677f', 'label.urlTemplateHint':'\u8986\u76d6\u7aef\u70b9\u8def\u5f84\u3002\u5360\u4f4d\u7b26\uff1a{base_url}\u3001{model}',
+    'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09', 'label.urlTemplate':'URL \u6a21\u677f', 'label.streamUrlTemplate':'\u6d41\u5f0f URL \u6a21\u677f', 'label.urlTemplateHint':'\u8986\u76d6\u7aef\u70b9\u8def\u5f84\u3002\u5360\u4f4d\u7b26\uff1a{base_url}\u3001{model}', 'label.selected':'\u5df2\u9009\u62e9', 'btn.enable':'\u542f\u7528', 'btn.disable':'\u7981\u7528', 'model.enabled':'\u5df2\u542f\u7528', 'model.disabled':'\u5df2\u7981\u7528', 'label.on':'\u5f00', 'label.off':'\u5173', 'test.embedding':'Embedding', 'confirm.bulkDelete':'\u5220\u9664 {count} \u4e2a\u6a21\u578b\uff1f', 'toast.bulkDone':'{action} \u5df2\u5e94\u7528\u5230 {count} \u4e2a\u6a21\u578b',
     'label.modelName':'\u6a21\u578b\u540d\u79f0', 'label.provider':'\u670d\u52a1\u65b9', 'label.upstreamModel':'\u4e0a\u6e38\u6a21\u578b', 'label.capabilities':'\u80fd\u529b', 'label.systemOptions':'\u7cfb\u7edf\u9009\u9879', 'label.flattenSystem':'\u5c55\u5e73\u7cfb\u7edf\u6d88\u606f\u5185\u5bb9', 'label.flattenSystemHint':'\u5c06\u7cfb\u7edf\u6d88\u606f\u5185\u5bb9\u6570\u7ec4\u5c55\u5e73\u4e3a\u7eaf\u6587\u672c\u5b57\u7b26\u4e32\uff0c\u4ee5\u517c\u5bb9\u4e0a\u6e38\u670d\u52a1\u3002',
     'label.reasoningConfig':'\u63a8\u7406\u914d\u7f6e', 'label.thinkingType':'\u601d\u8003\u7c7b\u578b', 'label.budgetRatio':'\u9884\u7b97 Token \u6bd4\u4f8b', 'label.disabledStrategy':'\u7981\u7528\u7b56\u7565', 'label.inheritProvider':'(\u7ee7\u627f\u81ea Provider)', 'label.inherited':'\u7ee7\u627f',
     'modal.addProvider':'\u6dfb\u52a0\u670d\u52a1\u65b9', 'modal.editProvider':'\u7f16\u8f91\u670d\u52a1\u65b9',
@@ -2125,7 +2146,7 @@ function renderModels() {
   document.getElementById('sortProvider').className = 'sortable' + (_modelSortKey === 'provider' ? ` ${_modelSortDir}` : '');
 
   if (totalCount === 0) {
-    tbody.innerHTML = `<tr><td colspan="3" style="color:var(--text-dim)">${t('empty.models')}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="4" style="color:var(--text-dim)">${t('empty.models')}</td></tr>`;
     document.getElementById('modelCount').textContent = '';
     return;
   }
@@ -2157,7 +2178,7 @@ function renderModels() {
   countEl.textContent = t('model.count', {shown: entries.length, total: totalCount});
 
   if (entries.length === 0) {
-    tbody.innerHTML = `<tr><td colspan="3" style="color:var(--text-dim)">${t('empty.models')}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="4" style="color:var(--text-dim)">${t('empty.models')}</td></tr>`;
     return;
   }
 
@@ -2169,6 +2190,8 @@ function renderModels() {
 
   tbody.innerHTML = entries.map(({name, prov, info}) => {
     const provDisabled = disabledProviders.has(prov);
+    const modelEnabled = typeof info === 'object' ? info.enabled !== false : true;
+    const rowDimmed = provDisabled || !modelEnabled;
     const caps = typeof info === 'string' ? ['text'] : (info.capabilities || ['text']);
     const capBadges = caps.map(c => {
       const cls = c === 'vision' ? 'badge-cap-vision' : c === 'tools' ? 'badge-cap-tools' : c === 'embedding' ? 'badge-cap-embed' : c === 'reasoning' ? 'badge-cap-reasoning' : 'badge-cap';
@@ -2180,26 +2203,34 @@ function renderModels() {
     const isEmbedding = caps.includes('embedding');
     const upstream = (typeof info === 'object' && info.upstream_model) ? info.upstream_model : '';
     const upstreamTag = upstream ? ` <span style="font-size:11px;color:var(--text-dim)" title="Upstream: ${esc(upstream)}">→ ${esc(upstream)}</span>` : '';
-      const urlTpl = (typeof info === 'object' && info.url_template) ? info.url_template : '';
-      const urlTplTag = urlTpl ? ` <span style="font-size:10px;color:var(--text-dim);background:var(--bg-card);padding:1px 4px;border-radius:3px;border:1px solid var(--border)" title="URL Template: ${esc(urlTpl)}">⛓ url</span>` : '';
-    return `<tr${provDisabled ? ' style="opacity:0.4"' : ''}>
+    const urlTpl = (typeof info === 'object' && info.url_template) ? info.url_template : '';
+    const urlTplTag = urlTpl ? ` <span style="font-size:10px;color:var(--text-dim);background:var(--bg-card);padding:1px 4px;border-radius:3px;border:1px solid var(--border)" title="URL Template: ${esc(urlTpl)}">⛓ url</span>` : '';
+    return `<tr${rowDimmed ? ' class="model-disabled"' : ''}>
+      <td><input type="checkbox" class="row-check" data-model="${esc(name)}" onchange="updateModelBulk()"></td>
       <td><code class="copyable" title="Click to copy" onclick="copyText('${esc(name)}')">${esc(name)}</code>${upstreamTag}${urlTplTag} ${capBadges}</td>
       <td>${esc(prov)}${provDisabled ? ` <span style="color:var(--text-dim);font-size:11px">(${t('provider.disabled')})</span>` : ''}</td>
       <td style="text-align:right; white-space:nowrap">
-        ${isEmbedding ? `<button class="btn btn-sm btn-test" style="border-radius:var(--radius);color:var(--orange);font-weight:600" onclick="runTest('${esc(name)}','embedding')">${t('btn.test')}</button>` : `<div class="test-group">
-          <button class="btn btn-sm btn-test" onclick="runTest('${esc(name)}','text')">${t('btn.test')}</button>
+        <div class="pill-toggle ${modelEnabled ? 'is-on' : 'is-off'}" onclick="toggleModel('${esc(name)}')" title="${modelEnabled ? t('model.enabled') : t('model.disabled')}"><span class="pill-on">${t('label.on')}</span><span class="pill-off">${t('label.off')}</span></div>
+        <div class="test-group">
+          <button class="btn btn-sm btn-test${isEmbedding ? ' btn-test-embed' : ''}" onclick="runTest('${esc(name)}','${isEmbedding ? 'embedding' : 'text'}')">${t('btn.test')}</button>
           <button class="btn btn-sm btn-caret" onclick="toggleTestMenu(this)">&#9662;</button>
           <div class="test-menu">
-            <div class="test-menu-item" onclick="runTest('${esc(name)}','text')">${t('test.text')}</div>
-            <div class="test-menu-item" onclick="runTest('${esc(name)}','stream')">${t('test.stream')}</div>
+            ${isEmbedding ? `<div class="test-menu-item" onclick="runTest('${esc(name)}','embedding')">${t('test.embedding')}</div>` : `<div class="test-menu-item" onclick="runTest('${esc(name)}','text')">${t('test.text')}</div>`}
+            <div class="test-menu-item${isEmbedding ? ' disabled' : ''}" onclick="${isEmbedding ? '' : `runTest('${esc(name)}','stream')`}">${t('test.stream')}</div>
             <div class="test-menu-item${hasTools ? '' : ' disabled'}" onclick="${hasTools ? `runTest('${esc(name)}','tools')` : ''}">${t('test.tools')}</div>
             <div class="test-menu-item${hasVision ? '' : ' disabled'}" onclick="${hasVision ? `runTest('${esc(name)}','vision')` : ''}">${t('test.vision')}</div>
             <div class="test-menu-item${hasReasoning ? '' : ' disabled'}" onclick="${hasReasoning ? `runTest('${esc(name)}','reasoning')` : ''}">${t('test.reasoning')}</div>
           </div>
-        </div>`}
-        <button class="btn btn-sm" onclick="cloneModel('${esc(name)}')">${t('btn.clone')}</button>
+        </div>
         <button class="btn btn-sm" onclick="editModel('${esc(name)}','${esc(prov)}')">${t('btn.edit')}</button>
-        <button class="btn btn-sm btn-danger" onclick="deleteModel('${esc(name)}', this)">${t('btn.delete')}</button>
+        <div class="model-more-menu" style="display:inline-block;position:relative">
+          <button class="btn btn-sm" onclick="toggleMoreMenu(this)" style="padding:3px 6px">⋯</button>
+          <div class="more-menu" style="display:none;position:absolute;right:0;top:calc(100% + 4px);min-width:110px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.12);z-index:10;overflow:hidden">
+            <div style="padding:7px 14px;font-size:13px;cursor:pointer" onmouseenter="this.style.background='var(--bg)'" onmouseleave="this.style.background=''" onclick="this.closest('.more-menu').style.display='none';cloneModel('${esc(name)}')">${t('btn.clone')}</div>
+            <div style="border-top:1px solid var(--border);margin:2px 0"></div>
+            <div style="padding:7px 14px;font-size:13px;cursor:pointer;color:var(--danger, #cf222e)" onmouseenter="this.style.background='#fff1f0'" onmouseleave="this.style.background=''" onclick="this.closest('.more-menu').style.display='none';deleteModel('${esc(name)}', this)">${t('btn.delete')}</div>
+          </div>
+        </div>
       </td>
     </tr>`;
   }).join('');
@@ -2515,6 +2546,46 @@ async function _doDeleteModel(name) {
   const res = await api.del(`/admin/api/config/models/${encodeURIComponent(name)}`);
   if (res.ok) { showToast(t('toast.modelDeleted',{name})); loadConfig(); }
   else { showToast(res.error || 'Failed', 'error'); }
+}
+
+
+async function toggleModel(name) {
+  const res = await api.post(`/admin/api/config/models/${encodeURIComponent(name)}/toggle`);
+  if (res.ok) {
+    const stateKey = res.enabled ? 'model.enabled' : 'model.disabled';
+    showToast(`${name}: ${t(stateKey)}`);
+    loadConfig();
+  } else { showToast(res.error || 'Failed', 'error'); }
+}
+
+function selectAllModels(headerCb) {
+  document.querySelectorAll('#modelTable .row-check').forEach(cb => cb.checked = headerCb.checked);
+  updateModelBulk();
+}
+
+function updateModelBulk() {
+  const checked = document.querySelectorAll('#modelTable .row-check:checked');
+  const bar = document.getElementById('modelBulkBar');
+  document.getElementById('modelBulkCount').textContent = checked.length;
+  bar.style.display = checked.length > 0 ? 'flex' : 'none';
+}
+
+async function bulkModels(action) {
+  const checked = document.querySelectorAll('#modelTable .row-check:checked');
+  const names = [...checked].map(cb => cb.dataset.model);
+  if (!names.length) return;
+  if (action === 'delete' && !confirm(t('confirm.bulkDelete', {count: names.length}))) return;
+  const res = await api.post('/admin/api/config/models/bulk', {action, models: names});
+  if (res.ok) {
+    showToast(t('toast.bulkDone', {action, count: res.affected.length}));
+    loadConfig();
+  } else { showToast(res.error || 'Failed', 'error'); }
+}
+
+function toggleMoreMenu(btn) {
+  const menu = btn.nextElementSibling;
+  document.querySelectorAll('.more-menu').forEach(m => { if (m !== menu) m.style.display = 'none'; });
+  menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
 }
 
 function editModel(name, provider) {
@@ -3788,6 +3859,12 @@ checkAuthAndInit();
     }
   }
 })();
+
+document.addEventListener('click', function(e) {
+  if (!e.target.closest('.model-more-menu')) {
+    document.querySelectorAll('.more-menu').forEach(m => m.style.display = 'none');
+  }
+});
 </script>
 </body>
 </html>

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -341,7 +341,7 @@ canvas { width: 100%; height: 160px; }
 .test-menu-item:hover { background: var(--bg-hover); }
 .test-menu-item:first-child { border-radius: var(--radius) var(--radius) 0 0; }
 .test-menu-item:last-child { border-radius: 0 0 var(--radius) var(--radius); }
-.test-menu-item.disabled { color: var(--text-dim); opacity: 0.4; cursor: not-allowed; }
+.test-menu-item.disabled { color: var(--text-dim); opacity: 0.4; cursor: not-allowed; pointer-events: none; }
 .test-menu-item.disabled:hover { background: none; }
 
 /* Test result modal (wider) */
@@ -588,6 +588,14 @@ body { padding-bottom: 26px; }
         <input id="modelSearch" placeholder="Search models..." oninput="renderModels()" data-i18n-placeholder="label.searchModels">
         <span class="model-count" id="modelCount"></span>
       </div>
+      <div class="bulk-bar" id="modelBulkBar">
+        <span class="bulk-count" id="modelBulkCount">0</span> <span data-i18n="label.selected">selected</span>
+        <div class="bulk-actions">
+          <button class="btn btn-sm" onclick="bulkModels('enable')" data-i18n="btn.enable">Enable</button>
+          <button class="btn btn-sm" onclick="bulkModels('disable')" data-i18n="btn.disable">Disable</button>
+          <button class="btn btn-sm btn-danger" onclick="bulkModels('delete')" data-i18n="btn.delete">Delete</button>
+        </div>
+      </div>
       <div class="table-scroll"><table>
         <thead><tr>
           <th style="width:30px"><input type="checkbox" class="row-check" onchange="selectAllModels(this)"></th>
@@ -595,14 +603,6 @@ body { padding-bottom: 26px; }
           <th class="sortable" onclick="sortModels('provider')" id="sortProvider" data-i18n="col.provider">Provider</th>
           <th></th>
         </tr></thead>
-        <div class="bulk-bar" id="modelBulkBar">
-          <span class="bulk-count" id="modelBulkCount">0</span> <span data-i18n="label.selected">selected</span>
-          <div class="bulk-actions">
-            <button class="btn btn-sm" onclick="bulkModels('enable')" data-i18n="btn.enable">Enable</button>
-            <button class="btn btn-sm" onclick="bulkModels('disable')" data-i18n="btn.disable">Disable</button>
-            <button class="btn btn-sm btn-danger" onclick="bulkModels('delete')" data-i18n="btn.delete">Delete</button>
-          </div>
-        </div>
         <tbody id="modelTable"></tbody>
       </table></div>
     </div>

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -1157,7 +1157,7 @@ const I18N = {
     'label.selectOne':'— select —',
     'label.baseUrl':'Base URL',
     'label.apiKey':'API Key (or ${ENV_VAR} placeholder)', 'label.keyUnchangedHint':'Leave blank to keep current key',
-    'label.proxyUrl':'Proxy URL (optional, overrides global)', 'label.selected':'selected', 'btn.enable':'Enable', 'btn.disable':'Disable', 'model.enabled':'Enabled', 'model.disabled':'Disabled', 'label.on':'ON', 'label.off':'OFF', 'test.embedding':'Embedding', 'confirm.bulkDelete':'Delete {count} model(s)?', 'toast.bulkDone':'{action} applied to {count} model(s)', 'label.urlTemplate':'URL Template', 'label.streamUrlTemplate':'Stream URL Template', 'label.urlTemplateHint':'Override the endpoint path. Placeholders: {base_url}, {model}',
+    'label.proxyUrl':'Proxy URL (optional, overrides global)', 'label.selected':'selected', 'btn.enable':'Enable', 'btn.disable':'Disable', 'model.enabled':'Enabled', 'model.disabled':'Disabled', 'label.on':'ON', 'label.off':'OFF', 'test.embedding':'Embedding', 'test.embedBatch':'Batch', 'test.matryoshka':'Matryoshka', 'test.embedMultimodal':'Multimodal (image)', 'test.matryoshkaDimPrompt':'Enter dimensions for matryoshka embedding:', 'error.invalidDimension':'Invalid dimension value', 'confirm.bulkDelete':'Delete {count} model(s)?', 'toast.bulkDone':'{action} applied to {count} model(s)', 'label.urlTemplate':'URL Template', 'label.streamUrlTemplate':'Stream URL Template', 'label.urlTemplateHint':'Override the endpoint path. Placeholders: {base_url}, {model}',
     'label.modelName':'Model Name', 'label.provider':'Provider', 'label.upstreamModel':'Upstream Model', 'label.capabilities':'Capabilities', 'label.systemOptions':'System Options', 'label.flattenSystem':'Flatten system content', 'label.flattenSystemHint':'Flatten system message content arrays to plain strings for upstream compatibility.',
     'label.reasoningConfig':'Reasoning Config', 'label.thinkingType':'Thinking Type', 'label.budgetRatio':'Budget Tokens Ratio', 'label.disabledStrategy':'Disabled Strategy', 'label.inheritProvider':'(inherit from provider)', 'label.inherited':'inherited',
     'modal.addProvider':'Add Provider', 'modal.editProvider':'Edit Provider',
@@ -1287,7 +1287,7 @@ const I18N = {
     'label.selectOne':'\u2014 \u8bf7\u9009\u62e9 \u2014',
     'label.baseUrl':'Base URL',
     'label.apiKey':'API Key\uff08\u6216 ${ENV_VAR} \u5360\u4f4d\u7b26\uff09', 'label.keyUnchangedHint':'\u7559\u7a7a\u4ee5\u4fdd\u7559\u5f53\u524d\u5bc6\u94a5',
-    'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09', 'label.urlTemplate':'URL \u6a21\u677f', 'label.streamUrlTemplate':'\u6d41\u5f0f URL \u6a21\u677f', 'label.urlTemplateHint':'\u8986\u76d6\u7aef\u70b9\u8def\u5f84\u3002\u5360\u4f4d\u7b26\uff1a{base_url}\u3001{model}', 'label.selected':'\u5df2\u9009\u62e9', 'btn.enable':'\u542f\u7528', 'btn.disable':'\u7981\u7528', 'model.enabled':'\u5df2\u542f\u7528', 'model.disabled':'\u5df2\u7981\u7528', 'label.on':'\u5f00', 'label.off':'\u5173', 'test.embedding':'Embedding', 'confirm.bulkDelete':'\u5220\u9664 {count} \u4e2a\u6a21\u578b\uff1f', 'toast.bulkDone':'{action} \u5df2\u5e94\u7528\u5230 {count} \u4e2a\u6a21\u578b',
+    'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09', 'label.urlTemplate':'URL \u6a21\u677f', 'label.streamUrlTemplate':'\u6d41\u5f0f URL \u6a21\u677f', 'label.urlTemplateHint':'\u8986\u76d6\u7aef\u70b9\u8def\u5f84\u3002\u5360\u4f4d\u7b26\uff1a{base_url}\u3001{model}', 'label.selected':'\u5df2\u9009\u62e9', 'btn.enable':'\u542f\u7528', 'btn.disable':'\u7981\u7528', 'model.enabled':'\u5df2\u542f\u7528', 'model.disabled':'\u5df2\u7981\u7528', 'label.on':'\u5f00', 'label.off':'\u5173', 'test.embedding':'Embedding', 'test.embedBatch':'\u6279\u91cf', 'test.matryoshka':'\u5957\u5a03 (Matryoshka)', 'test.embedMultimodal':'\u591a\u6a21\u6001 (\u56fe\u7247)', 'test.matryoshkaDimPrompt':'\u8f93\u5165 Matryoshka \u7ef4\u5ea6\uff1a', 'error.invalidDimension':'\u65e0\u6548\u7684\u7ef4\u5ea6\u503c', 'confirm.bulkDelete':'\u5220\u9664 {count} \u4e2a\u6a21\u578b\uff1f', 'toast.bulkDone':'{action} \u5df2\u5e94\u7528\u5230 {count} \u4e2a\u6a21\u578b',
     'label.modelName':'\u6a21\u578b\u540d\u79f0', 'label.provider':'\u670d\u52a1\u65b9', 'label.upstreamModel':'\u4e0a\u6e38\u6a21\u578b', 'label.capabilities':'\u80fd\u529b', 'label.systemOptions':'\u7cfb\u7edf\u9009\u9879', 'label.flattenSystem':'\u5c55\u5e73\u7cfb\u7edf\u6d88\u606f\u5185\u5bb9', 'label.flattenSystemHint':'\u5c06\u7cfb\u7edf\u6d88\u606f\u5185\u5bb9\u6570\u7ec4\u5c55\u5e73\u4e3a\u7eaf\u6587\u672c\u5b57\u7b26\u4e32\uff0c\u4ee5\u517c\u5bb9\u4e0a\u6e38\u670d\u52a1\u3002',
     'label.reasoningConfig':'\u63a8\u7406\u914d\u7f6e', 'label.thinkingType':'\u601d\u8003\u7c7b\u578b', 'label.budgetRatio':'\u9884\u7b97 Token \u6bd4\u4f8b', 'label.disabledStrategy':'\u7981\u7528\u7b56\u7565', 'label.inheritProvider':'(\u7ee7\u627f\u81ea Provider)', 'label.inherited':'\u7ee7\u627f',
     'modal.addProvider':'\u6dfb\u52a0\u670d\u52a1\u65b9', 'modal.editProvider':'\u7f16\u8f91\u670d\u52a1\u65b9',
@@ -2215,11 +2215,18 @@ function renderModels() {
           <button class="btn btn-sm btn-test${isEmbedding ? ' btn-test-embed' : ''}" onclick="runTest('${esc(name)}','${isEmbedding ? 'embedding' : 'text'}')">${t('btn.test')}</button>
           <button class="btn btn-sm btn-caret" onclick="toggleTestMenu(this)">&#9662;</button>
           <div class="test-menu">
-            ${isEmbedding ? `<div class="test-menu-item" onclick="runTest('${esc(name)}','embedding')">${t('test.embedding')}</div>` : `<div class="test-menu-item" onclick="runTest('${esc(name)}','text')">${t('test.text')}</div>`}
-            <div class="test-menu-item${isEmbedding ? ' disabled' : ''}" onclick="${isEmbedding ? '' : `runTest('${esc(name)}','stream')`}">${t('test.stream')}</div>
+            ${isEmbedding ? `
+            <div class="test-menu-item" onclick="runTest('${esc(name)}','embedding')">${t('test.embedding')}</div>
+            <div class="test-menu-item" onclick="runTest('${esc(name)}','embed_batch')">${t('test.embedBatch')}</div>
+            <div class="test-menu-item" onclick="promptMatryoshka('${esc(name)}')">${t('test.matryoshka')}</div>
+            <div class="test-menu-item" onclick="runTest('${esc(name)}','embed_multimodal')">${t('test.embedMultimodal')}</div>
+            ` : `
+            <div class="test-menu-item" onclick="runTest('${esc(name)}','text')">${t('test.text')}</div>
+            <div class="test-menu-item" onclick="runTest('${esc(name)}','stream')">${t('test.stream')}</div>
             <div class="test-menu-item${hasTools ? '' : ' disabled'}" onclick="${hasTools ? `runTest('${esc(name)}','tools')` : ''}">${t('test.tools')}</div>
             <div class="test-menu-item${hasVision ? '' : ' disabled'}" onclick="${hasVision ? `runTest('${esc(name)}','vision')` : ''}">${t('test.vision')}</div>
             <div class="test-menu-item${hasReasoning ? '' : ' disabled'}" onclick="${hasReasoning ? `runTest('${esc(name)}','reasoning')` : ''}">${t('test.reasoning')}</div>
+            `}
           </div>
         </div>
         <button class="btn btn-sm" onclick="editModel('${esc(name)}','${esc(prov)}')">${t('btn.edit')}</button>
@@ -3488,7 +3495,7 @@ const TEST_IMAGE_URL = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDA
 
 function getTestLabel(type) { return t('test.' + type); }
 
-function buildTestPayload(model, type) {
+function buildTestPayload(model, type, extraParam) {
   const base = {model, max_tokens: 256};
   switch(type) {
     case 'text':
@@ -3515,6 +3522,12 @@ function buildTestPayload(model, type) {
       return {...base, reasoning_effort: 'low', messages:[{role:'user', content:'What is 15 * 37? Show your reasoning briefly.'}]};
     case 'embedding':
       return {model, input: 'Hello, world!'};
+    case 'embed_batch':
+      return {model, input: ['Hello, world!', 'The quick brown fox jumps over the lazy dog.', 'Embeddings are useful for semantic search.']};
+    case 'embed_multimodal':
+      return {model, input: [{type: 'text', text: 'Describe this image.'}, {type: 'image_url', image_url: {url: TEST_IMAGE_URL}}]};
+    case 'matryoshka':
+      return {model, input: 'Hello, world!', dimensions: extraParam};
   }
 }
 
@@ -3569,7 +3582,16 @@ function _newTestSignal() {
   return ctrl.signal;
 }
 
-async function runTest(model, type) {
+
+function promptMatryoshka(model) {
+  const dim = prompt(t('test.matryoshkaDimPrompt'), '256');
+  if (dim === null) return;
+  const dimensions = parseInt(dim, 10);
+  if (isNaN(dimensions) || dimensions < 1) { showToast(t('error.invalidDimension'), 'error'); return; }
+  runTest(model, 'matryoshka', dimensions);
+}
+
+async function runTest(model, type, extraParam) {
   // Close any open dropdown
   document.querySelectorAll('.test-menu.open').forEach(m => m.classList.remove('open'));
 
@@ -3591,7 +3613,7 @@ async function runTest(model, type) {
   resBody.textContent = '';
   resDetails.style.display = 'none';
   // Show image preview for vision tests
-  if (type === 'vision') {
+  if (type === 'vision' || type === 'embed_multimodal') {
     imgDetails.style.display = '';
     imgBody.innerHTML = `<img src="${TEST_IMAGE_URL}" alt="test image">`;
   } else {
@@ -3600,7 +3622,7 @@ async function runTest(model, type) {
   }
   document.getElementById('testModal').classList.add('open');
 
-  const payload = buildTestPayload(model, type);
+  const payload = buildTestPayload(model, type, extraParam);
   reqBody.textContent = truncatePayloadForDisplay(payload);
 
   const t0 = performance.now();
@@ -3610,7 +3632,8 @@ async function runTest(model, type) {
     // --- Async task path (embedding + all non-streaming tests) ---
     // Browser never holds a long connection; the gateway's httpx pool
     // handles the upstream call.
-    const endpoint = type === 'embedding' ? '/v1/embeddings' : '/v1/chat/completions';
+    const isEmbedType = ['embedding','embed_batch','embed_multimodal','matryoshka'].includes(type);
+    const endpoint = isEmbedType ? '/v1/embeddings' : '/v1/chat/completions';
     output.innerHTML = `<span class="test-spinner"></span>${t('test.sending')}`;
     // Show Cancel button and live elapsed timer
     const cancelBtn = document.getElementById('testCancelBtn');

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -41,6 +41,8 @@ from .config import (
     put_provider,
     put_server_settings,
     reload_config,
+    bulk_update_models,
+    toggle_model,
     toggle_provider,
 )
 from .keys import (
@@ -112,6 +114,10 @@ def register_admin_routes(app: Any) -> None:
     )
     app.route("/admin/api/config/models/<path:name>", methods=["PUT"])(put_model)
     app.route("/admin/api/config/models/<path:name>", methods=["DELETE"])(delete_model)
+    app.route("/admin/api/config/models/<path:name>/toggle", methods=["POST"])(
+        toggle_model
+    )
+    app.route("/admin/api/config/models/bulk", methods=["POST"])(bulk_update_models)
     app.route("/admin/api/config/providers/<name>/models", methods=["GET"])(
         fetch_upstream_models
     )

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -110,6 +110,8 @@ def _normalize_model_entry(value: Any) -> dict[str, Any]:
     ):
         if value.get(key):
             entry[key] = value[key]
+    if value.get("enabled") is not None:
+        entry["enabled"] = value["enabled"]
     return entry
 
 
@@ -370,6 +372,124 @@ async def toggle_provider(request: Any, **kwargs: Any) -> Response:
         )
 
     return JSONResponse({"ok": True, "provider": name, "enabled": new_enabled})
+
+
+async def toggle_model(request: Any, **kwargs: Any) -> Response:
+    """Toggle a model's enabled/disabled state."""
+    config_path = _get_config_path(request)
+
+    name = request.path_params["name"]
+
+    try:
+        data = _get_config_io(request).load_raw(config_path)
+    except Exception as exc:
+        return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
+
+    models = data.get("models", {})
+    if name not in models:
+        return JSONResponse({"error": f"Model '{name}' not found"}, status_code=404)
+
+    # Normalize string shorthand to dict
+    if isinstance(models[name], str):
+        models[name] = {"provider": models[name]}
+
+    currently_enabled = models[name].get("enabled", True)
+    new_enabled = not currently_enabled
+
+    if new_enabled:
+        models[name].pop("enabled", None)
+    else:
+        models[name]["enabled"] = False
+
+    try:
+        _get_config_io(request).save(config_path, data)
+    except Exception as exc:
+        return JSONResponse(
+            {"error": f"Failed to write config: {exc}"}, status_code=500
+        )
+
+    try:
+        _reload_gateway_config(request, config_path)
+    except Exception as exc:
+        return JSONResponse(
+            {
+                "error": f"Config saved but reload failed: {exc}",
+                "saved": True,
+                "reloaded": False,
+            },
+            status_code=500,
+        )
+
+    return JSONResponse({"ok": True, "model": name, "enabled": new_enabled})
+
+
+async def bulk_update_models(request: Any) -> Response:
+    """Bulk enable, disable, or delete models."""
+    config_path = _get_config_path(request)
+
+    try:
+        body = request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    action = body.get("action")
+    names = body.get("models", [])
+    if action not in ("enable", "disable", "delete") or not names:
+        return JSONResponse(
+            {"error": "'action' (enable/disable/delete) and 'models' are required"},
+            status_code=400,
+        )
+
+    try:
+        data = _get_config_io(request).load_raw(config_path)
+    except Exception as exc:
+        return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
+
+    models = data.get("models", {})
+    affected: list[str] = []
+
+    for name in names:
+        if name not in models:
+            continue
+        if action == "delete":
+            del models[name]
+            affected.append(name)
+        else:
+            if isinstance(models[name], str):
+                models[name] = {"provider": models[name]}
+            if action == "enable":
+                models[name].pop("enabled", None)
+            else:
+                models[name]["enabled"] = False
+            affected.append(name)
+
+    try:
+        _get_config_io(request).save(config_path, data)
+    except Exception as exc:
+        return JSONResponse(
+            {"error": f"Failed to write config: {exc}"}, status_code=500
+        )
+
+    try:
+        new_config = _reload_gateway_config(request, config_path)
+    except Exception as exc:
+        return JSONResponse(
+            {
+                "error": f"Config saved but reload failed: {exc}",
+                "saved": True,
+                "reloaded": False,
+            },
+            status_code=500,
+        )
+
+    return JSONResponse(
+        {
+            "ok": True,
+            "action": action,
+            "affected": affected,
+            "models": dict(new_config.models),
+        }
+    )
 
 
 async def put_model(request: Any, **kwargs: Any) -> Response:

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -355,6 +355,10 @@ class GatewayConfig:
             else:
                 raise ValueError(f"config: invalid model entry for '{name}'")
 
+            # Skip disabled models
+            if isinstance(value, dict) and value.get("enabled") is False:
+                continue
+
             if provider_name not in raw_providers:
                 continue
 


### PR DESCRIPTION
## Summary

- Per-model enable/disable toggle with ON/OFF pill switch in the model table
- Bulk operations: checkbox multi-select with Enable/Disable/Delete action bar
- Model table actions restructured: Test▾ and Edit stay visible; Clone and Delete collapse into ⋯ dropdown
- Test button unified across LLM and embedding models (embedding shows same Test▾ width with grayed-out LLM-only options)
- Disabled models render with reduced opacity
- URL template admin UI for provider and model cards (from prior commit)

### Backend
- `toggle_model` route: per-model `enabled` field toggle (mirrors `toggle_provider` pattern)
- `bulk_update_models` route: batch enable/disable/delete via `POST /admin/api/config/models/bulk`
- `GatewayConfig._parse_models` skips models with `enabled: false`
- `_normalize_model_entry` correctly passes `enabled: false` to frontend (uses `is not None` check)

## Test plan
- [x] `make test` — 164 gateway tests pass
- [x] Pill toggle: click ON/OFF switches model enabled state, toast confirms, row dims
- [x] Bulk bar: selecting checkboxes shows "N selected" with Enable/Disable/Delete buttons
- [x] ⋯ dropdown: Clone and Delete accessible, closes on outside click
- [x] Embedding Test▾: same width as LLM, dropdown shows Embedding option + grayed-out LLM options
- [x] `enabled: false` in config correctly renders as OFF toggle + dimmed row