### PR TITLE
fix(test): align test_auth with open_on_no_keys behavior

### DIFF
--- a/tests/gateway/test_auth.py
+++ b/tests/gateway/test_auth.py
@@ -45,10 +45,10 @@ def _run(coro: Any) -> Any:
 
 
 class TestNoApiKey:
-    """When no api_key is configured, all requests pass through."""
+    """When no api_key is configured, behavior depends on open_on_no_keys."""
 
-    def test_all_requests_allowed(self):
-        state = AuthState(frozenset(), {}, None)
+    def test_open_on_no_keys_allows_all(self):
+        state = AuthState(frozenset(), {}, None, open_on_no_keys=True)
         hook = create_auth_hook(state)
 
         for path in [
@@ -59,6 +59,21 @@ class TestNoApiKey:
         ]:
             resp = _run(hook(_make_request(path)))
             assert resp is None, f"Expected pass-through for {path}"
+
+    def test_closed_on_no_keys_blocks_api(self):
+        state = AuthState(frozenset(), {}, None, open_on_no_keys=False)
+        hook = create_auth_hook(state)
+
+        resp = _run(hook(_make_request("/v1/chat/completions")))
+        assert resp is not None
+        assert resp.status_code == 403
+
+    def test_closed_on_no_keys_allows_health(self):
+        state = AuthState(frozenset(), {}, None, open_on_no_keys=False)
+        hook = create_auth_hook(state)
+
+        resp = _run(hook(_make_request("/health")))
+        assert resp is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix `test_all_requests_allowed` which assumed empty key_set = pass-through, but `open_on_no_keys` (default `False`) now gates that behavior
- Split into 3 tests: open mode allows all, closed mode blocks API, closed mode still allows health

## Test plan
- [x] `pytest tests/gateway/test_auth.py` — 32 passed