### PR TITLE
fix: filter null values from usage token details

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -174,16 +174,21 @@ class OpenAIChatConverter(BaseConverter):
         }
         p_prompt_details = p_usage.get("prompt_tokens_details")
         if p_prompt_details:
-            usage_info["prompt_tokens_details"] = p_prompt_details
-            if "cached_tokens" in p_prompt_details:
-                usage_info["cache_read_tokens"] = p_prompt_details["cached_tokens"]
+            # Filter None values — IR requires dict[str, int]
+            cleaned = {k: v for k, v in p_prompt_details.items() if v is not None}
+            if cleaned:
+                usage_info["prompt_tokens_details"] = cleaned
+            cached = p_prompt_details.get("cached_tokens")
+            if cached is not None:
+                usage_info["cache_read_tokens"] = cached
         p_completion_details = p_usage.get("completion_tokens_details")
         if p_completion_details:
-            usage_info["completion_tokens_details"] = p_completion_details
-            if "reasoning_tokens" in p_completion_details:
-                usage_info["reasoning_tokens"] = p_completion_details[
-                    "reasoning_tokens"
-                ]
+            cleaned = {k: v for k, v in p_completion_details.items() if v is not None}
+            if cleaned:
+                usage_info["completion_tokens_details"] = cleaned
+            reasoning = p_completion_details.get("reasoning_tokens")
+            if reasoning is not None:
+                usage_info["reasoning_tokens"] = reasoning
         return cast(UsageInfo, usage_info)
 
     def _apply_tool_config(


### PR DESCRIPTION
## Summary

- Fix 502 error when proxying to upstreams that return `null` in token detail fields (e.g. `cache_write_tokens: null` from gpt-5.4-mini via argo)
- The OpenAI Chat converter's `_build_ir_usage` was passing `prompt_tokens_details` and `completion_tokens_details` dicts through raw, but the IR type requires `dict[str, int]` — null values fail validation
- Now filters out `None` values before putting these dicts into the IR, and guards individual field extraction with `is not None` checks

## Test plan

- [x] `make test` — all 218 OpenAI Chat converter tests pass
- [x] Full non-gateway test suite (1966 passed)