### PR TITLE
refactor: enforce Complexipy v6 checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,9 @@ repos:
         require_serial: true
         types: [python]
 
-  # - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-  #   rev: v5.1.0
-  #   hooks:
-  #     - id: complexipy
-  #       files: ^src/llm_rosetta/
-  #       exclude: ^src/llm_rosetta/_vendor/
-  #       args: [-mx, "25"]
+  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+    rev: v6.2.0
+    hooks:
+      - id: complexipy
+        files: ^(src/llm_rosetta|tests)/
+        exclude: ^src/llm_rosetta/_vendor/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "pre-commit>=4.0.0",
-    "complexipy>=5.2.0",
+    "complexipy>=6.2.0",
     "ruff==0.15.20",
     "ty==0.0.54",
     "build>=1.2.2.post1",
@@ -98,6 +98,6 @@ max-complexity = 15
 "src/llm_rosetta/_vendor/*" = ["C901", "UP"]
 
 [tool.complexipy]
-paths = ["src"]
+paths = ["src", "tests"]
 max-complexity-allowed = 25
 exclude = ["src/llm_rosetta/_vendor"]

--- a/src/llm_rosetta/converters/anthropic/tool_ops.py
+++ b/src/llm_rosetta/converters/anthropic/tool_ops.py
@@ -56,6 +56,34 @@ def _collect_anthropic_tool_ids(
     return known_use_ids, answered_ids
 
 
+def _filter_anthropic_user_msg(
+    msg: dict[str, Any],
+    known_use_ids: set[str],
+    orphaned_result_ids: list[str],
+) -> dict[str, Any] | None:
+    """Remove orphaned tool_result blocks from a user message.
+
+    Returns:
+        The original message if no orphaned blocks; a new message with
+        orphaned blocks removed; or ``None`` if the entire message was orphaned.
+    """
+    content = msg.get("content", [])
+    if not isinstance(content, list):
+        return msg
+    orphaned = extract_part_ids(content, "tool_result", "tool_use_id") - known_use_ids
+    if not orphaned:
+        return msg
+    orphaned_result_ids.extend(orphaned)
+    filtered = [
+        b
+        for b in content
+        if not (isinstance(b, dict) and b.get("tool_use_id") in orphaned)
+    ]
+    if not filtered:
+        return None  # entire message was orphaned
+    return {**msg, "content": filtered}
+
+
 def fix_orphaned_tool_calls(
     messages: list[dict[str, Any]],
     *,
@@ -104,21 +132,10 @@ def fix_orphaned_tool_calls(
         msg_role = msg.get("role")
         content = msg.get("content", [])
 
-        # Filter orphaned tool_result blocks from user messages
-        if msg_role == "user" and isinstance(content, list):
-            orphaned = (
-                extract_part_ids(content, "tool_result", "tool_use_id") - known_use_ids
-            )
-            if orphaned:
-                orphaned_result_ids.extend(orphaned)
-                filtered = [
-                    b
-                    for b in content
-                    if not (isinstance(b, dict) and b.get("tool_use_id") in orphaned)
-                ]
-                if not filtered:
-                    continue  # entire message was orphaned
-                msg = {**msg, "content": filtered}
+        if msg_role == "user":
+            msg = _filter_anthropic_user_msg(msg, known_use_ids, orphaned_result_ids)
+            if msg is None:
+                continue
 
         patched.append(msg)
 

--- a/src/llm_rosetta/converters/base/helpers/reasoning.py
+++ b/src/llm_rosetta/converters/base/helpers/reasoning.py
@@ -281,6 +281,29 @@ def _derive_budget_tokens(
     return min(budget, max_tokens - 1)
 
 
+def _apply_thinking_type_override(
+    result: dict[str, Any],
+    cap: ReasoningCapability | None,
+    max_tokens: int | None,
+) -> None:
+    """Apply the shim-declared thinking type and required budget."""
+    if cap is None or cap.thinking_type is None or "thinking" not in result:
+        return
+    thinking = result["thinking"]
+    current_type = thinking.get("type")
+    target_type = cap.thinking_type
+    if target_type == "enabled" and "budget_tokens" not in thinking:
+        derived = _derive_budget_tokens(cap, max_tokens)
+        if derived is not None:
+            thinking["budget_tokens"] = derived
+        else:
+            target_type = "adaptive"
+    if current_type != target_type:
+        thinking["type"] = target_type
+        if target_type == "adaptive" and "budget_tokens" in thinking:
+            del thinking["budget_tokens"]
+
+
 # ── Converter-specific pass-through extras ─────────────────────────────────
 
 
@@ -303,20 +326,7 @@ def _apply_openai_chat_extras(
     if thinking:
         result["thinking"] = thinking
 
-    # Apply shim thinking_type override if set.
-    if cap is not None and cap.thinking_type is not None and "thinking" in result:
-        current_type = result["thinking"].get("type")
-        target_type = cap.thinking_type
-        if target_type == "enabled" and "budget_tokens" not in result["thinking"]:
-            derived = _derive_budget_tokens(cap, max_tokens)
-            if derived is not None:
-                result["thinking"]["budget_tokens"] = derived
-            else:
-                target_type = "adaptive"
-        if current_type != target_type:
-            result["thinking"]["type"] = target_type
-            if target_type == "adaptive" and "budget_tokens" in result["thinking"]:
-                del result["thinking"]["budget_tokens"]
+    _apply_thinking_type_override(result, cap, max_tokens)
 
 
 def _apply_openai_responses_extras(
@@ -373,22 +383,7 @@ def _apply_anthropic_extras(
     elif budget_tokens is not None:
         result["thinking"] = {"type": "enabled", "budget_tokens": budget_tokens}
 
-    # Apply shim thinking_type override if set.
-    if cap is not None and cap.thinking_type is not None and "thinking" in result:
-        current_type = result["thinking"].get("type")
-        target_type = cap.thinking_type
-        # Anthropic requires budget_tokens when type=enabled; if missing,
-        # try to derive from ratio, otherwise fall back to adaptive.
-        if target_type == "enabled" and "budget_tokens" not in result["thinking"]:
-            derived = _derive_budget_tokens(cap, max_tokens)
-            if derived is not None:
-                result["thinking"]["budget_tokens"] = derived
-            else:
-                target_type = "adaptive"
-        if current_type != target_type:
-            result["thinking"]["type"] = target_type
-            if target_type == "adaptive" and "budget_tokens" in result["thinking"]:
-                del result["thinking"]["budget_tokens"]
+    _apply_thinking_type_override(result, cap, max_tokens)
 
 
 def _apply_google_extras(

--- a/src/llm_rosetta/converters/base/helpers/schema.py
+++ b/src/llm_rosetta/converters/base/helpers/schema.py
@@ -262,14 +262,8 @@ def sanitize_schema(
 # ---- nullable → type-array conversion ----
 
 
-def _nullable_to_type_array(schema: dict[str, Any]) -> dict[str, Any]:
-    """Recursively convert ``"nullable": true`` to standard JSON Schema type arrays.
-
-    Transforms ``{"type": "string", "nullable": true}`` into
-    ``{"type": ["string", "null"]}`` and removes the ``nullable`` key.
-    When ``type`` is already a list, appends ``"null"`` if absent.
-    When ``type`` is missing, only strips the ``nullable`` key.
-    """
+def _rewrite_nullable_children(schema: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite child schemas while stripping the current nullable marker."""
     result: dict[str, Any] = {}
     for key, value in schema.items():
         if key == "nullable":
@@ -283,23 +277,38 @@ def _nullable_to_type_array(schema: dict[str, Any]) -> dict[str, Any]:
             ]
         else:
             result[key] = value
+    return result
 
+
+def _apply_nullable_marker(result: dict[str, Any]) -> None:
+    """Fold a nullable marker into a type or union schema."""
+    if "type" in result:
+        current_type = result["type"]
+        if isinstance(current_type, str):
+            result["type"] = [current_type, "null"]
+        elif isinstance(current_type, list) and "null" not in current_type:
+            result["type"] = [*current_type, "null"]
+        return
+    for kw in ("anyOf", "oneOf"):
+        if kw in result and isinstance(result[kw], list):
+            null_variant = {"type": "null"}
+            if null_variant not in result[kw]:
+                result[kw] = [*result[kw], null_variant]
+            break
+
+
+def _nullable_to_type_array(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively convert ``"nullable": true`` to standard JSON Schema type arrays.
+
+    Transforms ``{"type": "string", "nullable": true}`` into
+    ``{"type": ["string", "null"]}`` and removes the ``nullable`` key.
+    When ``type`` is already a list, appends ``"null"`` if absent.
+    When ``type`` is missing, only strips the ``nullable`` key (but injects a
+    null variant into ``anyOf``/``oneOf`` if one is present).
+    """
+    result = _rewrite_nullable_children(schema)
     if schema.get("nullable") is True:
-        if "type" in result:
-            current_type = result["type"]
-            if isinstance(current_type, str):
-                result["type"] = [current_type, "null"]
-            elif isinstance(current_type, list) and "null" not in current_type:
-                result["type"] = [*current_type, "null"]
-        else:
-            # No type field — inject null variant into anyOf/oneOf if present
-            for kw in ("anyOf", "oneOf"):
-                if kw in result and isinstance(result[kw], list):
-                    null_variant = {"type": "null"}
-                    if null_variant not in result[kw]:
-                        result[kw] = [*result[kw], null_variant]
-                    break
-
+        _apply_nullable_marker(result)
     return result
 
 

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -224,27 +224,35 @@ class GoogleGenAIConverter(BaseConverter):
         )
         result: dict[str, Any] = {"model": ir_request["model"]}
 
-        # 1. Handle system_instruction
+        self._build_contents_section(ir_request, result, ctx)
+
+        # Tools/tool_config (writes into result["config"])
+        self._apply_tool_config(ir_request, result, ctx)
+
+        # Generation / response_format / reasoning / stream / cache / extensions
+        self._apply_generation_sections(ir_request, result, ctx)
+
+        if output_format == "rest":
+            return self._to_rest_body(result), ctx.warnings
+
+        return result, ctx.warnings
+
+    def _build_contents_section(
+        self,
+        ir_request: IRRequest,
+        result: dict[str, Any],
+        ctx: ConversionContext,
+    ) -> None:
+        """Build ``contents`` + ``system_instruction`` in-place on ``result``."""
         system_instruction = self._build_system_instruction(ir_request)
 
-        # 2. Handle messages — fix orphaned tool_calls/results and strip
-        #    orphaned tool_choice/tool_config at IR level before conversion.
         ir_messages = fix_orphaned_tool_calls_ir(ir_request.get("messages", []))
         ctx.warnings.extend(strip_orphaned_tool_config(ir_request))
 
-        # Extract system messages from message list
-        for item in ir_messages:
-            if is_message(item) and item.get("role") == "system":
-                msg_parts = []
-                for part in item.get("content", []):
-                    if is_text_part(part):
-                        msg_parts.append({"text": part["text"]})
-                if system_instruction is None:
-                    system_instruction = {"role": "user", "parts": msg_parts}
-                else:
-                    cast(list, system_instruction["parts"]).extend(msg_parts)
+        system_instruction = self._merge_inline_system_messages(
+            ir_messages, system_instruction
+        )
 
-        # Convert non-system messages
         contents, msg_warnings = self.message_ops.ir_messages_to_p(ir_messages)
         ctx.warnings.extend(msg_warnings)
         result["contents"] = contents
@@ -252,23 +260,43 @@ class GoogleGenAIConverter(BaseConverter):
         if system_instruction:
             result["system_instruction"] = system_instruction
 
-        # 3. Build config dict (tools written by _apply_tool_config)
-        self._apply_tool_config(ir_request, result, ctx)
+    @staticmethod
+    def _merge_inline_system_messages(
+        ir_messages: list[Any],
+        system_instruction: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """Fold any ``role=system`` messages in ``ir_messages`` into system_instruction."""
+        for item in ir_messages:
+            if not (is_message(item) and item.get("role") == "system"):
+                continue
+            msg_parts = [
+                {"text": part["text"]}
+                for part in item.get("content", [])
+                if is_text_part(part)
+            ]
+            if system_instruction is None:
+                system_instruction = {"role": "user", "parts": msg_parts}
+            else:
+                cast(list, system_instruction["parts"]).extend(msg_parts)
+        return system_instruction
+
+    def _apply_generation_sections(
+        self,
+        ir_request: IRRequest,
+        result: dict[str, Any],
+        ctx: ConversionContext,
+    ) -> None:
+        """Write generation / response_format / reasoning / stream / cache / extensions."""
         config = result.setdefault("config", {})
 
-        # Generation config
         gen_config = ir_request.get("generation")
         if gen_config:
-            gen_fields = self.config_ops.ir_generation_config_to_p(gen_config)
-            config.update(gen_fields)
+            config.update(self.config_ops.ir_generation_config_to_p(gen_config))
 
-        # Response format
         resp_format = ir_request.get("response_format")
         if resp_format:
-            rf_fields = self.config_ops.ir_response_format_to_p(resp_format)
-            config.update(rf_fields)
+            config.update(self.config_ops.ir_response_format_to_p(resp_format))
 
-        # Reasoning config
         reasoning = ir_request.get("reasoning")
         if reasoning:
             rc_kw = (
@@ -276,32 +304,19 @@ class GoogleGenAIConverter(BaseConverter):
                 if ctx and "reasoning_cap" in ctx.options
                 else {}
             )
-            reasoning_fields = self.config_ops.ir_reasoning_config_to_p(
-                reasoning, **rc_kw
-            )
-            config.update(reasoning_fields)
+            config.update(self.config_ops.ir_reasoning_config_to_p(reasoning, **rc_kw))
 
-        # Stream config
         stream = ir_request.get("stream")
         if stream:
-            stream_fields = self.config_ops.ir_stream_config_to_p(stream)
-            config.update(stream_fields)
+            config.update(self.config_ops.ir_stream_config_to_p(stream))
 
-        # Cache config
         cache = ir_request.get("cache")
         if cache:
-            cache_fields = self.config_ops.ir_cache_config_to_p(cache)
-            config.update(cache_fields)
+            config.update(self.config_ops.ir_cache_config_to_p(cache))
 
-        # Provider extensions
         extensions = ir_request.get("provider_extensions")
         if extensions:
             config.update(extensions)
-
-        if output_format == "rest":
-            return self._to_rest_body(result), ctx.warnings
-
-        return result, ctx.warnings
 
     def request_from_provider(
         self,

--- a/src/llm_rosetta/converters/google_genai/message_ops.py
+++ b/src/llm_rosetta/converters/google_genai/message_ops.py
@@ -245,8 +245,19 @@ class GoogleGenAIMessageOps(BaseMessageOps):
         Args:
             ir_messages: IR messages list (modified in-place).
         """
-        # Build ordered list of (tool_call_id, tool_name) from tool_call parts.
-        call_queue: dict[str, list[str]] = {}  # tool_name → [tool_call_ids]
+        call_queue = GoogleGenAIMessageOps._build_tool_call_queue(ir_messages)
+        if not call_queue:
+            return
+        GoogleGenAIMessageOps._apply_tool_call_id_reconciliation(
+            ir_messages, call_queue
+        )
+
+    @staticmethod
+    def _build_tool_call_queue(
+        ir_messages: Sequence[Message | ExtensionItem],
+    ) -> dict[str, list[str]]:
+        """Return ordered ``tool_name → [tool_call_id, ...]`` from assistant messages."""
+        call_queue: dict[str, list[str]] = {}
         for msg in ir_messages:
             if not is_message(msg) or msg.get("role") != "assistant":
                 continue
@@ -254,35 +265,38 @@ class GoogleGenAIMessageOps(BaseMessageOps):
                 if is_tool_call_part(part):
                     name = part.get("tool_name", "")
                     call_queue.setdefault(name, []).append(part.get("tool_call_id", ""))
+        return call_queue
 
-        if not call_queue:
-            return
+    @staticmethod
+    def _resolve_tool_name_for_result(
+        result_id: str, call_queue: dict[str, list[str]]
+    ) -> str:
+        """Find the queued tool_name matching ``result_id`` (exact or ``name_...``)."""
+        for name in call_queue:
+            # Match if the result_id starts with the tool name
+            # (Gemini CLI format: "<name>_<timestamp>_<index>")
+            # or equals the tool name exactly.
+            if result_id == name or result_id.startswith(name + "_"):
+                return name
+        return result_id  # default guess
 
-        # Track which tool_call_ids have already been consumed.
-        consumed: dict[str, int] = {}  # tool_name → next index in call_queue
-
+    @staticmethod
+    def _apply_tool_call_id_reconciliation(
+        ir_messages: Sequence[Message | ExtensionItem],
+        call_queue: dict[str, list[str]],
+    ) -> None:
+        """Rewrite each ``tool_result.tool_call_id`` to the FIFO-matched call id."""
+        consumed: dict[str, int] = {}
         for msg in ir_messages:
             if not is_message(msg) or msg.get("role") != "tool":
                 continue
             for part in msg.get("content", []):
                 if not is_tool_result_part(part):
                     continue
-                # Determine the function name for this result.
-                # The tool_call_id in the result may actually be the
-                # function name (Google convention) or a client-generated
-                # ID.  We need to find the matching tool_call by name.
                 result_id = part.get("tool_call_id", "")
-                # Try to identify the function name: check if result_id
-                # matches any known tool_name directly.
-                tool_name = result_id  # default guess
-                for name in call_queue:
-                    # Match if the result_id starts with the tool name
-                    # (Gemini CLI format: "<name>_<timestamp>_<index>")
-                    # or equals the tool name exactly.
-                    if result_id == name or result_id.startswith(name + "_"):
-                        tool_name = name
-                        break
-
+                tool_name = GoogleGenAIMessageOps._resolve_tool_name_for_result(
+                    result_id, call_queue
+                )
                 ids = call_queue.get(tool_name)
                 if not ids:
                     continue

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -40,7 +40,7 @@ from ..base.helpers import fix_orphaned_tool_calls_ir, strip_orphaned_tool_confi
 from ._constants import OPENAI_CHAT_REASON_FROM_PROVIDER, OPENAI_CHAT_REASON_TO_PROVIDER
 from .config_ops import OpenAIChatConfigOps
 from .content_ops import OpenAIChatContentOps
-from .message_ops import OpenAIChatMessageOps
+from .message_ops import OpenAIChatMessageOps, _restore_reasoning_metadata
 from .tool_ops import OpenAIChatToolOps
 
 
@@ -213,7 +213,7 @@ class OpenAIChatConverter(BaseConverter):
                     "OpenAI Chat does not support max_tool_calls, ignored"
                 )
 
-    def _build_choice_to_provider(  # noqa: C901
+    def _build_choice_to_provider(
         self, choice: dict[str, Any]
     ) -> dict[str, Any] | None:
         """Build a single OpenAI Chat choice dict from an IR choice."""
@@ -221,28 +221,29 @@ class OpenAIChatConverter(BaseConverter):
         if not message:
             return None
 
+        openai_message = self._build_openai_message_from_choice(message)
+
+        reason = choice.get("finish_reason", {}).get("reason", "stop")
+        openai_choice: dict[str, Any] = {
+            "index": choice.get("index", 0),
+            "message": openai_message,
+            "finish_reason": OPENAI_CHAT_REASON_TO_PROVIDER.get(reason, "stop"),
+        }
+
+        if "logprobs" in choice:
+            openai_choice["logprobs"] = choice["logprobs"]
+
+        return openai_choice
+
+    def _build_openai_message_from_choice(
+        self, message: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Build the ``message`` payload of an OpenAI choice from an IR message."""
         openai_message: dict[str, Any] = {"role": message.get("role", "assistant")}
-
         content_parts = message.get("content", [])
-        text_parts: list[str] = []
-        reasoning_parts: list[str] = []
-        tool_calls: list[dict[str, Any]] = []
-        refusal_text: str | None = None
-        annotations: list[dict[str, Any]] = []
-
-        for part in content_parts:
-            if is_text_part(part):
-                text_parts.append(part["text"])
-            elif is_reasoning_part(part):
-                reasoning_parts.append(part.get("reasoning", ""))
-            elif is_tool_call_part(part):
-                tool_calls.append(self.tool_ops.ir_tool_call_to_p(part))
-            elif is_refusal_part(part):
-                refusal_text = part.get("refusal", "")
-            elif is_citation_part(part):
-                ann = self.content_ops.ir_citation_to_p(part)
-                if ann:
-                    annotations.append(ann)
+        text_parts, reasoning_parts, tool_calls, refusal_text, annotations = (
+            self._classify_choice_content_parts(content_parts)
+        )
 
         if text_parts:
             openai_message["content"] = " ".join(text_parts)
@@ -262,27 +263,36 @@ class OpenAIChatConverter(BaseConverter):
 
         if reasoning_parts:
             openai_message["reasoning_content"] = "\n".join(reasoning_parts)
-            # Restore reasoning_details / encrypted_content from provider_metadata
-            for part in content_parts:
-                if is_reasoning_part(part):
-                    pm = part.get("provider_metadata", {}).get("openai_chat", {})
-                    if "reasoning_details" in pm:
-                        openai_message["reasoning_details"] = pm["reasoning_details"]
-                    if "encrypted_content" in pm:
-                        openai_message["encrypted_content"] = pm["encrypted_content"]
-                    break
+            _restore_reasoning_metadata(openai_message, content_parts)
 
-        reason = choice.get("finish_reason", {}).get("reason", "stop")
-        openai_choice: dict[str, Any] = {
-            "index": choice.get("index", 0),
-            "message": openai_message,
-            "finish_reason": OPENAI_CHAT_REASON_TO_PROVIDER.get(reason, "stop"),
-        }
+        return openai_message
 
-        if "logprobs" in choice:
-            openai_choice["logprobs"] = choice["logprobs"]
+    def _classify_choice_content_parts(
+        self, content_parts: list[Any]
+    ) -> tuple[
+        list[str], list[str], list[dict[str, Any]], str | None, list[dict[str, Any]]
+    ]:
+        """Split IR choice content into (text, reasoning, tool_calls, refusal, anns)."""
+        text_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        refusal_text: str | None = None
+        annotations: list[dict[str, Any]] = []
 
-        return openai_choice
+        for part in content_parts:
+            if is_text_part(part):
+                text_parts.append(part["text"])
+            elif is_reasoning_part(part):
+                reasoning_parts.append(part.get("reasoning", ""))
+            elif is_tool_call_part(part):
+                tool_calls.append(self.tool_ops.ir_tool_call_to_p(part))
+            elif is_refusal_part(part):
+                refusal_text = part.get("refusal", "")
+            elif is_citation_part(part):
+                ann = self.content_ops.ir_citation_to_p(part)
+                if ann:
+                    annotations.append(ann)
+        return text_parts, reasoning_parts, tool_calls, refusal_text, annotations
 
     def _extract_system_and_messages(
         self, messages: list[Any]

--- a/src/llm_rosetta/converters/openai_chat/message_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/message_ops.py
@@ -54,6 +54,83 @@ def _has_multimodal_content(result: Any) -> bool:
     )
 
 
+def _restore_reasoning_metadata(
+    target: dict[str, Any], content_parts: Sequence[Any]
+) -> None:
+    """Copy openai_chat reasoning_details / encrypted_content onto ``target``.
+
+    Scans ``content_parts`` for the first reasoning part carrying
+    ``provider_metadata["openai_chat"]`` and mutates ``target`` in-place so
+    the assistant message / choice payload preserves upstream reasoning
+    context on IR → provider conversion.
+    """
+    for part in content_parts:
+        if not is_reasoning_part(part):
+            continue
+        pm = part.get("provider_metadata", {}).get("openai_chat", {})
+        if "reasoning_details" in pm:
+            target["reasoning_details"] = pm["reasoning_details"]
+        if "encrypted_content" in pm:
+            target["encrypted_content"] = pm["encrypted_content"]
+        return
+
+
+def _parse_synthetic_tool_content_msg(
+    msg: dict[str, Any],
+    unpacked: dict[str, list[dict[str, Any]]],
+) -> None:
+    """Parse a single synthetic ``<tool-content>`` message into ``unpacked``.
+
+    Walks the message's content parts, tracks the current ``call_id``
+    section, and appends non-tag blocks to ``unpacked[call_id]``.  Handles
+    unclosed sections defensively.
+    """
+    content = msg.get("content", [])
+    current_call_id: str | None = None
+    current_blocks: list[dict[str, Any]] = []
+
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        section_change = _handle_synthetic_tag(
+            part, unpacked, current_call_id, current_blocks
+        )
+        if section_change is not None:
+            current_call_id, current_blocks = section_change
+            continue
+        if current_call_id is not None:
+            current_blocks.append(part)
+
+    if current_call_id and current_blocks:
+        unpacked[current_call_id] = current_blocks
+
+
+def _handle_synthetic_tag(
+    part: dict[str, Any],
+    unpacked: dict[str, list[dict[str, Any]]],
+    current_call_id: str | None,
+    current_blocks: list[dict[str, Any]],
+) -> tuple[str | None, list[dict[str, Any]]] | None:
+    """Return the new (call_id, blocks) state if ``part`` is an open/close tag.
+
+    Returns ``None`` when the part is not a synthetic tag, signalling the
+    caller to treat it as a regular content block.
+    """
+    if part.get("type") != "text":
+        return None
+    text = part.get("text", "")
+    open_match = TOOL_CONTENT_OPEN_TAG_RE.match(text)
+    if open_match:
+        if current_call_id and current_blocks:
+            unpacked[current_call_id] = current_blocks
+        return open_match.group(1), []
+    if text == TOOL_CONTENT_CLOSE_TAG:
+        if current_call_id and current_blocks:
+            unpacked[current_call_id] = current_blocks
+        return None, []
+    return None
+
+
 class OpenAIChatMessageOps(BaseMessageOps):
     """OpenAI Chat Completions message conversion operations.
 
@@ -134,6 +211,27 @@ class OpenAIChatMessageOps(BaseMessageOps):
         Returns:
             Reordered message list.
         """
+        tool_msgs, non_tool = OpenAIChatMessageOps._split_tool_and_non_tool(messages)
+        if not tool_msgs:
+            return messages
+
+        tool_by_id = OpenAIChatMessageOps._index_tools_by_call_id(tool_msgs)
+        result = OpenAIChatMessageOps._rebuild_with_tool_pairing(
+            non_tool, tool_by_id, tool_msgs, warnings
+        )
+
+        if result != messages:
+            warnings.append(
+                "Reordered tool messages to follow assistant tool_calls "
+                "(workaround for Codex CLI item ordering)"
+            )
+        return result
+
+    @staticmethod
+    def _split_tool_and_non_tool(
+        messages: list[dict[str, Any]],
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Partition ``messages`` into (tool-role, non-tool-role) preserving order."""
         tool_msgs: list[dict[str, Any]] = []
         non_tool: list[dict[str, Any]] = []
         for m in messages:
@@ -141,47 +239,51 @@ class OpenAIChatMessageOps(BaseMessageOps):
                 tool_msgs.append(m)
             else:
                 non_tool.append(m)
+        return tool_msgs, non_tool
 
-        if not tool_msgs:
-            return messages
-
-        # Group tool messages by tool_call_id
+    @staticmethod
+    def _index_tools_by_call_id(
+        tool_msgs: list[dict[str, Any]],
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Group tool messages by ``tool_call_id`` (skipping entries without one)."""
         tool_by_id: dict[str, list[dict[str, Any]]] = {}
         for tm in tool_msgs:
             tcid = tm.get("tool_call_id")
             if tcid:
                 tool_by_id.setdefault(tcid, []).append(tm)
+        return tool_by_id
 
-        # Rebuild: after each assistant message with tool_calls, insert
-        # matching tool messages in tool_calls order.
+    @staticmethod
+    def _rebuild_with_tool_pairing(
+        non_tool: list[dict[str, Any]],
+        tool_by_id: dict[str, list[dict[str, Any]]],
+        tool_msgs: list[dict[str, Any]],
+        warnings: list[str],
+    ) -> list[dict[str, Any]]:
+        """Reassemble message list, placing tool results after their assistant call."""
         result: list[dict[str, Any]] = []
         matched_ids: set[int] = set()
         for m in non_tool:
             result.append(m)
-            if m.get("role") == "assistant" and "tool_calls" in m:
-                for tc in m["tool_calls"]:
-                    tcid = tc.get("id")
-                    if tcid and tcid in tool_by_id:
-                        for tool_msg in tool_by_id[tcid]:
-                            result.append(tool_msg)
-                            matched_ids.add(id(tool_msg))
+            if m.get("role") != "assistant" or "tool_calls" not in m:
+                continue
+            for tc in m["tool_calls"]:
+                tcid = tc.get("id")
+                if not tcid or tcid not in tool_by_id:
+                    continue
+                for tool_msg in tool_by_id[tcid]:
+                    result.append(tool_msg)
+                    matched_ids.add(id(tool_msg))
 
-        # Append unmatched tool messages at end (don't silently drop them)
         for tm in tool_msgs:
-            if id(tm) not in matched_ids:
-                tcid = tm.get("tool_call_id")
-                warnings.append(
-                    f"Tool message with tool_call_id='{tcid}' has no matching "
-                    "assistant tool_calls entry"
-                )
-                result.append(tm)
-
-        if result != messages:
+            if id(tm) in matched_ids:
+                continue
+            tcid = tm.get("tool_call_id")
             warnings.append(
-                "Reordered tool messages to follow assistant tool_calls "
-                "(workaround for Codex CLI item ordering)"
+                f"Tool message with tool_call_id='{tcid}' has no matching "
+                "assistant tool_calls entry"
             )
-
+            result.append(tm)
         return result
 
     def _ir_message_to_p(
@@ -285,16 +387,46 @@ class OpenAIChatMessageOps(BaseMessageOps):
         result_messages.extend(tool_messages)
         return result_messages, warnings
 
-    def _ir_assistant_to_p(  # noqa: C901
+    def _ir_assistant_to_p(
         self, content: list, warnings: list[str]
     ) -> tuple[dict[str, Any], list[str]]:
         """Convert IR assistant message content to OpenAI assistant message.
 
         Text parts are concatenated. Tool calls are collected into tool_calls list.
         """
+        text_parts, tool_calls, refusal_text, reasoning_text = (
+            self._classify_assistant_parts(content, warnings)
+        )
+
+        openai_message: dict[str, Any] = {"role": "assistant"}
+
+        if reasoning_text is not None:
+            openai_message["reasoning_content"] = reasoning_text
+            _restore_reasoning_metadata(openai_message, content)
+
+        if text_parts:
+            openai_message["content"] = " ".join(text_parts)
+
+        if tool_calls:
+            openai_message["tool_calls"] = tool_calls
+            if not text_parts:
+                openai_message["content"] = None
+
+        if not text_parts and not tool_calls:
+            openai_message["content"] = ""
+
+        if refusal_text is not None:
+            openai_message["refusal"] = refusal_text
+
+        return openai_message, warnings
+
+    def _classify_assistant_parts(
+        self, content: list, warnings: list[str]
+    ) -> tuple[list[str], list[dict[str, Any]], str | None, str | None]:
+        """Split IR assistant content into (text, tool_calls, refusal, reasoning)."""
         text_parts: list[str] = []
         tool_calls: list[dict[str, Any]] = []
-        refusal_text = None
+        refusal_text: str | None = None
         reasoning_text: str | None = None
 
         for part in content:
@@ -313,41 +445,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
                 warnings.append(
                     f"Unsupported content part type in assistant message: {part.get('type')}"
                 )
-
-        openai_message: dict[str, Any] = {"role": "assistant"}
-
-        # Set reasoning content (DeepSeek / extended OpenAI Chat providers)
-        if reasoning_text is not None:
-            openai_message["reasoning_content"] = reasoning_text
-            # Restore reasoning_details / encrypted_content from provider_metadata
-            for part in content:
-                if is_reasoning_part(part):
-                    pm = part.get("provider_metadata", {}).get("openai_chat", {})
-                    if "reasoning_details" in pm:
-                        openai_message["reasoning_details"] = pm["reasoning_details"]
-                    if "encrypted_content" in pm:
-                        openai_message["encrypted_content"] = pm["encrypted_content"]
-                    break
-
-        # Set text content
-        if text_parts:
-            openai_message["content"] = " ".join(text_parts)
-
-        # Set tool calls
-        if tool_calls:
-            openai_message["tool_calls"] = tool_calls
-            if not text_parts:
-                openai_message["content"] = None
-
-        # OpenAI requires assistant messages to have content or tool_calls
-        if not text_parts and not tool_calls:
-            openai_message["content"] = ""
-
-        # Set refusal if present
-        if refusal_text is not None:
-            openai_message["refusal"] = refusal_text
-
-        return openai_message, warnings
+        return text_parts, tool_calls, refusal_text, reasoning_text
 
     def _ir_tool_messages_to_p(
         self,
@@ -772,44 +870,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
             if not OpenAIChatMessageOps._is_synthetic_tool_content_msg(msg):
                 clean.append(msg)
                 continue
-
-            # Parse <tool-content call-id="..."> sections
-            content = msg.get("content", [])
-            current_call_id: str | None = None
-            current_blocks: list[dict[str, Any]] = []
-
-            for part in content:
-                if not isinstance(part, dict):
-                    continue
-
-                if part.get("type") == "text":
-                    text = part.get("text", "")
-
-                    # Check for open tag
-                    open_match = TOOL_CONTENT_OPEN_TAG_RE.match(text)
-                    if open_match:
-                        # Save previous section if any
-                        if current_call_id and current_blocks:
-                            unpacked[current_call_id] = current_blocks
-                        current_call_id = open_match.group(1)
-                        current_blocks = []
-                        continue
-
-                    # Check for close tag
-                    if text == TOOL_CONTENT_CLOSE_TAG:
-                        if current_call_id and current_blocks:
-                            unpacked[current_call_id] = current_blocks
-                        current_call_id = None
-                        current_blocks = []
-                        continue
-
-                # Content block within a section
-                if current_call_id is not None:
-                    current_blocks.append(part)
-
-            # Handle unclosed section
-            if current_call_id and current_blocks:
-                unpacked[current_call_id] = current_blocks
+            _parse_synthetic_tool_content_msg(msg, unpacked)
 
         return unpacked, clean
 

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -190,6 +190,29 @@ class OpenAIResponsesConverter(BaseConverter):
             "messages": [],
         }
 
+        # Stage 1: input surface (instructions + input items → IR messages).
+        self._convert_input_stage_from_p(provider_request, ir_request)
+
+        # Stage 2: tools surface (tool defs, choice, config).
+        self._convert_tools_stage_from_p(provider_request, ir_request)
+
+        # Stage 3: generation / reasoning / response_format / stream.
+        self._convert_sampling_stage_from_p(provider_request, ir_request)
+
+        # Stage 4: cache + provider extensions passthrough.
+        self._convert_extensions_stage_from_p(provider_request, ir_request)
+
+        # Preserve mode: capture request fields for echo-back in response
+        self._maybe_capture_request_echo(provider_request, context)
+
+        return self._validate_ir_request(ir_request)
+
+    def _convert_input_stage_from_p(
+        self,
+        provider_request: dict[str, Any],
+        ir_request: dict[str, Any],
+    ) -> None:
+        """Populate system_instruction and messages on ``ir_request``."""
         # 1. Instructions → system_instruction (list[TextPart])
         instructions = provider_request.get("instructions")
         if instructions:
@@ -208,11 +231,16 @@ class OpenAIResponsesConverter(BaseConverter):
                 }
             ]
         if isinstance(input_items, list):
-            ir_messages = self.message_ops.p_messages_to_ir(input_items)
-            ir_request["messages"] = ir_messages
+            ir_request["messages"] = self.message_ops.p_messages_to_ir(input_items)
 
-        # 3. Tools (with process-level cache)
-        # Filter out disabled tools before caching (external_web_access=False)
+    def _convert_tools_stage_from_p(
+        self,
+        provider_request: dict[str, Any],
+        ir_request: dict[str, Any],
+    ) -> None:
+        """Populate tools, tool_choice and tool_config on ``ir_request``."""
+        # 3. Tools (with process-level cache). Filter out tools whose
+        # external_web_access=False before caching.
         tools = provider_request.get("tools")
         if tools:
             active_tools = [
@@ -228,6 +256,12 @@ class OpenAIResponsesConverter(BaseConverter):
         # 4-5. Tool choice + tool config
         self._convert_tool_config_from_p(provider_request, ir_request)
 
+    def _convert_sampling_stage_from_p(
+        self,
+        provider_request: dict[str, Any],
+        ir_request: dict[str, Any],
+    ) -> None:
+        """Populate generation, response_format, reasoning, and stream config."""
         # 6. Generation config
         gen_config = self.config_ops.p_generation_config_to_ir(provider_request)
         if gen_config:
@@ -253,6 +287,12 @@ class OpenAIResponsesConverter(BaseConverter):
                 {"stream": stream, "stream_options": stream_options}
             )
 
+    def _convert_extensions_stage_from_p(
+        self,
+        provider_request: dict[str, Any],
+        ir_request: dict[str, Any],
+    ) -> None:
+        """Populate cache config and provider extensions passthrough."""
         # 10. Cache config
         self._convert_cache_from_p(provider_request, ir_request)
 
@@ -263,18 +303,20 @@ class OpenAIResponsesConverter(BaseConverter):
                 allowed_tools
             )
 
-        # Preserve mode: capture request fields for echo-back in response
+    @staticmethod
+    def _maybe_capture_request_echo(
+        provider_request: dict[str, Any],
+        context: ConversionContext | None,
+    ) -> None:
+        """In preserve mode, snapshot request-side echo fields onto *context*."""
         ctx = context if context is not None else ConversionContext()
-        if ctx.metadata_mode == "preserve":
-            echo = {
-                k: v
-                for k, v in provider_request.items()
-                if k in RESPONSES_PRESERVE_FIELDS
-            }
-            if echo:
-                ctx.store_request_echo(echo)
-
-        return self._validate_ir_request(ir_request)
+        if ctx.metadata_mode != "preserve":
+            return
+        echo = {
+            k: v for k, v in provider_request.items() if k in RESPONSES_PRESERVE_FIELDS
+        }
+        if echo:
+            ctx.store_request_echo(echo)
 
     def response_from_provider(
         self,
@@ -543,7 +585,6 @@ class OpenAIResponsesConverter(BaseConverter):
         ctx: ConversionContext,
     ) -> None:
         """Capture extra fields from provider response for lossless round-trip."""
-        output_items = provider_response.get("output", [])
         extras = {
             k: v
             for k, v in provider_response.items()
@@ -552,32 +593,43 @@ class OpenAIResponsesConverter(BaseConverter):
         if extras:
             ctx.store_response_extras(extras)
 
-        items_meta: list[dict[str, Any]] = []
-        for item in output_items:
-            if not isinstance(item, dict):
-                continue
-            meta: dict[str, Any] = {}
-            if "id" in item:
-                meta["id"] = item["id"]
-            if "status" in item:
-                meta["status"] = item["status"]
-            content = item.get("content", [])
-            if isinstance(content, list):
-                parts_meta: list[dict[str, Any]] = []
-                for cp in content:
-                    if not isinstance(cp, dict):
-                        continue
-                    pm: dict[str, Any] = {}
-                    if "annotations" in cp:
-                        pm["annotations"] = cp["annotations"]
-                    if "logprobs" in cp:
-                        pm["logprobs"] = cp["logprobs"]
-                    parts_meta.append(pm)
-                if parts_meta:
-                    meta["content_meta"] = parts_meta
-            items_meta.append(meta)
+        items_meta = [
+            OpenAIResponsesConverter._capture_output_item_meta(item)
+            for item in provider_response.get("output", [])
+            if isinstance(item, dict)
+        ]
         if items_meta:
             ctx.store_output_items_meta(items_meta)
+
+    @staticmethod
+    def _capture_output_item_meta(item: dict[str, Any]) -> dict[str, Any]:
+        """Snapshot ``id``/``status`` plus per-content-part metadata for one output item."""
+        meta: dict[str, Any] = {}
+        if "id" in item:
+            meta["id"] = item["id"]
+        if "status" in item:
+            meta["status"] = item["status"]
+
+        content = item.get("content", [])
+        if isinstance(content, list):
+            parts_meta = [
+                OpenAIResponsesConverter._capture_content_part_meta(cp)
+                for cp in content
+                if isinstance(cp, dict)
+            ]
+            if parts_meta:
+                meta["content_meta"] = parts_meta
+        return meta
+
+    @staticmethod
+    def _capture_content_part_meta(cp: dict[str, Any]) -> dict[str, Any]:
+        """Snapshot ``annotations`` and ``logprobs`` for one content part."""
+        pm: dict[str, Any] = {}
+        if "annotations" in cp:
+            pm["annotations"] = cp["annotations"]
+        if "logprobs" in cp:
+            pm["logprobs"] = cp["logprobs"]
+        return pm
 
     @staticmethod
     def _apply_preserve_metadata(
@@ -585,50 +637,61 @@ class OpenAIResponsesConverter(BaseConverter):
         ctx: ConversionContext,
     ) -> None:
         """Re-inject captured metadata fields in *preserve* mode."""
-        echo = ctx.get_echo_fields()
-        core_keys = {
-            "id",
-            "object",
-            "created_at",
-            "model",
-            "output",
-            "status",
-            "usage",
-        }
+        OpenAIResponsesConverter._restore_response_echo(provider_response, ctx)
+        OpenAIResponsesConverter._patch_echoed_tool_strict(provider_response)
+        OpenAIResponsesConverter._restore_output_items_meta(provider_response, ctx)
+
+    _CORE_RESPONSE_KEYS = frozenset(
+        {"id", "object", "created_at", "model", "output", "status", "usage"}
+    )
+
+    @staticmethod
+    def _restore_response_echo(
+        provider_response: dict[str, Any], ctx: ConversionContext
+    ) -> None:
+        """Apply required defaults, then overlay captured echo fields (non-core only)."""
+        core_keys = OpenAIResponsesConverter._CORE_RESPONSE_KEYS
         # Apply required defaults first, then override with actual echo
         for k, v in RESPONSES_REQUIRED_DEFAULTS.items():
             if k not in core_keys and k not in provider_response:
                 provider_response[k] = v
-        for k, v in echo.items():
+        for k, v in ctx.get_echo_fields().items():
             if k not in core_keys:
                 provider_response[k] = v
 
-        # Ensure echoed tools have required 'strict' field
+    @staticmethod
+    def _patch_echoed_tool_strict(provider_response: dict[str, Any]) -> None:
+        """Ensure echoed function tools have the required ``strict`` field present."""
         for tool in provider_response.get("tools", []):
             if isinstance(tool, dict) and tool.get("type") == "function":
                 tool.setdefault("strict", None)
 
-        # Restore per-output-item metadata
-        items_meta = ctx.get_output_items_meta()
+    @staticmethod
+    def _restore_output_items_meta(
+        provider_response: dict[str, Any], ctx: ConversionContext
+    ) -> None:
+        """Restore per-output-item metadata (id/status/content-part fields)."""
         output = provider_response.get("output", [])
-        for i, meta in enumerate(items_meta):
-            if i >= len(output):
-                break
-            item = output[i]
+        for meta, item in zip(ctx.get_output_items_meta(), output):
             if "id" in meta:
                 item["id"] = meta["id"]
             if "status" in meta:
                 item["status"] = meta["status"]
-            # Restore per-content-part metadata
-            content_meta = meta.get("content_meta", [])
-            content = item.get("content", [])
-            for j, pm in enumerate(content_meta):
-                if j >= len(content):
-                    break
-                if "annotations" in pm:
-                    content[j]["annotations"] = pm["annotations"]
-                if "logprobs" in pm:
-                    content[j]["logprobs"] = pm["logprobs"]
+            OpenAIResponsesConverter._restore_content_meta(
+                meta.get("content_meta", []), item.get("content", [])
+            )
+
+    @staticmethod
+    def _restore_content_meta(
+        content_meta: list[dict[str, Any]],
+        content: list[Any],
+    ) -> None:
+        """Restore ``annotations``/``logprobs`` on each content part in *content*."""
+        for pm, part in zip(content_meta, content):
+            if "annotations" in pm:
+                part["annotations"] = pm["annotations"]
+            if "logprobs" in pm:
+                part["logprobs"] = pm["logprobs"]
 
     def messages_to_provider(
         self,

--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -351,52 +351,83 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
         current_message: dict[str, Any] | None = None
 
         for item in provider_messages:
-            if isinstance(item, dict) and "type" not in item and "role" in item:
-                item = self._normalize_shorthand_item(item)
-
-            item_type = item.get("type") if isinstance(item, dict) else None
-
-            if item_type == "message":
-                new_message = self._p_message_to_ir(item)
-                if new_message:
-                    if current_message:
-                        ir_input.append(current_message)
-                    current_message = new_message
-
-            elif item_type in self._TOOL_CALL_TYPES:
-                tool_call = self.tool_ops.p_tool_call_to_ir(item)
-                current_message = self._append_or_start(
-                    ir_input, current_message, tool_call, "assistant"
-                )
-
-            elif item_type in self._TOOL_RESULT_TYPES:
-                tool_result = self.tool_ops.p_tool_result_to_ir(item)
-                current_message = self._append_or_start(
-                    ir_input, current_message, tool_result, "tool"
-                )
-
-            elif item_type == "reasoning":
-                reasoning = self.content_ops.p_reasoning_to_ir(item)
-                if reasoning:
-                    current_message = self._append_or_start(
-                        ir_input, current_message, reasoning, "assistant"
-                    )
-
-            elif item_type == "system_event":
-                if current_message:
-                    ir_input.append(current_message)
-                    current_message = None
-                ir_input.append(self._make_system_event(item))
-
-            elif isinstance(item_type, str) and ":" in item_type:
-                current_message = self._handle_p_extension_item(
-                    item, current_message, ir_input
-                )
+            current_message = self._dispatch_p_item(item, current_message, ir_input)
 
         if current_message and current_message.get("content"):
             ir_input.append(current_message)
 
         return ir_input
+
+    def _dispatch_p_item(
+        self,
+        item: Any,
+        current_message: dict[str, Any] | None,
+        ir_input: list[Any],
+    ) -> dict[str, Any] | None:
+        """Route a single Responses input item to its per-type handler.
+
+        Returns the (possibly updated) ``current_message`` accumulator so the
+        caller's flush ordering is preserved.
+        """
+        if isinstance(item, dict) and "type" not in item and "role" in item:
+            item = self._normalize_shorthand_item(item)
+
+        item_type = item.get("type") if isinstance(item, dict) else None
+
+        if item_type == "message":
+            return self._handle_p_message_item(item, current_message, ir_input)
+        if item_type in self._TOOL_CALL_TYPES:
+            return self._append_or_start(
+                ir_input,
+                current_message,
+                self.tool_ops.p_tool_call_to_ir(item),
+                "assistant",
+            )
+        if item_type in self._TOOL_RESULT_TYPES:
+            return self._append_or_start(
+                ir_input,
+                current_message,
+                self.tool_ops.p_tool_result_to_ir(item),
+                "tool",
+            )
+        if item_type == "reasoning":
+            reasoning = self.content_ops.p_reasoning_to_ir(item)
+            if reasoning:
+                return self._append_or_start(
+                    ir_input, current_message, reasoning, "assistant"
+                )
+            return current_message
+        if item_type == "system_event":
+            return self._handle_p_system_event_item(item, current_message, ir_input)
+        if isinstance(item_type, str) and ":" in item_type:
+            return self._handle_p_extension_item(item, current_message, ir_input)
+        return current_message
+
+    def _handle_p_message_item(
+        self,
+        item: dict[str, Any],
+        current_message: dict[str, Any] | None,
+        ir_input: list[Any],
+    ) -> dict[str, Any] | None:
+        """Flush *current_message* and start a new one from a ``message`` item."""
+        new_message = self._p_message_to_ir(item)
+        if not new_message:
+            return current_message
+        if current_message:
+            ir_input.append(current_message)
+        return new_message
+
+    def _handle_p_system_event_item(
+        self,
+        item: dict[str, Any],
+        current_message: dict[str, Any] | None,
+        ir_input: list[Any],
+    ) -> None:
+        """Flush *current_message* and append a ``system_event`` marker to *ir_input*."""
+        if current_message:
+            ir_input.append(current_message)
+        ir_input.append(self._make_system_event(item))
+        return None
 
     @staticmethod
     def _make_system_event(item: dict[str, Any]) -> dict[str, Any]:

--- a/src/llm_rosetta/converters/openai_responses/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/tool_ops.py
@@ -32,6 +32,22 @@ from ..base.helpers import extract_part_ids, log_orphan_warnings, sanitize_schem
 
 logger = logging.getLogger(__name__)
 
+# IR ToolDefinition.type is restricted to Literal["function", "mcp"];
+# see types/ir/tools.py.
+_IR_ALLOWED_TOOL_TYPES = frozenset({"function", "mcp"})
+
+# Responses API item types handled by the shared "extended" tool-call parser.
+_EXTENDED_CALL_ITEM_TYPES = frozenset(
+    {"shell_call", "computer_call", "code_interpreter_call"}
+)
+
+# Mapping from Responses extended item type → IR tool_type.
+_EXTENDED_CALL_TYPE_MAP = {
+    "shell_call": "code_interpreter",
+    "computer_call": "computer_use",
+    "code_interpreter_call": "code_interpreter",
+}
+
 
 # ==================== Orphaned Tool Call Fix ====================
 
@@ -181,19 +197,11 @@ class OpenAIResponsesToolOps(BaseToolOps):
         Returns:
             IR ToolDefinition.
         """
-        # IR ToolDefinition.type is restricted to Literal["function", "mcp"];
-        # see types/ir/tools.py.
-        _IR_ALLOWED_TYPES = {"function", "mcp"}
-
         # Handle nested format ({"type": "function", "function": {...}})
         if "function" in provider_tool and isinstance(provider_tool["function"], dict):
-            func = provider_tool["function"]
-            result: dict[str, Any] = {
-                "type": "function",
-                "name": func.get("name", ""),
-                "description": func.get("description", ""),
-                "parameters": func.get("parameters", {}),
-            }
+            result = OpenAIResponsesToolOps._p_nested_definition_to_ir(
+                provider_tool["function"]
+            )
         else:
             tool_type = provider_tool.get("type", "function")
             # Non-function tools outside the IR type set (e.g. web_search or
@@ -201,66 +209,99 @@ class OpenAIResponsesToolOps(BaseToolOps):
             # lossy conversion. IR ``type`` is forced to "function" to
             # satisfy validation; ``ir_tool_definition_to_p`` restores the
             # original payload on the outbound leg.
-            if tool_type != "function" and tool_type not in _IR_ALLOWED_TYPES:
-                # Synthesize a minimal JSON Schema for cross-provider
-                # degradation so other providers see "a function that
-                # accepts one text input" instead of an empty schema.
-                synth_params: dict[str, Any] = {}
-                if provider_tool.get("name"):
-                    synth_params = {
-                        "type": "object",
-                        "properties": {
-                            "input": {
-                                "type": "string",
-                                "description": "Free-form text input",
-                            }
-                        },
-                        "required": ["input"],
-                    }
-                # Append format constraint info to description so
-                # cross-provider models get a hint about the expected
-                # output shape (best-effort, not enforced).
-                desc = provider_tool.get("description", "")
-                fmt = provider_tool.get("format")
-                if fmt:
-                    fmt_type = fmt.get("type", "unknown")
-                    fmt_syntax = fmt.get("syntax", "")
-                    hint = f"[Output format: {fmt_type}"
-                    if fmt_syntax:
-                        hint += f", syntax: {fmt_syntax}"
-                    hint += "]"
-                    desc = f"{desc}\n\n{hint}" if desc else hint
-                result = {
-                    "type": "function",
-                    "name": provider_tool.get("name", tool_type),
-                    "description": desc,
-                    "parameters": synth_params,
-                    "_passthrough": dict(provider_tool),
-                }
-                result["metadata"] = {"provider_type": tool_type}
-                result["required_parameters"] = (
-                    synth_params.get("required", []) if synth_params else []
+            if tool_type != "function" and tool_type not in _IR_ALLOWED_TOOL_TYPES:
+                return OpenAIResponsesToolOps._p_extended_definition_to_ir(
+                    provider_tool, tool_type
                 )
-                return cast(ToolDefinition, result)
+            result = OpenAIResponsesToolOps._p_flat_definition_to_ir(
+                provider_tool, tool_type
+            )
 
-            # Flat format (Responses API native).
-            # Custom tools use "schema" instead of "parameters".
-            params = provider_tool.get("parameters", {})
-            if tool_type != "function" and not params:
-                params = provider_tool.get("schema", {})
-            # Downgrade unknown provider tool types (e.g. Codex "custom") to
-            # IR "function" so the request passes IR validation.
-            ir_type = tool_type if tool_type in _IR_ALLOWED_TYPES else "function"
-            result = {
-                "type": ir_type,
-                "name": provider_tool.get("name", ""),
-                "description": provider_tool.get("description", ""),
-                "parameters": params,
+        OpenAIResponsesToolOps._finalize_ir_tool_definition(result)
+        return cast(ToolDefinition, result)
+
+    @staticmethod
+    def _p_nested_definition_to_ir(func: dict[str, Any]) -> dict[str, Any]:
+        """Nested ``{"function": {...}}`` provider tool → intermediate IR dict."""
+        return {
+            "type": "function",
+            "name": func.get("name", ""),
+            "description": func.get("description", ""),
+            "parameters": func.get("parameters", {}),
+        }
+
+    @staticmethod
+    def _p_flat_definition_to_ir(
+        provider_tool: dict[str, Any], tool_type: str
+    ) -> dict[str, Any]:
+        """Flat Responses-native tool → intermediate IR dict (with downgrade tag)."""
+        # Custom tools use "schema" instead of "parameters".
+        params = provider_tool.get("parameters", {})
+        if tool_type != "function" and not params:
+            params = provider_tool.get("schema", {})
+        # Downgrade unknown provider tool types (e.g. Codex "custom") to
+        # IR "function" so the request passes IR validation.
+        ir_type = tool_type if tool_type in _IR_ALLOWED_TOOL_TYPES else "function"
+        result: dict[str, Any] = {
+            "type": ir_type,
+            "name": provider_tool.get("name", ""),
+            "description": provider_tool.get("description", ""),
+            "parameters": params,
+        }
+        if ir_type != tool_type:
+            result["_downgraded_from"] = tool_type
+        return result
+
+    @staticmethod
+    def _p_extended_definition_to_ir(
+        provider_tool: dict[str, Any], tool_type: str
+    ) -> ToolDefinition:
+        """Non-function extended tool (e.g. Codex custom) → passthrough IR."""
+        # Synthesize a minimal JSON Schema for cross-provider degradation.
+        synth_params: dict[str, Any] = {}
+        if provider_tool.get("name"):
+            synth_params = {
+                "type": "object",
+                "properties": {
+                    "input": {
+                        "type": "string",
+                        "description": "Free-form text input",
+                    }
+                },
+                "required": ["input"],
             }
-            if ir_type != tool_type:
-                result["_downgraded_from"] = tool_type
+        desc = OpenAIResponsesToolOps._decorate_extended_description(
+            provider_tool.get("description", ""), provider_tool.get("format")
+        )
+        result: dict[str, Any] = {
+            "type": "function",
+            "name": provider_tool.get("name", tool_type),
+            "description": desc,
+            "parameters": synth_params,
+            "_passthrough": dict(provider_tool),
+            "metadata": {"provider_type": tool_type},
+            "required_parameters": (
+                synth_params.get("required", []) if synth_params else []
+            ),
+        }
+        return cast(ToolDefinition, result)
 
-        # Extract required_parameters from JSON Schema if available
+    @staticmethod
+    def _decorate_extended_description(desc: str, fmt: Any) -> str:
+        """Append format-hint suffix to *desc* when *fmt* metadata is present."""
+        if not fmt:
+            return desc
+        fmt_type = fmt.get("type", "unknown")
+        fmt_syntax = fmt.get("syntax", "")
+        hint = f"[Output format: {fmt_type}"
+        if fmt_syntax:
+            hint += f", syntax: {fmt_syntax}"
+        hint += "]"
+        return f"{desc}\n\n{hint}" if desc else hint
+
+    @staticmethod
+    def _finalize_ir_tool_definition(result: dict[str, Any]) -> None:
+        """In-place: fill required_parameters and metadata for a flat/nested IR tool."""
         parameters = result.get("parameters", {})
         if isinstance(parameters, dict) and "required" in parameters:
             result["required_parameters"] = parameters["required"]
@@ -271,7 +312,6 @@ class OpenAIResponsesToolOps(BaseToolOps):
         result["metadata"] = (
             {"provider_type": downgraded_from} if downgraded_from else {}
         )
-        return cast(ToolDefinition, result)
 
     # ==================== Tool Choice ====================
 
@@ -376,100 +416,128 @@ class OpenAIResponsesToolOps(BaseToolOps):
             json.dumps(tool_input) if isinstance(tool_input, dict) else str(tool_input)
         )
 
-        # Detect MCP call
-        if tool_name and tool_name.startswith("mcp://"):
-            return {
-                "type": "mcp_call",
-                "id": tool_call_id,
-                "name": tool_name,
-                "arguments": arguments,
-                "server_label": ir_tool_call.get("server_name", "default"),
-                "status": "calling",
-            }
-        elif tool_type == "mcp":
-            return {
-                "type": "mcp_call",
-                "id": tool_call_id,
-                "name": tool_name,
-                "arguments": arguments,
-                "server_label": ir_tool_call.get("server_name", "default"),
-                "status": "calling",
-            }
-        elif tool_type == "function":
-            # Recover Responses API item ID from provider_metadata if available;
-            # the API requires 'id' to start with 'fc_' prefix.
-            metadata = ir_tool_call.get("provider_metadata") or {}
-            item_id = metadata.get("responses_item_id")
-            if not item_id:
-                # Cross-format: ensure fc_ prefix required by Responses API
-                if tool_call_id and tool_call_id.startswith("fc_"):
-                    item_id = tool_call_id
-                elif tool_call_id and tool_call_id.startswith("call_"):
-                    item_id = "fc_" + tool_call_id[5:]
-                else:
-                    # Other prefixes (e.g. toolu_ from Anthropic)
-                    item_id = "fc_" + tool_call_id
-            return {
-                "type": "function_call",
-                "id": item_id,
-                "call_id": tool_call_id,
-                "name": tool_name,
-                "arguments": arguments,
-                "status": "completed",
-            }
-        elif tool_type == "custom":
-            # Custom tool calls use plain text 'input' instead of JSON
-            # 'arguments'.  If tool_input has a single "input" key, unwrap
-            # it to plain text; otherwise JSON-serialize the dict.
-            if isinstance(tool_input, dict) and list(tool_input.keys()) == ["input"]:
-                input_str = str(tool_input["input"])
-            else:
-                input_str = (
-                    json.dumps(tool_input)
-                    if isinstance(tool_input, dict)
-                    else str(tool_input)
-                )
-            return {
-                "type": "custom_tool_call",
-                "call_id": tool_call_id,
-                "name": tool_name,
-                "input": input_str,
-            }
-        elif tool_type == "web_search":
-            return {
-                "type": "function_web_search",
-                "call_id": tool_call_id,
-                "query": tool_input.get("query", "")
-                if isinstance(tool_input, dict)
-                else "",
-                "arguments": arguments,
-            }
-        elif tool_type == "code_interpreter":
-            return {
-                "type": "code_interpreter_call",
-                "call_id": tool_call_id,
-                "code": tool_input.get("code", "")
-                if isinstance(tool_input, dict)
-                else "",
-                "arguments": arguments,
-            }
-        elif tool_type == "file_search":
-            return {
-                "type": "file_search_call",
-                "call_id": tool_call_id,
-                "query": tool_input.get("query", "")
-                if isinstance(tool_input, dict)
-                else "",
-                "arguments": arguments,
-            }
+        # MCP call detected by either scheme prefix or explicit tool_type.
+        if (tool_name and tool_name.startswith("mcp://")) or tool_type == "mcp":
+            return OpenAIResponsesToolOps._build_p_mcp_call(
+                tool_call_id, tool_name, arguments, ir_tool_call
+            )
+        if tool_type == "function":
+            return OpenAIResponsesToolOps._build_p_function_call(
+                tool_call_id, tool_name, arguments, ir_tool_call
+            )
+        if tool_type == "custom":
+            return OpenAIResponsesToolOps._build_p_custom_call(
+                tool_call_id, tool_name, tool_input
+            )
+        if tool_type == "web_search":
+            return OpenAIResponsesToolOps._build_p_query_call(
+                "function_web_search", tool_call_id, tool_input, arguments, "query"
+            )
+        if tool_type == "code_interpreter":
+            return OpenAIResponsesToolOps._build_p_query_call(
+                "code_interpreter_call", tool_call_id, tool_input, arguments, "code"
+            )
+        if tool_type == "file_search":
+            return OpenAIResponsesToolOps._build_p_query_call(
+                "file_search_call", tool_call_id, tool_input, arguments, "query"
+            )
+        # Default to function_call
+        return {
+            "type": "function_call",
+            "call_id": tool_call_id,
+            "name": f"{tool_type}_{tool_name}",
+            "arguments": arguments,
+        }
+
+    @staticmethod
+    def _build_p_mcp_call(
+        tool_call_id: str,
+        tool_name: str,
+        arguments: str,
+        ir_tool_call: ToolCallPart,
+    ) -> dict:
+        """Build a Responses API ``mcp_call`` item."""
+        return {
+            "type": "mcp_call",
+            "id": tool_call_id,
+            "name": tool_name,
+            "arguments": arguments,
+            "server_label": ir_tool_call.get("server_name", "default"),
+            "status": "calling",
+        }
+
+    @staticmethod
+    def _build_p_function_call(
+        tool_call_id: str,
+        tool_name: str,
+        arguments: str,
+        ir_tool_call: ToolCallPart,
+    ) -> dict:
+        """Build a Responses API ``function_call`` item."""
+        metadata = ir_tool_call.get("provider_metadata") or {}
+        item_id = metadata.get("responses_item_id") or (
+            OpenAIResponsesToolOps._derive_function_item_id(tool_call_id)
+        )
+        return {
+            "type": "function_call",
+            "id": item_id,
+            "call_id": tool_call_id,
+            "name": tool_name,
+            "arguments": arguments,
+            "status": "completed",
+        }
+
+    @staticmethod
+    def _derive_function_item_id(tool_call_id: str) -> str:
+        """Ensure the Responses-API-required ``fc_`` prefix on function item IDs."""
+        # The API requires 'id' to start with 'fc_' prefix. Convert
+        # Chat-Completions/Anthropic prefixes appropriately.
+        if tool_call_id and tool_call_id.startswith("fc_"):
+            return tool_call_id
+        if tool_call_id and tool_call_id.startswith("call_"):
+            return "fc_" + tool_call_id[5:]
+        # Other prefixes (e.g. toolu_ from Anthropic)
+        return "fc_" + tool_call_id
+
+    @staticmethod
+    def _build_p_custom_call(
+        tool_call_id: str, tool_name: str, tool_input: Any
+    ) -> dict:
+        """Build a Responses API ``custom_tool_call`` item."""
+        # Custom tool calls use plain text 'input' instead of JSON 'arguments'.
+        # If tool_input has a single "input" key, unwrap it to plain text;
+        # otherwise JSON-serialize the dict.
+        if isinstance(tool_input, dict) and list(tool_input.keys()) == ["input"]:
+            input_str = str(tool_input["input"])
+        elif isinstance(tool_input, dict):
+            input_str = json.dumps(tool_input)
         else:
-            # Default to function_call
-            return {
-                "type": "function_call",
-                "call_id": tool_call_id,
-                "name": f"{tool_type}_{tool_name}",
-                "arguments": arguments,
-            }
+            input_str = str(tool_input)
+        return {
+            "type": "custom_tool_call",
+            "call_id": tool_call_id,
+            "name": tool_name,
+            "input": input_str,
+        }
+
+    @staticmethod
+    def _build_p_query_call(
+        item_type: str,
+        tool_call_id: str,
+        tool_input: Any,
+        arguments: str,
+        field_key: str,
+    ) -> dict:
+        """Build a Responses API extended-tool call (web_search / code_interpreter / file_search)."""
+        field_value = (
+            tool_input.get(field_key, "") if isinstance(tool_input, dict) else ""
+        )
+        return {
+            "type": item_type,
+            "call_id": tool_call_id,
+            field_key: field_value,
+            "arguments": arguments,
+        }
 
     @staticmethod
     def p_tool_call_to_ir(provider_tool_call: Any, **kwargs: Any) -> ToolCallPart:
@@ -485,97 +553,121 @@ class OpenAIResponsesToolOps(BaseToolOps):
             IR ToolCallPart.
         """
         item_type = provider_tool_call.get("type")
-
-        # Parse arguments
-        arguments = provider_tool_call.get("arguments", {})
-        if isinstance(arguments, dict):
-            tool_input = arguments
-        elif isinstance(arguments, str):
-            try:
-                tool_input = json.loads(arguments) if arguments else {}
-            except json.JSONDecodeError:
-                tool_input = {"input": arguments}
-        else:
-            tool_input = {}
+        tool_input = OpenAIResponsesToolOps._parse_tool_arguments(
+            provider_tool_call.get("arguments", {})
+        )
 
         if item_type == "function_call":
-            # Responses API has both 'id' (item ID, fc_ prefix) and
-            # 'call_id' (correlation ID, call_ prefix). Store call_id as
-            # tool_call_id for correlation, preserve 'id' in provider_metadata
-            # for lossless round-trip.
-            call_id = provider_tool_call.get("call_id")
-            item_id = provider_tool_call.get("id", "")
-            if not call_id:
-                # Fallback: derive call_ prefix from fc_ prefix
-                if item_id.startswith("fc_"):
-                    call_id = "call_" + item_id[3:]
-                else:
-                    call_id = item_id
-            part = ToolCallPart(
-                type="tool_call",
-                tool_call_id=call_id,
-                tool_name=provider_tool_call.get("name", ""),
-                tool_input=tool_input,
-                tool_type="function",
+            return OpenAIResponsesToolOps._p_function_call_to_ir(
+                provider_tool_call, tool_input
             )
-            if item_id and item_id != call_id:
-                part["provider_metadata"] = {"responses_item_id": item_id}
-            return part
-        elif item_type == "mcp_call":
-            # MCP call may use server/tool fields or name field
-            server = provider_tool_call.get("server", "")
-            tool = provider_tool_call.get("tool", provider_tool_call.get("name", ""))
-            tool_name = f"mcp://{server}/{tool}" if server and tool else tool
+        if item_type == "mcp_call":
+            return OpenAIResponsesToolOps._p_mcp_call_to_ir(
+                provider_tool_call, tool_input
+            )
+        if item_type in _EXTENDED_CALL_ITEM_TYPES:
+            return OpenAIResponsesToolOps._p_extended_call_to_ir(
+                provider_tool_call, tool_input, item_type
+            )
+        if item_type == "custom_tool_call":
+            return OpenAIResponsesToolOps._p_custom_call_to_ir(provider_tool_call)
+        raise ValueError(f"Unsupported OpenAI Responses item type: {item_type}")
 
-            return ToolCallPart(
-                type="tool_call",
-                tool_call_id=provider_tool_call.get("id", ""),
-                tool_name=tool_name,
-                tool_input=tool_input,
-                tool_type="mcp",
-            )
-        elif item_type in ("shell_call", "computer_call", "code_interpreter_call"):
-            tool_type_map = {
-                "shell_call": "code_interpreter",
-                "computer_call": "computer_use",
-                "code_interpreter_call": "code_interpreter",
-            }
-            return cast(
-                ToolCallPart,
-                {
-                    "type": "tool_call",
-                    "tool_call_id": provider_tool_call.get(
-                        "call_id", provider_tool_call.get("id", "")
-                    ),
-                    "tool_name": provider_tool_call.get("name", item_type),
-                    "tool_input": tool_input,
-                    "tool_type": tool_type_map.get(item_type, "function"),
-                },
-            )
-        elif item_type == "custom_tool_call":
-            # custom_tool_call uses plain text 'input' instead of JSON
-            # 'arguments'.  Wrap as {"input": str} for IR compatibility
-            # (tool_input must be dict).  If the input happens to be valid
-            # JSON, parse it so cross-provider converters can inspect fields.
-            input_str = provider_tool_call.get("input", "")
+    @staticmethod
+    def _parse_tool_arguments(arguments: Any) -> dict:
+        """Parse Responses API ``arguments`` field into a dict tool_input."""
+        if isinstance(arguments, dict):
+            return arguments
+        if isinstance(arguments, str):
             try:
-                parsed_input = json.loads(input_str) if input_str else {}
-            except (json.JSONDecodeError, TypeError):
-                parsed_input = {"input": input_str}
-            # Ensure tool_input is always a dict
-            if not isinstance(parsed_input, dict):
-                parsed_input = {"input": parsed_input}
-            return ToolCallPart(
-                type="tool_call",
-                tool_call_id=provider_tool_call.get(
+                return json.loads(arguments) if arguments else {}
+            except json.JSONDecodeError:
+                return {"input": arguments}
+        return {}
+
+    @staticmethod
+    def _p_function_call_to_ir(
+        provider_tool_call: dict[str, Any], tool_input: dict
+    ) -> ToolCallPart:
+        """Responses API ``function_call`` item → IR ToolCallPart."""
+        # Responses API has both 'id' (item ID, fc_ prefix) and
+        # 'call_id' (correlation ID, call_ prefix). Store call_id as
+        # tool_call_id for correlation, preserve 'id' in provider_metadata
+        # for lossless round-trip.
+        call_id = provider_tool_call.get("call_id")
+        item_id = provider_tool_call.get("id", "")
+        if not call_id:
+            # Fallback: derive call_ prefix from fc_ prefix
+            call_id = "call_" + item_id[3:] if item_id.startswith("fc_") else item_id
+        part = ToolCallPart(
+            type="tool_call",
+            tool_call_id=call_id,
+            tool_name=provider_tool_call.get("name", ""),
+            tool_input=tool_input,
+            tool_type="function",
+        )
+        if item_id and item_id != call_id:
+            part["provider_metadata"] = {"responses_item_id": item_id}
+        return part
+
+    @staticmethod
+    def _p_mcp_call_to_ir(
+        provider_tool_call: dict[str, Any], tool_input: dict
+    ) -> ToolCallPart:
+        """Responses API ``mcp_call`` item → IR ToolCallPart."""
+        # MCP call may use server/tool fields or name field
+        server = provider_tool_call.get("server", "")
+        tool = provider_tool_call.get("tool", provider_tool_call.get("name", ""))
+        tool_name = f"mcp://{server}/{tool}" if server and tool else tool
+        return ToolCallPart(
+            type="tool_call",
+            tool_call_id=provider_tool_call.get("id", ""),
+            tool_name=tool_name,
+            tool_input=tool_input,
+            tool_type="mcp",
+        )
+
+    @staticmethod
+    def _p_extended_call_to_ir(
+        provider_tool_call: dict[str, Any], tool_input: dict, item_type: str
+    ) -> ToolCallPart:
+        """Responses API shell/computer/code_interpreter call → IR ToolCallPart."""
+        return cast(
+            ToolCallPart,
+            {
+                "type": "tool_call",
+                "tool_call_id": provider_tool_call.get(
                     "call_id", provider_tool_call.get("id", "")
                 ),
-                tool_name=provider_tool_call.get("name", ""),
-                tool_input=parsed_input,
-                tool_type="custom",
-            )
-        else:
-            raise ValueError(f"Unsupported OpenAI Responses item type: {item_type}")
+                "tool_name": provider_tool_call.get("name", item_type),
+                "tool_input": tool_input,
+                "tool_type": _EXTENDED_CALL_TYPE_MAP.get(item_type, "function"),
+            },
+        )
+
+    @staticmethod
+    def _p_custom_call_to_ir(provider_tool_call: dict[str, Any]) -> ToolCallPart:
+        """Responses API ``custom_tool_call`` item → IR ToolCallPart."""
+        # custom_tool_call uses plain text 'input' instead of JSON 'arguments'.
+        # Wrap as {"input": str} for IR compatibility (tool_input must be dict).
+        # If the input happens to be valid JSON, parse it so cross-provider
+        # converters can inspect fields.
+        input_str = provider_tool_call.get("input", "")
+        try:
+            parsed_input = json.loads(input_str) if input_str else {}
+        except (json.JSONDecodeError, TypeError):
+            parsed_input = {"input": input_str}
+        if not isinstance(parsed_input, dict):
+            parsed_input = {"input": parsed_input}
+        return ToolCallPart(
+            type="tool_call",
+            tool_call_id=provider_tool_call.get(
+                "call_id", provider_tool_call.get("id", "")
+            ),
+            tool_name=provider_tool_call.get("name", ""),
+            tool_input=parsed_input,
+            tool_type="custom",
+        )
 
     # ==================== Tool Result ====================
 

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -769,6 +769,61 @@ def _format_connection_error(exc: Exception, url: str) -> str:
     return f"Failed to connect to upstream: {err_str}"
 
 
+def _build_models_url(ptype: str, base_url: str) -> str:
+    """Return the upstream models-listing URL for a given API standard."""
+    if ptype == "google":
+        return f"{base_url}/v1beta/models"
+    if ptype == "anthropic":
+        return f"{base_url}/v1/models"
+    # OpenAI-compatible (openai_chat, openai_responses, etc.)
+    return f"{base_url}/models"
+
+
+def _extract_google_model_ids(body: dict[str, Any], id_field: str | None) -> list[str]:
+    """Extract model IDs from a Google-format ``/models`` response."""
+    ids: list[str] = []
+    for m in body.get("models", []):
+        name = m.get("name", "")
+        if name.startswith("models/"):
+            name = name[len("models/") :]
+        ids.append(m.get(id_field, name) if id_field else name)
+    return ids
+
+
+def _extract_openai_model_ids(body: dict[str, Any], id_field: str | None) -> list[str]:
+    """Extract model IDs from an OpenAI/Anthropic-format ``/models`` response."""
+    ids: list[str] = []
+    for m in body.get("data", []):
+        ids.append(m.get(id_field, m.get("id", "")) if id_field else m.get("id", ""))
+    return ids
+
+
+def _extract_model_ids(
+    body: dict[str, Any], ptype: str, id_field: str | None
+) -> list[str]:
+    """Normalize an upstream ``/models`` response to a sorted list of IDs."""
+    if ptype == "google":
+        ids = _extract_google_model_ids(body, id_field)
+    else:
+        ids = _extract_openai_model_ids(body, id_field)
+    ids = [m for m in ids if m]
+    ids.sort()
+    return ids
+
+
+async def _fetch_upstream_models_response(
+    pinfo: Any, models_url: str, headers: dict[str, str]
+) -> HttpResponse:
+    """Issue the GET to the upstream, returning the raw HTTP response."""
+    client = AsyncClient(timeout=10.0, proxy=pinfo.proxy_url)
+    try:
+        raw_resp = await client.get(models_url, headers=headers)
+    finally:
+        await client.aclose()
+    assert isinstance(raw_resp, HttpResponse), "Expected non-streaming response"
+    return raw_resp
+
+
 async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
     """Fetch the model list from an upstream provider's /v1/models endpoint."""
     from llm_rosetta.shims import get_shim
@@ -785,24 +840,11 @@ async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
 
     pinfo = config.providers[provider_name]
     ptype = config.provider_types.get(provider_name, "unknown")
-
-    # Build the models listing URL based on provider type
-    if ptype == "google":
-        models_url = f"{pinfo.base_url}/v1beta/models"
-    elif ptype == "anthropic":
-        models_url = f"{pinfo.base_url}/v1/models"
-    else:
-        # OpenAI-compatible (openai_chat, openai_responses, etc.)
-        models_url = f"{pinfo.base_url}/models"
+    models_url = _build_models_url(ptype, pinfo.base_url)
 
     headers = pinfo.auth_headers()
-
     try:
-        client = AsyncClient(timeout=10.0, proxy=pinfo.proxy_url)
-        raw_resp = await client.get(models_url, headers=headers)
-        assert isinstance(raw_resp, HttpResponse), "Expected non-streaming response"
-        resp: HttpResponse = raw_resp
-        await client.aclose()
+        resp = await _fetch_upstream_models_response(pinfo, models_url, headers)
     except Exception as exc:
         logger.warning("Failed to fetch models from %s: %s", provider_name, exc)
         msg = _format_connection_error(exc, models_url)
@@ -833,24 +875,7 @@ async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
     shim = get_shim(shim_name) if shim_name else None
     id_field = shim.model_id_field if shim and shim.model_id_field else None
 
-    # Normalize response — different providers return different formats
-    model_ids: list[str] = []
-    if ptype == "google":
-        # Google: {"models": [{"name": "models/gemini-...", ...}]}
-        for m in body.get("models", []):
-            name = m.get("name", "")
-            if name.startswith("models/"):
-                name = name[len("models/") :]
-            model_ids.append(m.get(id_field, name) if id_field else name)
-    else:
-        # Anthropic & OpenAI-compatible: {"data": [{"id": "...", ...}]}
-        for m in body.get("data", []):
-            model_ids.append(
-                m.get(id_field, m.get("id", "")) if id_field else m.get("id", "")
-            )
-
-    model_ids = [m for m in model_ids if m]
-    model_ids.sort()
+    model_ids = _extract_model_ids(body, ptype, id_field)
 
     return JSONResponse(
         {

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -224,41 +224,71 @@ class GatewayConfig:
             self._raw_providers
         )
 
+        raw_models = raw.get("models", {})
         self.models, self.model_capabilities, self.model_upstream_names = (
-            self._parse_models(raw.get("models", {}), self._raw_providers)
+            self._parse_models(raw_models, self._raw_providers)
         )
 
-        # Per-model URL template overrides.
-        self.model_url_templates: dict[str, str] = {}
-        self.model_stream_url_templates: dict[str, str] = {}
-        for model_name, value in raw.get("models", {}).items():
-            if isinstance(value, dict):
-                if "url_template" in value:
-                    self.model_url_templates[model_name] = value["url_template"]
-                if "stream_url_template" in value:
-                    self.model_stream_url_templates[model_name] = value[
-                        "stream_url_template"
-                    ]
+        self.model_url_templates, self.model_stream_url_templates = (
+            self._parse_url_templates(raw_models)
+        )
+        self.model_reasoning_overrides = self._parse_reasoning_overrides(raw_models)
+        self.model_flatten_system = self._parse_flatten_system(raw_models)
 
-        # Per-model reasoning overrides from config.jsonc (admin UI edits).
-        # Keyed by gateway model name (same as self.models keys).
-        self.model_reasoning_overrides: dict[str, dict[str, Any]] = {}
-        for model_name, value in raw.get("models", {}).items():
+        self._apply_server_settings(raw.get("server", {}))
+        self._apply_debug_settings(raw.get("debug", {}))
+
+        self._validate()
+
+        # Build ProviderInfo objects (with key rotation support)
+        self.providers: dict[str, ProviderInfo] = {
+            name: build_provider_info(
+                self.provider_types[name], cfg, global_proxy=self.proxy
+            )
+            for name, cfg in self._raw_providers.items()
+        }
+
+    @staticmethod
+    def _parse_url_templates(
+        raw_models: dict[str, Any],
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """Extract per-model url_template / stream_url_template overrides."""
+        url_templates: dict[str, str] = {}
+        stream_url_templates: dict[str, str] = {}
+        for model_name, value in raw_models.items():
+            if not isinstance(value, dict):
+                continue
+            if "url_template" in value:
+                url_templates[model_name] = value["url_template"]
+            if "stream_url_template" in value:
+                stream_url_templates[model_name] = value["stream_url_template"]
+        return url_templates, stream_url_templates
+
+    @staticmethod
+    def _parse_reasoning_overrides(
+        raw_models: dict[str, Any],
+    ) -> dict[str, dict[str, Any]]:
+        """Extract per-model reasoning_override blocks (admin UI edits)."""
+        overrides: dict[str, dict[str, Any]] = {}
+        for model_name, value in raw_models.items():
             if isinstance(value, dict) and value.get("reasoning_override"):
-                self.model_reasoning_overrides[model_name] = value["reasoning_override"]
+                overrides[model_name] = value["reasoning_override"]
+        return overrides
 
-        # Per-model flatten_system flag (explicit config or auto-detected).
-        # When True, system message content arrays are flattened to plain
-        # strings before sending upstream.
-        self.model_flatten_system: dict[str, bool] = {}
-        for model_name, value in raw.get("models", {}).items():
+    @staticmethod
+    def _parse_flatten_system(raw_models: dict[str, Any]) -> dict[str, bool]:
+        """Extract per-model flatten_system (explicit or gemini auto-detect)."""
+        flatten: dict[str, bool] = {}
+        for model_name, value in raw_models.items():
             if isinstance(value, dict) and "flatten_system" in value:
-                self.model_flatten_system[model_name] = bool(value["flatten_system"])
+                flatten[model_name] = bool(value["flatten_system"])
             elif re.search(r"gemini", model_name, re.IGNORECASE):
                 # Auto-detect: gemini models default to flatten_system=True
-                self.model_flatten_system[model_name] = True
+                flatten[model_name] = True
+        return flatten
 
-        _server = raw.get("server", {})
+    def _apply_server_settings(self, _server: dict[str, Any]) -> None:
+        """Populate server, auth, and admin attributes from ``server`` block."""
         self.host: str = _server.get("host", "0.0.0.0")
         self.port: int = _server.get("port", 8765)
         self.proxy: str | None = _server.get("proxy")
@@ -292,6 +322,10 @@ class GatewayConfig:
         # a raw dict here so admin layer owns the resolution policy.
         self.request_log: dict[str, Any] = _server.get("request_log", {}) or {}
 
+        self._apply_api_keys(_server)
+
+    def _apply_api_keys(self, _server: dict[str, Any]) -> None:
+        """Populate api_keys/api_key_set/api_key_labels from server block."""
         # Multi-key auth: server.api_keys takes precedence over server.api_key
         self.api_keys: list[dict[str, str]] = _server.get("api_keys", [])
         if not self.api_keys and _server.get("api_key"):
@@ -312,8 +346,8 @@ class GatewayConfig:
             entry["key"]: entry.get("label", "") for entry in self.api_keys
         }
 
-        # Debug / logging options (config + env-var overrides)
-        _debug = raw.get("debug", {})
+    def _apply_debug_settings(self, _debug: dict[str, Any]) -> None:
+        """Populate verbose/log_bodies/error_dumps (config + env overrides)."""
         self.verbose: bool = _debug.get("verbose", False) or os.environ.get(
             "LLM_ROSETTA_VERBOSE", ""
         ).lower() in ("1", "true", "yes")
@@ -321,16 +355,6 @@ class GatewayConfig:
             "LLM_ROSETTA_LOG_BODIES", ""
         ).lower() in ("1", "true", "yes")
         self.error_dumps_enabled: bool = _debug.get("error_dumps", True)
-
-        self._validate()
-
-        # Build ProviderInfo objects (with key rotation support)
-        self.providers: dict[str, ProviderInfo] = {
-            name: build_provider_info(
-                self.provider_types[name], cfg, global_proxy=self.proxy
-            )
-            for name, cfg in self._raw_providers.items()
-        }
 
     def _validate(self) -> None:
         if not self._raw_providers:

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -236,27 +236,37 @@ def load_providers_from_dir(
     """
     builtin = providers_dir == _PROVIDERS_DIR
     shims: list[ProviderShim] = []
-    for d in sorted(providers_dir.iterdir()):
-        if not d.is_dir() or d.name.startswith(("_", ".")):
-            continue
-        yaml_path = d / "provider.yaml"
-        if yaml_path.exists():
-            shim = _load_single_provider(d, group=group, _builtin=builtin)
-            if shim is not None:
-                shims.append(shim)
+    for d in _iter_shim_dirs(providers_dir):
+        if (d / "provider.yaml").exists():
+            _append_leaf_shim(shims, d, group=group, builtin=builtin)
         else:
-            # Potential group folder — scan children.
             child_group = f"{group}.{d.name}" if group else d.name
-            for sub in sorted(d.iterdir()):
-                if not sub.is_dir() or sub.name.startswith(("_", ".")):
-                    continue
+            for sub in _iter_shim_dirs(d):
                 if (sub / "provider.yaml").exists():
-                    shim = _load_single_provider(
-                        sub, group=child_group, _builtin=builtin
-                    )
-                    if shim is not None:
-                        shims.append(shim)
+                    _append_leaf_shim(shims, sub, group=child_group, builtin=builtin)
     return shims
+
+
+def _iter_shim_dirs(root: Path) -> list[Path]:
+    """Return sorted subdirectories of *root* eligible as provider dirs."""
+    return [
+        d
+        for d in sorted(root.iterdir())
+        if d.is_dir() and not d.name.startswith(("_", "."))
+    ]
+
+
+def _append_leaf_shim(
+    shims: list[ProviderShim],
+    provider_dir: Path,
+    *,
+    group: str | None,
+    builtin: bool,
+) -> None:
+    """Load a leaf provider directory and append the shim if successful."""
+    shim = _load_single_provider(provider_dir, group=group, _builtin=builtin)
+    if shim is not None:
+        shims.append(shim)
 
 
 def load_providers() -> list[ProviderShim]:

--- a/src/llm_rosetta/shims/transforms.py
+++ b/src/llm_rosetta/shims/transforms.py
@@ -352,6 +352,37 @@ def unwind_parallel_tool_calls(pattern: str | None = None) -> IRTransform:
 # ---------------------------------------------------------------------------
 
 
+def _flatten_system_part(part: Any) -> str:
+    """Reduce one content part to its text form."""
+    if isinstance(part, dict):
+        return part.get("text", "")
+    return str(part)
+
+
+def _flatten_system_message(msg: Any) -> None:
+    """Flatten a single system message's list-content in place."""
+    if not isinstance(msg, dict) or msg.get("role") != "system":
+        return
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return
+    msg["content"] = " ".join(_flatten_system_part(p) for p in content)
+
+
+def _flatten_system_body(
+    body: dict[str, Any], compiled: re.Pattern[str] | None
+) -> dict[str, Any]:
+    """Apply system-message flattening to *body* if the model matches."""
+    if compiled is not None and not compiled.search(body.get("model", "")):
+        return body
+    messages = body.get("messages")
+    if not messages or not isinstance(messages, list):
+        return body
+    for msg in messages:
+        _flatten_system_message(msg)
+    return body
+
+
 def flatten_system_content(pattern: str | None = None) -> Transform:
     """Return a body-level transform that flattens system message content
     arrays to plain strings.
@@ -371,27 +402,7 @@ def flatten_system_content(pattern: str | None = None) -> Transform:
     compiled = re.compile(pattern) if pattern else None
 
     def _flatten(body: dict[str, Any]) -> dict[str, Any]:
-        if compiled is not None:
-            model = body.get("model", "")
-            if not compiled.search(model):
-                return body
-
-        messages = body.get("messages")
-        if not messages or not isinstance(messages, list):
-            return body
-
-        for msg in messages:
-            if not isinstance(msg, dict) or msg.get("role") != "system":
-                continue
-            content = msg.get("content")
-            if isinstance(content, list):
-                text = " ".join(
-                    p.get("text", "") if isinstance(p, dict) else str(p)
-                    for p in content
-                )
-                msg["content"] = text
-
-        return body
+        return _flatten_system_body(body, compiled)
 
     label = "flatten_system_content("
     if pattern:

--- a/tests/converters/base/test_reasoning_helpers.py
+++ b/tests/converters/base/test_reasoning_helpers.py
@@ -1,0 +1,176 @@
+"""Tests for the shared thinking_type override helper in reasoning.py."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from llm_rosetta.converters.base.helpers.reasoning import (
+    _apply_thinking_type_override,
+    apply_reasoning_config,
+)
+from llm_rosetta.shims.provider_shim import (
+    EffortField,
+    EffortMap,
+    ReasoningCapability,
+    ThinkingType,
+)
+
+
+def _cap(
+    *,
+    effort_field: EffortField = "none",
+    effort_map: EffortMap | None = None,
+    thinking_type: ThinkingType | None = None,
+    budget_tokens_default_ratio: float | None = None,
+) -> ReasoningCapability:
+    return ReasoningCapability(
+        effort_field=effort_field,
+        effort_map=effort_map or {},
+        thinking_type=thinking_type,
+        budget_tokens_default_ratio=budget_tokens_default_ratio,
+    )
+
+
+class TestApplyThinkingTypeOverride:
+    def test_noop_when_cap_missing(self):
+        result = {"thinking": {"type": "adaptive"}}
+        _apply_thinking_type_override(result, None, None)
+        assert result == {"thinking": {"type": "adaptive"}}
+
+    def test_noop_when_thinking_type_none(self):
+        result = {"thinking": {"type": "adaptive"}}
+        _apply_thinking_type_override(result, _cap(thinking_type=None), None)
+        assert result == {"thinking": {"type": "adaptive"}}
+
+    def test_noop_when_no_thinking_key(self):
+        result: dict = {}
+        _apply_thinking_type_override(result, _cap(thinking_type="adaptive"), None)
+        assert result == {}
+
+    def test_switches_type_and_strips_budget_when_moving_to_adaptive(self):
+        result = {"thinking": {"type": "enabled", "budget_tokens": 2048}}
+        _apply_thinking_type_override(result, _cap(thinking_type="adaptive"), None)
+        assert result == {"thinking": {"type": "adaptive"}}
+
+    def test_leaves_type_unchanged_when_already_target(self):
+        result = {"thinking": {"type": "adaptive"}}
+        _apply_thinking_type_override(result, _cap(thinking_type="adaptive"), None)
+        assert result == {"thinking": {"type": "adaptive"}}
+
+    def test_enabled_target_derives_budget_from_ratio(self):
+        result = {"thinking": {"type": "adaptive"}}
+        cap = _cap(thinking_type="enabled", budget_tokens_default_ratio=0.5)
+        _apply_thinking_type_override(result, cap, max_tokens=8192)
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 4096
+
+    def test_enabled_target_falls_back_to_adaptive_without_ratio(self):
+        result = {"thinking": {"type": "adaptive"}}
+        cap = _cap(thinking_type="enabled")
+        _apply_thinking_type_override(result, cap, max_tokens=8192)
+        assert result["thinking"] == {"type": "adaptive"}
+
+    def test_enabled_target_falls_back_when_max_tokens_too_small(self):
+        result = {"thinking": {"type": "adaptive"}}
+        cap = _cap(thinking_type="enabled", budget_tokens_default_ratio=0.5)
+        # max_tokens <= 1024 → derivation returns None
+        _apply_thinking_type_override(result, cap, max_tokens=512)
+        assert result["thinking"] == {"type": "adaptive"}
+
+    def test_enabled_target_keeps_existing_budget(self):
+        result = {"thinking": {"type": "enabled", "budget_tokens": 999}}
+        cap = _cap(thinking_type="enabled", budget_tokens_default_ratio=0.5)
+        _apply_thinking_type_override(result, cap, max_tokens=8192)
+        assert result["thinking"] == {"type": "enabled", "budget_tokens": 999}
+
+
+class TestOpenaiChatExtrasEndToEnd:
+    """Guard-rails: apply_reasoning_config for openai_chat still delegates."""
+
+    def test_shim_forces_adaptive_from_enabled(self):
+        cap = _cap(
+            effort_field="reasoning_effort",
+            effort_map={"low": "low"},
+            thinking_type="adaptive",
+        )
+        out = apply_reasoning_config(
+            {"mode": "enabled", "budget_tokens": 2048},
+            cap,
+            converter_type="openai_chat",
+        )
+        assert out["thinking"] == {"type": "adaptive"}
+
+    def test_shim_forces_enabled_derives_budget(self):
+        cap = _cap(
+            thinking_type="enabled",
+            budget_tokens_default_ratio=0.5,
+        )
+        out = apply_reasoning_config(
+            {"mode": "auto"},
+            cap,
+            converter_type="openai_chat",
+            max_tokens=8192,
+        )
+        assert out["thinking"]["type"] == "enabled"
+        assert out["thinking"]["budget_tokens"] == 4096
+
+
+class TestAnthropicExtrasEndToEnd:
+    def test_enabled_without_budget_warns_and_falls_back(self):
+        cap = _cap(effort_field="output_config.effort")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            out = apply_reasoning_config(
+                {"mode": "enabled"},
+                cap,
+                converter_type="anthropic",
+            )
+        assert out["thinking"] == {"type": "adaptive"}
+        assert any("budget_tokens" in str(w.message) for w in caught)
+
+    def test_enabled_derives_budget_from_ratio(self):
+        cap = _cap(
+            effort_field="output_config.effort",
+            budget_tokens_default_ratio=0.5,
+        )
+        out = apply_reasoning_config(
+            {"mode": "enabled"},
+            cap,
+            converter_type="anthropic",
+            max_tokens=8192,
+        )
+        assert out["thinking"] == {"type": "enabled", "budget_tokens": 4096}
+
+    def test_shim_thinking_type_override_after_effort(self):
+        # When mode=enabled with budget, then shim forces adaptive: budget stripped.
+        cap = _cap(
+            effort_field="output_config.effort",
+            effort_map={"low": "low"},
+            thinking_type="adaptive",
+        )
+        out = apply_reasoning_config(
+            {"mode": "enabled", "budget_tokens": 2048},
+            cap,
+            converter_type="anthropic",
+        )
+        assert out["thinking"] == {"type": "adaptive"}
+
+    def test_shim_forces_enabled_needs_budget_or_falls_back(self):
+        cap = _cap(
+            effort_field="output_config.effort",
+            effort_map={"low": "low"},
+            thinking_type="enabled",
+        )
+        out = apply_reasoning_config(
+            {"effort": "low"},
+            cap,
+            converter_type="anthropic",
+        )
+        # No ratio → falls back to adaptive
+        assert out["thinking"]["type"] == "adaptive"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/converters/google_genai/test_helpers.py
+++ b/tests/converters/google_genai/test_helpers.py
@@ -1,0 +1,89 @@
+"""Unit tests for extracted helpers in the Google GenAI converter/message ops."""
+
+from typing import Any, cast
+
+from llm_rosetta.converters.google_genai.message_ops import GoogleGenAIMessageOps
+from llm_rosetta.types.ir import Message, is_tool_result_part
+
+
+def _msg(role: str, parts: list[dict[str, Any]]) -> Message:
+    return cast(Message, {"role": role, "content": parts})
+
+
+def test_build_tool_call_queue_orders_by_appearance() -> None:
+    messages = [
+        _msg(
+            "assistant",
+            [
+                {"type": "tool_call", "tool_call_id": "a1", "tool_name": "search"},
+                {"type": "tool_call", "tool_call_id": "a2", "tool_name": "search"},
+            ],
+        ),
+        _msg(
+            "assistant",
+            [{"type": "tool_call", "tool_call_id": "a3", "tool_name": "lookup"}],
+        ),
+    ]
+    q = GoogleGenAIMessageOps._build_tool_call_queue(messages)
+    assert q == {"search": ["a1", "a2"], "lookup": ["a3"]}
+
+
+def test_resolve_tool_name_prefix_and_exact_match() -> None:
+    q = {"search": ["a1"], "lookup": ["a2"]}
+    assert (
+        GoogleGenAIMessageOps._resolve_tool_name_for_result("search_123_0", q)
+        == "search"
+    )
+    assert GoogleGenAIMessageOps._resolve_tool_name_for_result("lookup", q) == "lookup"
+    # Unknown result_id → default guess = itself
+    assert (
+        GoogleGenAIMessageOps._resolve_tool_name_for_result("mystery", q) == "mystery"
+    )
+
+
+def test_apply_reconciliation_fifo_pairs_ids() -> None:
+    messages = [
+        _msg(
+            "assistant",
+            [
+                {"type": "tool_call", "tool_call_id": "call_1", "tool_name": "search"},
+                {"type": "tool_call", "tool_call_id": "call_2", "tool_name": "search"},
+            ],
+        ),
+        _msg(
+            "tool",
+            [
+                {
+                    "type": "tool_result",
+                    "tool_call_id": "search_A",
+                    "result": "r1",
+                },
+                {
+                    "type": "tool_result",
+                    "tool_call_id": "search_B",
+                    "result": "r2",
+                },
+            ],
+        ),
+    ]
+    GoogleGenAIMessageOps._reconcile_tool_call_ids(messages)
+    result_parts = messages[1]["content"]
+    assert all(is_tool_result_part(part) for part in result_parts)
+    result_ids = [
+        part["tool_call_id"] for part in result_parts if is_tool_result_part(part)
+    ]
+    assert result_ids == ["call_1", "call_2"]
+
+
+def test_reconcile_noop_when_no_tool_calls() -> None:
+    messages = [
+        _msg(
+            "tool",
+            [{"type": "tool_result", "tool_call_id": "x", "result": "r"}],
+        ),
+    ]
+    # Should not raise / rewrite anything
+    GoogleGenAIMessageOps._reconcile_tool_call_ids(messages)
+    part = messages[0]["content"][0]
+    assert is_tool_result_part(part)
+    assert part["tool_call_id"] == "x"

--- a/tests/converters/openai_chat/test_helpers.py
+++ b/tests/converters/openai_chat/test_helpers.py
@@ -1,0 +1,142 @@
+"""Unit tests for module-level helpers extracted from the OpenAI Chat converter.
+
+These target the small pure helpers introduced when reducing cognitive
+complexity so they stay covered even if the parent functions change shape.
+"""
+
+from llm_rosetta.converters.openai_chat.message_ops import (
+    OpenAIChatMessageOps,
+    _handle_synthetic_tag,
+    _parse_synthetic_tool_content_msg,
+    _restore_reasoning_metadata,
+)
+
+
+def test_restore_reasoning_metadata_copies_details_and_encrypted() -> None:
+    target: dict = {}
+    parts = [
+        {"type": "text", "text": "hi"},
+        {
+            "type": "reasoning",
+            "reasoning": "think",
+            "provider_metadata": {
+                "openai_chat": {
+                    "reasoning_details": [{"id": "r1"}],
+                    "encrypted_content": "abc",
+                }
+            },
+        },
+    ]
+    _restore_reasoning_metadata(target, parts)
+    assert target == {
+        "reasoning_details": [{"id": "r1"}],
+        "encrypted_content": "abc",
+    }
+
+
+def test_restore_reasoning_metadata_skips_without_metadata() -> None:
+    target: dict = {}
+    parts = [{"type": "reasoning", "reasoning": "x"}]
+    _restore_reasoning_metadata(target, parts)
+    assert target == {}
+
+
+def test_restore_reasoning_metadata_uses_first_reasoning_part() -> None:
+    target: dict = {}
+    parts = [
+        {
+            "type": "reasoning",
+            "reasoning": "first",
+            "provider_metadata": {"openai_chat": {"reasoning_details": ["A"]}},
+        },
+        {
+            "type": "reasoning",
+            "reasoning": "second",
+            "provider_metadata": {"openai_chat": {"reasoning_details": ["B"]}},
+        },
+    ]
+    _restore_reasoning_metadata(target, parts)
+    assert target == {"reasoning_details": ["A"]}
+
+
+def test_parse_synthetic_tool_content_msg_multi_sections() -> None:
+    unpacked: dict = {}
+    msg = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": '<tool-content call-id="c1">'},
+            {"type": "image_url", "image_url": {"url": "u1"}},
+            {"type": "text", "text": "</tool-content>"},
+            {"type": "text", "text": '<tool-content call-id="c2">'},
+            {"type": "image_url", "image_url": {"url": "u2"}},
+            {"type": "text", "text": "</tool-content>"},
+        ],
+    }
+    _parse_synthetic_tool_content_msg(msg, unpacked)
+    assert list(unpacked.keys()) == ["c1", "c2"]
+    assert unpacked["c1"][0]["image_url"]["url"] == "u1"
+    assert unpacked["c2"][0]["image_url"]["url"] == "u2"
+
+
+def test_parse_synthetic_tool_content_msg_unclosed_section_saved() -> None:
+    unpacked: dict = {}
+    msg = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": '<tool-content call-id="c1">'},
+            {"type": "image_url", "image_url": {"url": "u1"}},
+        ],
+    }
+    _parse_synthetic_tool_content_msg(msg, unpacked)
+    assert "c1" in unpacked
+    assert unpacked["c1"][0]["image_url"]["url"] == "u1"
+
+
+def test_handle_synthetic_tag_ignores_non_text_part() -> None:
+    assert (
+        _handle_synthetic_tag(
+            {"type": "image_url", "image_url": {"url": "x"}}, {}, None, []
+        )
+        is None
+    )
+
+
+def test_reorder_split_index_rebuild_helpers() -> None:
+    messages = [
+        {"role": "assistant", "tool_calls": [{"id": "t1"}, {"id": "t2"}]},
+        {"role": "tool", "tool_call_id": "t2", "content": "b"},
+        {"role": "tool", "tool_call_id": "t1", "content": "a"},
+    ]
+    tool_msgs, non_tool = OpenAIChatMessageOps._split_tool_and_non_tool(messages)
+    assert len(tool_msgs) == 2 and len(non_tool) == 1
+
+    by_id = OpenAIChatMessageOps._index_tools_by_call_id(tool_msgs)
+    assert set(by_id.keys()) == {"t1", "t2"}
+
+    warnings: list[str] = []
+    rebuilt = OpenAIChatMessageOps._rebuild_with_tool_pairing(
+        non_tool, by_id, tool_msgs, warnings
+    )
+    # Tool messages emitted in tool_calls order, not original order.
+    assert [m.get("tool_call_id") for m in rebuilt if m.get("role") == "tool"] == [
+        "t1",
+        "t2",
+    ]
+    assert warnings == []
+
+
+def test_rebuild_with_tool_pairing_appends_unmatched() -> None:
+    messages = [
+        {"role": "assistant", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "a"},
+        {"role": "tool", "tool_call_id": "orphan", "content": "b"},
+    ]
+    tool_msgs, non_tool = OpenAIChatMessageOps._split_tool_and_non_tool(messages)
+    by_id = OpenAIChatMessageOps._index_tools_by_call_id(tool_msgs)
+    warnings: list[str] = []
+    rebuilt = OpenAIChatMessageOps._rebuild_with_tool_pairing(
+        non_tool, by_id, tool_msgs, warnings
+    )
+    ids = [m.get("tool_call_id") for m in rebuilt if m.get("role") == "tool"]
+    assert ids == ["t1", "orphan"]
+    assert any("orphan" in w for w in warnings)

--- a/tests/converters/openai_responses/test_converter.py
+++ b/tests/converters/openai_responses/test_converter.py
@@ -11,6 +11,7 @@ from llm_rosetta.types.ir import (
     IRRequest,
     IRResponse,
     Message,
+    is_text_part,
 )
 
 
@@ -1052,3 +1053,209 @@ class TestOpenAIResponsesConverterFullRoundTrip:
         assert len(messages) >= 2
         system_msgs = [m for m in messages if m.get("role") == "system"]
         assert len(system_msgs) >= 1
+
+
+# ==================== preserve-mode capture/restore ====================
+
+
+class TestOpenAIResponsesPreserveMetadata:
+    """Behavioural tests for the refactored _capture/_apply preserve helpers."""
+
+    def setup_method(self):
+        from llm_rosetta.converters.base.context import ConversionContext
+
+        self.converter = OpenAIResponsesConverter()
+        self.ctx = ConversionContext(options={"metadata_mode": "preserve"})
+
+    def _capture(self, provider_response: dict) -> None:
+        self.converter._capture_preserve_metadata(provider_response, self.ctx)
+
+    def _apply(self, provider_response: dict) -> None:
+        self.converter._apply_preserve_metadata(provider_response, self.ctx)
+
+    def test_capture_skips_non_dict_output_items(self):
+        """Non-dict items in output are ignored during metadata capture."""
+        self._capture(
+            {
+                "output": [
+                    "not-a-dict",
+                    {"id": "msg_1", "status": "completed"},
+                    42,
+                ]
+            }
+        )
+        meta = self.ctx.get_output_items_meta()
+        assert meta == [{"id": "msg_1", "status": "completed"}]
+
+    def test_capture_preserves_annotations_and_logprobs_per_content_part(self):
+        """Per-content-part annotations/logprobs land inside content_meta lists."""
+        self._capture(
+            {
+                "output": [
+                    {
+                        "id": "msg_1",
+                        "content": [
+                            {"annotations": ["cite-a"], "logprobs": [0.1]},
+                            {"annotations": ["cite-b"]},
+                            "raw-string-skipped",
+                        ],
+                    }
+                ]
+            }
+        )
+        meta = self.ctx.get_output_items_meta()
+        # Raw non-dict content parts are skipped (mirrors legacy behavior).
+        assert meta[0]["content_meta"] == [
+            {"annotations": ["cite-a"], "logprobs": [0.1]},
+            {"annotations": ["cite-b"]},
+        ]
+
+    def test_capture_omits_content_meta_when_all_parts_lack_metadata(self):
+        """No content_meta key is stored when every part yields an empty snapshot."""
+        # Only string parts and dicts with no annotations/logprobs
+        self._capture(
+            {
+                "output": [
+                    {
+                        "id": "msg_1",
+                        "content": [{"type": "output_text", "text": "hi"}],
+                    }
+                ]
+            }
+        )
+        # An empty dict is captured per content part, so content_meta is present
+        # only if at least one part yields keys. Verify by inspection:
+        meta = self.ctx.get_output_items_meta()
+        assert "content_meta" in meta[0]
+        # But the inner snapshot is empty for the single text part.
+        assert meta[0]["content_meta"] == [{}]
+
+    def test_capture_and_apply_round_trip(self):
+        """Captured id/status/annotations survive round-trip through _apply."""
+        original = {
+            "output": [
+                {
+                    "id": "msg_1",
+                    "status": "completed",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "hi",
+                            "annotations": ["cite"],
+                        }
+                    ],
+                }
+            ],
+            "background": False,  # a RESPONSES_PRESERVE_FIELDS-eligible field
+        }
+        self._capture(original)
+
+        # Simulate a re-converted response without the preserved fields
+        rebuilt = {
+            "output": [
+                {
+                    "content": [{"type": "output_text", "text": "hi"}],
+                }
+            ]
+        }
+        self._apply(rebuilt)
+
+        item = rebuilt["output"][0]
+        assert item["id"] == "msg_1"
+        assert item["status"] == "completed"
+        assert item["content"][0]["annotations"] == ["cite"]
+
+    def test_apply_does_not_overwrite_core_response_keys(self):
+        """Echoed values for core keys (id/model/…) must not clobber rebuilt response."""
+        self.ctx.store_response_extras({"id": "old-id", "background": True})
+        rebuilt = {"id": "new-id"}
+        self._apply(rebuilt)
+        # "id" is a core key and stays as rebuilt
+        assert rebuilt["id"] == "new-id"
+        # But non-core keys are echoed in
+        assert rebuilt.get("background") is True
+
+    def test_apply_patches_missing_strict_on_echoed_function_tools(self):
+        """Echoed function tools without ``strict`` get the required default set."""
+        self.ctx.store_response_extras(
+            {"tools": [{"type": "function", "name": "f"}, {"type": "web_search"}]}
+        )
+        rebuilt: dict[str, Any] = {}
+        self._apply(rebuilt)
+        tools = rebuilt["tools"]
+        assert tools[0]["strict"] is None
+        assert "strict" not in tools[1]
+
+    def test_apply_stops_at_shorter_output(self):
+        """When rebuilt output is shorter than captured meta, extras are dropped safely."""
+        self._capture(
+            {
+                "output": [
+                    {"id": "msg_1", "status": "completed"},
+                    {"id": "msg_2", "status": "in_progress"},
+                ]
+            }
+        )
+        rebuilt = {"output": [{"content": []}]}
+        self._apply(rebuilt)
+        assert rebuilt["output"][0]["id"] == "msg_1"
+        assert len(rebuilt["output"]) == 1
+
+
+# ==================== request_from_provider stage helpers ====================
+
+
+class TestOpenAIResponsesRequestStages:
+    """Ensure the request_from_provider stage split preserves observable behaviour."""
+
+    def setup_method(self):
+        self.converter = OpenAIResponsesConverter()
+
+    def test_string_input_is_wrapped_into_user_message(self):
+        ir = self.converter.request_from_provider({"model": "gpt-4o", "input": "hi"})
+        assert ir["messages"][0]["role"] == "user"
+        part = ir["messages"][0]["content"][0]
+        assert is_text_part(part)
+        assert part["text"] == "hi"
+
+    def test_allowed_tools_passthrough_lands_in_provider_extensions(self):
+        ir = self.converter.request_from_provider(
+            {"model": "gpt-4o", "input": [], "allowed_tools": ["f1", "f2"]}
+        )
+        assert ir.get("provider_extensions", {}).get("allowed_tools") == ["f1", "f2"]
+
+    def test_disabled_external_web_access_tool_is_filtered(self):
+        ir = self.converter.request_from_provider(
+            {
+                "model": "gpt-4o",
+                "input": [],
+                "tools": [
+                    {
+                        "type": "web_search",
+                        "external_web_access": False,
+                    }
+                ],
+            }
+        )
+        assert "tools" not in ir
+
+    def test_preserve_mode_captures_request_echo(self):
+        from llm_rosetta.converters.base.context import ConversionContext
+
+        ctx = ConversionContext(options={"metadata_mode": "preserve"})
+        self.converter.request_from_provider(
+            {"model": "gpt-4o", "input": "hi", "background": True},
+            context=ctx,
+        )
+        # background is in RESPONSES_PRESERVE_FIELDS
+        assert ctx.get_echo_fields().get("background") is True
+
+    def test_strip_mode_does_not_capture_echo(self):
+        from llm_rosetta.converters.base.context import ConversionContext
+
+        ctx = ConversionContext(options={"metadata_mode": "strip"})
+        self.converter.request_from_provider(
+            {"model": "gpt-4o", "input": "hi", "background": True},
+            context=ctx,
+        )
+        assert ctx.get_echo_fields() == {}

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -121,81 +121,97 @@ class _Socks5Handler(socketserver.StreamRequestHandler):
         except Exception:
             return
 
-    def _do_handshake(self):  # noqa: C901
-        # Phase 1: method negotiation
-        header = self.rfile.read(2)
-        if len(header) < 2:
+    def _do_handshake(self):
+        methods = self._read_method_negotiation()
+        if methods is None:
             return
-        ver, nmethods = struct.unpack("BB", header)
-        if ver != 0x05:
+        if not self._perform_auth(methods):
             return
-        methods = self.rfile.read(nmethods)
-        if len(methods) < nmethods:
+        target_info = self._read_connect_request()
+        if target_info is None:
             return
-
-        require_auth = self.server.socks5_auth is not None  # type: ignore
-
-        if require_auth:
-            if 0x02 not in methods:
-                self.wfile.write(struct.pack("BB", 0x05, 0xFF))
-                return
-            self.wfile.write(struct.pack("BB", 0x05, 0x02))
-            # Phase 2: username/password auth (RFC 1929)
-            auth_header = self.rfile.read(2)
-            if len(auth_header) < 2:
-                return
-            _auth_ver, ulen = struct.unpack("BB", auth_header)
-            uname = self.rfile.read(ulen)
-            plen_byte = self.rfile.read(1)
-            if not plen_byte:
-                return
-            plen = struct.unpack("B", plen_byte)[0]
-            passwd = self.rfile.read(plen)
-
-            expected_user, expected_pass = self.server.socks5_auth  # type: ignore
-            if uname.decode() != expected_user or passwd.decode() != expected_pass:
-                self.wfile.write(struct.pack("BB", 0x01, 0x01))  # auth failure
-                return
-            self.wfile.write(struct.pack("BB", 0x01, 0x00))  # auth success
-        else:
-            self.wfile.write(struct.pack("BB", 0x05, 0x00))  # no auth
-
-        # Phase 3: connect request
-        req_header = self.rfile.read(4)
-        if len(req_header) < 4:
-            return
-        ver, cmd, _rsv, atype = struct.unpack("BBBB", req_header)
-        if cmd != 0x01:  # only CONNECT supported
-            self._send_reply(0x07)
-            return
-
-        # Parse target address
-        if atype == 0x01:  # IPv4
-            addr_bytes = self.rfile.read(4)
-            target_host = socket.inet_ntoa(addr_bytes)
-        elif atype == 0x03:  # domain
-            addr_len = struct.unpack("B", self.rfile.read(1))[0]
-            target_host = self.rfile.read(addr_len).decode()
-        elif atype == 0x04:  # IPv6
-            addr_bytes = self.rfile.read(16)
-            target_host = socket.inet_ntop(socket.AF_INET6, addr_bytes)
-        else:
-            self._send_reply(0x08)
-            return
-
-        target_port = struct.unpack("!H", self.rfile.read(2))[0]
-
-        # Connect to target
+        target_host, target_port = target_info
         try:
             target = socket.create_connection((target_host, target_port), timeout=10)
         except Exception:
             self._send_reply(0x05)  # connection refused
             return
-
-        # Success reply
         self._send_reply(0x00)
+        self._relay(target)
 
-        # Bidirectional relay
+    def _read_method_negotiation(self):
+        """Phase 1: read version + method list. Returns methods bytes or None."""
+        header = self.rfile.read(2)
+        if len(header) < 2:
+            return None
+        ver, nmethods = struct.unpack("BB", header)
+        if ver != 0x05:
+            return None
+        methods = self.rfile.read(nmethods)
+        if len(methods) < nmethods:
+            return None
+        return methods
+
+    def _perform_auth(self, methods):
+        """Phase 2: select method and optionally authenticate. Returns True on success."""
+        if self.server.socks5_auth is None:  # type: ignore
+            self.wfile.write(struct.pack("BB", 0x05, 0x00))  # no auth
+            return True
+        if 0x02 not in methods:
+            self.wfile.write(struct.pack("BB", 0x05, 0xFF))
+            return False
+        self.wfile.write(struct.pack("BB", 0x05, 0x02))
+        return self._read_userpass_auth()
+
+    def _read_userpass_auth(self):
+        """RFC 1929 username/password sub-negotiation."""
+        auth_header = self.rfile.read(2)
+        if len(auth_header) < 2:
+            return False
+        _auth_ver, ulen = struct.unpack("BB", auth_header)
+        uname = self.rfile.read(ulen)
+        plen_byte = self.rfile.read(1)
+        if not plen_byte:
+            return False
+        plen = struct.unpack("B", plen_byte)[0]
+        passwd = self.rfile.read(plen)
+
+        expected_user, expected_pass = self.server.socks5_auth  # type: ignore
+        if uname.decode() != expected_user or passwd.decode() != expected_pass:
+            self.wfile.write(struct.pack("BB", 0x01, 0x01))  # auth failure
+            return False
+        self.wfile.write(struct.pack("BB", 0x01, 0x00))  # auth success
+        return True
+
+    def _read_connect_request(self):
+        """Phase 3: parse CONNECT request. Returns (host, port) or None on error."""
+        req_header = self.rfile.read(4)
+        if len(req_header) < 4:
+            return None
+        ver, cmd, _rsv, atype = struct.unpack("BBBB", req_header)
+        if cmd != 0x01:  # only CONNECT supported
+            self._send_reply(0x07)
+            return None
+        target_host = self._read_target_host(atype)
+        if target_host is None:
+            return None
+        target_port = struct.unpack("!H", self.rfile.read(2))[0]
+        return target_host, target_port
+
+    def _read_target_host(self, atype):
+        """Parse SOCKS5 address by type. Sends error reply on unsupported type."""
+        if atype == 0x01:  # IPv4
+            return socket.inet_ntoa(self.rfile.read(4))
+        if atype == 0x03:  # domain
+            addr_len = struct.unpack("B", self.rfile.read(1))[0]
+            return self.rfile.read(addr_len).decode()
+        if atype == 0x04:  # IPv6
+            return socket.inet_ntop(socket.AF_INET6, self.rfile.read(16))
+        self._send_reply(0x08)
+        return None
+
+    def _relay(self, target):
+        """Bidirectional non-blocking relay between client and target."""
         client_sock = self.connection
         client_sock.setblocking(False)
         target.setblocking(False)
@@ -204,21 +220,27 @@ class _Socks5Handler(socketserver.StreamRequestHandler):
                 readable, _, _ = select.select([client_sock, target], [], [], 1.0)
                 if not readable:
                     continue
-                for sock in readable:
-                    try:
-                        data = sock.recv(8192)
-                    except (BlockingIOError, ConnectionResetError):
-                        data = b""
-                    if not data:
-                        return
-                    if sock is client_sock:
-                        target.sendall(data)
-                    else:
-                        client_sock.sendall(data)
+                if not self._pump_readable(readable, client_sock, target):
+                    return
         except Exception:
             pass
         finally:
             target.close()
+
+    def _pump_readable(self, readable, client_sock, target):
+        """Forward data for each readable socket. Returns False when EOF hit."""
+        for sock in readable:
+            try:
+                data = sock.recv(8192)
+            except (BlockingIOError, ConnectionResetError):
+                data = b""
+            if not data:
+                return False
+            if sock is client_sock:
+                target.sendall(data)
+            else:
+                client_sock.sendall(data)
+        return True
 
     def _send_reply(self, reply_code):
         """Send a SOCKS5 reply with the given status code."""

--- a/tests/gateway/test_config_parsers.py
+++ b/tests/gateway/test_config_parsers.py
@@ -1,0 +1,114 @@
+"""Tests for GatewayConfig fine-grained parsing (v6.2.0 refactor)."""
+
+from __future__ import annotations
+
+from llm_rosetta.gateway.config import GatewayConfig
+
+
+def _cfg(**overrides):
+    base = {
+        "providers": {
+            "openai": {
+                "base_url": "https://api.openai.com/v1",
+                "api_key": "sk-x",
+                "type": "openai_chat",
+            }
+        },
+        "models": {},
+    }
+    base.update(overrides)
+    return GatewayConfig(base)
+
+
+class TestReasoningOverrides:
+    def test_override_extracted(self):
+        c = _cfg(
+            models={
+                "m1": {
+                    "provider": "openai",
+                    "reasoning_override": {"disabled": "omit"},
+                },
+                "m2": {"provider": "openai"},
+            }
+        )
+        assert c.model_reasoning_overrides == {"m1": {"disabled": "omit"}}
+
+    def test_empty_override_ignored(self):
+        c = _cfg(models={"m1": {"provider": "openai", "reasoning_override": {}}})
+        assert c.model_reasoning_overrides == {}
+
+
+class TestUrlTemplates:
+    def test_url_and_stream_templates(self):
+        c = _cfg(
+            models={
+                "m1": {
+                    "provider": "openai",
+                    "url_template": "{base_url}/chat",
+                    "stream_url_template": "{base_url}/stream",
+                },
+                "m2": {"provider": "openai", "url_template": "{base_url}/only"},
+            }
+        )
+        assert c.model_url_templates == {
+            "m1": "{base_url}/chat",
+            "m2": "{base_url}/only",
+        }
+        assert c.model_stream_url_templates == {"m1": "{base_url}/stream"}
+
+    def test_string_model_entry_ignored(self):
+        c = _cfg(models={"m1": "openai"})
+        assert c.model_url_templates == {}
+        assert c.model_stream_url_templates == {}
+
+
+class TestFlattenSystem:
+    def test_gemini_auto_detected(self):
+        c = _cfg(models={"gemini-2.0-pro": "openai"})
+        assert c.model_flatten_system == {"gemini-2.0-pro": True}
+
+    def test_explicit_true(self):
+        c = _cfg(models={"m1": {"provider": "openai", "flatten_system": True}})
+        assert c.model_flatten_system == {"m1": True}
+
+    def test_explicit_false_overrides_gemini_default(self):
+        c = _cfg(models={"gemini-pro": {"provider": "openai", "flatten_system": False}})
+        assert c.model_flatten_system == {"gemini-pro": False}
+
+    def test_no_pattern_match(self):
+        c = _cfg(models={"gpt-4": "openai"})
+        assert c.model_flatten_system == {}
+
+
+class TestLegacyApiKey:
+    def test_legacy_api_key_wrapped(self):
+        c = _cfg(server={"api_key": "sk-legacy"})
+        assert c.api_keys == [
+            {
+                "id": "default",
+                "key": "sk-legacy",
+                "label": "default",
+                "created": "",
+            }
+        ]
+        assert c.api_key == "sk-legacy"
+        assert "sk-legacy" in c.api_key_set
+        assert c.api_key_labels["sk-legacy"] == "default"
+
+    def test_api_keys_preferred(self):
+        c = _cfg(
+            server={
+                "api_key": "sk-legacy",
+                "api_keys": [
+                    {"id": "a", "key": "sk-new", "label": "new", "created": ""}
+                ],
+            }
+        )
+        assert c.api_keys[0]["key"] == "sk-new"
+        assert c.api_key == "sk-new"
+
+    def test_empty_api_keys(self):
+        c = _cfg()
+        assert c.api_keys == []
+        assert c.api_key is None
+        assert c.api_key_set == frozenset()

--- a/tests/gateway/test_fetch_upstream_models.py
+++ b/tests/gateway/test_fetch_upstream_models.py
@@ -1,0 +1,67 @@
+"""Unit tests for fetch_upstream_models helpers."""
+
+from __future__ import annotations
+
+from llm_rosetta.gateway.admin.routes.config import (
+    _build_models_url,
+    _extract_google_model_ids,
+    _extract_model_ids,
+    _extract_openai_model_ids,
+)
+
+
+class TestBuildModelsUrl:
+    def test_google(self):
+        assert _build_models_url("google", "https://x") == "https://x/v1beta/models"
+
+    def test_anthropic(self):
+        assert _build_models_url("anthropic", "https://x") == "https://x/v1/models"
+
+    def test_openai_default(self):
+        assert _build_models_url("openai_chat", "https://x") == "https://x/models"
+        assert _build_models_url("unknown", "https://x") == "https://x/models"
+
+
+class TestExtractGoogleModelIds:
+    def test_strips_models_prefix(self):
+        body = {"models": [{"name": "models/gemini-2.0"}, {"name": "gemini-1.5"}]}
+        assert _extract_google_model_ids(body, None) == [
+            "gemini-2.0",
+            "gemini-1.5",
+        ]
+
+    def test_uses_id_field_when_set(self):
+        body = {"models": [{"name": "models/gemini-2.0", "internal_id": "g20"}]}
+        assert _extract_google_model_ids(body, "internal_id") == ["g20"]
+
+    def test_missing_models(self):
+        assert _extract_google_model_ids({}, None) == []
+
+
+class TestExtractOpenAIModelIds:
+    def test_default_id(self):
+        body = {"data": [{"id": "gpt-4"}, {"id": "gpt-5"}]}
+        assert _extract_openai_model_ids(body, None) == ["gpt-4", "gpt-5"]
+
+    def test_id_field_override(self):
+        body = {"data": [{"id": "gpt-4", "internal_id": "argo:gpt-4"}]}
+        assert _extract_openai_model_ids(body, "internal_id") == ["argo:gpt-4"]
+
+    def test_missing_data(self):
+        assert _extract_openai_model_ids({}, None) == []
+
+
+class TestExtractModelIds:
+    def test_dispatch_google(self):
+        body = {"models": [{"name": "models/z"}, {"name": "models/a"}]}
+        # Filtered and sorted
+        assert _extract_model_ids(body, "google", None) == ["a", "z"]
+
+    def test_dispatch_openai(self):
+        body = {"data": [{"id": "b"}, {"id": ""}, {"id": "a"}]}
+        # Empty ids dropped, sorted
+        assert _extract_model_ids(body, "openai_chat", None) == ["a", "b"]
+
+    def test_anthropic_uses_data_format(self):
+        body = {"data": [{"id": "claude-3"}]}
+        assert _extract_model_ids(body, "anthropic", None) == ["claude-3"]

--- a/tests/integration/_sse_helpers.py
+++ b/tests/integration/_sse_helpers.py
@@ -1,0 +1,62 @@
+"""Shared SSE transport for REST integration tests."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Iterator
+
+import requests
+
+
+def _iter_sse_json(response: requests.Response) -> Iterator[dict[str, Any]]:
+    """Yield JSON payloads from ``data: `` lines until stream end or [DONE]."""
+    for line in response.iter_lines():
+        if not line:
+            continue
+        decoded = line.decode("utf-8")
+        if not decoded.startswith("data: "):
+            continue
+        data_str = decoded[6:]
+        if data_str.strip() == "[DONE]":
+            return
+        try:
+            yield json.loads(data_str)
+        except json.JSONDecodeError:
+            continue
+
+
+def stream_sse_events(
+    url: str,
+    headers: dict[str, str],
+    provider_req: dict,
+    *,
+    max_retries: int = 3,
+    timeout: int = 60,
+) -> Iterator[dict[str, Any]]:
+    """POST ``provider_req`` and yield parsed SSE JSON events.
+
+    Retries on HTTP 429 with exponential backoff (``2 ** (attempt + 1)``
+    seconds).  After ``max_retries`` retryable failures, a final attempt
+    is made whose ``raise_for_status`` error is propagated to the caller.
+    """
+    for attempt in range(max_retries):
+        response = requests.post(
+            url, headers=headers, json=provider_req, timeout=timeout, stream=True
+        )
+        if response.status_code == 429:
+            wait = 2 ** (attempt + 1)
+            print(f"  [Rate limited, retrying in {wait}s...]")
+            time.sleep(wait)
+            continue
+        response.raise_for_status()
+        yield from _iter_sse_json(response)
+        return
+
+    # All retries exhausted on 429 — do one final unguarded attempt so
+    # the caller sees the eventual raise_for_status error.
+    response = requests.post(
+        url, headers=headers, json=provider_req, timeout=timeout, stream=True
+    )
+    response.raise_for_status()
+    yield from _iter_sse_json(response)

--- a/tests/integration/test_anthropic_rest_e2e.py
+++ b/tests/integration/test_anthropic_rest_e2e.py
@@ -26,6 +26,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 import dotenv
 import requests
 
+from tests.integration._sse_helpers import stream_sse_events
+
 from typing import cast
 
 from examples.tools import available_tools, tools_spec
@@ -107,51 +109,14 @@ def call_api(provider_req: dict, max_retries: int = 3) -> dict:
 def call_api_stream(provider_req: dict, max_retries: int = 3):
     """Call the Anthropic Messages API with streaming and yield SSE events.
 
-    Retries on 429 (rate limit) with exponential backoff.
+    Retries on 429 (rate limit) with exponential backoff.  Transport
+    and SSE parsing are shared with the OpenAI Chat REST tests via
+    :func:`_sse_helpers.stream_sse_events`.
     """
     provider_req["stream"] = True
-    for attempt in range(max_retries):
-        response = requests.post(
-            API_URL, headers=HEADERS, json=provider_req, timeout=60, stream=True
-        )
-        if response.status_code == 429:
-            wait = 2 ** (attempt + 1)
-            print(f"  [Rate limited, retrying in {wait}s...]")
-            time.sleep(wait)
-            continue
-        response.raise_for_status()
-
-        for line in response.iter_lines():
-            if not line:
-                continue
-            decoded = line.decode("utf-8")
-            if decoded.startswith("data: "):
-                data_str = decoded[6:]
-                if data_str.strip() == "[DONE]":
-                    return
-                try:
-                    yield json.loads(data_str)
-                except json.JSONDecodeError:
-                    continue
-        return
-
-    # Final attempt
-    response = requests.post(
-        API_URL, headers=HEADERS, json=provider_req, timeout=60, stream=True
+    yield from stream_sse_events(
+        API_URL, HEADERS, provider_req, max_retries=max_retries
     )
-    response.raise_for_status()
-    for line in response.iter_lines():
-        if not line:
-            continue
-        decoded = line.decode("utf-8")
-        if decoded.startswith("data: "):
-            data_str = decoded[6:]
-            if data_str.strip() == "[DONE]":
-                return
-            try:
-                yield json.loads(data_str)
-            except json.JSONDecodeError:
-                continue
 
 
 def execute_tool(tc: ToolCallPart) -> str:

--- a/tests/integration/test_openai_chat_rest_e2e.py
+++ b/tests/integration/test_openai_chat_rest_e2e.py
@@ -27,6 +27,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 import dotenv
 import requests
 
+from tests.integration._sse_helpers import stream_sse_events
+
 from typing import cast
 
 from examples.tools import available_tools, tools_spec
@@ -115,51 +117,14 @@ def call_api(provider_req: dict, max_retries: int = 3) -> dict:
 def call_api_stream(provider_req: dict, max_retries: int = 3):
     """Call the OpenAI Chat Completions API with streaming and yield SSE events.
 
-    Retries on 429 (rate limit) with exponential backoff.
+    Retries on 429 (rate limit) with exponential backoff.  Transport
+    and SSE parsing are shared with the Anthropic REST tests via
+    :func:`_sse_helpers.stream_sse_events`.
     """
     provider_req["stream"] = True
-    for attempt in range(max_retries):
-        response = requests.post(
-            API_URL, headers=HEADERS, json=provider_req, timeout=60, stream=True
-        )
-        if response.status_code == 429:
-            wait = 2 ** (attempt + 1)
-            print(f"  [Rate limited, retrying in {wait}s...]")
-            time.sleep(wait)
-            continue
-        response.raise_for_status()
-
-        for line in response.iter_lines():
-            if not line:
-                continue
-            decoded = line.decode("utf-8")
-            if decoded.startswith("data: "):
-                data_str = decoded[6:]
-                if data_str.strip() == "[DONE]":
-                    return
-                try:
-                    yield json.loads(data_str)
-                except json.JSONDecodeError:
-                    continue
-        return
-
-    # Final attempt
-    response = requests.post(
-        API_URL, headers=HEADERS, json=provider_req, timeout=60, stream=True
+    yield from stream_sse_events(
+        API_URL, HEADERS, provider_req, max_retries=max_retries
     )
-    response.raise_for_status()
-    for line in response.iter_lines():
-        if not line:
-            continue
-        decoded = line.decode("utf-8")
-        if decoded.startswith("data: "):
-            data_str = decoded[6:]
-            if data_str.strip() == "[DONE]":
-                return
-            try:
-                yield json.loads(data_str)
-            except json.JSONDecodeError:
-                continue
 
 
 def execute_tool(tc: ToolCallPart) -> str:

--- a/tests/test_shim_loader.py
+++ b/tests/test_shim_loader.py
@@ -432,3 +432,59 @@ class TestPluginEntryPoints:
         )
         result = _load_plugin_shims()
         assert result == []
+
+
+class TestGroupedLayoutAndOverrides:
+    """Grouped layout scanning and per-model reasoning overrides."""
+
+    def test_grouped_layout_registers_children(self, tmp_path):
+
+        group = tmp_path / "vendor"
+        group.mkdir()
+        # Group has no provider.yaml itself
+        leaf_a = group / "openai_chat"
+        leaf_a.mkdir()
+        (leaf_a / "provider.yaml").write_text(
+            "name: vendor-openai\nbase: openai_chat\n"
+        )
+        leaf_b = group / "anthropic"
+        leaf_b.mkdir()
+        (leaf_b / "provider.yaml").write_text("name: vendor-anth\nbase: anthropic\n")
+        # Sibling dot/underscore dirs are skipped
+        (group / "_hidden").mkdir()
+        (group / ".skip").mkdir()
+
+        shims = load_providers_from_dir(tmp_path)
+        names = {s.name for s in shims}
+        assert {"vendor-openai", "vendor-anth"} <= names
+
+    def test_model_reasoning_overrides_inherit_defaults(self, tmp_path):
+        d = tmp_path / "provider_with_overrides"
+        d.mkdir()
+        (d / "provider.yaml").write_text(
+            "name: pwo\n"
+            "base: anthropic\n"
+            "reasoning:\n"
+            "  disabled: omit\n"
+            "  effort_field: reasoning_effort\n"
+            "  max_effort: high\n"
+            "  unsigned_reasoning_blocks: strip\n"
+            "  model_overrides:\n"
+            "    claudeopus47:\n"
+            "      unsigned_reasoning_blocks: preserve\n"
+            "    bad-entry: not-a-dict\n"
+        )
+        shims = load_providers_from_dir(tmp_path)
+        shim = next(s for s in shims if s.name == "pwo")
+        assert shim.reasoning is not None
+        assert shim.reasoning.disabled == "omit"
+        assert shim.model_reasoning is not None
+        # Non-dict override entry is silently skipped
+        assert "bad-entry" not in shim.model_reasoning
+        assert "claudeopus47" in shim.model_reasoning
+        m = shim.model_reasoning["claudeopus47"]
+        # Overrides applied
+        assert m.unsigned_reasoning_blocks == "preserve"
+        # Inherited defaults
+        assert m.disabled == "omit"
+        assert m.max_effort == "high"


### PR DESCRIPTION
## Summary

- migrate complexity enforcement to the official Complexipy v6.2.0 pre-commit hook
- scan both `src/llm_rosetta` and `tests` at threshold 25 while excluding vendored code through pre-commit path filtering
- split the 23 v6 violations along protocol stages, metadata boundaries, parsing phases, and test transport helpers
- add focused regression coverage for extracted converter, gateway config, shim loader, and stream helpers

Complexipy 6 aligns its scoring with the SonarSource v1.7 paper, so the previous v5 scores in #201 were no longer an accurate baseline. The refactor keeps the threshold at 25 and does not add source exclusions or complexity suppressions.

Closes #201.

## Test plan

- [x] `conda run -n llm-rosetta pre-commit run complexipy --all-files --verbose`
- [x] `conda run -n llm-rosetta pre-commit run --all-files`
- [x] `conda run -n llm-rosetta make test` — 2232 collected
- [x] high-effort diff review; fixed the one confirmed exception-boundary regression and reran all gates

AI was used to assist with implementation and review; the changes were reviewed and tested.