### PR TITLE
test(gateway): isolate auth test event loops

### DIFF
--- a/tests/gateway/test_auth.py
+++ b/tests/gateway/test_auth.py
@@ -36,7 +36,7 @@ def _make_request(
 
 
 def _run(coro: Any) -> Any:
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- run auth hook coroutines with `asyncio.run()` instead of relying on the process-wide default event loop
- prevent earlier async tests from making `test_auth.py` order-dependent

## Test plan

- [x] `pytest tests/gateway/test_embeddings.py tests/gateway/test_auth.py -q --no-cov`
- [x] `pytest tests/ --ignore=tests/integration -q --no-cov` (`2158 passed, 4 skipped`)

AI was used to assist with implementation and testing.