### PR TITLE
feat(auth): add server.open_on_no_keys to opt into anonymous access

### DIFF
--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -589,13 +589,19 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
         config.api_key_labels,
         internal_token,
         admin_password=config.admin_password,
+        open_on_no_keys=config.open_on_no_keys,
     )
     if not config.api_key_set:
-        logger.warning(
-            "No API keys configured — all /v1/* endpoints are BLOCKED. "
-            "Generate keys in the admin panel or set server.api_keys "
-            "in your config to allow access."
+        _no_key_msg = (
+            "No API keys configured — all /v1/* endpoints are OPEN "
+            "(server.open_on_no_keys=true). Set server.api_keys in your "
+            "config or generate keys in the admin panel to restrict access."
+            if config.open_on_no_keys
+            else "No API keys configured — all /v1/* endpoints are BLOCKED. "
+            "Generate keys in the admin panel, set server.api_keys, or "
+            "set server.open_on_no_keys=true to allow anonymous access."
         )
+        logger.warning(_no_key_msg)
     app.before_request(create_auth_hook(auth_state))
 
     # --- CORS ---

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -264,6 +264,15 @@ class GatewayConfig:
         self.proxy: str | None = _server.get("proxy")
         self.socket: str | None = _server.get("socket")
         self.credential_visible: bool = _server.get("credential_visible", True)
+
+        # When no API keys are configured, ``open_on_no_keys`` decides whether
+        # the standalone gateway serves /v1/* anonymously (True) or rejects
+        # every request with 403 (False). Defaults to False (secure by
+        # default). Set to True to restore the pre-0.7 behaviour for a
+        # trusted, localhost-only deployment, e.g.:
+        #   "server": { "open_on_no_keys": true }
+        self.open_on_no_keys: bool = bool(_server.get("open_on_no_keys", False))
+
         self.admin_password: str | None = _server.get("admin_password")
         if self.admin_password and _ENV_VAR_RE.search(self.admin_password):
             raise ValueError(

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -46,3 +46,25 @@ class TestAdminPasswordUnresolvedEnvVar:
         raw = _minimal_raw()
         cfg = GatewayConfig(raw)
         assert cfg.admin_password is None
+
+
+class TestOpenOnNoKeys:
+    """server.open_on_no_keys controls anonymous access when no keys exist."""
+
+    def test_defaults_to_false(self):
+        # Secure by default: absent flag → closed.
+        cfg = GatewayConfig(_minimal_raw())
+        assert cfg.open_on_no_keys is False
+
+    def test_explicit_true(self):
+        cfg = GatewayConfig(_minimal_raw(open_on_no_keys=True))
+        assert cfg.open_on_no_keys is True
+
+    def test_explicit_false(self):
+        cfg = GatewayConfig(_minimal_raw(open_on_no_keys=False))
+        assert cfg.open_on_no_keys is False
+
+    def test_coerced_to_bool(self):
+        # Truthy/falsy JSON values are normalised to real bools.
+        assert GatewayConfig(_minimal_raw(open_on_no_keys=1)).open_on_no_keys is True
+        assert GatewayConfig(_minimal_raw(open_on_no_keys=0)).open_on_no_keys is False


### PR DESCRIPTION
## Summary

Adds a `server.open_on_no_keys` config flag so a **standalone gateway with no API keys configured** can serve `/v1/*` anonymously again, while keeping the secure-by-default behaviour introduced in `936c7937`.

### Background

The auth-hardening work landed in two quick commits:

- **`b430fac`** *"reject requests by default when no API keys configured"* — introduced `AuthState(open_on_no_keys=...)` and, per its own message, *"The standalone gateway sets `open_on_no_keys=True` for backward compatibility."* It wired `open_on_no_keys=True` into `create_app()`.
- **`936c7937`** (3.5 min later) *"block requests when no API keys configured"* — removed `open_on_no_keys=True` from `create_app()`, so the standalone gateway now returns **403 for every `/v1/*` request** when no keys are set, with no way to opt back in.

That's the correct default for embedded/downstream use, but it removed the ability to run the standalone gateway anonymously — a common setup for a trusted, `127.0.0.1`-bound proxy fronting local dev tools (Codex, editors, desktop apps that expect a keyless local endpoint).

`AuthState` still accepts `open_on_no_keys`, and there are already tests for both modes in `tests/gateway/test_auth.py` — but nothing reads it from config, and `create_app()` uses the hardcoded default.

### Change

- **config**: parse `server.open_on_no_keys` (bool, default `False`)
- **app**: pass it through to `AuthState`; the startup warning now reflects `OPEN` vs `BLOCKED` and points at the flag in both cases
- **tests**: `TestOpenOnNoKeys` covering default / true / false / truthy-coercion

**Secure-by-default is unchanged.** With no flag and no keys, the gateway still returns 403. Operators of trusted localhost deployments can set:

```jsonc
"server": { "open_on_no_keys": true }
```

to restore the pre-0.7 behaviour.

## Test plan

- [x] `ruff check` clean (incl. `C901`, `max-complexity=15` — warning kept branch-free)
- [x] `pytest tests/gateway/test_config.py tests/gateway/test_auth.py` — 40 passed
- [x] End-to-end: `create_app()` with `{}` → `auth_state.open_on_no_keys is False` (403); with `{"open_on_no_keys": true}` → `True` (open); with `api_keys` → keys enforced regardless

---

🤖 Drafted with Claude Code; authored/reviewed by @saforem2.