### PR TITLE
refactor(admin): model modal three-tab layout

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -184,6 +184,25 @@ tr:hover td { background: var(--bg-hover); }
 .provider-card .field code { overflow: hidden; text-overflow: ellipsis; max-width: 220px; display: inline-block; vertical-align: bottom; }
 .provider-card.disabled { opacity: 0.5; }
 .model-disabled td:not(:first-child):not(:last-child) { opacity: 0.4; }
+.model-tab-bar { display:flex;gap:0;border-bottom:2px solid var(--border);margin-bottom:16px; }
+.model-tab { padding:7px 16px;font-size:13px;font-weight:500;cursor:pointer;color:var(--text-dim);border-bottom:2px solid transparent;margin-bottom:-2px;transition:all 0.15s;user-select:none; }
+.model-tab:hover { color:var(--text); }
+.model-tab.active { font-weight:600;color:var(--accent);border-bottom-color:var(--accent); }
+.model-tab-content { display:none; }
+.model-tab-content.active { display:block; }
+.seg-control { display:inline-flex;border-radius:8px;overflow:hidden;box-shadow:0 0 0 1px var(--border); }
+.seg-control > * { display:flex;align-items:center;padding:6px 20px;font-size:13px;font-weight:500;cursor:pointer;border-right:1px solid var(--border);transition:all 0.15s;user-select:none;color:var(--text-dim);text-transform:none;letter-spacing:0;margin:0; }
+.seg-control > *:last-child { border-right:none; }
+.seg-control > *:hover { background:var(--bg); }
+.seg-control input { position:absolute;opacity:0;width:0;height:0;pointer-events:none; }
+.seg-control > *.active { background:var(--accent);color:#fff; }
+.chip-group { display:flex;gap:6px;flex-wrap:wrap; }
+.chip { display:inline-flex;align-items:center;gap:5px;padding:5px 12px;border:1px solid var(--border);border-radius:20px;font-size:13px;cursor:pointer;user-select:none;transition:all 0.15s;background:var(--bg-card);color:var(--text-dim); }
+.chip:hover { border-color:var(--accent);color:var(--accent); }
+.chip.active { background:var(--accent);border-color:var(--accent);color:#fff; }
+.chip input { position:absolute;opacity:0;width:0;height:0;pointer-events:none; }
+.expand-link { font-size:12px;color:var(--accent);cursor:pointer;display:inline-flex;align-items:center;gap:4px;margin-top:6px; }
+.expand-link:hover { text-decoration:underline; }
 .bulk-bar { display:none;align-items:center;gap:10px;padding:8px 14px;margin-bottom:8px;background:#ddf4ff;border:1px solid #a8d4f5;border-radius:8px;font-size:13px; }
 .bulk-bar .bulk-count { font-weight:600;color:var(--accent); }
 .bulk-bar .bulk-actions { margin-left:auto;display:flex;gap:6px; }
@@ -895,78 +914,107 @@ body { padding-bottom: 26px; }
 <div class="modal-overlay" id="modelModal">
   <div class="modal">
     <h3 id="modelModalTitle" data-i18n="modal.addModel">Add Model</h3>
-    <div class="form-group">
-      <label data-i18n="label.modelName">Model Name</label>
-      <input id="modelName" placeholder="e.g. gpt-4o, claude-sonnet-4-20250514">
+
+    <!-- Tab bar -->
+    <div class="model-tab-bar">
+      <div class="model-tab active" onclick="switchModelTab(this,'modelTab-general')" data-i18n="tab.general">General</div>
+      <div class="model-tab" onclick="switchModelTab(this,'modelTab-routing')" data-i18n="tab.routing">Routing</div>
+      <div class="model-tab" onclick="switchModelTab(this,'modelTab-transforms')" data-i18n="tab.transforms">Transforms</div>
     </div>
-    <div class="form-group">
-      <label data-i18n="label.provider">Provider</label>
-      <select id="modelProvider"></select>
-    </div>
-    <div class="form-group">
-      <label data-i18n="label.upstreamModel">Upstream Model <span style="font-weight:normal;color:var(--text-dim)">(optional)</span></label>
-      <input id="modelUpstream" placeholder="e.g. claudeopus45 (leave blank if same as model name)">
-    </div>
-    <div class="form-group">
-      <label data-i18n="label.modelType">Model Type</label>
-      <div class="fetch-type-radios">
-        <label><input type="radio" name="modelType" value="llm" checked onchange="onModelTypeChange()"> <span data-i18n="label.llm">LLM</span></label>
-        <label><input type="radio" name="modelType" value="embedding" onchange="onModelTypeChange()"> <span data-i18n="label.embedding">Embedding</span></label>
-      </div>
-    </div>
-    <div class="form-group" id="modelCapsGroup">
-      <label data-i18n="label.capabilities">Capabilities</label>
-      <div class="checkbox-group">
-        <label><input type="checkbox" id="capText" checked> text</label>
-        <label><input type="checkbox" id="capVision"> vision</label>
-        <label><input type="checkbox" id="capTools" checked> tools</label>
-        <label><input type="checkbox" id="capReasoning" onchange="updateReasoningVisibility()"> reasoning</label>
-      </div>
-    </div>
-    <div class="form-group">
-      <label data-i18n="label.systemOptions">System Options</label>
-      <div class="checkbox-group">
-        <label><input type="checkbox" id="flattenSystem"> <span data-i18n="label.flattenSystem">Flatten system content</span></label>
-      </div>
-      <div style="font-size:0.8em;color:var(--text-dim);margin-top:2px" data-i18n="label.flattenSystemHint">Flatten system message content arrays to plain strings for upstream compatibility.</div>
-    </div>
-    <div class="form-group">
-      <label data-i18n="label.urlTemplate">URL Template <span style="font-weight:normal;color:var(--text-dim)">(optional)</span></label>
-      <input id="modelUrlTemplate" placeholder="{base_url}/models/{model}/generate">
-      <div style="font-size:0.8em;color:var(--text-dim);margin-top:2px" data-i18n="label.urlTemplateHint">Override the endpoint path. Placeholders: {base_url}, {model}</div>
-    </div>
-    <div class="form-group">
-      <label data-i18n="label.streamUrlTemplate">Stream URL Template <span style="font-weight:normal;color:var(--text-dim)">(optional)</span></label>
-      <input id="modelStreamUrlTemplate" placeholder="Leave blank to use URL Template above">
-    </div>
-    <div class="form-group" id="modelReasoningGroup" style="display:none">
-      <label><span data-i18n="label.reasoningConfig">Reasoning Config</span>
-        <span class="badge badge-sm" id="reasoningSourceBadge" style="margin-left:6px"></span>
-      </label>
-      <div style="display:flex;flex-direction:column;gap:8px">
-        <div style="display:flex;align-items:center;gap:8px">
-          <label style="min-width:140px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.thinkingType">Thinking Type</label>
-          <select id="reasoningThinkingType" style="flex:1">
-            <option value="" data-i18n="label.inheritProvider">(inherit from provider)</option>
-            <option value="enabled">enabled</option>
-            <option value="adaptive">adaptive</option>
-          </select>
+
+    <!-- Tab: General -->
+    <div class="model-tab-content active" id="modelTab-general">
+      <div style="display:flex;gap:12px">
+        <div class="form-group" style="flex:1">
+          <label data-i18n="label.modelName">Model Name</label>
+          <input id="modelName" placeholder="e.g. gpt-4o, claude-sonnet-4-20250514">
         </div>
-        <div style="display:flex;align-items:center;gap:8px">
-          <label style="min-width:140px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.budgetRatio">Budget Tokens Ratio</label>
-          <input id="reasoningBudgetRatio" type="number" step="0.1" min="0" max="1" placeholder="(inherit)" style="flex:1">
+        <div class="form-group" style="flex:1">
+          <label data-i18n="label.provider">Provider</label>
+          <select id="modelProvider"></select>
         </div>
-        <div style="display:flex;align-items:center;gap:8px">
-          <label style="min-width:140px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.disabledStrategy">Disabled Strategy</label>
-          <select id="reasoningDisabled" style="flex:1">
-            <option value="" data-i18n="label.inheritProvider">(inherit from provider)</option>
-            <option value="omit">omit</option>
-            <option value="thinking_disabled">thinking_disabled</option>
-            <option value="thinking_budget_zero">thinking_budget_zero</option>
-          </select>
+      </div>
+      <div class="form-group">
+        <label data-i18n="label.upstreamModel">Upstream Model <span style="font-weight:normal;color:var(--text-dim)">(optional)</span></label>
+        <input id="modelUpstream" placeholder="e.g. claudeopus45 (leave blank if same as model name)">
+      </div>
+      <div class="form-group">
+        <label data-i18n="label.modelType">Type</label>
+        <div class="seg-control">
+          <div class="active" onclick="segModelType(this,'llm')"><input type="radio" name="modelType" value="llm" checked><span data-i18n="label.llm">LLM</span></div>
+          <div onclick="segModelType(this,'embedding')"><input type="radio" name="modelType" value="embedding"><span data-i18n="label.embedding">Embedding</span></div>
+        </div>
+      </div>
+      <div class="form-group" id="modelCapsGroup">
+        <label data-i18n="label.capabilities">Capabilities</label>
+        <div class="chip-group">
+          <div class="chip active" onclick="toggleCap(this,'capText')"><input type="checkbox" id="capText" checked>text</div>
+          <div class="chip" onclick="toggleCap(this,'capVision')"><input type="checkbox" id="capVision">vision</div>
+          <div class="chip active" onclick="toggleCap(this,'capTools')"><input type="checkbox" id="capTools" checked>tools</div>
+          <div class="chip" onclick="toggleCap(this,'capReasoning')"><input type="checkbox" id="capReasoning">reasoning</div>
         </div>
       </div>
     </div>
+
+    <!-- Tab: Routing -->
+    <div class="model-tab-content" id="modelTab-routing">
+      <div class="form-group">
+        <label data-i18n="label.urlTemplate">URL Template <span style="font-weight:normal;color:var(--text-dim)">(optional)</span></label>
+        <input id="modelUrlTemplate" placeholder="{base_url}/v1/chat/completions">
+        <div style="font-size:0.8em;color:var(--text-dim);margin-top:4px" data-i18n="label.urlTemplateHint">Override the endpoint path. Placeholders: {base_url}, {model}</div>
+        <div class="expand-link" onclick="toggleStreamUrl(this)">
+          <span>+</span> <span data-i18n="label.diffStreamUrl">Use a different URL for streaming</span>
+        </div>
+      </div>
+      <div id="modelStreamUrlGroup" style="display:none">
+        <div class="form-group">
+          <label data-i18n="label.streamUrlTemplate">Stream URL Template</label>
+          <input id="modelStreamUrlTemplate" placeholder="{base_url}/v1/chat/completions?stream=true">
+        </div>
+      </div>
+      <div style="color:var(--text-dim);font-size:0.8em;margin-top:16px;padding:10px;background:var(--bg);border-radius:6px" data-i18n="label.urlPrecedenceHint">When blank, the provider's default URL template is used. Per-model overrides take precedence over per-provider overrides.</div>
+    </div>
+
+    <!-- Tab: Transforms -->
+    <div class="model-tab-content" id="modelTab-transforms">
+      <div class="form-group">
+        <label data-i18n="label.systemOptions">System Message</label>
+        <div class="checkbox-group">
+          <label><input type="checkbox" id="flattenSystem"> <span data-i18n="label.flattenSystem">Flatten system content</span></label>
+        </div>
+        <div style="font-size:0.8em;color:var(--text-dim);margin-top:2px" data-i18n="label.flattenSystemHint">Flatten system message content arrays to plain strings for upstream compatibility.</div>
+      </div>
+      <hr style="border:none;border-top:1px solid var(--border);margin:16px 0">
+      <div class="form-group" id="modelReasoningGroup" style="display:none">
+        <label><span data-i18n="label.reasoningConfig">Reasoning</span>
+          <span class="badge badge-sm" id="reasoningSourceBadge" style="margin-left:6px"></span>
+        </label>
+        <div style="display:flex;flex-direction:column;gap:8px">
+          <div style="display:flex;align-items:center;gap:8px">
+            <label style="min-width:140px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.thinkingType">Thinking Type</label>
+            <select id="reasoningThinkingType" style="flex:1">
+              <option value="" data-i18n="label.inheritProvider">(inherit from provider)</option>
+              <option value="enabled">enabled</option>
+              <option value="adaptive">adaptive</option>
+            </select>
+          </div>
+          <div style="display:flex;align-items:center;gap:8px">
+            <label style="min-width:140px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.budgetRatio">Budget Tokens Ratio</label>
+            <input id="reasoningBudgetRatio" type="number" step="0.1" min="0" max="1" placeholder="(inherit)" style="flex:1">
+          </div>
+          <div style="display:flex;align-items:center;gap:8px">
+            <label style="min-width:140px;margin:0;font-size:0.85em;color:var(--text-dim);text-transform:none;letter-spacing:0" data-i18n="label.disabledStrategy">Disabled Strategy</label>
+            <select id="reasoningDisabled" style="flex:1">
+              <option value="" data-i18n="label.inheritProvider">(inherit from provider)</option>
+              <option value="omit">omit</option>
+              <option value="thinking_disabled">thinking_disabled</option>
+              <option value="thinking_budget_zero">thinking_budget_zero</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="modal-actions">
       <button class="btn" onclick="closeModal('modelModal')" data-i18n="btn.cancel">Cancel</button>
       <button class="btn btn-primary" onclick="saveModel()" data-i18n="btn.save">Save</button>
@@ -1172,7 +1220,7 @@ const I18N = {
     'label.selectOne':'— select —',
     'label.baseUrl':'Base URL',
     'label.apiKey':'API Key (or ${ENV_VAR} placeholder)', 'label.keyUnchangedHint':'Leave blank to keep current key',
-    'label.proxyUrl':'Proxy URL (optional, overrides global)', 'label.selected':'selected', 'btn.enable':'Enable', 'btn.disable':'Disable', 'model.enabled':'Enabled', 'model.disabled':'Disabled', 'label.on':'ON', 'label.off':'OFF', 'test.embedding':'Embedding', 'test.embedBatch':'Batch', 'test.matryoshka':'Matryoshka', 'test.embedMultimodal':'Multimodal (image)', 'test.matryoshkaDimPrompt':'Enter dimensions for matryoshka embedding:', 'btn.ok':'OK', 'error.invalidDimension':'Invalid dimension value', 'confirm.bulkDelete':'Delete {count} model(s)?', 'toast.bulkDone':'{action} applied to {count} model(s)', 'label.urlTemplate':'URL Template', 'label.streamUrlTemplate':'Stream URL Template', 'label.urlTemplateHint':'Override the endpoint path. Placeholders: {base_url}, {model}',
+    'label.proxyUrl':'Proxy URL (optional, overrides global)', 'label.selected':'selected', 'btn.enable':'Enable', 'btn.disable':'Disable', 'model.enabled':'Enabled', 'model.disabled':'Disabled', 'label.on':'ON', 'label.off':'OFF', 'test.embedding':'Embedding', 'test.embedBatch':'Batch', 'test.matryoshka':'Matryoshka', 'test.embedMultimodal':'Multimodal (image)', 'test.matryoshkaDimPrompt':'Enter dimensions for matryoshka embedding:', 'btn.ok':'OK', 'tab.general':'General', 'tab.routing':'Routing', 'tab.transforms':'Transforms', 'label.diffStreamUrl':'Use a different URL for streaming', 'label.urlPrecedenceHint':'When blank, the provider\'s default URL template is used. Per-model overrides take precedence over per-provider overrides.', 'error.invalidDimension':'Invalid dimension value', 'confirm.bulkDelete':'Delete {count} model(s)?', 'toast.bulkDone':'{action} applied to {count} model(s)', 'label.urlTemplate':'URL Template', 'label.streamUrlTemplate':'Stream URL Template', 'label.urlTemplateHint':'Override the endpoint path. Placeholders: {base_url}, {model}',
     'label.modelName':'Model Name', 'label.provider':'Provider', 'label.upstreamModel':'Upstream Model', 'label.capabilities':'Capabilities', 'label.systemOptions':'System Options', 'label.flattenSystem':'Flatten system content', 'label.flattenSystemHint':'Flatten system message content arrays to plain strings for upstream compatibility.',
     'label.reasoningConfig':'Reasoning Config', 'label.thinkingType':'Thinking Type', 'label.budgetRatio':'Budget Tokens Ratio', 'label.disabledStrategy':'Disabled Strategy', 'label.inheritProvider':'(inherit from provider)', 'label.inherited':'inherited',
     'modal.addProvider':'Add Provider', 'modal.editProvider':'Edit Provider',
@@ -1302,7 +1350,7 @@ const I18N = {
     'label.selectOne':'\u2014 \u8bf7\u9009\u62e9 \u2014',
     'label.baseUrl':'Base URL',
     'label.apiKey':'API Key\uff08\u6216 ${ENV_VAR} \u5360\u4f4d\u7b26\uff09', 'label.keyUnchangedHint':'\u7559\u7a7a\u4ee5\u4fdd\u7559\u5f53\u524d\u5bc6\u94a5',
-    'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09', 'label.urlTemplate':'URL \u6a21\u677f', 'label.streamUrlTemplate':'\u6d41\u5f0f URL \u6a21\u677f', 'label.urlTemplateHint':'\u8986\u76d6\u7aef\u70b9\u8def\u5f84\u3002\u5360\u4f4d\u7b26\uff1a{base_url}\u3001{model}', 'label.selected':'\u5df2\u9009\u62e9', 'btn.enable':'\u542f\u7528', 'btn.disable':'\u7981\u7528', 'model.enabled':'\u5df2\u542f\u7528', 'model.disabled':'\u5df2\u7981\u7528', 'label.on':'\u5f00', 'label.off':'\u5173', 'test.embedding':'Embedding', 'test.embedBatch':'\u6279\u91cf', 'test.matryoshka':'\u5957\u5a03 (Matryoshka)', 'test.embedMultimodal':'\u591a\u6a21\u6001 (\u56fe\u7247)', 'test.matryoshkaDimPrompt':'\u8f93\u5165 Matryoshka \u7ef4\u5ea6\uff1a', 'error.invalidDimension':'\u65e0\u6548\u7684\u7ef4\u5ea6\u503c', 'btn.ok':'\u786e\u5b9a', 'confirm.bulkDelete':'\u5220\u9664 {count} \u4e2a\u6a21\u578b\uff1f', 'toast.bulkDone':'{action} \u5df2\u5e94\u7528\u5230 {count} \u4e2a\u6a21\u578b',
+    'label.proxyUrl':'\u4ee3\u7406 URL\uff08\u53ef\u9009\uff0c\u8986\u76d6\u5168\u5c40\u8bbe\u7f6e\uff09', 'label.urlTemplate':'URL \u6a21\u677f', 'label.streamUrlTemplate':'\u6d41\u5f0f URL \u6a21\u677f', 'label.urlTemplateHint':'\u8986\u76d6\u7aef\u70b9\u8def\u5f84\u3002\u5360\u4f4d\u7b26\uff1a{base_url}\u3001{model}', 'label.selected':'\u5df2\u9009\u62e9', 'btn.enable':'\u542f\u7528', 'btn.disable':'\u7981\u7528', 'model.enabled':'\u5df2\u542f\u7528', 'model.disabled':'\u5df2\u7981\u7528', 'label.on':'\u5f00', 'label.off':'\u5173', 'test.embedding':'Embedding', 'test.embedBatch':'\u6279\u91cf', 'test.matryoshka':'\u5957\u5a03 (Matryoshka)', 'test.embedMultimodal':'\u591a\u6a21\u6001 (\u56fe\u7247)', 'test.matryoshkaDimPrompt':'\u8f93\u5165 Matryoshka \u7ef4\u5ea6\uff1a', 'error.invalidDimension':'\u65e0\u6548\u7684\u7ef4\u5ea6\u503c', 'btn.ok':'\u786e\u5b9a', 'tab.general':'\u57fa\u672c', 'tab.routing':'\u8def\u7531', 'tab.transforms':'\u8f6c\u6362', 'label.diffStreamUrl':'\u4f7f\u7528\u4e0d\u540c\u7684\u6d41\u5f0f URL', 'label.urlPrecedenceHint':'\u7559\u7a7a\u65f6\u4f7f\u7528 provider \u9ed8\u8ba4 URL \u6a21\u677f\u3002\u6a21\u578b\u7ea7\u522b\u8986\u76d6\u4f18\u5148\u4e8e provider \u7ea7\u522b\u8986\u76d6\u3002', 'confirm.bulkDelete':'\u5220\u9664 {count} \u4e2a\u6a21\u578b\uff1f', 'toast.bulkDone':'{action} \u5df2\u5e94\u7528\u5230 {count} \u4e2a\u6a21\u578b',
     'label.modelName':'\u6a21\u578b\u540d\u79f0', 'label.provider':'\u670d\u52a1\u65b9', 'label.upstreamModel':'\u4e0a\u6e38\u6a21\u578b', 'label.capabilities':'\u80fd\u529b', 'label.systemOptions':'\u7cfb\u7edf\u9009\u9879', 'label.flattenSystem':'\u5c55\u5e73\u7cfb\u7edf\u6d88\u606f\u5185\u5bb9', 'label.flattenSystemHint':'\u5c06\u7cfb\u7edf\u6d88\u606f\u5185\u5bb9\u6570\u7ec4\u5c55\u5e73\u4e3a\u7eaf\u6587\u672c\u5b57\u7b26\u4e32\uff0c\u4ee5\u517c\u5bb9\u4e0a\u6e38\u670d\u52a1\u3002',
     'label.reasoningConfig':'\u63a8\u7406\u914d\u7f6e', 'label.thinkingType':'\u601d\u8003\u7c7b\u578b', 'label.budgetRatio':'\u9884\u7b97 Token \u6bd4\u4f8b', 'label.disabledStrategy':'\u7981\u7528\u7b56\u7565', 'label.inheritProvider':'(\u7ee7\u627f\u81ea Provider)', 'label.inherited':'\u7ee7\u627f',
     'modal.addProvider':'\u6dfb\u52a0\u670d\u52a1\u65b9', 'modal.editProvider':'\u7f16\u8f91\u670d\u52a1\u65b9',
@@ -1897,6 +1945,41 @@ function openProviderModal(name, baseUrl, apiKey, proxy, provType) {
   }
 }
 
+
+function switchModelTab(clicked, showId) {
+  const modal = clicked.closest('.modal');
+  modal.querySelectorAll('.model-tab-content').forEach(el => el.classList.remove('active'));
+  modal.querySelector('#' + showId).classList.add('active');
+  clicked.parentElement.querySelectorAll('.model-tab').forEach(t => t.classList.remove('active'));
+  clicked.classList.add('active');
+}
+
+function segModelType(el, value) {
+  el.parentElement.querySelectorAll(':scope > *').forEach(l => l.classList.remove('active'));
+  el.classList.add('active');
+  el.querySelector('input').checked = true;
+  onModelTypeChange();
+}
+
+function toggleCap(el, checkboxId) {
+  const cb = document.getElementById(checkboxId);
+  cb.checked = !cb.checked;
+  el.classList.toggle('active', cb.checked);
+  if (checkboxId === 'capReasoning') updateReasoningVisibility();
+}
+
+function toggleStreamUrl(el) {
+  const group = document.getElementById('modelStreamUrlGroup');
+  const icon = el.querySelector('span:first-child');
+  if (group.style.display === 'none') {
+    group.style.display = 'block';
+    icon.textContent = '\u2212';
+  } else {
+    group.style.display = 'none';
+    icon.textContent = '+';
+  }
+}
+
 function openModelModal(model, provider, capabilities, upstreamModel, sourceModel) {
   // sourceModel: when cloning, the original model name to read reasoning from
   // (the visible name field is left blank so the user picks a new name).
@@ -1915,14 +1998,31 @@ function openModelModal(model, provider, capabilities, upstreamModel, sourceMode
       sel.appendChild(opt);
     }
   }
-  // Set model type and capability checkboxes
+  // Reset to General tab
+  const modal = document.getElementById('modelModal');
+  modal.querySelectorAll('.model-tab-content').forEach(el => el.classList.remove('active'));
+  modal.querySelector('#modelTab-general').classList.add('active');
+  modal.querySelectorAll('.model-tab').forEach(t => t.classList.remove('active'));
+  modal.querySelector('.model-tab').classList.add('active');
+  // Reset stream URL expand
+  document.getElementById('modelStreamUrlGroup').style.display = 'none';
+  const expandIcon = modal.querySelector('.expand-link span:first-child');
+  if (expandIcon) expandIcon.textContent = '+';
+
+  // Set model type via seg-control
   const caps = capabilities || ['text', 'tools'];
   const isEmbedding = caps.includes('embedding') && !caps.includes('text');
+  const segLabels = modal.querySelectorAll('.seg-control > *:not(input)');
+  segLabels.forEach(l => l.classList.remove('active'));
+  segLabels[isEmbedding ? 1 : 0].classList.add('active');
   document.querySelector('input[name="modelType"][value="' + (isEmbedding ? 'embedding' : 'llm') + '"]').checked = true;
-  document.getElementById('capText').checked = caps.includes('text');
-  document.getElementById('capVision').checked = caps.includes('vision');
-  document.getElementById('capTools').checked = caps.includes('tools');
-  document.getElementById('capReasoning').checked = caps.includes('reasoning');
+  // Set capability chips
+  const chipMap = {capText: 'text', capVision: 'vision', capTools: 'tools', capReasoning: 'reasoning'};
+  for (const [id, cap] of Object.entries(chipMap)) {
+    const cb = document.getElementById(id);
+    cb.checked = caps.includes(cap);
+    cb.closest('.chip').classList.toggle('active', caps.includes(cap));
+  }
   // flatten_system — read from model config, or infer auto-detect for gemini
   const fsModel = model && configData ? configData.models[model] : null;
   const fsCfg = fsModel && fsModel.flatten_system;
@@ -1930,7 +2030,13 @@ function openModelModal(model, provider, capabilities, upstreamModel, sourceMode
   document.getElementById('flattenSystem').checked = fsCfg != null ? !!fsCfg : !!fsAuto;
   // URL template overrides
   document.getElementById('modelUrlTemplate').value = (fsModel && fsModel.url_template) || '';
-  document.getElementById('modelStreamUrlTemplate').value = (fsModel && fsModel.stream_url_template) || '';
+  const streamTpl = (fsModel && fsModel.stream_url_template) || '';
+  document.getElementById('modelStreamUrlTemplate').value = streamTpl;
+  if (streamTpl) {
+    document.getElementById('modelStreamUrlGroup').style.display = 'block';
+    const ei = modal.querySelector('.expand-link span:first-child');
+    if (ei) ei.textContent = '\u2212';
+  }
   onModelTypeChange();
 
   // Populate reasoning config section.


### PR DESCRIPTION
## Summary

Redesign the model edit/add modal from a single long-scroll form into a three-tab layout:

- **General**: Name + Provider side-by-side, Upstream model, segmented LLM/Embedding type control, pill-style capability chips
- **Routing**: URL template with expand-link for stream URL, precedence info box
- **Transforms**: Flatten system content + Reasoning config (thinking type, budget ratio, disabled strategy)

### UI changes
- Radio buttons → segmented control (LLM | Embedding)
- Checkboxes → pill chips for capabilities (text, vision, tools, reasoning)
- URL template fields moved to dedicated Routing tab with Design C expand pattern
- Flatten system + reasoning grouped under Transforms tab
- Tab resets to General on modal open; stream URL auto-expands if value exists

## Test plan
- [ ] General tab: name/provider side-by-side, seg-control LLM/Embedding toggle hides caps, chip toggle works
- [ ] Routing tab: URL template input, expand link shows stream URL field, auto-expands on edit if value exists
- [ ] Transforms tab: flatten checkbox, reasoning config with inherit labels
- [ ] Save round-trip: all fields across all tabs persist correctly
- [ ] Clone model: all tabs populated from source model