### PR TITLE
fix(converters): preserve function_call item id across all conversion paths

### DIFF
--- a/src/llm_rosetta/converters/google_genai/tool_ops.py
+++ b/src/llm_rosetta/converters/google_genai/tool_ops.py
@@ -236,12 +236,12 @@ class GoogleGenAIToolOps(BaseToolOps):
             }
         }
 
-        # Preserve thought_signature from provider_metadata
         preserve_metadata = kwargs.get("preserve_metadata", True)
         if preserve_metadata and "provider_metadata" in ir_tool_call:
             metadata = ir_tool_call["provider_metadata"]
             if "google" in metadata and "thought_signature" in metadata["google"]:
                 part["thoughtSignature"] = metadata["google"]["thought_signature"]
+            part["_provider_metadata"] = metadata
 
         return part
 
@@ -277,16 +277,17 @@ class GoogleGenAIToolOps(BaseToolOps):
             "tool_type": "function",
         }
 
-        # Preserve thought_signature to provider_metadata
         preserve_metadata = kwargs.get("preserve_metadata", True)
         if preserve_metadata:
+            pm = provider_tool_call.get("_provider_metadata")
+            if pm:
+                tool_call_kwargs["provider_metadata"] = pm
             thought_sig = provider_tool_call.get(
                 "thoughtSignature"
             ) or provider_tool_call.get("thought_signature")
             if thought_sig:
-                tool_call_kwargs["provider_metadata"] = {
-                    "google": {"thought_signature": thought_sig}
-                }
+                pm = tool_call_kwargs.setdefault("provider_metadata", {})
+                pm.setdefault("google", {})["thought_signature"] = thought_sig
 
         return cast(ToolCallPart, tool_call_kwargs)
 

--- a/src/llm_rosetta/converters/openai_chat/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/tool_ops.py
@@ -290,7 +290,7 @@ class OpenAIChatToolOps(BaseToolOps):
             json.dumps(tool_input) if isinstance(tool_input, dict) else str(tool_input)
         )
 
-        return {
+        result: dict[str, Any] = {
             "id": ir_tool_call["tool_call_id"],
             "type": "function",
             "function": {
@@ -298,6 +298,9 @@ class OpenAIChatToolOps(BaseToolOps):
                 "arguments": arguments,
             },
         }
+        if "provider_metadata" in ir_tool_call:
+            result["_provider_metadata"] = ir_tool_call["provider_metadata"]
+        return result
 
     @staticmethod
     def p_tool_call_to_ir(provider_tool_call: Any, **kwargs: Any) -> ToolCallPart:
@@ -319,13 +322,17 @@ class OpenAIChatToolOps(BaseToolOps):
         except (json.JSONDecodeError, TypeError):
             tool_input = {"raw_arguments": arguments_str}
 
-        return ToolCallPart(
+        part = ToolCallPart(
             type="tool_call",
             tool_call_id=provider_tool_call.get("id", ""),
             tool_name=func.get("name", ""),
             tool_input=tool_input,
             tool_type="function",
         )
+        pm = provider_tool_call.get("_provider_metadata")
+        if pm:
+            part["provider_metadata"] = pm
+        return part
 
     # ==================== Tool Result ====================
 

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -871,6 +871,10 @@ class OpenAIResponsesConverter(BaseConverter):
                     tool_name=item.get("name", ""),
                     tool_type=tool_type,
                 )
+                if item_id and item_id != call_id:
+                    start_event_tc["provider_metadata"] = {
+                        "responses_item_id": item_id,
+                    }
                 output_index = chunk.get("output_index")
                 if output_index is not None:
                     start_event_tc["tool_call_index"] = output_index
@@ -1338,7 +1342,8 @@ class OpenAIResponsesConverter(BaseConverter):
         call_id = event["tool_call_id"]
         tool_name = event["tool_name"]
         tool_type = event.get("tool_type", "function")
-        item_id = call_id
+        pm = event.get("provider_metadata") or {}
+        item_id = pm.get("responses_item_id") or call_id
 
         # Register in context for later done events
         if context is not None and call_id:

--- a/tests/converters/google_genai/test_tool_ops.py
+++ b/tests/converters/google_genai/test_tool_ops.py
@@ -479,3 +479,69 @@ class TestGoogleGenAIToolOps:
         result = GoogleGenAIToolOps.ir_tool_definition_to_p(ir_tool)
         params = result["function_declarations"][0]["parameters"]
         assert params["properties"]["field"]["nullable"] is True
+
+
+class TestProviderMetadataPreservation:
+    """Tests for generic provider_metadata round-trip through Google format.
+
+    Covers issue #401: responses_item_id must survive Google converter boundary.
+    """
+
+    def test_ir_to_p_preserves_full_provider_metadata(self):
+        """ir_tool_call_to_p stashes entire provider_metadata as _provider_metadata."""
+        ir_part = cast(
+            ToolCallPart,
+            {
+                "type": "tool_call",
+                "tool_call_id": "call_xyz",
+                "tool_name": "get_weather",
+                "tool_input": {"city": "London"},
+                "tool_type": "function",
+                "provider_metadata": {"responses_item_id": "fc_abc123"},
+            },
+        )
+        result = GoogleGenAIToolOps.ir_tool_call_to_p(ir_part)
+        assert result["_provider_metadata"] == {"responses_item_id": "fc_abc123"}
+
+    def test_p_to_ir_restores_provider_metadata(self):
+        """p_tool_call_to_ir restores _provider_metadata to provider_metadata."""
+        p_call = {
+            "functionCall": {"name": "get_weather", "args": {"city": "London"}},
+            "_provider_metadata": {"responses_item_id": "fc_abc123"},
+        }
+        result = GoogleGenAIToolOps.p_tool_call_to_ir(p_call)
+        assert (
+            result.get("provider_metadata", {}).get("responses_item_id") == "fc_abc123"
+        )
+
+    def test_thought_signature_merged_with_provider_metadata(self):
+        """thought_signature is merged into existing provider_metadata."""
+        p_call = {
+            "functionCall": {"name": "get_weather", "args": {}},
+            "thoughtSignature": "sig_123",
+            "_provider_metadata": {"responses_item_id": "fc_abc123"},
+        }
+        result = GoogleGenAIToolOps.p_tool_call_to_ir(p_call)
+        pm = result.get("provider_metadata", {})
+        assert pm.get("responses_item_id") == "fc_abc123"
+        assert pm.get("google", {}).get("thought_signature") == "sig_123"
+
+    def test_provider_metadata_round_trip(self):
+        """provider_metadata survives IR → Google → IR round-trip."""
+        ir_part = cast(
+            ToolCallPart,
+            {
+                "type": "tool_call",
+                "tool_call_id": "call_xyz",
+                "tool_name": "get_weather",
+                "tool_input": {"city": "London"},
+                "tool_type": "function",
+                "provider_metadata": {"responses_item_id": "fc_abc123"},
+            },
+        )
+        google_call = GoogleGenAIToolOps.ir_tool_call_to_p(ir_part)
+        restored = GoogleGenAIToolOps.p_tool_call_to_ir(google_call)
+        assert (
+            restored.get("provider_metadata", {}).get("responses_item_id")
+            == "fc_abc123"
+        )

--- a/tests/converters/openai_chat/test_tool_ops.py
+++ b/tests/converters/openai_chat/test_tool_ops.py
@@ -319,3 +319,69 @@ class TestOpenAIChatToolOps:
         provider = OpenAIChatToolOps.ir_tool_config_to_p(original)
         restored = OpenAIChatToolOps.p_tool_config_to_ir(provider)
         assert restored["disable_parallel"] == original["disable_parallel"]
+
+
+class TestProviderMetadataPreservation:
+    """Tests for generic provider_metadata round-trip through Chat format.
+
+    Covers issue #401: responses_item_id must survive Chat converter boundary.
+    """
+
+    def test_ir_to_p_preserves_provider_metadata(self):
+        """ir_tool_call_to_p stashes provider_metadata as _provider_metadata."""
+        ir_part = cast(
+            ToolCallPart,
+            {
+                "type": "tool_call",
+                "tool_call_id": "call_xyz",
+                "tool_name": "get_weather",
+                "tool_input": {"city": "London"},
+                "tool_type": "function",
+                "provider_metadata": {"responses_item_id": "fc_abc123"},
+            },
+        )
+        result = OpenAIChatToolOps.ir_tool_call_to_p(ir_part)
+        assert result["_provider_metadata"] == {"responses_item_id": "fc_abc123"}
+
+    def test_p_to_ir_restores_provider_metadata(self):
+        """p_tool_call_to_ir restores _provider_metadata to provider_metadata."""
+        p_call = {
+            "id": "call_xyz",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city": "London"}'},
+            "_provider_metadata": {"responses_item_id": "fc_abc123"},
+        }
+        result = OpenAIChatToolOps.p_tool_call_to_ir(p_call)
+        assert result.get("provider_metadata") == {"responses_item_id": "fc_abc123"}
+
+    def test_no_metadata_when_absent(self):
+        """No _provider_metadata when IR part has no provider_metadata."""
+        ir_part = cast(
+            ToolCallPart,
+            {
+                "type": "tool_call",
+                "tool_call_id": "call_xyz",
+                "tool_name": "get_weather",
+                "tool_input": {},
+                "tool_type": "function",
+            },
+        )
+        result = OpenAIChatToolOps.ir_tool_call_to_p(ir_part)
+        assert "_provider_metadata" not in result
+
+    def test_provider_metadata_round_trip(self):
+        """provider_metadata survives IR → Chat → IR round-trip."""
+        ir_part = cast(
+            ToolCallPart,
+            {
+                "type": "tool_call",
+                "tool_call_id": "call_xyz",
+                "tool_name": "get_weather",
+                "tool_input": {"city": "London"},
+                "tool_type": "function",
+                "provider_metadata": {"responses_item_id": "fc_abc123"},
+            },
+        )
+        chat_call = OpenAIChatToolOps.ir_tool_call_to_p(ir_part)
+        restored = OpenAIChatToolOps.p_tool_call_to_ir(chat_call)
+        assert restored.get("provider_metadata") == {"responses_item_id": "fc_abc123"}

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -1618,3 +1618,200 @@ class TestCustomToolCallStreaming:
         )
         assert restored["type"] == "response.custom_tool_call_input.delta"
         assert restored["delta"] == "search query"
+
+
+class TestFunctionCallItemIdPreservation:
+    """Tests for preserving Responses function_call item id (fc_ prefix)
+    through streaming round-trip, distinct from call_id (call_ prefix).
+
+    Covers issue #401.
+    """
+
+    def setup_method(self):
+        self.converter = OpenAIResponsesConverter()
+
+    # --- from_p: ToolCallStartEvent carries responses_item_id ---
+
+    def test_from_p_carries_item_id_in_provider_metadata(self):
+        """output_item.added with distinct id/call_id stores responses_item_id."""
+        chunk = {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "type": "function_call",
+                "id": "fc_abc123",
+                "call_id": "call_xyz789",
+                "name": "get_weather",
+                "arguments": "",
+                "status": "in_progress",
+            },
+        }
+        events = cast(list[Any], self.converter.stream_response_from_provider(chunk))
+        assert len(events) == 1
+        event = events[0]
+        assert event["type"] == "tool_call_start"
+        assert event["tool_call_id"] == "call_xyz789"
+        pm = event.get("provider_metadata", {})
+        assert pm.get("responses_item_id") == "fc_abc123"
+
+    def test_from_p_no_metadata_when_ids_equal(self):
+        """output_item.added where id == call_id does not set provider_metadata."""
+        chunk = {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "type": "function_call",
+                "id": "call_abc",
+                "call_id": "call_abc",
+                "name": "search",
+                "arguments": "",
+                "status": "in_progress",
+            },
+        }
+        events = cast(list[Any], self.converter.stream_response_from_provider(chunk))
+        assert "provider_metadata" not in events[0]
+
+    def test_from_p_no_metadata_when_id_empty(self):
+        """output_item.added with empty id does not set provider_metadata."""
+        chunk = {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "type": "function_call",
+                "id": "",
+                "call_id": "call_abc",
+                "name": "search",
+                "arguments": "",
+                "status": "in_progress",
+            },
+        }
+        events = cast(list[Any], self.converter.stream_response_from_provider(chunk))
+        assert "provider_metadata" not in events[0]
+
+    # --- to_p: restores fc_ item id from provider_metadata ---
+
+    def test_to_p_restores_fc_item_id(self):
+        """ToolCallStartEvent with provider_metadata restores fc_ item id."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.response_id = "resp_001"
+        ctx.model = "gpt-4"
+        ctx.mark_started()
+
+        event = ToolCallStartEvent(
+            type="tool_call_start",
+            tool_call_id="call_xyz789",
+            tool_name="get_weather",
+            provider_metadata={"responses_item_id": "fc_abc123"},
+        )
+        result = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(event, context=ctx),
+        )
+        assert result["item"]["id"] == "fc_abc123"
+        assert result["item"]["call_id"] == "call_xyz789"
+
+    def test_to_p_fallback_without_metadata(self):
+        """ToolCallStartEvent without provider_metadata uses call_id as id."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.response_id = "resp_001"
+        ctx.model = "gpt-4"
+        ctx.mark_started()
+
+        event = ToolCallStartEvent(
+            type="tool_call_start",
+            tool_call_id="call_xyz789",
+            tool_name="get_weather",
+        )
+        result = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(event, context=ctx),
+        )
+        assert result["item"]["id"] == "call_xyz789"
+        assert result["item"]["call_id"] == "call_xyz789"
+
+    # --- Full round-trip ---
+
+    def test_round_trip_preserves_fc_item_id(self):
+        """Full streaming round-trip preserves distinct fc_ item id."""
+        ctx_from = OpenAIResponsesStreamContext()
+        ctx_to = OpenAIResponsesStreamContext()
+        ctx_to.response_id = "resp_001"
+        ctx_to.model = "gpt-4"
+        ctx_to.mark_started()
+
+        added_chunk = {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "type": "function_call",
+                "id": "fc_abc123",
+                "call_id": "call_xyz789",
+                "name": "get_weather",
+                "arguments": "",
+                "status": "in_progress",
+            },
+        }
+        ir_events = cast(
+            list[Any],
+            self.converter.stream_response_from_provider(added_chunk, context=ctx_from),
+        )
+        restored = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(ir_events[0], context=ctx_to),
+        )
+        assert restored["item"]["id"] == "fc_abc123"
+        assert restored["item"]["call_id"] == "call_xyz789"
+
+    def test_done_and_completed_use_fc_item_id(self):
+        """Done and completed events use the fc_ item id from start event."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.response_id = "resp_001"
+        ctx.model = "gpt-4"
+        ctx.mark_started()
+
+        # Register tool call with distinct ids via start event
+        start_event = ToolCallStartEvent(
+            type="tool_call_start",
+            tool_call_id="call_xyz789",
+            tool_name="get_weather",
+            provider_metadata={"responses_item_id": "fc_abc123"},
+        )
+        self.converter.stream_response_to_provider(start_event, context=ctx)
+
+        # Delta should use fc_ item_id
+        delta_event = ToolCallDeltaEvent(
+            type="tool_call_delta",
+            tool_call_id="call_xyz789",
+            arguments_delta='{"city": "London"}',
+        )
+        delta_result = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(delta_event, context=ctx),
+        )
+        assert delta_result["item_id"] == "fc_abc123"
+
+        # Finish triggers done events
+        finish_event = FinishEvent(
+            type="finish",
+            finish_reason={"reason": "tool_calls"},
+        )
+        results = self.converter.stream_response_to_provider(finish_event, context=ctx)
+        result_list = results if isinstance(results, list) else [results]
+
+        # output_item.done should have fc_ id
+        done_events = [
+            e
+            for e in result_list
+            if isinstance(e, dict) and e.get("type") == "response.output_item.done"
+        ]
+        assert len(done_events) == 1
+        assert done_events[0]["item"]["id"] == "fc_abc123"
+        assert done_events[0]["item"]["call_id"] == "call_xyz789"
+
+        # response.completed output should have fc_ id
+        assert ctx.pending_response is not None
+        output = ctx.pending_response.get("output", [])
+        fc_items = [o for o in output if o.get("type") == "function_call"]
+        assert len(fc_items) == 1
+        assert fc_items[0]["id"] == "fc_abc123"
+        assert fc_items[0]["call_id"] == "call_xyz789"


### PR DESCRIPTION
## Summary

- Preserve Responses API `function_call` item `id` (fc_ prefix) through streaming round-trip via `provider_metadata.responses_item_id` on `ToolCallStartEvent`
- Add generic `_provider_metadata` round-trip to **Chat** converter (same pattern Anthropic already uses)
- Extend **Google** converter to preserve full `provider_metadata` (not just `thought_signature`)
- 15 new tests covering streaming identity, cross-format metadata survival, and fallback behavior

## Context

The Responses API has two identity fields per function_call: `id` (fc_ prefix, item identity) and `call_id` (call_ prefix, correlation key). Other APIs have only one. The non-streaming Responses path already preserved `id` via `provider_metadata`, but three gaps remained:

1. **Streaming** lost `id` because `ToolCallStartEvent` didn't carry it
2. **Chat** converter dropped all `provider_metadata` on tool calls
3. **Google** converter only kept `thought_signature`, dropping everything else

## Test plan

- [x] `make lint` — all checks passed
- [x] `make test` — 2206 passed, 0 failed

Closes #401
Part of #397