### PR TITLE
fix(gateway): skip auth on CORS preflight requests

### DIFF
--- a/src/llm_rosetta/gateway/auth.py
+++ b/src/llm_rosetta/gateway/auth.py
@@ -208,6 +208,13 @@ def create_auth_hook(auth_state: AuthState) -> Any:
     """
 
     async def auth_hook(request: Any) -> Response | None:
+        # CORS preflight must bypass auth — browsers send no credentials
+        # on OPTIONS and need CORS headers back to proceed with the
+        # actual request.  The downstream cors_preflight route handler
+        # returns 204 with the appropriate Access-Control-* headers.
+        if request.method == "OPTIONS":
+            return None
+
         # Reset per-request label
         api_key_label_var.set(None)
 


### PR DESCRIPTION
## Summary

- Auth `before_request` hook now bypasses `OPTIONS` requests, allowing CORS preflight to reach the `cors_preflight` route handler that returns `204 + Access-Control-*` headers
- Fixes browser-based clients (including the [Open Responses compliance test UI](https://www.openresponses.org/compliance)) getting `NetworkError` when testing against the gateway cross-origin

## Root cause

The auth hook ran on all HTTP methods including `OPTIONS`. Browsers send no credentials on CORS preflight, so the hook returned `401` with no CORS headers. The browser then blocked the entire request sequence.

`curl` and server-side clients were unaffected since they don't perform preflight.

## Safety

`OPTIONS` preflight is credential-less by design (RFC 6454 / Fetch spec). The downstream handler only returns CORS permission headers — no data, no proxy, no upstream access. All actual `POST`/`GET`/etc. requests remain fully authenticated.

## Test plan

- [x] `make test` — 197 passed
- [x] `ruff check` + `ruff format` clean
- [ ] Deploy and re-run Open Responses compliance tests at https://www.openresponses.org/compliance