### PR TITLE
feat(ir): add generic provider passthrough carriers

### DIFF
--- a/src/llm_rosetta/converters/anthropic/_constants.py
+++ b/src/llm_rosetta/converters/anthropic/_constants.py
@@ -25,6 +25,7 @@ ANTHROPIC_REASON_TO_PROVIDER: dict[str, str] = {
 class AnthropicEventType:
     """Anthropic Messages API server-sent event type constants."""
 
+    PING = "ping"
     MESSAGE_START = "message_start"
     CONTENT_BLOCK_START = "content_block_start"
     CONTENT_BLOCK_DELTA = "content_block_delta"

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -19,8 +19,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 from ...types.ir import (
-    ExtensionItem,
-    Message,
+    IRInputItem,
     TextPart,
     is_text_part,
     is_tool_call_part,
@@ -125,6 +124,7 @@ class AnthropicConverter(BaseConverter):
         message_kwargs: dict[str, Any] = {}
         if ctx and "reasoning_cap" in ctx.options:
             message_kwargs["reasoning_cap"] = ctx.options["reasoning_cap"]
+        message_kwargs["target_provider"] = self._CONVERTER_TAG
         converted_msgs, msg_warnings = self.message_ops.ir_messages_to_p(
             ir_messages, **message_kwargs
         )
@@ -372,6 +372,12 @@ class AnthropicConverter(BaseConverter):
         ctx = context if context is not None else ConversionContext()
         if ctx.metadata_mode == "preserve":
             self._apply_preserve_metadata(provider_response, ctx)
+        self._restore_response_passthrough_items(
+            provider_response,
+            ir_response,
+            output_key="content",
+            context=ctx,
+        )
 
         return provider_response
 
@@ -538,7 +544,7 @@ class AnthropicConverter(BaseConverter):
 
     def messages_to_provider(
         self,
-        messages: Sequence[Message | ExtensionItem],
+        messages: Sequence[IRInputItem],
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
@@ -553,6 +559,7 @@ class AnthropicConverter(BaseConverter):
         Returns:
             Tuple of (converted messages, warnings).
         """
+        kwargs["target_provider"] = self._CONVERTER_TAG
         return self.message_ops.ir_messages_to_p(messages, **kwargs)
 
     def messages_from_provider(
@@ -561,7 +568,7 @@ class AnthropicConverter(BaseConverter):
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
-    ) -> list[Message | ExtensionItem]:
+    ) -> list[IRInputItem]:
         """Convert Anthropic messages to IR message list.
 
         Delegates to message_ops.

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -804,6 +804,7 @@ class AnthropicConverter(BaseConverter):
             events.append(StreamEndEvent(type="stream_end"))
 
     _FROM_P_DISPATCH: dict[str, str] = {
+        AnthropicEventType.PING: "_handle_provider_passthrough_from_p",
         AnthropicEventType.MESSAGE_START: "_handle_message_start_from_p",
         AnthropicEventType.CONTENT_BLOCK_START: "_handle_content_block_start_from_p",
         AnthropicEventType.CONTENT_BLOCK_DELTA: "_handle_content_block_delta_from_p",

--- a/src/llm_rosetta/converters/anthropic/message_ops.py
+++ b/src/llm_rosetta/converters/anthropic/message_ops.py
@@ -18,7 +18,7 @@ from typing import Any, cast
 from ...shims.provider_shim import ReasoningCapability
 from ...types.ir import (
     ContentPart,
-    ExtensionItem,
+    IRInputItem,
     Message,
     ReasoningPart,
     TextPart,
@@ -58,7 +58,7 @@ class AnthropicMessageOps(BaseMessageOps):
 
     def ir_messages_to_p(
         self,
-        ir_messages: Sequence[Message | ExtensionItem],
+        ir_messages: Sequence[IRInputItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """IR Messages → Anthropic messages.
@@ -79,6 +79,14 @@ class AnthropicMessageOps(BaseMessageOps):
             reasoning_cap = None
 
         for item in ir_messages:
+            passthrough_warnings = self._restore_provider_passthrough_item(
+                item,
+                messages,
+                target_provider=kwargs.get("target_provider", ""),
+            )
+            if passthrough_warnings is not None:
+                warnings.extend(passthrough_warnings)
+                continue
             if is_message(item):
                 msg = cast(Message, item)
                 role = msg.get("role")
@@ -294,7 +302,7 @@ class AnthropicMessageOps(BaseMessageOps):
         self,
         provider_messages: list[Any],
         **kwargs: Any,
-    ) -> list[Message | ExtensionItem]:
+    ) -> list[IRInputItem]:
         """Anthropic messages → IR Messages.
 
         Converts each Anthropic message to the appropriate IR message type.
@@ -305,7 +313,7 @@ class AnthropicMessageOps(BaseMessageOps):
         Returns:
             List of IR messages.
         """
-        ir_messages: list[Message | ExtensionItem] = []
+        ir_messages: list[IRInputItem] = []
 
         for msg in provider_messages:
             converted = self._p_message_to_ir(msg)

--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
+from ...types.ir.passthrough import ProviderPassthroughEvent
 from ...types.ir.request import IRInputItem, IRRequest
 from ...types.ir.response import IRResponse, UsageInfo
 from ...types.ir.stream import IRStreamEvent
@@ -71,6 +72,7 @@ class BaseConverter(ABC):
         "tool_call_delta": "_handle_tool_call_delta_to_p",
         "finish": "_handle_finish_to_p",
         "usage": "_handle_usage_to_p",
+        "provider_passthrough": "_handle_provider_passthrough_to_p",
     }
 
     # ==================== 顶层转换接口 Top-level conversion interface ====================
@@ -282,6 +284,31 @@ class BaseConverter(ABC):
             return {}
         result = getattr(self, handler_name)(event, context)
         return self._post_process_to_provider(result, event, context)
+
+    def _handle_provider_passthrough_from_p(
+        self,
+        chunk: dict[str, Any],
+        context: StreamContext | None,
+        events: list[IRStreamEvent],
+    ) -> None:
+        """Wrap a provider-native chunk in a generic passthrough event."""
+        events.append(
+            ProviderPassthroughEvent(
+                type="provider_passthrough",
+                provider=self._CONVERTER_TAG,
+                payload=dict(chunk),
+            )
+        )
+
+    def _handle_provider_passthrough_to_p(
+        self,
+        event: ProviderPassthroughEvent,
+        context: StreamContext | None,
+    ) -> dict[str, Any]:
+        """Restore opaque events only for the originating converter dialect."""
+        if event["provider"] != self._CONVERTER_TAG:
+            return {}
+        return dict(event["payload"])
 
     def _post_process_to_provider(
         self,

--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -9,9 +9,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
-from ...types.ir.extensions_experimental import ExtensionItem
-from ...types.ir.messages import Message
-from ...types.ir.request import IRRequest
+from ...types.ir.request import IRInputItem, IRRequest
 from ...types.ir.response import IRResponse, UsageInfo
 from ...types.ir.stream import IRStreamEvent
 from ...types.ir.validation import (
@@ -21,6 +19,7 @@ from ...types.ir.validation import (
     validate_tools,
 )
 from .context import ConversionContext, StreamContext
+from .passthrough import merge_provider_output_items
 
 
 class BaseConverter(ABC):
@@ -186,7 +185,7 @@ class BaseConverter(ABC):
     @abstractmethod
     def messages_to_provider(
         self,
-        messages: Sequence[Message | ExtensionItem],
+        messages: Sequence[IRInputItem],
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
@@ -214,7 +213,7 @@ class BaseConverter(ABC):
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
-    ) -> list[Message | ExtensionItem]:
+    ) -> list[IRInputItem]:
         """将provider消息转换为IR消息列表
         Convert provider messages to IR message list
 
@@ -305,6 +304,30 @@ class BaseConverter(ABC):
             The (possibly modified) result.
         """
         return result
+
+    def _restore_response_passthrough_items(
+        self,
+        provider_response: dict[str, Any],
+        ir_response: IRResponse,
+        *,
+        output_key: str,
+        context: ConversionContext | None,
+    ) -> None:
+        """Restore matching opaque output items into a provider list field."""
+        passthrough_items = ir_response.get("provider_passthrough_items")
+        if not passthrough_items:
+            return
+        portable_items = provider_response.get(output_key, [])
+        if not isinstance(portable_items, list):
+            portable_items = []
+        merged, warnings = merge_provider_output_items(
+            portable_items,
+            passthrough_items,
+            target_provider=self._CONVERTER_TAG,
+        )
+        provider_response[output_key] = merged
+        if context is not None:
+            context.warnings.extend(warnings)
 
     # ==================== Provider-specific helpers (abstract) ====================
 
@@ -671,7 +694,7 @@ class BaseConverter(ABC):
 
     def message_to_provider(
         self,
-        message: Message | ExtensionItem,
+        message: IRInputItem,
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
@@ -698,7 +721,7 @@ class BaseConverter(ABC):
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
-    ) -> Message | ExtensionItem:
+    ) -> IRInputItem:
         """将provider消息转换为IR格式（便利方法）
         Convert provider message to IR format (convenience method)
 
@@ -713,4 +736,4 @@ class BaseConverter(ABC):
         result = self.messages_from_provider(
             [provider_message], context=context, **kwargs
         )
-        return result[0] if result else cast(Message, {})
+        return result[0] if result else cast(IRInputItem, {})

--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -305,7 +305,11 @@ class BaseConverter(ABC):
         event: ProviderPassthroughEvent,
         context: StreamContext | None,
     ) -> dict[str, Any]:
-        """Restore opaque events only for the originating converter dialect."""
+        """Restore opaque events only for the originating converter dialect.
+
+        Cross-format drops return an empty dict by convention; StreamProcessor
+        filters falsy provider chunks from its output list.
+        """
         if event["provider"] != self._CONVERTER_TAG:
             return {}
         return dict(event["payload"])

--- a/src/llm_rosetta/converters/base/helpers/tool_orphan_fix.py
+++ b/src/llm_rosetta/converters/base/helpers/tool_orphan_fix.py
@@ -13,7 +13,7 @@ import logging
 from collections.abc import Sequence
 from typing import Any, cast
 
-from ....types.ir import Message
+from ....types.ir import IRInputItem, is_message
 from ....types.ir.request import IRRequest
 
 logger = logging.getLogger(__name__)
@@ -82,12 +82,14 @@ def log_orphan_warnings(
 
 
 def _collect_ir_tool_ids(
-    messages: Sequence[Message],
+    messages: Sequence[IRInputItem],
 ) -> tuple[set[str], set[str]]:
     """Collect all tool_call IDs and answered (tool_result) IDs from IR messages."""
     known_call_ids: set[str] = set()
     answered_ids: set[str] = set()
     for msg in messages:
+        if not is_message(msg):
+            continue
         content = msg.get("content", [])
         role = msg.get("role")
         if role == "assistant":
@@ -98,10 +100,10 @@ def _collect_ir_tool_ids(
 
 
 def fix_orphaned_tool_calls_ir(
-    messages: Sequence[Message],
+    messages: Sequence[IRInputItem],
     *,
     placeholder: str = "[No output available yet]",
-) -> list[Message]:
+) -> list[IRInputItem]:
     """Fix mismatched tool_calls and tool results at IR level.
 
     Both the OpenAI Chat Completions API and the Responses API **strictly
@@ -143,11 +145,14 @@ def fix_orphaned_tool_calls_ir(
     if not known_call_ids and not answered_ids:
         return msg_list
 
-    patched: list[Message] = []
+    patched: list[IRInputItem] = []
     orphaned_call_ids: list[str] = []
     orphaned_result_ids: list[str] = []
 
     for msg in msg_list:
+        if not is_message(msg):
+            patched.append(msg)
+            continue
         role = msg.get("role")
         content = msg.get("content", [])
 

--- a/src/llm_rosetta/converters/base/messages.py
+++ b/src/llm_rosetta/converters/base/messages.py
@@ -18,11 +18,12 @@ Note: This layer will call methods from content.py and tools.py to handle messag
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Any, Union
+from typing import Any
 
 from ..._vendor.validate import ValidationError, validate
-from ...types.ir.extensions_experimental import ExtensionItem
-from ...types.ir.messages import Message
+from ...types.ir.request import IRInputItem
+from ...types.ir.type_guards import is_provider_passthrough_item
+from .passthrough import restore_provider_passthrough_item
 
 
 class BaseMessageOps(ABC):
@@ -33,12 +34,29 @@ class BaseMessageOps(ABC):
     Handles conversion of complete messages (role + content), serving as a bridge between content layer and request/response layer.
     """
 
+    def _restore_provider_passthrough_item(
+        self,
+        item: IRInputItem,
+        output: list[Any],
+        *,
+        target_provider: str,
+    ) -> list[str] | None:
+        """Restore a matching provider item, or return None if not passthrough."""
+        if not is_provider_passthrough_item(item):
+            return None
+        payload, warning = restore_provider_passthrough_item(
+            item, target_provider=target_provider
+        )
+        if payload is not None:
+            output.append(payload)
+        return [warning] if warning is not None else []
+
     # ==================== 批量消息转换 Batch message conversion ====================
 
     @staticmethod
     @abstractmethod
     def ir_messages_to_p(
-        ir_messages: Sequence[Message | ExtensionItem], **kwargs: Any
+        ir_messages: Sequence[IRInputItem], **kwargs: Any
     ) -> tuple[list[Any], list[str]]:
         """IR Messages → Provider Messages
         将IR消息列表转换为Provider消息列表
@@ -68,7 +86,7 @@ class BaseMessageOps(ABC):
     @abstractmethod
     def p_messages_to_ir(
         provider_messages: list[Any], **kwargs: Any
-    ) -> list[Message | ExtensionItem]:
+    ) -> list[IRInputItem]:
         """Provider Messages → IR Messages
         将Provider消息列表转换为IR消息列表
 
@@ -96,7 +114,7 @@ class BaseMessageOps(ABC):
     # ==================== 单个消息转换（可选的便利方法） Single message conversion (optional convenience methods) ====================
 
     def ir_message_to_p(
-        self, ir_message: Message | ExtensionItem, **kwargs: Any
+        self, ir_message: IRInputItem, **kwargs: Any
     ) -> tuple[Any, list[str]]:
         """IR Message → Provider Message（便利方法）
         将单个IR消息转换为Provider消息（便利方法）
@@ -119,7 +137,7 @@ class BaseMessageOps(ABC):
 
     def p_message_to_ir(
         self, provider_message: Any, **kwargs: Any
-    ) -> Message | ExtensionItem | None:
+    ) -> IRInputItem | None:
         """Provider Message → IR Message（便利方法）
         将Provider消息转换为IR消息（便利方法）
 
@@ -141,9 +159,7 @@ class BaseMessageOps(ABC):
 
     # ==================== 辅助方法（子类可选实现） Helper methods (optional for subclasses) ====================
 
-    def validate_messages(
-        self, messages: Sequence[Message | ExtensionItem]
-    ) -> list[str]:
+    def validate_messages(self, messages: Sequence[IRInputItem]) -> list[str]:
         """Validate message list against IR Message/ExtensionItem types.
 
         Uses zerodep validate for structural validation against TypedDict
@@ -156,7 +172,7 @@ class BaseMessageOps(ABC):
             List of validation error strings; empty list means valid.
         """
         try:
-            validate(list(messages), list[Union[Message, ExtensionItem]])
+            validate(list(messages), list[IRInputItem])
             return []
         except ValidationError as e:
             return [err.message for err in e.errors]

--- a/src/llm_rosetta/converters/base/passthrough.py
+++ b/src/llm_rosetta/converters/base/passthrough.py
@@ -1,0 +1,68 @@
+"""Shared helpers for provider-specific opaque IR items."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from ...types.ir.passthrough import ProviderPassthroughItem
+
+
+def restore_provider_passthrough_item(
+    item: ProviderPassthroughItem,
+    *,
+    target_provider: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Restore an opaque item for the matching provider dialect."""
+    source_provider = item["provider"]
+    if source_provider != target_provider:
+        warning = (
+            f"Dropped provider passthrough item from {source_provider!r} "
+            f"when converting to {target_provider!r}"
+        )
+        return None, warning
+    return dict(item["payload"]), None
+
+
+def merge_provider_output_items(
+    portable_items: Sequence[dict[str, Any]],
+    passthrough_items: Sequence[ProviderPassthroughItem],
+    *,
+    target_provider: str,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Merge matching provider output items into their recorded positions."""
+    merged = [dict(item) for item in portable_items]
+    warnings: list[str] = []
+    positioned: list[tuple[int, int, dict[str, Any]]] = []
+    trailing: list[dict[str, Any]] = []
+
+    for order, item in enumerate(passthrough_items):
+        payload, warning = restore_provider_passthrough_item(
+            item, target_provider=target_provider
+        )
+        if warning is not None:
+            warnings.append(warning)
+            continue
+        assert payload is not None
+        position = item.get("position")
+        if position is None:
+            trailing.append(payload)
+        else:
+            positioned.append((max(position, 0), order, payload))
+
+    inserted = 0
+    previous_position: int | None = None
+    for position, _order, payload in sorted(positioned):
+        if previous_position == position:
+            insertion_index = min(position + inserted, len(merged))
+            inserted += 1
+        else:
+            insertion_index = min(position, len(merged))
+            previous_position = position
+            inserted = 1
+        merged.insert(insertion_index, payload)
+    merged.extend(trailing)
+    return merged, warnings
+
+
+__all__ = ["merge_provider_output_items", "restore_provider_passthrough_item"]

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -21,9 +21,8 @@ from typing import Any, cast
 
 
 from ...types.ir import (
-    ExtensionItem,
+    IRInputItem,
     IRInput,
-    Message,
     TextPart,
     ToolChoice,
     ToolDefinition,
@@ -245,7 +244,9 @@ class GoogleGenAIConverter(BaseConverter):
                     cast(list, system_instruction["parts"]).extend(msg_parts)
 
         # Convert non-system messages
-        contents, msg_warnings = self.message_ops.ir_messages_to_p(ir_messages)
+        contents, msg_warnings = self.message_ops.ir_messages_to_p(
+            ir_messages, target_provider=self._CONVERTER_TAG
+        )
         ctx.warnings.extend(msg_warnings)
         result["contents"] = contents
 
@@ -500,6 +501,13 @@ class GoogleGenAIConverter(BaseConverter):
         ir_usage = ir_response.get("usage")
         if ir_usage:
             provider_response["usageMetadata"] = self._build_provider_usage(ir_usage)
+        ctx = context if context is not None else ConversionContext()
+        self._restore_response_passthrough_items(
+            provider_response,
+            ir_response,
+            output_key="candidates",
+            context=ctx,
+        )
 
         return provider_response
 
@@ -638,7 +646,7 @@ class GoogleGenAIConverter(BaseConverter):
 
     def messages_to_provider(
         self,
-        messages: Sequence[Message | ExtensionItem],
+        messages: Sequence[IRInputItem],
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
@@ -653,6 +661,7 @@ class GoogleGenAIConverter(BaseConverter):
         Returns:
             Tuple of (converted Content list, warnings).
         """
+        kwargs["target_provider"] = self._CONVERTER_TAG
         return self.message_ops.ir_messages_to_p(messages, **kwargs)
 
     def messages_from_provider(
@@ -661,7 +670,7 @@ class GoogleGenAIConverter(BaseConverter):
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
-    ) -> list[Message | ExtensionItem]:
+    ) -> list[IRInputItem]:
         """Convert Google GenAI Content list to IR message list.
 
         Delegates to message_ops.
@@ -726,7 +735,7 @@ class GoogleGenAIConverter(BaseConverter):
             return self.request_to_provider(cast(IRRequest, ir_input))
 
         # Handle IRInput (message list)
-        ir_input_list: list[Message | ExtensionItem] = list(cast(IRInput, ir_input))
+        ir_input_list: list[IRInputItem] = list(cast(IRInput, ir_input))
         warnings_list: list[str] = []
 
         # Extract system messages
@@ -735,7 +744,9 @@ class GoogleGenAIConverter(BaseConverter):
         )
 
         # Convert non-system messages
-        contents, msg_warnings = self.message_ops.ir_messages_to_p(remaining)
+        contents, msg_warnings = self.message_ops.ir_messages_to_p(
+            remaining, target_provider=self._CONVERTER_TAG
+        )
         warnings_list.extend(msg_warnings)
 
         # Build result

--- a/src/llm_rosetta/converters/google_genai/message_ops.py
+++ b/src/llm_rosetta/converters/google_genai/message_ops.py
@@ -19,7 +19,7 @@ from typing import Any, cast
 
 from ...types.ir import (
     ContentPart,
-    ExtensionItem,
+    IRInputItem,
     Message,
     is_audio_part,
     is_extension_item,
@@ -72,7 +72,7 @@ class GoogleGenAIMessageOps(BaseMessageOps):
 
     def ir_messages_to_p(
         self,
-        ir_messages: Sequence[Message | ExtensionItem],
+        ir_messages: Sequence[IRInputItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """IR Messages → Google GenAI Content list + system_instruction.
@@ -105,6 +105,14 @@ class GoogleGenAIMessageOps(BaseMessageOps):
         )
 
         for item in ir_input_list:
+            passthrough_warnings = self._restore_provider_passthrough_item(
+                item,
+                contents,
+                target_provider=kwargs.get("target_provider", ""),
+            )
+            if passthrough_warnings is not None:
+                warnings_list.extend(passthrough_warnings)
+                continue
             if is_message(item):
                 msg = cast(Message, item)
                 role = msg.get("role")
@@ -191,7 +199,7 @@ class GoogleGenAIMessageOps(BaseMessageOps):
         self,
         provider_messages: list[Any],
         **kwargs: Any,
-    ) -> list[Message | ExtensionItem]:
+    ) -> list[IRInputItem]:
         """Google GenAI Content list → IR Messages.
 
         Converts each Google Content to the appropriate IR message type.
@@ -207,7 +215,7 @@ class GoogleGenAIMessageOps(BaseMessageOps):
         Returns:
             List of IR messages.
         """
-        ir_messages: list[Message | ExtensionItem] = []
+        ir_messages: list[IRInputItem] = []
 
         for msg in provider_messages:
             converted = self._p_message_to_ir(msg)
@@ -226,7 +234,7 @@ class GoogleGenAIMessageOps(BaseMessageOps):
 
     @staticmethod
     def _reconcile_tool_call_ids(
-        ir_messages: Sequence[Message | ExtensionItem],
+        ir_messages: Sequence[IRInputItem],
     ) -> None:
         """Match tool_result tool_call_ids to tool_call tool_call_ids by name.
 
@@ -377,8 +385,8 @@ class GoogleGenAIMessageOps(BaseMessageOps):
 
     @staticmethod
     def extract_system_instruction(
-        ir_messages: Sequence[Message | ExtensionItem],
-    ) -> tuple[Any, list[Message | ExtensionItem]]:
+        ir_messages: Sequence[IRInputItem],
+    ) -> tuple[Any, list[IRInputItem]]:
         """Extract system messages from IR message list.
 
         Returns the system_instruction Content dict and the remaining
@@ -391,7 +399,7 @@ class GoogleGenAIMessageOps(BaseMessageOps):
             Tuple of (system_instruction Content dict or None, remaining messages).
         """
         system_instruction: dict[str, Any] | None = None
-        remaining: list[Message | ExtensionItem] = []
+        remaining: list[IRInputItem] = []
 
         for item in ir_messages:
             if is_message(item) and item.get("role") == "system":

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -10,8 +10,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 from ...types.ir import (
-    ExtensionItem,
-    Message,
+    IRInputItem,
     TextPart,
     is_citation_part,
     is_reasoning_part,
@@ -109,7 +108,9 @@ class OpenAIChatConverter(BaseConverter):
         # tool_calls from interrupted sessions.
         ir_messages = fix_orphaned_tool_calls_ir(ir_request.get("messages", []))
         ctx.warnings.extend(strip_orphaned_tool_config(ir_request))
-        converted_msgs, msg_warnings = self.message_ops.ir_messages_to_p(ir_messages)
+        converted_msgs, msg_warnings = self.message_ops.ir_messages_to_p(
+            ir_messages, target_provider=self._CONVERTER_TAG
+        )
         messages.extend(converted_msgs)
         ctx.warnings.extend(msg_warnings)
         result["messages"] = messages
@@ -496,6 +497,13 @@ class OpenAIChatConverter(BaseConverter):
 
         if "system_fingerprint" in ir_response:
             provider_response["system_fingerprint"] = ir_response["system_fingerprint"]
+        ctx = context if context is not None else ConversionContext()
+        self._restore_response_passthrough_items(
+            provider_response,
+            ir_response,
+            output_key="choices",
+            context=ctx,
+        )
 
         return provider_response
 
@@ -526,7 +534,7 @@ class OpenAIChatConverter(BaseConverter):
 
     def messages_to_provider(
         self,
-        messages: Sequence[Message | ExtensionItem],
+        messages: Sequence[IRInputItem],
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
@@ -541,6 +549,7 @@ class OpenAIChatConverter(BaseConverter):
         Returns:
             Tuple of (converted messages, warnings).
         """
+        kwargs["target_provider"] = self._CONVERTER_TAG
         return self.message_ops.ir_messages_to_p(messages, **kwargs)
 
     def messages_from_provider(
@@ -549,7 +558,7 @@ class OpenAIChatConverter(BaseConverter):
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
-    ) -> list[Message | ExtensionItem]:
+    ) -> list[IRInputItem]:
         """Convert OpenAI Chat messages to IR message list.
 
         Delegates to message_ops.

--- a/src/llm_rosetta/converters/openai_chat/message_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/message_ops.py
@@ -14,7 +14,7 @@ from typing import Any, cast
 
 from ...types.ir import (
     ContentPart,
-    ExtensionItem,
+    IRInputItem,
     FileData,
     FilePart,
     Message,
@@ -73,7 +73,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
 
     def ir_messages_to_p(
         self,
-        ir_messages: Sequence[Message | ExtensionItem],
+        ir_messages: Sequence[IRInputItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """IR Messages → OpenAI Chat messages.
@@ -93,6 +93,14 @@ class OpenAIChatMessageOps(BaseMessageOps):
         multimodal_packs: dict[str, list[dict[str, Any]]] = {}
 
         for item in ir_messages:
+            passthrough_warnings = self._restore_provider_passthrough_item(
+                item,
+                messages,
+                target_provider=kwargs.get("target_provider", ""),
+            )
+            if passthrough_warnings is not None:
+                warnings.extend(passthrough_warnings)
+                continue
             if is_message(item):
                 converted, msg_warnings = self._ir_message_to_p(
                     cast(Message, item), multimodal_packs
@@ -527,7 +535,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
         self,
         provider_messages: list[Any],
         **kwargs: Any,
-    ) -> list[Message | ExtensionItem]:
+    ) -> list[IRInputItem]:
         """OpenAI Chat messages → IR Messages.
 
         Pre-processes synthetic user messages (from dual encoding packing)
@@ -541,7 +549,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
         """
         unpacked_content, clean_messages = self._unpack_tool_content(provider_messages)
 
-        ir_messages: list[Message | ExtensionItem] = []
+        ir_messages: list[IRInputItem] = []
         for msg in clean_messages:
             converted = self._p_message_to_ir(msg, unpacked_content)
             if converted is not None:

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -1089,6 +1089,7 @@ class OpenAIResponsesConverter(BaseConverter):
             events.append(StreamEndEvent(type="stream_end"))
 
     _FROM_P_DISPATCH: dict[str, str] = {
+        ResponsesEventType.RESPONSE_IN_PROGRESS: "_handle_provider_passthrough_from_p",
         ResponsesEventType.RESPONSE_CREATED: "_handle_response_created_from_p",
         ResponsesEventType.OUTPUT_TEXT_DELTA: "_handle_output_text_delta_from_p",
         ResponsesEventType.REASONING_SUMMARY_TEXT_DELTA: "_handle_reasoning_delta_from_p",

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -14,13 +14,13 @@ from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 from ...types.ir import (
-    ExtensionItem,
-    Message,
+    IRInputItem,
     TextPart,
     is_text_part,
     is_tool_call_part,
     is_reasoning_part,
 )
+from ...types.ir.passthrough import ProviderPassthroughItem
 from ...types.ir.request import IRRequest
 from ...types.ir.response import IRResponse, UsageInfo
 from ...types.ir.stream import (
@@ -119,7 +119,9 @@ class OpenAIResponsesConverter(BaseConverter):
         # function_call to have a matching function_call_output.
         ir_messages = fix_orphaned_tool_calls_ir(ir_request.get("messages", []))
         ctx.warnings.extend(strip_orphaned_tool_config(ir_request))
-        items, msg_warnings = self.message_ops.ir_messages_to_p(ir_messages)
+        items, msg_warnings = self.message_ops.ir_messages_to_p(
+            ir_messages, target_provider=self._CONVERTER_TAG
+        )
         ctx.warnings.extend(msg_warnings)
         result["input"] = items
 
@@ -341,6 +343,19 @@ class OpenAIResponsesConverter(BaseConverter):
             "model": provider_response.get("model", ""),
             "choices": choices,
         }
+        passthrough_items = [
+            ProviderPassthroughItem(
+                type="provider_passthrough_item",
+                provider=self._CONVERTER_TAG,
+                payload=dict(item),
+                position=position,
+            )
+            for position, item in enumerate(output_items)
+            if isinstance(item, dict)
+            and not self.message_ops.is_portable_response_output_item(item)
+        ]
+        if passthrough_items:
+            ir_response["provider_passthrough_items"] = passthrough_items
 
         # Handle usage
         p_usage = provider_response.get("usage")
@@ -442,6 +457,12 @@ class OpenAIResponsesConverter(BaseConverter):
         ctx = context if context is not None else ConversionContext()
         if ctx.metadata_mode == "preserve":
             self._apply_preserve_metadata(provider_response, ctx)
+        self._restore_response_passthrough_items(
+            provider_response,
+            ir_response,
+            output_key="output",
+            context=ctx,
+        )
 
         return provider_response
 
@@ -554,7 +575,7 @@ class OpenAIResponsesConverter(BaseConverter):
 
         items_meta: list[dict[str, Any]] = []
         for item in output_items:
-            if not isinstance(item, dict):
+            if not OpenAIResponsesMessageOps.is_portable_response_output_item(item):
                 continue
             meta: dict[str, Any] = {}
             if "id" in item:
@@ -632,7 +653,7 @@ class OpenAIResponsesConverter(BaseConverter):
 
     def messages_to_provider(
         self,
-        messages: Sequence[Message | ExtensionItem],
+        messages: Sequence[IRInputItem],
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
@@ -647,6 +668,7 @@ class OpenAIResponsesConverter(BaseConverter):
         Returns:
             Tuple of (converted items, warnings).
         """
+        kwargs["target_provider"] = self._CONVERTER_TAG
         return self.message_ops.ir_messages_to_p(messages, **kwargs)
 
     def messages_from_provider(
@@ -655,7 +677,7 @@ class OpenAIResponsesConverter(BaseConverter):
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
-    ) -> list[Message | ExtensionItem]:
+    ) -> list[IRInputItem]:
         """Convert OpenAI Responses items to IR message list.
 
         Delegates to message_ops.
@@ -689,7 +711,9 @@ class OpenAIResponsesConverter(BaseConverter):
             return self.request_to_provider(ir_input, **kwargs)
 
         # It's a plain message list - wrap in a minimal request
-        items, warnings = self.message_ops.ir_messages_to_p(ir_input)
+        items, warnings = self.message_ops.ir_messages_to_p(
+            ir_input, target_provider=self._CONVERTER_TAG
+        )
         result: dict[str, Any] = {"input": items}
 
         if tools:

--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -341,7 +341,11 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
 
     @classmethod
     def is_portable_response_output_item(cls, item: Any) -> bool:
-        """Return whether non-stream response conversion rebuilds this item."""
+        """Return whether non-stream response conversion rebuilds this item.
+
+        Add newly portable Responses output item types here; otherwise they
+        are deliberately captured as ``ProviderPassthroughItem`` values.
+        """
         if not isinstance(item, dict):
             return False
         item_type = item.get("type")

--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -17,7 +17,7 @@ from typing import Any, cast
 
 from ...types.ir import (
     ContentPart,
-    ExtensionItem,
+    IRInputItem,
     Message,
     TextPart,
     is_extension_item,
@@ -54,7 +54,7 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
 
     def ir_messages_to_p(
         self,
-        ir_messages: Sequence[Message | ExtensionItem],
+        ir_messages: Sequence[IRInputItem],
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """IR Messages → OpenAI Responses input items.
@@ -73,6 +73,14 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
         warnings: list[str] = []
 
         for item in ir_messages:
+            passthrough_warnings = self._restore_provider_passthrough_item(
+                item,
+                items,
+                target_provider=kwargs.get("target_provider", ""),
+            )
+            if passthrough_warnings is not None:
+                warnings.extend(passthrough_warnings)
+                continue
             if is_message(item):
                 converted, msg_warnings = self._ir_message_to_p(cast(Message, item))
                 warnings.extend(msg_warnings)
@@ -331,11 +339,21 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
 
     _TOOL_RESULT_TYPES = frozenset({"function_call_output", "mcp_call_output"})
 
+    @classmethod
+    def is_portable_response_output_item(cls, item: Any) -> bool:
+        """Return whether non-stream response conversion rebuilds this item."""
+        if not isinstance(item, dict):
+            return False
+        item_type = item.get("type")
+        return (
+            item_type in {"message", "reasoning"} or item_type in cls._TOOL_CALL_TYPES
+        )
+
     def p_messages_to_ir(
         self,
         provider_messages: list[Any],
         **kwargs: Any,
-    ) -> list[Message | ExtensionItem]:
+    ) -> list[IRInputItem]:
         """OpenAI Responses items → IR Messages.
 
         Converts a flat list of Responses API items to IR messages.

--- a/src/llm_rosetta/types/__init__.py
+++ b/src/llm_rosetta/types/__init__.py
@@ -52,6 +52,7 @@ from .ir import (
     # Response types
     IRResponse,
     ProviderPassthroughItem,
+    ProviderPassthroughEvent,
     ExtensionItem,
     UsageInfo,
     FinishReason,
@@ -119,6 +120,7 @@ __all__ = [
     # Response types
     "IRResponse",
     "ProviderPassthroughItem",
+    "ProviderPassthroughEvent",
     "ExtensionItem",
     "UsageInfo",
     "FinishReason",

--- a/src/llm_rosetta/types/__init__.py
+++ b/src/llm_rosetta/types/__init__.py
@@ -47,9 +47,11 @@ from .ir import (
     ReasoningConfig,
     CacheConfig,
     # Request types
+    IRInputItem,
     IRRequest,
     # Response types
     IRResponse,
+    ProviderPassthroughItem,
     ExtensionItem,
     UsageInfo,
     FinishReason,
@@ -112,9 +114,11 @@ __all__ = [
     "ReasoningConfig",
     "CacheConfig",
     # Request types
+    "IRInputItem",
     "IRRequest",
     # Response types
     "IRResponse",
+    "ProviderPassthroughItem",
     "ExtensionItem",
     "UsageInfo",
     "FinishReason",

--- a/src/llm_rosetta/types/ir/__init__.py
+++ b/src/llm_rosetta/types/ir/__init__.py
@@ -86,6 +86,7 @@ from .messages import (
 )
 
 # 内容部分类型 Content part types
+from .passthrough import ProviderPassthroughItem
 from .parts import (
     AssistantContentPart,
     AudioData,
@@ -107,7 +108,7 @@ from .parts import (
 )
 
 # 请求类型 Request types
-from .request import IRRequest
+from .request import IRInputItem, IRRequest
 
 # 响应类型 Response types
 from .response import (
@@ -159,6 +160,7 @@ from .type_guards import (  # noqa: F401
     is_tool_call_start_event,
     is_tool_result_part,
     is_usage_event,
+    is_provider_passthrough_item,
     isinstance_part,
 )
 
@@ -166,7 +168,7 @@ from .type_guards import (  # noqa: F401
 # For backward compatibility, define old type aliases
 from collections.abc import Sequence
 
-IRInput = Sequence[Message | ExtensionItem]
+IRInput = Sequence[IRInputItem]
 IRInputSimple = Sequence[Message]
 
 # Experimental extension types — imported on demand, not in default namespace
@@ -219,15 +221,18 @@ __all__ = [
     "ReasoningEffortLevel",
     "CacheConfig",
     # ========== 请求类型 Request types ==========
+    "IRInputItem",
     "IRRequest",
     # ========== 响应类型 Response types ==========
     "IRResponse",
     "ExtensionItem",
+    "ProviderPassthroughItem",
     "UsageInfo",
     "FinishReason",
     "ChoiceInfo",
     # ========== 流式事件类型 Stream event types ==========
     "IRStreamEvent",
+    "is_provider_passthrough_item",
     "StreamStartEvent",
     "StreamEndEvent",
     "ContentBlockStartEvent",

--- a/src/llm_rosetta/types/ir/__init__.py
+++ b/src/llm_rosetta/types/ir/__init__.py
@@ -86,7 +86,7 @@ from .messages import (
 )
 
 # 内容部分类型 Content part types
-from .passthrough import ProviderPassthroughItem
+from .passthrough import ProviderPassthroughEvent, ProviderPassthroughItem
 from .parts import (
     AssistantContentPart,
     AudioData,
@@ -160,6 +160,7 @@ from .type_guards import (  # noqa: F401
     is_tool_call_start_event,
     is_tool_result_part,
     is_usage_event,
+    is_provider_passthrough_event,
     is_provider_passthrough_item,
     isinstance_part,
 )
@@ -227,11 +228,13 @@ __all__ = [
     "IRResponse",
     "ExtensionItem",
     "ProviderPassthroughItem",
+    "ProviderPassthroughEvent",
     "UsageInfo",
     "FinishReason",
     "ChoiceInfo",
     # ========== 流式事件类型 Stream event types ==========
     "IRStreamEvent",
+    "is_provider_passthrough_event",
     "is_provider_passthrough_item",
     "StreamStartEvent",
     "StreamEndEvent",

--- a/src/llm_rosetta/types/ir/passthrough.py
+++ b/src/llm_rosetta/types/ir/passthrough.py
@@ -11,6 +11,14 @@ else:
     from typing_extensions import NotRequired, Required, TypedDict
 
 
+class ProviderPassthroughEvent(TypedDict):
+    """Opaque provider-native streaming event."""
+
+    type: Required[Literal["provider_passthrough"]]
+    provider: Required[str]
+    payload: Required[dict[str, Any]]
+
+
 class ProviderPassthroughItem(TypedDict):
     """Opaque provider-native non-streaming item."""
 
@@ -20,4 +28,4 @@ class ProviderPassthroughItem(TypedDict):
     position: NotRequired[int]
 
 
-__all__ = ["ProviderPassthroughItem"]
+__all__ = ["ProviderPassthroughEvent", "ProviderPassthroughItem"]

--- a/src/llm_rosetta/types/ir/passthrough.py
+++ b/src/llm_rosetta/types/ir/passthrough.py
@@ -1,0 +1,23 @@
+"""Provider-specific opaque IR payload types."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Literal
+
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, Required, TypedDict
+else:
+    from typing_extensions import NotRequired, Required, TypedDict
+
+
+class ProviderPassthroughItem(TypedDict):
+    """Opaque provider-native non-streaming item."""
+
+    type: Required[Literal["provider_passthrough_item"]]
+    provider: Required[str]
+    payload: Required[dict[str, Any]]
+    position: NotRequired[int]
+
+
+__all__ = ["ProviderPassthroughItem"]

--- a/src/llm_rosetta/types/ir/request.py
+++ b/src/llm_rosetta/types/ir/request.py
@@ -11,7 +11,7 @@ Unified request parameter types based on sdk_body_structures.md
 """
 
 import sys
-from typing import Any
+from typing import Any, Union
 
 if sys.version_info >= (3, 11):
     from typing import NotRequired, Required, TypedDict
@@ -25,9 +25,13 @@ from .configs import (
     ResponseFormatConfig,
     StreamConfig,
 )
+from .extensions_experimental import ExtensionItem
 from .messages import Message
+from .passthrough import ProviderPassthroughItem
 from .parts import TextPart
 from .tools import ToolCallConfig, ToolChoice, ToolDefinition
+
+IRInputItem = Union[Message, ExtensionItem, ProviderPassthroughItem]
 
 # ============================================================================
 # 主请求类型 Main Request Type
@@ -56,7 +60,7 @@ class IRRequest(TypedDict):
 
     # ========== 必需字段 Required Fields ==========
     model: Required[str]
-    messages: Required[list[Message]]
+    messages: Required[list[IRInputItem]]
 
     # ========== 系统指令 System Instruction ==========
     # 映射关系:
@@ -106,5 +110,6 @@ class IRRequest(TypedDict):
 
 __all__ = [
     # 主请求类型
+    "IRInputItem",
     "IRRequest",
 ]

--- a/src/llm_rosetta/types/ir/response.py
+++ b/src/llm_rosetta/types/ir/response.py
@@ -15,6 +15,7 @@ else:
 
 from .extensions_experimental import ExtensionItem, is_extension_item
 from .messages import Message
+from .passthrough import ProviderPassthroughItem
 
 # ============================================================================
 # 响应统计信息 Response statistics
@@ -118,6 +119,7 @@ class IRResponse(TypedDict):
     usage: NotRequired[UsageInfo]  # Token使用统计 Token usage statistics
     service_tier: NotRequired[str]  # 服务等级 Service tier
     system_fingerprint: NotRequired[str | None]  # 系统指纹 System fingerprint
+    provider_passthrough_items: NotRequired[list[ProviderPassthroughItem]]
 
 
 # ============================================================================

--- a/src/llm_rosetta/types/ir/stream.py
+++ b/src/llm_rosetta/types/ir/stream.py
@@ -37,6 +37,7 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import NotRequired, Required, TypedDict
 
+from .passthrough import ProviderPassthroughEvent
 from .response import FinishReason, UsageInfo
 
 # ============================================================================
@@ -186,6 +187,7 @@ IRStreamEvent = Union[
     ToolCallDeltaEvent,
     FinishEvent,
     UsageEvent,
+    ProviderPassthroughEvent,
 ]
 
 # ============================================================================
@@ -203,5 +205,6 @@ __all__ = [
     "ToolCallDeltaEvent",
     "FinishEvent",
     "UsageEvent",
+    "ProviderPassthroughEvent",
     "IRStreamEvent",
 ]

--- a/src/llm_rosetta/types/ir/type_guards.py
+++ b/src/llm_rosetta/types/ir/type_guards.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping
 
 from typing import TypeGuard
 
-from .passthrough import ProviderPassthroughItem
+from .passthrough import ProviderPassthroughEvent, ProviderPassthroughItem
 from .parts import (
     AudioPart,
     CitationPart,
@@ -162,6 +162,13 @@ def is_usage_event(event: IRStreamEvent) -> TypeGuard[UsageEvent]:
     return isinstance(event, dict) and event.get("type") == "usage"
 
 
+def is_provider_passthrough_event(
+    event: IRStreamEvent,
+) -> TypeGuard[ProviderPassthroughEvent]:
+    """Check if a stream event is a ProviderPassthroughEvent."""
+    return isinstance(event, dict) and event.get("type") == "provider_passthrough"
+
+
 def is_provider_passthrough_item(item: Any) -> TypeGuard[ProviderPassthroughItem]:
     """Check if an item is a ProviderPassthroughItem."""
     return isinstance(item, dict) and item.get("type") == "provider_passthrough_item"
@@ -298,6 +305,7 @@ __all__ = [
     "is_tool_call_delta_event",
     "is_finish_event",
     "is_usage_event",
+    "is_provider_passthrough_event",
     "is_provider_passthrough_item",
     # Generic functions
     "is_part_type",

--- a/src/llm_rosetta/types/ir/type_guards.py
+++ b/src/llm_rosetta/types/ir/type_guards.py
@@ -10,6 +10,7 @@ from collections.abc import Mapping
 
 from typing import TypeGuard
 
+from .passthrough import ProviderPassthroughItem
 from .parts import (
     AudioPart,
     CitationPart,
@@ -161,6 +162,11 @@ def is_usage_event(event: IRStreamEvent) -> TypeGuard[UsageEvent]:
     return isinstance(event, dict) and event.get("type") == "usage"
 
 
+def is_provider_passthrough_item(item: Any) -> TypeGuard[ProviderPassthroughItem]:
+    """Check if an item is a ProviderPassthroughItem."""
+    return isinstance(item, dict) and item.get("type") == "provider_passthrough_item"
+
+
 # ============================================================================
 # Generic type checking (backward compatible)
 # ============================================================================
@@ -292,6 +298,7 @@ __all__ = [
     "is_tool_call_delta_event",
     "is_finish_event",
     "is_usage_event",
+    "is_provider_passthrough_item",
     # Generic functions
     "is_part_type",
     "isinstance_part",

--- a/src/llm_rosetta/types/ir/validation.py
+++ b/src/llm_rosetta/types/ir/validation.py
@@ -9,12 +9,10 @@ downstream in converters.
 
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import Any
 
 from ..._vendor.validate import ValidationError, validate
-from .extensions_experimental import ExtensionItem
-from .messages import Message
-from .request import IRRequest
+from .request import IRInputItem, IRRequest
 from .response import IRResponse
 from .tools import ToolDefinition
 
@@ -51,7 +49,7 @@ def validate_ir_response(data: dict[str, Any]) -> IRResponse:
 
 def validate_messages(
     messages: list[Any],
-) -> list[Message | ExtensionItem]:
+) -> list[IRInputItem]:
     """Validate a message list against IR Message/ExtensionItem types.
 
     Args:
@@ -63,7 +61,7 @@ def validate_messages(
     Raises:
         ValidationError: If any message doesn't match expected structure.
     """
-    return validate(messages, list[Union[Message, ExtensionItem]])
+    return validate(messages, list[IRInputItem])
 
 
 def validate_tools(

--- a/tests/converters/anthropic/test_converter.py
+++ b/tests/converters/anthropic/test_converter.py
@@ -639,11 +639,13 @@ class TestAnthropicConverter:
         assert events[0]["type"] == "usage"
         assert events[0]["usage"]["prompt_tokens"] == 100
 
-    def test_stream_ping_ignored(self):
-        """Test ping event is ignored."""
+    def test_stream_ping_passthrough(self):
+        """Ping is preserved as a provider passthrough event."""
         event = {"type": "ping"}
         events = self.converter.stream_response_from_provider(event)
-        assert len(events) == 0
+        assert events == [
+            {"type": "provider_passthrough", "provider": "anthropic", "payload": event}
+        ]
 
     def test_stream_content_block_stop_ignored(self):
         """Test content_block_stop is ignored."""

--- a/tests/converters/anthropic/test_stream.py
+++ b/tests/converters/anthropic/test_stream.py
@@ -239,11 +239,13 @@ class TestStreamResponseFromProvider:
         events = self.converter.stream_response_from_provider(event)
         assert events == []
 
-    def test_ping_ignored(self):
-        """ping produces no events."""
+    def test_ping_passthrough(self):
+        """Ping is preserved as a provider passthrough event."""
         event = {"type": "ping"}
         events = self.converter.stream_response_from_provider(event)
-        assert events == []
+        assert events == [
+            {"type": "provider_passthrough", "provider": "anthropic", "payload": event}
+        ]
 
     # --- SDK object normalization ---
 

--- a/tests/converters/base/test_conversion_context.py
+++ b/tests/converters/base/test_conversion_context.py
@@ -182,8 +182,8 @@ class TestStreamContextBufferMethods:
 class TestBaseConverterDispatch:
     """Test BaseConverter._TO_P_DISPATCH and dispatch skeleton."""
 
-    def test_dispatch_table_has_10_entries(self):
-        assert len(BaseConverter._TO_P_DISPATCH) == 10
+    def test_dispatch_table_has_11_entries(self):
+        assert len(BaseConverter._TO_P_DISPATCH) == 11
 
     def test_dispatch_table_keys(self):
         expected = {
@@ -197,6 +197,7 @@ class TestBaseConverterDispatch:
             "tool_call_delta",
             "finish",
             "usage",
+            "provider_passthrough",
         }
         assert set(BaseConverter._TO_P_DISPATCH.keys()) == expected
 

--- a/tests/converters/openai_chat/test_converter.py
+++ b/tests/converters/openai_chat/test_converter.py
@@ -141,7 +141,7 @@ class TestOpenAIChatConverter:
         result = self.converter.request_from_provider(provider_request)
         assert result["model"] == "gpt-4o"
         assert result["system_instruction"] == [{"type": "text", "text": "Be helpful"}]
-        messages = list(result["messages"])
+        messages = cast(list[Message], result["messages"])
         assert len(messages) == 1
         assert messages[0]["role"] == "user"
 

--- a/tests/converters/openai_responses/test_converter.py
+++ b/tests/converters/openai_responses/test_converter.py
@@ -137,7 +137,7 @@ class TestOpenAIResponsesConverter:
         result = self.converter.request_from_provider(provider_request)
         assert result["model"] == "gpt-4o"
         assert result["system_instruction"] == [{"type": "text", "text": "Be helpful"}]
-        messages = list(result["messages"])
+        messages = cast(list[Message], result["messages"])
         assert len(messages) == 1
         assert messages[0]["role"] == "user"
 

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -260,11 +260,17 @@ class TestStreamResponseFromProvider:
         events = self.converter.stream_response_from_provider(event)
         assert events == []
 
-    def test_response_in_progress_ignored(self):
-        """response.in_progress produces no events."""
+    def test_response_in_progress_passthrough(self):
+        """response.in_progress is preserved as a passthrough event."""
         event = {"type": "response.in_progress", "response": {}}
         events = self.converter.stream_response_from_provider(event)
-        assert events == []
+        assert events == [
+            {
+                "type": "provider_passthrough",
+                "provider": "openai_responses",
+                "payload": event,
+            }
+        ]
 
     def test_output_item_done_ignored(self):
         """response.output_item.done produces no events."""

--- a/tests/converters/test_provider_passthrough.py
+++ b/tests/converters/test_provider_passthrough.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import cast
+
+from llm_rosetta.converters.anthropic.converter import AnthropicConverter
+from llm_rosetta.converters.base import BaseConverter
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.converters.base.helpers.tool_orphan_fix import (
+    fix_orphaned_tool_calls_ir,
+)
+from llm_rosetta.converters.openai_responses.converter import OpenAIResponsesConverter
+from llm_rosetta.converters.openai_chat.converter import OpenAIChatConverter
+from llm_rosetta.converters.google_genai.converter import GoogleGenAIConverter
+from llm_rosetta.types.ir import (
+    IRInputItem,
+    IRResponse,
+    ProviderPassthroughItem,
+    is_provider_passthrough_item,
+)
+from llm_rosetta.types.ir.validation import (
+    validate_ir_request,
+    validate_ir_response,
+    validate_messages,
+)
+
+
+def _item(provider: str = "openai_responses", position: int = 1):
+    return ProviderPassthroughItem(
+        type="provider_passthrough_item",
+        provider=provider,
+        payload={"type": "vendor_event", "value": 1},
+        position=position,
+    )
+
+
+class TestPassthroughTypes:
+    def test_item_type_guard(self):
+        item = _item()
+        assert is_provider_passthrough_item(item)
+        assert not is_provider_passthrough_item({"role": "user", "content": []})
+
+    def test_request_validation_accepts_passthrough_item(self):
+        request = validate_ir_request(
+            {"model": "test", "messages": [_item(position=0)]}
+        )
+        item = cast(ProviderPassthroughItem, request["messages"][0])
+        assert item["type"] == "provider_passthrough_item"
+
+    def test_validate_messages_accepts_passthrough_item(self):
+        messages = validate_messages([_item(position=0)])
+        item = cast(ProviderPassthroughItem, messages[0])
+        assert item["provider"] == "openai_responses"
+
+    def test_response_validation_accepts_provider_passthrough_items(self):
+        response = validate_ir_response(
+            {
+                "id": "resp_1",
+                "object": "response",
+                "created": 1,
+                "model": "test",
+                "choices": [],
+                "provider_passthrough_items": [_item(position=0)],
+            }
+        )
+        assert (
+            response["provider_passthrough_items"][0]["provider"] == "openai_responses"
+        )
+
+
+class TestNonStreamPassthroughHelpers:
+    def test_message_ops_restore_same_provider(self):
+        items, warnings = OpenAIResponsesConverter().message_ops.ir_messages_to_p(
+            [_item(position=0)], target_provider="openai_responses"
+        )
+        assert items == [{"type": "vendor_event", "value": 1}]
+        assert warnings == []
+
+    def test_message_ops_drop_cross_provider_with_warning(self):
+        messages, warnings = AnthropicConverter().message_ops.ir_messages_to_p(
+            [_item(position=0)]
+        )
+        assert messages == []
+        assert len(warnings) == 1
+
+    def test_all_message_ops_restore_same_tag_and_drop_foreign(self):
+        converters = [
+            OpenAIResponsesConverter(),
+            OpenAIChatConverter(),
+            AnthropicConverter(),
+            GoogleGenAIConverter(),
+        ]
+        for converter in converters:
+            local = _item(provider=converter._CONVERTER_TAG, position=0)
+            restored, warnings = converter.message_ops.ir_messages_to_p(
+                [local], target_provider=converter._CONVERTER_TAG
+            )
+            assert restored == [{"type": "vendor_event", "value": 1}]
+            assert warnings == []
+
+            foreign = _item(provider="foreign", position=0)
+            dropped, warnings = converter.message_ops.ir_messages_to_p(
+                [foreign], target_provider=converter._CONVERTER_TAG
+            )
+            assert dropped == []
+            assert len(warnings) == 1
+
+    def test_same_position_merge_is_stable(self):
+        from llm_rosetta.converters.base.passthrough import merge_provider_output_items
+
+        first = _item(position=0)
+        first["payload"] = {"type": "first"}
+        second = _item(position=0)
+        second["payload"] = {"type": "second"}
+        merged, warnings = merge_provider_output_items(
+            [{"type": "message"}],
+            [first, second],
+            target_provider="openai_responses",
+        )
+        assert [entry["type"] for entry in merged] == [
+            "first",
+            "second",
+            "message",
+        ]
+        assert warnings == []
+
+    def test_restore_same_provider_returns_copy(self):
+        from llm_rosetta.converters.base.passthrough import (
+            restore_provider_passthrough_item,
+        )
+
+        item = _item()
+        payload, warning = restore_provider_passthrough_item(
+            item, target_provider="openai_responses"
+        )
+        assert payload == item["payload"]
+        assert payload is not item["payload"]
+        assert warning is None
+
+    def test_restore_cross_provider_warns_and_drops(self):
+        from llm_rosetta.converters.base.passthrough import (
+            restore_provider_passthrough_item,
+        )
+
+        payload, warning = restore_provider_passthrough_item(
+            _item(), target_provider="anthropic"
+        )
+        assert payload is None
+        assert warning is not None
+        assert "openai_responses" in warning
+        assert "anthropic" in warning
+
+    def test_merge_output_items_by_position(self):
+        from llm_rosetta.converters.base.passthrough import merge_provider_output_items
+
+        portable = [
+            {"type": "reasoning", "id": "r"},
+            {"type": "function_call", "id": "f"},
+        ]
+        passthrough = [_item(position=1)]
+        original = deepcopy(passthrough)
+        merged, warnings = merge_provider_output_items(
+            portable,
+            passthrough,
+            target_provider="openai_responses",
+        )
+        assert [entry["type"] for entry in merged] == [
+            "reasoning",
+            "vendor_event",
+            "function_call",
+        ]
+        assert warnings == []
+        assert passthrough == original
+
+    def test_cross_provider_output_items_are_dropped(self):
+        from llm_rosetta.converters.base.passthrough import merge_provider_output_items
+
+        merged, warnings = merge_provider_output_items(
+            [{"type": "message"}],
+            [_item(position=0)],
+            target_provider="anthropic",
+        )
+        assert merged == [{"type": "message"}]
+        assert len(warnings) == 1
+
+    def test_conversion_context_metadata_coexists(self):
+        from llm_rosetta.converters.base.passthrough import merge_provider_output_items
+
+        ctx = ConversionContext(options={"metadata_mode": "preserve"})
+        ctx.store_response_extras({"billing": {"payer": "developer"}})
+        ctx.store_output_items_meta([{"id": "msg_1"}])
+        item = _item(position=0)
+
+        merged, warnings = merge_provider_output_items(
+            [{"type": "message"}],
+            [item],
+            target_provider="openai_responses",
+        )
+
+        assert [entry["type"] for entry in merged] == [
+            "vendor_event",
+            "message",
+        ]
+        assert warnings == []
+        assert ctx.get_echo_fields() == {"billing": {"payer": "developer"}}
+        assert ctx.get_output_items_meta() == [{"id": "msg_1"}]
+
+    def test_orphan_fix_preserves_passthrough_item_position(self):
+        passthrough = _item(position=1)
+        messages: list[IRInputItem] = [
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            passthrough,
+        ]
+        fixed = fix_orphaned_tool_calls_ir(messages)
+        assert fixed == messages
+        assert fixed[1] is passthrough
+
+    def test_responses_nonstream_captures_and_restores_unknown_output_item(self):
+        converter = OpenAIResponsesConverter()
+        ctx = ConversionContext(options={"metadata_mode": "preserve"})
+        provider_response = {
+            "id": "resp_1",
+            "object": "response",
+            "created_at": 1,
+            "model": "test",
+            "status": "completed",
+            "output": [
+                {"type": "vendor_event", "id": "vendor_1", "value": 1},
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "hello",
+                            "annotations": [],
+                        }
+                    ],
+                },
+            ],
+        }
+        ir_response = converter.response_from_provider(provider_response, context=ctx)
+        assert ir_response["provider_passthrough_items"] == [
+            {
+                "type": "provider_passthrough_item",
+                "provider": "openai_responses",
+                "payload": provider_response["output"][0],
+                "position": 0,
+            }
+        ]
+
+        restored = converter.response_to_provider(ir_response, context=ctx)
+        assert [item["type"] for item in restored["output"]] == [
+            "vendor_event",
+            "message",
+        ]
+        assert restored["output"][1]["id"] == "msg_1"
+
+    def test_distinct_positions_merge_against_original_output_indices(self):
+        from llm_rosetta.converters.base.passthrough import merge_provider_output_items
+
+        first = _item(position=1)
+        first["payload"] = {"type": "first"}
+        second = _item(position=2)
+        second["payload"] = {"type": "second"}
+        merged, warnings = merge_provider_output_items(
+            [{"type": "portable_0"}, {"type": "portable_3"}],
+            [first, second],
+            target_provider="openai_responses",
+        )
+        assert [item["type"] for item in merged] == [
+            "portable_0",
+            "first",
+            "second",
+            "portable_3",
+        ]
+        assert warnings == []
+
+    def test_response_converters_restore_matching_passthrough_items(self):
+        converters_and_keys: list[tuple[BaseConverter, str]] = [
+            (OpenAIResponsesConverter(), "output"),
+            (OpenAIChatConverter(), "choices"),
+            (AnthropicConverter(), "content"),
+            (GoogleGenAIConverter(), "candidates"),
+        ]
+        for converter, output_key in converters_and_keys:
+            item = _item(provider=converter._CONVERTER_TAG, position=0)
+            response: IRResponse = {
+                "id": "resp_1",
+                "object": "response",
+                "created": 1,
+                "model": "test",
+                "choices": [],
+                "provider_passthrough_items": [item],
+            }
+            restored = converter.response_to_provider(response)
+            assert restored[output_key] == [{"type": "vendor_event", "value": 1}]
+
+    def test_response_converter_drops_foreign_items_with_warning(self):
+        ctx = ConversionContext()
+        response: IRResponse = {
+            "id": "resp_1",
+            "object": "response",
+            "created": 1,
+            "model": "test",
+            "choices": [],
+            "provider_passthrough_items": [
+                _item(provider="openai_responses", position=0)
+            ],
+        }
+        restored = AnthropicConverter().response_to_provider(response, context=ctx)
+        assert restored["content"] == []
+        assert len(ctx.warnings) == 1
+
+    def test_missing_position_appends(self):
+        from llm_rosetta.converters.base.passthrough import merge_provider_output_items
+
+        item = _item()
+        item.pop("position")
+        merged, warnings = merge_provider_output_items(
+            [{"type": "message"}],
+            [item],
+            target_provider="openai_responses",
+        )
+        assert [entry["type"] for entry in merged] == ["message", "vendor_event"]
+        assert warnings == []

--- a/tests/converters/test_provider_passthrough.py
+++ b/tests/converters/test_provider_passthrough.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import cast
+from typing import Any, cast
 
 from llm_rosetta.converters.anthropic.converter import AnthropicConverter
 from llm_rosetta.converters.base import BaseConverter
-from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.converters.base.context import ConversionContext, StreamContext
+from llm_rosetta.pipeline import StreamProcessor
 from llm_rosetta.converters.base.helpers.tool_orphan_fix import (
     fix_orphaned_tool_calls_ir,
 )
@@ -15,7 +16,9 @@ from llm_rosetta.converters.google_genai.converter import GoogleGenAIConverter
 from llm_rosetta.types.ir import (
     IRInputItem,
     IRResponse,
+    ProviderPassthroughEvent,
     ProviderPassthroughItem,
+    is_provider_passthrough_event,
     is_provider_passthrough_item,
 )
 from llm_rosetta.types.ir.validation import (
@@ -35,6 +38,15 @@ def _item(provider: str = "openai_responses", position: int = 1):
 
 
 class TestPassthroughTypes:
+    def test_event_type_guard(self):
+        event = ProviderPassthroughEvent(
+            type="provider_passthrough",
+            provider="anthropic",
+            payload={"type": "ping"},
+        )
+        assert is_provider_passthrough_event(event)
+        assert not is_provider_passthrough_event({"type": "text_delta", "text": "x"})
+
     def test_item_type_guard(self):
         item = _item()
         assert is_provider_passthrough_item(item)
@@ -66,6 +78,74 @@ class TestPassthroughTypes:
         assert (
             response["provider_passthrough_items"][0]["provider"] == "openai_responses"
         )
+
+
+class TestStreamPassthrough:
+    def test_anthropic_ping_emits_passthrough(self):
+        chunk = {"type": "ping"}
+        events = AnthropicConverter().stream_response_from_provider(chunk)
+        assert events == [
+            {
+                "type": "provider_passthrough",
+                "provider": "anthropic",
+                "payload": chunk,
+            }
+        ]
+        passthrough = cast(ProviderPassthroughEvent, events[0])
+        assert passthrough["payload"] is not chunk
+
+    def test_responses_in_progress_emits_passthrough(self):
+        chunk = {
+            "type": "response.in_progress",
+            "sequence_number": 3,
+            "response": {"id": "resp_1", "status": "in_progress"},
+        }
+        events = OpenAIResponsesConverter().stream_response_from_provider(chunk)
+        assert events == [
+            {
+                "type": "provider_passthrough",
+                "provider": "openai_responses",
+                "payload": chunk,
+            }
+        ]
+        passthrough = cast(ProviderPassthroughEvent, events[0])
+        assert passthrough["payload"] is not chunk
+
+    def test_same_format_restores_copy(self):
+        converter = AnthropicConverter()
+        event = ProviderPassthroughEvent(
+            type="provider_passthrough",
+            provider="anthropic",
+            payload={"type": "ping"},
+        )
+        restored = converter.stream_response_to_provider(event)
+        assert restored == {"type": "ping"}
+        assert restored is not event["payload"]
+
+    def test_cross_format_drops_event(self):
+        event = ProviderPassthroughEvent(
+            type="provider_passthrough",
+            provider="anthropic",
+            payload={"type": "ping"},
+        )
+        ctx = StreamContext()
+        assert OpenAIResponsesConverter().stream_response_to_provider(event, ctx) == {}
+        upgraded = ctx.metadata.get("_responses_stream_ctx")
+        assert upgraded is None or upgraded._sequence_number == 0
+
+    def test_responses_same_format_rewrites_sequence_number(self):
+        converter = OpenAIResponsesConverter()
+        ctx = converter.create_stream_context()
+        event = ProviderPassthroughEvent(
+            type="provider_passthrough",
+            provider="openai_responses",
+            payload={"type": "response.in_progress", "sequence_number": 99},
+        )
+        restored = cast(
+            dict[str, Any], converter.stream_response_to_provider(event, ctx)
+        )
+        assert restored["sequence_number"] == 1
+        assert event["payload"]["sequence_number"] == 99
 
 
 class TestNonStreamPassthroughHelpers:
@@ -326,3 +406,42 @@ class TestNonStreamPassthroughHelpers:
         )
         assert [entry["type"] for entry in merged] == ["message", "vendor_event"]
         assert warnings == []
+
+
+class TestStreamProcessorPassthrough:
+    def test_same_format_forwards_passthrough(self):
+        target = OpenAIResponsesConverter()
+        source = OpenAIResponsesConverter()
+        processor = StreamProcessor(
+            target_converter=target,
+            source_converter=source,
+            from_ctx=target.create_stream_context(),
+            to_ctx=source.create_stream_context(),
+        )
+        result = processor.process_chunk(
+            {
+                "type": "response.in_progress",
+                "sequence_number": 8,
+                "response": {"id": "resp_1", "status": "in_progress"},
+            }
+        )
+        assert result[0]["type"] == "response.in_progress"
+        assert result[0]["sequence_number"] == 1
+
+    def test_cross_format_drops_passthrough(self):
+        target = OpenAIResponsesConverter()
+        source = AnthropicConverter()
+        processor = StreamProcessor(
+            target_converter=target,
+            source_converter=source,
+            from_ctx=target.create_stream_context(),
+            to_ctx=source.create_stream_context(),
+        )
+        result = processor.process_chunk(
+            {
+                "type": "response.in_progress",
+                "sequence_number": 8,
+                "response": {"id": "resp_1", "status": "in_progress"},
+            }
+        )
+        assert result == []

--- a/tests/test_converters_base.py
+++ b/tests/test_converters_base.py
@@ -30,6 +30,7 @@ from llm_rosetta.types.ir import (
     CacheConfig,
     CitationPart,
     ExtensionItem,
+    IRInputItem,
     FilePart,
     # Configs
     GenerationConfig,
@@ -147,7 +148,7 @@ class MockMessageOps(BaseMessageOps):
 
     @staticmethod
     def ir_messages_to_p(
-        ir_messages: Sequence[Union[Message, ExtensionItem]], **kwargs: Any
+        ir_messages: Sequence[IRInputItem], **kwargs: Any
     ) -> tuple[list[Any], list[str]]:
         provider_messages = []
         warnings = []
@@ -412,7 +413,7 @@ class MockConverter(BaseConverter):
 
         if "messages" in provider_request:
             ir_request["messages"] = cast(
-                list[Message],
+                list[IRInputItem],
                 self.message_ops_class.p_messages_to_ir(
                     provider_request["messages"], **kwargs
                 ),
@@ -446,7 +447,7 @@ class MockConverter(BaseConverter):
 
     def messages_to_provider(
         self,
-        messages: Sequence[Union[Message, ExtensionItem]],
+        messages: Sequence[IRInputItem],
         *,
         context=None,
         **kwargs: Any,
@@ -455,7 +456,7 @@ class MockConverter(BaseConverter):
 
     def messages_from_provider(
         self, provider_messages: list[Any], *, context=None, **kwargs: Any
-    ) -> list[Union[Message, ExtensionItem]]:
+    ) -> list[IRInputItem]:
         return self.message_ops_class.p_messages_to_ir(provider_messages, **kwargs)
 
     def stream_response_from_provider(
@@ -796,7 +797,7 @@ class TestBaseMessageOps:
 
     def test_extension_item_handling(self):
         """测试扩展项处理"""
-        items: list[Message | ExtensionItem] = [
+        items: list[IRInputItem] = [
             cast(
                 UserMessage,
                 {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
@@ -821,7 +822,7 @@ class TestBaseMessageOps:
     def test_validate_messages(self):
         """测试消息验证"""
         # 有效消息
-        valid_messages: list[Message | ExtensionItem] = [
+        valid_messages: list[IRInputItem] = [
             cast(
                 UserMessage,
                 {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
@@ -832,13 +833,13 @@ class TestBaseMessageOps:
 
         # 无效消息 - 不是列表
         errors = self.message_ops.validate_messages(
-            cast(Sequence[Union[Message, ExtensionItem]], "not a list")
+            cast(Sequence[IRInputItem], "not a list")
         )
         assert len(errors) > 0
 
         # 无效消息 - 缺少role或type
         errors = self.message_ops.validate_messages(
-            cast(Sequence[Union[Message, ExtensionItem]], [{"some_field": "value"}])
+            cast(Sequence[IRInputItem], [{"some_field": "value"}])
         )
         assert len(errors) > 0
 

--- a/tests/test_types/ir/test_validation.py
+++ b/tests/test_types/ir/test_validation.py
@@ -1,8 +1,11 @@
 """Tests for IR validation utilities."""
 
+from typing import cast
+
 import pytest
 
 from llm_rosetta._vendor.validate import ValidationError
+from llm_rosetta.types.ir import Message
 from llm_rosetta.types.ir.validation import (
     validate_ir_request,
     validate_ir_response,
@@ -139,7 +142,8 @@ class TestValidateIRRequest:
                 ]
             )
         )
-        assert result["messages"][1]["role"] == "tool"
+        messages = cast(list[Message], result["messages"])
+        assert messages[1]["role"] == "tool"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Add a generic provider-tagged passthrough layer for provider-native data that has no portable IR representation.

### Non-streaming

- `ProviderPassthroughItem` stores opaque request/history items
- `IRInputItem` expands request messages to `Message | ExtensionItem | ProviderPassthroughItem`
- `IRResponse.provider_passthrough_items` stores independent opaque output items with original positions
- all MessageOps restore same-dialect items and warning/drop foreign items
- all response converters merge matching items into their provider-native output arrays
- OpenAI Responses captures unknown non-stream output items and restores their original order
- orphan tool-call repair preserves passthrough item positions

### Streaming

- `ProviderPassthroughEvent` joins `IRStreamEvent`
- `BaseConverter` centralizes provider chunk wrapping and same-dialect restoration
- OpenAI Responses now preserves `response.in_progress`
- Anthropic now preserves `ping`
- cross-format lifecycle/heartbeat events are silently dropped
- OpenAI Responses rebuilds a contiguous local `sequence_number` without mutating the IR payload

### Architecture boundary

`ConversionContext` remains an ephemeral side channel for one conversion pipeline (warnings, options, echo fields, original IDs/status/annotations). Passthrough items/events are serializable IR data that can survive caching, persistence, and later requests.

## Explicitly out of scope

- OpenAI Tool Search (`tool_search_call` / `tool_search_output`)
- shim passthrough capability policy
- semantic hosted-tool/MCP lifecycle passthrough
- Google grounding/safety metadata

Those will be separate issues/PRs built on this infrastructure. Related research: #394.

## Commits

1. `feat(ir): add non-stream provider passthrough items`
2. `feat(ir): add streaming provider passthrough events`

## Test plan

- [x] focused passthrough tests: 27 passed
- [x] full non-integration suite: 2191 passed, 4 skipped
- [x] `ruff check src/ tests/`
- [x] `ty check`
- [x] same-format stream forwarding (Responses and Anthropic)
- [x] cross-format stream drop
- [x] all four MessageOps same/foreign dialect behavior
- [x] all four response converter restore paths
- [x] OpenAI Responses unknown non-stream item capture + ordered round-trip
- [x] ConversionContext metadata coexists with durable passthrough items

## Documentation

Bilingual architecture and changelog updates were committed and pushed in the documentation worktrees:

- EN: `4f9d8da`
- ZH: `aba162a`

AI was used to assist with implementation, review, and test coverage. The resulting code was reviewed and validated locally.