### PR TITLE
fix(openai-chat): preserve empty reasoning content

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/message_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/message_ops.py
@@ -619,7 +619,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
         # Handle reasoning_content (DeepSeek / extended OpenAI Chat providers)
         # Prepend before text content to match convention (reasoning first)
         reasoning_content = msg.get("reasoning_content")
-        if reasoning_content:
+        if reasoning_content is not None:
             reasoning_part = self.content_ops.p_reasoning_to_ir(reasoning_content)
             # Preserve reasoning_details and encrypted_content in provider_metadata
             meta: dict[str, Any] = {}

--- a/tests/converters/openai_chat/test_message_ops.py
+++ b/tests/converters/openai_chat/test_message_ops.py
@@ -331,6 +331,39 @@ class TestOpenAIChatMessageOps:
         assert parts[1]["type"] == "text"
         assert parts[1]["text"] == "The answer is 42"
 
+    def test_empty_reasoning_content_tool_call_round_trip(self):
+        """Test explicit empty reasoning_content survives a tool call round-trip."""
+        provider_messages = [
+            {
+                "role": "assistant",
+                "reasoning_content": "",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "NYC"}',
+                        },
+                    }
+                ],
+            }
+        ]
+
+        ir_messages = cast(
+            list[Message], self.message_ops.p_messages_to_ir(provider_messages)
+        )
+        restored, warnings = self.message_ops.ir_messages_to_p(ir_messages)
+
+        assert warnings == []
+        assert ir_messages[0]["content"][0] == {
+            "type": "reasoning",
+            "reasoning": "",
+        }
+        assert restored[0]["reasoning_content"] == ""
+        assert restored[0]["tool_calls"][0]["id"] == "call_1"
+
     def test_reasoning_content_p_to_ir_no_reasoning(self):
         """Test standard assistant message without reasoning_content."""
         messages = [{"role": "assistant", "content": "Hello"}]


### PR DESCRIPTION
## Summary

- preserve an explicit empty `reasoning_content` value when converting OpenAI Chat assistant messages to IR
- add a tool-call round-trip regression test covering the DeepSeek failure mode

DeepSeek may emit an initial `reasoning_content: ""` chunk and requires the field to remain present in assistant tool-call history. The previous truthiness guard dropped that explicit empty value, causing the next request to fail with `The reasoning_content in the thinking mode must be passed back to the API`.

Fixes #357.

## Test plan

- [x] `conda run -n llm-rosetta env PYTHONPATH=src pytest tests/converters/openai_chat/test_message_ops.py -q`
- [x] `conda run -n llm-rosetta make lint`
- [x] `conda run -n llm-rosetta make test`
- [x] pre-commit hooks: ruff, ruff format, ty

AI was used to assist with reproduction, implementation, and validation; the changes were reviewed and tested.