### PR TITLE
refactor(converters): unify internal function naming conventions

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -216,7 +216,7 @@ class AnthropicConverter(BaseConverter):
         # 3. Tools (with process-level cache)
         tools = provider_request.get("tools")
         if tools:
-            ir_request["tools"] = self._get_cached_tools_from_p(tools)
+            ir_request["tools"] = self._get_cached_p_tools_to_ir(tools)
 
         # 4. Tool choice
         tool_choice = provider_request.get("tool_choice")
@@ -299,7 +299,7 @@ class AnthropicConverter(BaseConverter):
 
         # Usage (always present — downstream clients may crash without it)
         p_usage = provider_response.get("usage") or {}
-        ir_response["usage"] = self._build_ir_usage(p_usage)
+        ir_response["usage"] = self._build_p_usage_to_ir(p_usage)
 
         # Preserve mode: capture extra fields for lossless round-trip
         ctx = context if context is not None else ConversionContext()
@@ -366,7 +366,7 @@ class AnthropicConverter(BaseConverter):
 
         # Usage (always present — Anthropic responses require usage field)
         ir_usage = ir_response.get("usage") or {}
-        provider_response["usage"] = self._build_provider_usage(ir_usage)
+        provider_response["usage"] = self._build_ir_usage_to_p(ir_usage)
 
         # Preserve mode: inject captured extra fields
         ctx = context if context is not None else ConversionContext()
@@ -416,7 +416,7 @@ class AnthropicConverter(BaseConverter):
         """Apply tools, tool_choice, and tool_config to provider request."""
         tools = ir_request.get("tools")
         if tools:
-            result["tools"] = self._get_cached_tools_to_p(tools)
+            result["tools"] = self._get_cached_ir_tools_to_p(tools)
 
         tool_choice = ir_request.get("tool_choice")
         if tool_choice:
@@ -435,7 +435,7 @@ class AnthropicConverter(BaseConverter):
                 )
 
     @staticmethod
-    def _build_ir_usage(p_usage: dict[str, Any]) -> UsageInfo:
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> UsageInfo:
         """Build IR usage dict from Anthropic usage."""
         input_tokens = p_usage.get("input_tokens") or 0
         output_tokens = p_usage.get("output_tokens") or 0
@@ -451,7 +451,7 @@ class AnthropicConverter(BaseConverter):
         return cast(UsageInfo, usage_info)
 
     @staticmethod
-    def _build_provider_usage(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
+    def _build_ir_usage_to_p(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
         """Build Anthropic usage dict from IR usage."""
         usage: dict[str, Any] = {
             "input_tokens": ir_usage.get("prompt_tokens") or 0,
@@ -602,13 +602,13 @@ class AnthropicConverter(BaseConverter):
         events: list[IRStreamEvent] = []
 
         event_type = chunk.get("type", "")
-        handler_name = self._FROM_P_DISPATCH.get(event_type)
+        handler_name = self._P_TO_IR_DISPATCH.get(event_type)
         if handler_name is not None:
             getattr(self, handler_name)(chunk, context, events)
 
         return events
 
-    def _handle_message_start_from_p(
+    def _handle_p_message_start_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -640,11 +640,11 @@ class AnthropicConverter(BaseConverter):
             events.append(
                 UsageEvent(
                     type="usage",
-                    usage=self._build_ir_usage(start_usage),
+                    usage=self._build_p_usage_to_ir(start_usage),
                 )
             )
 
-    def _handle_content_block_start_from_p(
+    def _handle_p_content_block_start_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -681,7 +681,7 @@ class AnthropicConverter(BaseConverter):
                 start_evt["tool_call_index"] = len(context._tool_call_order) - 1
             events.append(start_evt)
 
-    def _handle_content_block_delta_from_p(
+    def _handle_p_content_block_delta_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -744,7 +744,7 @@ class AnthropicConverter(BaseConverter):
                 evt_s["block_index"] = chunk_block_index
             events.append(evt_s)
 
-    def _handle_content_block_stop_from_p(
+    def _handle_p_content_block_stop_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -760,7 +760,7 @@ class AnthropicConverter(BaseConverter):
                 )
             )
 
-    def _handle_message_delta_from_p(
+    def _handle_p_message_delta_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -776,7 +776,7 @@ class AnthropicConverter(BaseConverter):
             events.append(
                 UsageEvent(
                     type="usage",
-                    usage=self._build_ir_usage(usage),
+                    usage=self._build_p_usage_to_ir(usage),
                 )
             )
 
@@ -792,7 +792,7 @@ class AnthropicConverter(BaseConverter):
                 )
             )
 
-    def _handle_message_stop_from_p(
+    def _handle_p_message_stop_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -803,19 +803,19 @@ class AnthropicConverter(BaseConverter):
             context.mark_ended()
             events.append(StreamEndEvent(type="stream_end"))
 
-    _FROM_P_DISPATCH: dict[str, str] = {
-        AnthropicEventType.PING: "_handle_provider_passthrough_from_p",
-        AnthropicEventType.MESSAGE_START: "_handle_message_start_from_p",
-        AnthropicEventType.CONTENT_BLOCK_START: "_handle_content_block_start_from_p",
-        AnthropicEventType.CONTENT_BLOCK_DELTA: "_handle_content_block_delta_from_p",
-        AnthropicEventType.CONTENT_BLOCK_STOP: "_handle_content_block_stop_from_p",
-        AnthropicEventType.MESSAGE_DELTA: "_handle_message_delta_from_p",
-        AnthropicEventType.MESSAGE_STOP: "_handle_message_stop_from_p",
+    _P_TO_IR_DISPATCH: dict[str, str] = {
+        AnthropicEventType.PING: "_handle_p_passthrough_to_ir",
+        AnthropicEventType.MESSAGE_START: "_handle_p_message_start_to_ir",
+        AnthropicEventType.CONTENT_BLOCK_START: "_handle_p_content_block_start_to_ir",
+        AnthropicEventType.CONTENT_BLOCK_DELTA: "_handle_p_content_block_delta_to_ir",
+        AnthropicEventType.CONTENT_BLOCK_STOP: "_handle_p_content_block_stop_to_ir",
+        AnthropicEventType.MESSAGE_DELTA: "_handle_p_message_delta_to_ir",
+        AnthropicEventType.MESSAGE_STOP: "_handle_p_message_stop_to_ir",
     }
 
     # --- to_provider ---
 
-    def _handle_stream_start_to_p(
+    def _handle_ir_stream_start_to_p(
         self, event: StreamStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle StreamStartEvent → message_start."""
@@ -850,7 +850,7 @@ class AnthropicConverter(BaseConverter):
             },
         }
 
-    def _handle_stream_end_to_p(
+    def _handle_ir_stream_end_to_p(
         self, event: StreamEndEvent, context: StreamContext | None
     ) -> dict[str, Any] | list[dict[str, Any]]:
         """Handle StreamEndEvent → message_stop (with optional pending finish flush)."""
@@ -874,7 +874,7 @@ class AnthropicConverter(BaseConverter):
         results.append({"type": AnthropicEventType.MESSAGE_STOP})
         return results if len(results) > 1 else results[0]
 
-    def _handle_content_block_start_to_p(
+    def _handle_ir_content_block_start_to_p(
         self, event: ContentBlockStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ContentBlockStartEvent → content_block_start."""
@@ -903,7 +903,7 @@ class AnthropicConverter(BaseConverter):
         else:
             return {}
 
-    def _handle_content_block_end_to_p(
+    def _handle_ir_content_block_end_to_p(
         self, event: ContentBlockEndEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ContentBlockEndEvent → content_block_stop."""
@@ -915,7 +915,7 @@ class AnthropicConverter(BaseConverter):
             "index": event["block_index"],
         }
 
-    def _handle_text_delta_to_p(
+    def _handle_ir_text_delta_to_p(
         self, event: TextDeltaEvent, context: StreamContext | None
     ) -> dict[str, Any] | list[dict[str, Any]]:
         """Handle TextDeltaEvent → content_block_delta (with synthetic start if needed)."""
@@ -964,7 +964,7 @@ class AnthropicConverter(BaseConverter):
             result["index"] = context.current_block_index
         return result
 
-    def _handle_reasoning_delta_to_p(
+    def _handle_ir_reasoning_delta_to_p(
         self, event: ReasoningDeltaEvent, context: StreamContext | None
     ) -> dict[str, Any] | list[dict[str, Any]]:
         """Handle ReasoningDeltaEvent → content_block_delta (thinking or signature)."""
@@ -1023,7 +1023,7 @@ class AnthropicConverter(BaseConverter):
             rd_result["index"] = context.current_block_index
         return rd_result
 
-    def _handle_tool_call_start_to_p(
+    def _handle_ir_tool_call_start_to_p(
         self, event: ToolCallStartEvent, context: StreamContext | None
     ) -> dict[str, Any] | list[dict[str, Any]]:
         """Handle ToolCallStartEvent → content_block_start for tool_use."""
@@ -1060,7 +1060,7 @@ class AnthropicConverter(BaseConverter):
                 return preamble
         return result
 
-    def _handle_tool_call_delta_to_p(
+    def _handle_ir_tool_call_delta_to_p(
         self, event: ToolCallDeltaEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ToolCallDeltaEvent → content_block_delta with input_json_delta."""
@@ -1085,7 +1085,7 @@ class AnthropicConverter(BaseConverter):
             result["index"] = context.current_block_index
         return result
 
-    def _handle_finish_to_p(
+    def _handle_ir_finish_to_p(
         self, event: FinishEvent, context: StreamContext | None
     ) -> dict[str, Any] | list[dict[str, Any]]:
         """Handle FinishEvent → buffered message_delta + optional content_block_stop."""
@@ -1122,7 +1122,7 @@ class AnthropicConverter(BaseConverter):
             "usage": {"output_tokens": 0},
         }
 
-    def _handle_usage_to_p(
+    def _handle_ir_usage_to_p(
         self, event: UsageEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle UsageEvent → message_delta (merged with pending finish).

--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -61,18 +61,18 @@ class BaseConverter(ABC):
     # Default dispatch table for stream_response_to_provider.
     # Maps IR stream event types to handler method names.
     # Subclasses may override to extend or customise the mapping.
-    _TO_P_DISPATCH: dict[str, str] = {
-        "stream_start": "_handle_stream_start_to_p",
-        "stream_end": "_handle_stream_end_to_p",
-        "content_block_start": "_handle_content_block_start_to_p",
-        "content_block_end": "_handle_content_block_end_to_p",
-        "text_delta": "_handle_text_delta_to_p",
-        "reasoning_delta": "_handle_reasoning_delta_to_p",
-        "tool_call_start": "_handle_tool_call_start_to_p",
-        "tool_call_delta": "_handle_tool_call_delta_to_p",
-        "finish": "_handle_finish_to_p",
-        "usage": "_handle_usage_to_p",
-        "provider_passthrough": "_handle_provider_passthrough_to_p",
+    _IR_TO_P_DISPATCH: dict[str, str] = {
+        "stream_start": "_handle_ir_stream_start_to_p",
+        "stream_end": "_handle_ir_stream_end_to_p",
+        "content_block_start": "_handle_ir_content_block_start_to_p",
+        "content_block_end": "_handle_ir_content_block_end_to_p",
+        "text_delta": "_handle_ir_text_delta_to_p",
+        "reasoning_delta": "_handle_ir_reasoning_delta_to_p",
+        "tool_call_start": "_handle_ir_tool_call_start_to_p",
+        "tool_call_delta": "_handle_ir_tool_call_delta_to_p",
+        "finish": "_handle_ir_finish_to_p",
+        "usage": "_handle_ir_usage_to_p",
+        "provider_passthrough": "_handle_ir_passthrough_to_p",
     }
 
     # ==================== 顶层转换接口 Top-level conversion interface ====================
@@ -123,7 +123,7 @@ class BaseConverter(ABC):
         """将provider请求转换为IRRequest
         Convert provider request to IRRequest
 
-        Subclass helper: call ``self._convert_tools_from_p(tools)`` to convert
+        Subclass helper: call ``self._convert_p_tools_to_ir(tools)`` to convert
         provider tool definitions to IR format.
 
         Args:
@@ -147,7 +147,7 @@ class BaseConverter(ABC):
         """将provider响应转换为IRResponse
         Convert provider response to IRResponse
 
-        Subclass helper: call ``self._build_ir_usage(p_usage)`` to convert
+        Subclass helper: call ``self._build_p_usage_to_ir(p_usage)`` to convert
         provider usage to IR format.
 
         Args:
@@ -171,7 +171,7 @@ class BaseConverter(ABC):
         """将IRResponse转换为provider响应
         Convert IRResponse to provider response
 
-        Subclass helper: call ``self._build_provider_usage(ir_usage)`` to convert
+        Subclass helper: call ``self._build_ir_usage_to_p(ir_usage)`` to convert
         IR usage to provider format.
 
         Args:
@@ -263,8 +263,8 @@ class BaseConverter(ABC):
     ) -> dict[str, Any] | list[dict[str, Any]]:
         """Convert an IR stream event to provider-native stream chunk(s).
 
-        Uses ``_TO_P_DISPATCH`` to route each event type to its handler,
-        then applies ``_post_process_to_provider`` for any provider-specific
+        Uses ``_IR_TO_P_DISPATCH`` to route each event type to its handler,
+        then applies ``_post_process_ir_to_p`` for any provider-specific
         decoration of the result.
 
         Subclasses that need pre-dispatch logic (e.g., context upgrades)
@@ -279,13 +279,13 @@ class BaseConverter(ABC):
             A single provider-native stream chunk dict, or a list of chunk
             dicts when the event maps to multiple provider-level messages.
         """
-        handler_name = self._TO_P_DISPATCH.get(event.get("type", ""))
+        handler_name = self._IR_TO_P_DISPATCH.get(event.get("type", ""))
         if handler_name is None:
             return {}
         result = getattr(self, handler_name)(event, context)
-        return self._post_process_to_provider(result, event, context)
+        return self._post_process_ir_to_p(result, event, context)
 
-    def _handle_provider_passthrough_from_p(
+    def _handle_p_passthrough_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -300,7 +300,7 @@ class BaseConverter(ABC):
             )
         )
 
-    def _handle_provider_passthrough_to_p(
+    def _handle_ir_passthrough_to_p(
         self,
         event: ProviderPassthroughEvent,
         context: StreamContext | None,
@@ -314,7 +314,7 @@ class BaseConverter(ABC):
             return {}
         return dict(event["payload"])
 
-    def _post_process_to_provider(
+    def _post_process_ir_to_p(
         self,
         result: dict[str, Any] | list[dict[str, Any]],
         event: IRStreamEvent,
@@ -364,7 +364,7 @@ class BaseConverter(ABC):
 
     @staticmethod
     @abstractmethod
-    def _build_ir_usage(p_usage: dict[str, Any]) -> UsageInfo:
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> UsageInfo:
         """Convert provider usage dict to IR usage format.
 
         Called by ``response_from_provider`` to normalize provider-specific
@@ -375,7 +375,7 @@ class BaseConverter(ABC):
 
     @staticmethod
     @abstractmethod
-    def _build_provider_usage(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
+    def _build_ir_usage_to_p(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
         """Convert IR usage dict to provider-specific usage format.
 
         Called by ``response_to_provider`` to map IR token usage fields
@@ -384,7 +384,7 @@ class BaseConverter(ABC):
         """
         ...
 
-    def _convert_tools_from_p(self, tools: list[Any]) -> list[Any]:
+    def _convert_p_tools_to_ir(self, tools: list[Any]) -> list[Any]:
         """Convert provider tool definitions to IR ToolDefinition list.
 
         Default implementation iterates *tools* and calls
@@ -393,7 +393,7 @@ class BaseConverter(ABC):
 
         .. note::
             This is the **uncached** fallback.  In normal operation,
-            ``_get_cached_tools_from_p`` calls ``tool_ops`` directly
+            ``_get_cached_p_tools_to_ir`` calls ``tool_ops`` directly
             with per-entry caching.  This method is retained for
             direct use in tests or subclass customisation.
         """
@@ -628,7 +628,7 @@ class BaseConverter(ABC):
 
     # ==================== Per-entry conversion caching ====================
 
-    def _get_cached_tools_from_p(self, tools: list[Any]) -> list[Any]:
+    def _get_cached_p_tools_to_ir(self, tools: list[Any]) -> list[Any]:
         """Per-entry provider→IR tool conversion with caching.
 
         Looks up each tool individually in the conversion cache (spoke).
@@ -689,7 +689,7 @@ class BaseConverter(ABC):
 
         return ir_tools
 
-    def _get_cached_tools_to_p(self, ir_tools: list[Any]) -> list[Any]:
+    def _get_cached_ir_tools_to_p(self, ir_tools: list[Any]) -> list[Any]:
         """Per-entry IR→provider tool conversion with caching.
 
         Looks up each IR tool individually.  On miss, converts and

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -349,7 +349,7 @@ class GoogleGenAIConverter(BaseConverter):
         # Tools — check SDK config first, then REST top-level (with cache)
         tools = config.get("tools") or provider_request.get("tools")
         if tools:
-            ir_request["tools"] = self._get_cached_tools_from_p(tools)
+            ir_request["tools"] = self._get_cached_p_tools_to_ir(tools)
 
         # Tool choice — check SDK/REST snake_case/camelCase
         tool_config = (
@@ -445,7 +445,7 @@ class GoogleGenAIConverter(BaseConverter):
             "usageMetadata"
         )
         if p_usage:
-            ir_response["usage"] = self._build_ir_usage(p_usage)
+            ir_response["usage"] = self._build_p_usage_to_ir(p_usage)
 
         return self._validate_ir_response(ir_response)
 
@@ -500,7 +500,7 @@ class GoogleGenAIConverter(BaseConverter):
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            provider_response["usageMetadata"] = self._build_provider_usage(ir_usage)
+            provider_response["usageMetadata"] = self._build_ir_usage_to_p(ir_usage)
         ctx = context if context is not None else ConversionContext()
         self._restore_response_passthrough_items(
             provider_response,
@@ -525,7 +525,7 @@ class GoogleGenAIConverter(BaseConverter):
         config = result.setdefault("config", {})
         tools = ir_request.get("tools")
         if tools:
-            config["tools"] = self._get_cached_tools_to_p(tools)
+            config["tools"] = self._get_cached_ir_tools_to_p(tools)
 
         tool_choice = ir_request.get("tool_choice")
         if tool_choice:
@@ -534,7 +534,7 @@ class GoogleGenAIConverter(BaseConverter):
                 config["tool_config"] = tc_p
 
     @staticmethod
-    def _build_ir_usage(p_usage: dict[str, Any]) -> UsageInfo:
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> UsageInfo:
         """Build IR usage dict from Google usage metadata."""
         usage_info: dict[str, Any] = {
             "prompt_tokens": p_usage.get(
@@ -584,7 +584,7 @@ class GoogleGenAIConverter(BaseConverter):
         return cast(UsageInfo, usage_info)
 
     @staticmethod
-    def _build_provider_usage(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
+    def _build_ir_usage_to_p(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
         """Build Google usage metadata dict from IR usage."""
         usage_metadata: dict[str, Any] = {
             "promptTokenCount": ir_usage.get("prompt_tokens") or 0,
@@ -796,7 +796,7 @@ class GoogleGenAIConverter(BaseConverter):
         events: list[IRStreamEvent] = []
 
         if context is not None and not context.is_started:
-            self._handle_stream_start_from_p(chunk, context, events)
+            self._handle_p_stream_start_to_ir(chunk, context, events)
 
         has_finish_reason = False
         deferred_finish: FinishEvent | None = None
@@ -815,10 +815,10 @@ class GoogleGenAIConverter(BaseConverter):
             pre_parts_len = len(events)
 
             for part in content.get("parts", []):
-                self._handle_part_from_p(part, choice_index, context, events)
+                self._handle_p_part_to_ir(part, choice_index, context, events)
 
             # When a compound chunk has both text and finishReason,
-            # defer the text into context so _handle_finish_to_p can
+            # defer the text into context so _handle_ir_finish_to_p can
             # merge it into the finish candidate's parts, avoiding
             # an extra output event.
             if finish_reason and context is not None:
@@ -844,7 +844,7 @@ class GoogleGenAIConverter(BaseConverter):
                     choice_index=choice_index,
                 )
 
-        self._handle_usage_from_p(chunk, events)
+        self._handle_p_usage_to_ir(chunk, events)
 
         if deferred_finish is not None:
             events.append(deferred_finish)
@@ -855,7 +855,7 @@ class GoogleGenAIConverter(BaseConverter):
 
         return events
 
-    def _handle_stream_start_from_p(
+    def _handle_p_stream_start_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext,
@@ -875,7 +875,7 @@ class GoogleGenAIConverter(BaseConverter):
             )
         )
 
-    def _handle_part_from_p(
+    def _handle_p_part_to_ir(
         self,
         part: dict[str, Any],
         choice_index: int,
@@ -905,11 +905,11 @@ class GoogleGenAIConverter(BaseConverter):
 
         func_call = part.get("function_call") or part.get("functionCall")
         if func_call:
-            self._handle_function_call_from_p(
+            self._handle_p_function_call_to_ir(
                 func_call, part, choice_index, context, events
             )
 
-    def _handle_function_call_from_p(
+    def _handle_p_function_call_to_ir(
         self,
         func_call: dict[str, Any],
         part: dict[str, Any],
@@ -955,7 +955,7 @@ class GoogleGenAIConverter(BaseConverter):
         if context is not None:
             context.append_tool_call_args(tool_call_id, args_json)
 
-    def _handle_usage_from_p(
+    def _handle_p_usage_to_ir(
         self,
         chunk: dict[str, Any],
         events: list[IRStreamEvent],
@@ -997,7 +997,7 @@ class GoogleGenAIConverter(BaseConverter):
 
     # --- to_provider ---
 
-    def _handle_stream_start_to_p(
+    def _handle_ir_stream_start_to_p(
         self, event: StreamStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle StreamStartEvent → store metadata, no output."""
@@ -1007,7 +1007,7 @@ class GoogleGenAIConverter(BaseConverter):
             context.mark_started()
         return {}
 
-    def _handle_stream_end_to_p(
+    def _handle_ir_stream_end_to_p(
         self, event: StreamEndEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle StreamEndEvent → mark ended, no output."""
@@ -1015,19 +1015,19 @@ class GoogleGenAIConverter(BaseConverter):
             context.mark_ended()
         return {}
 
-    def _handle_content_block_start_to_p(
+    def _handle_ir_content_block_start_to_p(
         self, event: ContentBlockStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ContentBlockStartEvent → no-op for Google GenAI."""
         return {}
 
-    def _handle_content_block_end_to_p(
+    def _handle_ir_content_block_end_to_p(
         self, event: ContentBlockEndEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ContentBlockEndEvent → no-op for Google GenAI."""
         return {}
 
-    def _handle_text_delta_to_p(
+    def _handle_ir_text_delta_to_p(
         self, event: TextDeltaEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle TextDeltaEvent → text part chunk.
@@ -1050,7 +1050,7 @@ class GoogleGenAIConverter(BaseConverter):
             ]
         }
 
-    def _handle_reasoning_delta_to_p(
+    def _handle_ir_reasoning_delta_to_p(
         self, event: ReasoningDeltaEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ReasoningDeltaEvent → thought text part chunk."""
@@ -1067,7 +1067,7 @@ class GoogleGenAIConverter(BaseConverter):
             ]
         }
 
-    def _handle_tool_call_start_to_p(
+    def _handle_ir_tool_call_start_to_p(
         self, event: ToolCallStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ToolCallStartEvent → register in context, no output."""
@@ -1075,7 +1075,7 @@ class GoogleGenAIConverter(BaseConverter):
             context.register_tool_call(event["tool_call_id"], event["tool_name"])
         return {}
 
-    def _handle_tool_call_delta_to_p(
+    def _handle_ir_tool_call_delta_to_p(
         self, event: ToolCallDeltaEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ToolCallDeltaEvent → accumulate args, no output."""
@@ -1085,7 +1085,7 @@ class GoogleGenAIConverter(BaseConverter):
             )
         return {}
 
-    def _handle_finish_to_p(
+    def _handle_ir_finish_to_p(
         self, event: FinishEvent, context: StreamContext | None
     ) -> list[dict[str, Any]]:
         """Handle FinishEvent → flush tool calls + finish chunk."""
@@ -1143,7 +1143,7 @@ class GoogleGenAIConverter(BaseConverter):
 
         return chunks
 
-    def _handle_usage_to_p(
+    def _handle_ir_usage_to_p(
         self, event: UsageEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle UsageEvent → buffer for FinishEvent merge.

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -166,7 +166,7 @@ class OpenAIChatConverter(BaseConverter):
         return result, ctx.warnings
 
     @staticmethod
-    def _build_ir_usage(p_usage: dict[str, Any]) -> UsageInfo:
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> UsageInfo:
         """Build IR usage dict from OpenAI Chat usage."""
         usage_info: dict[str, Any] = {
             "prompt_tokens": p_usage.get("prompt_tokens") or 0,
@@ -201,7 +201,7 @@ class OpenAIChatConverter(BaseConverter):
         """Apply tools, tool_choice, and tool_config to provider request."""
         tools = ir_request.get("tools")
         if tools:
-            result["tools"] = self._get_cached_tools_to_p(tools)
+            result["tools"] = self._get_cached_ir_tools_to_p(tools)
         tool_choice = ir_request.get("tool_choice")
         if tool_choice:
             result["tool_choice"] = self.tool_ops.ir_tool_choice_to_p(tool_choice)
@@ -214,7 +214,7 @@ class OpenAIChatConverter(BaseConverter):
                     "OpenAI Chat does not support max_tool_calls, ignored"
                 )
 
-    def _build_choice_to_provider(  # noqa: C901
+    def _build_ir_choice_to_p(  # noqa: C901
         self, choice: dict[str, Any]
     ) -> dict[str, Any] | None:
         """Build a single OpenAI Chat choice dict from an IR choice."""
@@ -346,7 +346,7 @@ class OpenAIChatConverter(BaseConverter):
         # 2. Tools (with process-level cache)
         tools = provider_request.get("tools")
         if tools:
-            ir_request["tools"] = self._get_cached_tools_from_p(tools)
+            ir_request["tools"] = self._get_cached_p_tools_to_ir(tools)
 
         # 3. Tool choice
         tool_choice = provider_request.get("tool_choice")
@@ -449,7 +449,7 @@ class OpenAIChatConverter(BaseConverter):
         # Usage
         p_usage = provider_response.get("usage")
         if p_usage:
-            ir_response["usage"] = self._build_ir_usage(p_usage)
+            ir_response["usage"] = self._build_p_usage_to_ir(p_usage)
 
         if provider_response.get("service_tier") is not None:
             ir_response["service_tier"] = provider_response["service_tier"]
@@ -483,14 +483,14 @@ class OpenAIChatConverter(BaseConverter):
         }
 
         for choice in ir_response.get("choices", []):
-            openai_choice = self._build_choice_to_provider(choice)  # ty: ignore[invalid-argument-type]
+            openai_choice = self._build_ir_choice_to_p(choice)  # ty: ignore[invalid-argument-type]
             if openai_choice is not None:
                 provider_response["choices"].append(openai_choice)
 
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            provider_response["usage"] = self._build_provider_usage(ir_usage)
+            provider_response["usage"] = self._build_ir_usage_to_p(ir_usage)
 
         if "service_tier" in ir_response:
             provider_response["service_tier"] = ir_response["service_tier"]
@@ -508,7 +508,7 @@ class OpenAIChatConverter(BaseConverter):
         return provider_response
 
     @staticmethod
-    def _build_provider_usage(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
+    def _build_ir_usage_to_p(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
         """Build OpenAI Chat usage dict from IR usage."""
         usage: dict[str, Any] = {
             "prompt_tokens": ir_usage.get("prompt_tokens") or 0,
@@ -600,21 +600,21 @@ class OpenAIChatConverter(BaseConverter):
         events: list[IRStreamEvent] = []
 
         if context is not None and not context.is_started:
-            self._handle_stream_start_from_p(chunk, context, events)
+            self._handle_p_stream_start_to_ir(chunk, context, events)
 
         choices = chunk.get("choices", [])
         for p_choice in choices:
-            self._handle_choice_from_p(p_choice, context, events)
+            self._handle_p_choice_to_ir(p_choice, context, events)
 
         usage = chunk.get("usage")
         if usage:
-            self._handle_usage_from_p(usage, events)
+            self._handle_p_usage_to_ir(usage, events)
 
-        self._handle_stream_end_from_p(choices, events, usage, context)
+        self._handle_p_stream_end_to_ir(choices, events, usage, context)
 
         return events
 
-    def _handle_stream_start_from_p(
+    def _handle_p_stream_start_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext,
@@ -639,7 +639,7 @@ class OpenAIChatConverter(BaseConverter):
                 start_event["created"] = created
             events.append(start_event)
 
-    def _handle_choice_from_p(
+    def _handle_p_choice_to_ir(
         self,
         p_choice: dict[str, Any],
         context: StreamContext | None,
@@ -674,16 +674,16 @@ class OpenAIChatConverter(BaseConverter):
         # Tool call deltas
         tool_calls = delta.get("tool_calls")
         if tool_calls:
-            self._handle_tool_calls_from_p(tool_calls, choice_index, context, events)
+            self._handle_p_tool_calls_to_ir(tool_calls, choice_index, context, events)
 
         # Finish reason
         finish_reason = p_choice.get("finish_reason")
         if finish_reason:
-            self._handle_finish_reason_from_p(
+            self._handle_p_finish_reason_to_ir(
                 finish_reason, choice_index, context, events
             )
 
-    def _handle_tool_calls_from_p(
+    def _handle_p_tool_calls_to_ir(
         self,
         tool_calls: list[dict[str, Any]],
         choice_index: int,
@@ -733,7 +733,7 @@ class OpenAIChatConverter(BaseConverter):
                 if context is not None and effective_tc_id:
                     context.append_tool_call_args(effective_tc_id, arguments)
 
-    def _handle_finish_reason_from_p(
+    def _handle_p_finish_reason_to_ir(
         self,
         finish_reason: str,
         choice_index: int,
@@ -764,7 +764,7 @@ class OpenAIChatConverter(BaseConverter):
             )
         )
 
-    def _handle_usage_from_p(
+    def _handle_p_usage_to_ir(
         self,
         usage: dict[str, Any],
         events: list[IRStreamEvent],
@@ -773,11 +773,11 @@ class OpenAIChatConverter(BaseConverter):
         events.append(
             UsageEvent(
                 type="usage",
-                usage=self._build_ir_usage(usage),
+                usage=self._build_p_usage_to_ir(usage),
             )
         )
 
-    def _handle_stream_end_from_p(
+    def _handle_p_stream_end_to_ir(
         self,
         choices: list[dict[str, Any]],
         events: list[IRStreamEvent],
@@ -814,7 +814,7 @@ class OpenAIChatConverter(BaseConverter):
 
     # --- to_provider ---
 
-    def _post_process_to_provider(
+    def _post_process_ir_to_p(
         self,
         result: dict[str, Any] | list[dict[str, Any]],
         event: IRStreamEvent,
@@ -833,7 +833,7 @@ class OpenAIChatConverter(BaseConverter):
             result.setdefault("created", context.created)
         return result
 
-    def _handle_stream_start_to_p(
+    def _handle_ir_stream_start_to_p(
         self, event: StreamStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle StreamStartEvent → initial chunk with role delta.
@@ -867,7 +867,7 @@ class OpenAIChatConverter(BaseConverter):
             return {}
         return chunk
 
-    def _handle_stream_end_to_p(
+    def _handle_ir_stream_end_to_p(
         self, event: StreamEndEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle StreamEndEvent → usage chunk (if buffered) or empty.
@@ -886,7 +886,7 @@ class OpenAIChatConverter(BaseConverter):
                     "model": context.model,
                     "created": context.created,
                     "choices": [],
-                    "usage": self._build_provider_usage(usage),
+                    "usage": self._build_ir_usage_to_p(usage),
                 }
             return {}
         return {
@@ -897,13 +897,13 @@ class OpenAIChatConverter(BaseConverter):
             "choices": [],
         }
 
-    def _handle_content_block_start_to_p(
+    def _handle_ir_content_block_start_to_p(
         self, event: ContentBlockStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ContentBlockStartEvent → no-op for OpenAI Chat."""
         return {}
 
-    def _handle_content_block_end_to_p(
+    def _handle_ir_content_block_end_to_p(
         self, event: ContentBlockEndEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ContentBlockEndEvent → no-op for OpenAI Chat."""
@@ -931,7 +931,7 @@ class OpenAIChatConverter(BaseConverter):
             chunk["choices"][0].setdefault("delta", {})["role"] = "assistant"
         return chunk
 
-    def _handle_text_delta_to_p(
+    def _handle_ir_text_delta_to_p(
         self, event: TextDeltaEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle TextDeltaEvent → content delta chunk."""
@@ -946,7 +946,7 @@ class OpenAIChatConverter(BaseConverter):
         }
         return self._merge_pending_role(chunk, context)
 
-    def _handle_reasoning_delta_to_p(
+    def _handle_ir_reasoning_delta_to_p(
         self, event: ReasoningDeltaEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ReasoningDeltaEvent → reasoning_content delta chunk."""
@@ -960,7 +960,7 @@ class OpenAIChatConverter(BaseConverter):
             ]
         }
 
-    def _handle_tool_call_start_to_p(
+    def _handle_ir_tool_call_start_to_p(
         self, event: ToolCallStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ToolCallStartEvent → tool_calls delta with id and name."""
@@ -985,7 +985,7 @@ class OpenAIChatConverter(BaseConverter):
         }
         return self._merge_pending_role(chunk, context)
 
-    def _handle_tool_call_delta_to_p(
+    def _handle_ir_tool_call_delta_to_p(
         self, event: ToolCallDeltaEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ToolCallDeltaEvent → tool_calls delta with arguments."""
@@ -1006,7 +1006,7 @@ class OpenAIChatConverter(BaseConverter):
             ]
         }
 
-    def _handle_finish_to_p(
+    def _handle_ir_finish_to_p(
         self, event: FinishEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle FinishEvent → finish_reason chunk."""
@@ -1022,7 +1022,7 @@ class OpenAIChatConverter(BaseConverter):
             ]
         }
 
-    def _handle_usage_to_p(
+    def _handle_ir_usage_to_p(
         self, event: UsageEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle UsageEvent → buffer for StreamEndEvent merge.
@@ -1037,5 +1037,5 @@ class OpenAIChatConverter(BaseConverter):
             return {}
         return {
             "choices": [],
-            "usage": self._build_provider_usage(usage),
+            "usage": self._build_ir_usage_to_p(usage),
         }

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -223,12 +223,12 @@ class OpenAIResponsesConverter(BaseConverter):
                 if not (isinstance(t, dict) and t.get("external_web_access") is False)
             ]
             if active_tools:
-                ir_tools = self._get_cached_tools_from_p(active_tools)
+                ir_tools = self._get_cached_p_tools_to_ir(active_tools)
                 if ir_tools:
                     ir_request["tools"] = ir_tools
 
         # 4-5. Tool choice + tool config
-        self._convert_tool_config_from_p(provider_request, ir_request)
+        self._convert_p_tool_config_to_ir(provider_request, ir_request)
 
         # 6. Generation config
         gen_config = self.config_ops.p_generation_config_to_ir(provider_request)
@@ -256,7 +256,7 @@ class OpenAIResponsesConverter(BaseConverter):
             )
 
         # 10. Cache config
-        self._convert_cache_from_p(provider_request, ir_request)
+        self._convert_p_cache_to_ir(provider_request, ir_request)
 
         # 11. Provider extensions (passthrough fields like allowed_tools)
         allowed_tools = provider_request.get("allowed_tools")
@@ -360,7 +360,7 @@ class OpenAIResponsesConverter(BaseConverter):
         # Handle usage
         p_usage = provider_response.get("usage")
         if p_usage:
-            ir_response["usage"] = self._build_ir_usage(p_usage)
+            ir_response["usage"] = self._build_p_usage_to_ir(p_usage)
 
         if provider_response.get("service_tier") is not None:
             ir_response["service_tier"] = provider_response["service_tier"]
@@ -448,7 +448,7 @@ class OpenAIResponsesConverter(BaseConverter):
         # Usage
         ir_usage = ir_response.get("usage")
         if ir_usage:
-            provider_response["usage"] = self._build_provider_usage(ir_usage)
+            provider_response["usage"] = self._build_ir_usage_to_p(ir_usage)
 
         if "service_tier" in ir_response:
             provider_response["service_tier"] = ir_response["service_tier"]
@@ -471,7 +471,7 @@ class OpenAIResponsesConverter(BaseConverter):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _build_ir_usage(p_usage: dict[str, Any]) -> UsageInfo:
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> UsageInfo:
         """Build IR usage dict from Responses API usage."""
         usage_info: dict[str, Any] = {
             "prompt_tokens": p_usage.get("input_tokens") or 0,
@@ -489,7 +489,7 @@ class OpenAIResponsesConverter(BaseConverter):
         return cast(UsageInfo, usage_info)
 
     @staticmethod
-    def _build_provider_usage(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
+    def _build_ir_usage_to_p(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
         """Build Responses API usage dict from IR usage."""
         return {
             "input_tokens": ir_usage.get("prompt_tokens") or 0,
@@ -512,7 +512,7 @@ class OpenAIResponsesConverter(BaseConverter):
         """Apply tools, tool_choice, and tool_config to provider request."""
         tools = ir_request.get("tools")
         if tools:
-            result["tools"] = self._get_cached_tools_to_p(tools)
+            result["tools"] = self._get_cached_ir_tools_to_p(tools)
         tool_choice = ir_request.get("tool_choice")
         if tool_choice:
             result["tool_choice"] = self.tool_ops.ir_tool_choice_to_p(tool_choice)
@@ -521,7 +521,7 @@ class OpenAIResponsesConverter(BaseConverter):
             tc_fields = self.tool_ops.ir_tool_config_to_p(tool_config)
             result.update(tc_fields)
 
-    def _convert_tool_config_from_p(
+    def _convert_p_tool_config_to_ir(
         self,
         provider_request: dict[str, Any],
         ir_request: dict[str, Any],
@@ -542,7 +542,7 @@ class OpenAIResponsesConverter(BaseConverter):
                 tool_config_fields
             )
 
-    def _convert_cache_from_p(
+    def _convert_p_cache_to_ir(
         self,
         provider_request: dict[str, Any],
         ir_request: dict[str, Any],
@@ -726,19 +726,19 @@ class OpenAIResponsesConverter(BaseConverter):
 
     # ==================== Compatibility Aliases ====================
 
-    def _convert_image_to_responses(self, image_part):
+    def _convert_ir_image_to_p(self, image_part):
         """Convert IR image to Responses API format (compatibility alias)."""
         return self.content_ops.ir_image_to_p(image_part)
 
-    def _convert_file_to_responses(self, file_part):
+    def _convert_ir_file_to_p(self, file_part):
         """Convert IR file to Responses API format (compatibility alias)."""
         return self.content_ops.ir_file_to_p(file_part)
 
-    def _convert_image_from_responses(self, image_part):
+    def _convert_p_image_to_ir(self, image_part):
         """Convert Responses API image to IR format (compatibility alias)."""
         return self.content_ops.p_image_to_ir(image_part)
 
-    def _convert_file_from_responses(self, file_part):
+    def _convert_p_file_to_ir(self, file_part):
         """Convert Responses API file to IR format (compatibility alias)."""
         return self.content_ops.p_file_to_ir(file_part)
 
@@ -776,7 +776,7 @@ class OpenAIResponsesConverter(BaseConverter):
         events: list[IRStreamEvent] = []
         event_type = chunk.get("type", "")
 
-        handler_name = self._FROM_P_DISPATCH.get(event_type)
+        handler_name = self._P_TO_IR_DISPATCH.get(event_type)
         if handler_name is not None:
             getattr(self, handler_name)(chunk, context, events)
 
@@ -787,7 +787,7 @@ class OpenAIResponsesConverter(BaseConverter):
 
     # --- from_provider handlers ---
 
-    def _handle_response_created_from_p(
+    def _handle_p_response_created_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -819,7 +819,7 @@ class OpenAIResponsesConverter(BaseConverter):
                 if extras:
                     context.store_response_extras(extras)
 
-    def _handle_output_text_delta_from_p(
+    def _handle_p_output_text_delta_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -832,7 +832,7 @@ class OpenAIResponsesConverter(BaseConverter):
             )
         )
 
-    def _handle_reasoning_delta_from_p(
+    def _handle_p_reasoning_delta_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -845,7 +845,7 @@ class OpenAIResponsesConverter(BaseConverter):
             )
         )
 
-    def _handle_output_item_added_from_p(
+    def _handle_p_output_item_added_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -885,7 +885,7 @@ class OpenAIResponsesConverter(BaseConverter):
                 # ``response.content_part.added`` events on round-trip.
                 pass
 
-    def _handle_content_part_added_from_p(
+    def _handle_p_content_part_added_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -908,7 +908,7 @@ class OpenAIResponsesConverter(BaseConverter):
                 )
             )
 
-    def _handle_content_part_done_from_p(
+    def _handle_p_content_part_done_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -922,7 +922,7 @@ class OpenAIResponsesConverter(BaseConverter):
                 )
             )
 
-    def _handle_output_item_done_from_p(
+    def _handle_p_output_item_done_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -946,7 +946,7 @@ class OpenAIResponsesConverter(BaseConverter):
                 if call_id:
                     context.set_tool_call_args(call_id, item.get("input", ""))
 
-    def _handle_function_call_args_delta_from_p(
+    def _handle_p_function_call_args_delta_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -969,7 +969,7 @@ class OpenAIResponsesConverter(BaseConverter):
 
         events.append(delta_event)
 
-    def _handle_function_call_args_done_from_p(
+    def _handle_p_function_call_args_done_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -981,7 +981,7 @@ class OpenAIResponsesConverter(BaseConverter):
         if context is not None and call_id:
             context.set_tool_call_args(call_id, arguments)
 
-    def _handle_custom_tool_call_input_delta_from_p(
+    def _handle_p_custom_tool_call_input_delta_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -1005,7 +1005,7 @@ class OpenAIResponsesConverter(BaseConverter):
 
         events.append(delta_event)
 
-    def _handle_custom_tool_call_input_done_from_p(
+    def _handle_p_custom_tool_call_input_done_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -1017,7 +1017,7 @@ class OpenAIResponsesConverter(BaseConverter):
         if context is not None and call_id:
             context.set_tool_call_args(call_id, input_text)
 
-    def _handle_response_completed_from_p(
+    def _handle_p_response_completed_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -1054,7 +1054,7 @@ class OpenAIResponsesConverter(BaseConverter):
             events.append(
                 UsageEvent(
                     type="usage",
-                    usage=self._build_ir_usage(usage),
+                    usage=self._build_p_usage_to_ir(usage),
                 )
             )
 
@@ -1070,7 +1070,7 @@ class OpenAIResponsesConverter(BaseConverter):
             context.mark_ended()
             events.append(StreamEndEvent(type="stream_end"))
 
-    def _handle_response_failed_from_p(
+    def _handle_p_response_failed_to_ir(
         self,
         chunk: dict[str, Any],
         context: StreamContext | None,
@@ -1088,21 +1088,21 @@ class OpenAIResponsesConverter(BaseConverter):
             context.mark_ended()
             events.append(StreamEndEvent(type="stream_end"))
 
-    _FROM_P_DISPATCH: dict[str, str] = {
-        ResponsesEventType.RESPONSE_IN_PROGRESS: "_handle_provider_passthrough_from_p",
-        ResponsesEventType.RESPONSE_CREATED: "_handle_response_created_from_p",
-        ResponsesEventType.OUTPUT_TEXT_DELTA: "_handle_output_text_delta_from_p",
-        ResponsesEventType.REASONING_SUMMARY_TEXT_DELTA: "_handle_reasoning_delta_from_p",
-        ResponsesEventType.OUTPUT_ITEM_ADDED: "_handle_output_item_added_from_p",
-        ResponsesEventType.CONTENT_PART_ADDED: "_handle_content_part_added_from_p",
-        ResponsesEventType.CONTENT_PART_DONE: "_handle_content_part_done_from_p",
-        ResponsesEventType.OUTPUT_ITEM_DONE: "_handle_output_item_done_from_p",
-        ResponsesEventType.FUNCTION_CALL_ARGS_DELTA: "_handle_function_call_args_delta_from_p",
-        ResponsesEventType.FUNCTION_CALL_ARGS_DONE: "_handle_function_call_args_done_from_p",
-        ResponsesEventType.CUSTOM_TOOL_CALL_INPUT_DELTA: "_handle_custom_tool_call_input_delta_from_p",
-        ResponsesEventType.CUSTOM_TOOL_CALL_INPUT_DONE: "_handle_custom_tool_call_input_done_from_p",
-        ResponsesEventType.RESPONSE_COMPLETED: "_handle_response_completed_from_p",
-        ResponsesEventType.RESPONSE_FAILED: "_handle_response_failed_from_p",
+    _P_TO_IR_DISPATCH: dict[str, str] = {
+        ResponsesEventType.RESPONSE_IN_PROGRESS: "_handle_p_passthrough_to_ir",
+        ResponsesEventType.RESPONSE_CREATED: "_handle_p_response_created_to_ir",
+        ResponsesEventType.OUTPUT_TEXT_DELTA: "_handle_p_output_text_delta_to_ir",
+        ResponsesEventType.REASONING_SUMMARY_TEXT_DELTA: "_handle_p_reasoning_delta_to_ir",
+        ResponsesEventType.OUTPUT_ITEM_ADDED: "_handle_p_output_item_added_to_ir",
+        ResponsesEventType.CONTENT_PART_ADDED: "_handle_p_content_part_added_to_ir",
+        ResponsesEventType.CONTENT_PART_DONE: "_handle_p_content_part_done_to_ir",
+        ResponsesEventType.OUTPUT_ITEM_DONE: "_handle_p_output_item_done_to_ir",
+        ResponsesEventType.FUNCTION_CALL_ARGS_DELTA: "_handle_p_function_call_args_delta_to_ir",
+        ResponsesEventType.FUNCTION_CALL_ARGS_DONE: "_handle_p_function_call_args_done_to_ir",
+        ResponsesEventType.CUSTOM_TOOL_CALL_INPUT_DELTA: "_handle_p_custom_tool_call_input_delta_to_ir",
+        ResponsesEventType.CUSTOM_TOOL_CALL_INPUT_DONE: "_handle_p_custom_tool_call_input_done_to_ir",
+        ResponsesEventType.RESPONSE_COMPLETED: "_handle_p_response_completed_to_ir",
+        ResponsesEventType.RESPONSE_FAILED: "_handle_p_response_failed_to_ir",
     }
 
     def stream_response_to_provider(
@@ -1129,7 +1129,7 @@ class OpenAIResponsesConverter(BaseConverter):
 
         return super().stream_response_to_provider(event, context)
 
-    def _post_process_to_provider(
+    def _post_process_ir_to_p(
         self,
         result: dict[str, Any] | list[dict[str, Any]],
         event: IRStreamEvent,
@@ -1149,7 +1149,7 @@ class OpenAIResponsesConverter(BaseConverter):
 
     # --- to_provider handlers ---
 
-    def _handle_stream_start_to_p(
+    def _handle_ir_stream_start_to_p(
         self,
         event: StreamStartEvent,
         context: StreamContext | None,
@@ -1197,7 +1197,7 @@ class OpenAIResponsesConverter(BaseConverter):
             "response": response,
         }
 
-    def _handle_stream_end_to_p(
+    def _handle_ir_stream_end_to_p(
         self,
         event: StreamEndEvent,
         context: StreamContext | None,
@@ -1221,7 +1221,7 @@ class OpenAIResponsesConverter(BaseConverter):
                 }
         return {}
 
-    def _handle_content_block_start_to_p(
+    def _handle_ir_content_block_start_to_p(
         self,
         event: ContentBlockStartEvent,
         context: OpenAIResponsesStreamContext | None,
@@ -1251,7 +1251,7 @@ class OpenAIResponsesConverter(BaseConverter):
         # Other block types are no-ops for now
         return {}
 
-    def _handle_content_block_end_to_p(
+    def _handle_ir_content_block_end_to_p(
         self,
         event: ContentBlockEndEvent,
         context: OpenAIResponsesStreamContext | None,
@@ -1291,7 +1291,7 @@ class OpenAIResponsesConverter(BaseConverter):
             },
         }
 
-    def _handle_text_delta_to_p(
+    def _handle_ir_text_delta_to_p(
         self,
         event: TextDeltaEvent,
         context: OpenAIResponsesStreamContext | None,
@@ -1320,7 +1320,7 @@ class OpenAIResponsesConverter(BaseConverter):
 
         return delta_event
 
-    def _handle_reasoning_delta_to_p(
+    def _handle_ir_reasoning_delta_to_p(
         self,
         event: ReasoningDeltaEvent,
         context: StreamContext | None,
@@ -1330,7 +1330,7 @@ class OpenAIResponsesConverter(BaseConverter):
             "delta": event["reasoning"],
         }
 
-    def _handle_tool_call_start_to_p(
+    def _handle_ir_tool_call_start_to_p(
         self,
         event: ToolCallStartEvent,
         context: StreamContext | None,
@@ -1374,7 +1374,7 @@ class OpenAIResponsesConverter(BaseConverter):
         }
         return result
 
-    def _handle_tool_call_delta_to_p(
+    def _handle_ir_tool_call_delta_to_p(
         self,
         event: ToolCallDeltaEvent,
         context: StreamContext | None,
@@ -1423,7 +1423,7 @@ class OpenAIResponsesConverter(BaseConverter):
         }
         return result
 
-    def _handle_finish_to_p(
+    def _handle_ir_finish_to_p(
         self,
         event: FinishEvent,
         context: OpenAIResponsesStreamContext | None,
@@ -1710,7 +1710,7 @@ class OpenAIResponsesConverter(BaseConverter):
                     }
                 )
 
-    def _handle_usage_to_p(
+    def _handle_ir_usage_to_p(
         self,
         event: UsageEvent,
         context: StreamContext | None,

--- a/tests/converters/base/test_conversion_context.py
+++ b/tests/converters/base/test_conversion_context.py
@@ -180,10 +180,10 @@ class TestStreamContextBufferMethods:
 
 
 class TestBaseConverterDispatch:
-    """Test BaseConverter._TO_P_DISPATCH and dispatch skeleton."""
+    """Test BaseConverter._IR_TO_P_DISPATCH and dispatch skeleton."""
 
     def test_dispatch_table_has_11_entries(self):
-        assert len(BaseConverter._TO_P_DISPATCH) == 11
+        assert len(BaseConverter._IR_TO_P_DISPATCH) == 11
 
     def test_dispatch_table_keys(self):
         expected = {
@@ -199,13 +199,13 @@ class TestBaseConverterDispatch:
             "usage",
             "provider_passthrough",
         }
-        assert set(BaseConverter._TO_P_DISPATCH.keys()) == expected
+        assert set(BaseConverter._IR_TO_P_DISPATCH.keys()) == expected
 
     def test_post_process_noop(self):
-        # Google inherits base _post_process_to_provider without override
+        # Google inherits base _post_process_ir_to_p without override
         converter = GoogleGenAIConverter()
         result: dict[str, Any] = {"test": True}
-        out = converter._post_process_to_provider(
+        out = converter._post_process_ir_to_p(
             result,
             {"type": "text_delta"},  # ty: ignore[invalid-argument-type]
             None,

--- a/tests/converters/test_tool_caching.py
+++ b/tests/converters/test_tool_caching.py
@@ -185,7 +185,7 @@ CONVERTER_CONFIGS = [
 
 @pytest.mark.parametrize("conv_cls,tools,make_req", CONVERTER_CONFIGS)
 class TestFromProviderCache:
-    """Tests for _convert_tools_from_p caching in request_from_provider."""
+    """Tests for _convert_p_tools_to_ir caching in request_from_provider."""
 
     def test_cache_hit_on_second_call(self, conv_cls, tools, make_req):
         """Second call with same tools should hit the per-entry cache."""
@@ -319,7 +319,7 @@ def test_cache_survives_new_instance():
 def test_invalid_tools_not_cached():
     """Invalid tools should raise on the first call and not be cached.
 
-    Uses a non-dict tool entry which triggers ValueError in _convert_tools_from_p.
+    Uses a non-dict tool entry which triggers ValueError in _convert_p_tools_to_ir.
     """
     clear_all_caches()
 

--- a/tests/test_converters_base.py
+++ b/tests/test_converters_base.py
@@ -474,14 +474,14 @@ class MockConverter(BaseConverter):
         return {}
 
     @staticmethod
-    def _build_ir_usage(p_usage: dict[str, Any]) -> UsageInfo:
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> UsageInfo:
         return cast(UsageInfo, p_usage)
 
     @staticmethod
-    def _build_provider_usage(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
+    def _build_ir_usage_to_p(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
         return dict(ir_usage)
 
-    def _convert_tools_from_p(self, tools: list[Any]) -> list[Any]:
+    def _convert_p_tools_to_ir(self, tools: list[Any]) -> list[Any]:
         return tools
 
     def _apply_tool_config(


### PR DESCRIPTION
## Summary

- Standardize all internal converter functions to the `{source}_X_to_{target}` pattern, where `_to_` always points toward the target and the prefix always identifies the source domain (`ir_` or `p_`)
- Eliminate the ambiguous `_from_p` / `_from_provider` suffix from internal functions — `_from_` is now reserved for the public API only (`request_from_provider`, etc.)
- Add naming conventions documentation to both `docs_en` and `docs_zh` (already pushed to doc branches)

### Renames applied

| Old pattern | New pattern | Direction |
|---|---|---|
| `_handle_*_from_p` | `_handle_p_*_to_ir` | P→IR |
| `_handle_*_to_p` | `_handle_ir_*_to_p` | IR→P |
| `_build_ir_usage` / `_build_provider_usage` | `_build_p_usage_to_ir` / `_build_ir_usage_to_p` | both |
| `_build_choice_to_provider` | `_build_ir_choice_to_p` | IR→P |
| `_convert_*_to_responses` / `_convert_*_from_responses` | `_convert_ir_*_to_p` / `_convert_p_*_to_ir` | both |
| `_post_process_to_provider` | `_post_process_ir_to_p` | IR→P |
| `_FROM_P_DISPATCH` / `_TO_P_DISPATCH` | `_P_TO_IR_DISPATCH` / `_IR_TO_P_DISPATCH` | both |

Public API unchanged — `request_to_provider()`, `request_from_provider()`, etc. keep their natural English names.

## Test plan

- [x] `make lint` passes (ruff check + ruff format + ty check)
- [x] `make test` passes — 2191 passed, 0 failed
- [x] Pure rename, 185 additions / 185 deletions — no logic changes