### PR TITLE
fix(gateway): harden CORS preflight auth bypass

### DIFF
--- a/src/llm_rosetta/gateway/auth.py
+++ b/src/llm_rosetta/gateway/auth.py
@@ -208,15 +208,20 @@ def create_auth_hook(auth_state: AuthState) -> Any:
     """
 
     async def auth_hook(request: Any) -> Response | None:
+        # Reset per-request label before any early return so downstream
+        # hooks never see a stale value from a previous request.
+        api_key_label_var.set(None)
+
         # CORS preflight must bypass auth — browsers send no credentials
         # on OPTIONS and need CORS headers back to proceed with the
-        # actual request.  The downstream cors_preflight route handler
-        # returns 204 with the appropriate Access-Control-* headers.
-        if request.method == "OPTIONS":
+        # actual request.  Only skip auth for genuine preflights (Origin
+        # + Access-Control-Request-Method present per Fetch spec §3.2.2).
+        if (
+            request.method == "OPTIONS"
+            and request.headers.get("origin")
+            and request.headers.get("access-control-request-method")
+        ):
             return None
-
-        # Reset per-request label
-        api_key_label_var.set(None)
 
         path = request.path
 


### PR DESCRIPTION
## Summary

Follow-up to PR #404, addressing review feedback from Elena and Clementine:

- Only bypass auth for genuine CORS preflights that carry both `Origin` and `Access-Control-Request-Method` headers (per Fetch spec §3.2.2), rather than all `OPTIONS` requests
- Move `api_key_label_var` reset before the `OPTIONS` early-return so downstream hooks never see a stale label from a previous request

## Context

Elena's nit on #404:
> you could additionally check `request.headers.get("Origin")` or `Access-Control-Request-Method` to only bypass auth on *actual* preflights rather than any arbitrary OPTIONS request

Clementine's nit on #404:
> OPTIONS bypass 可能让它们拿到 `None` label … 值得脑子里记着

## Test plan

- [x] `make test` — 197 passed
- [x] `ruff check` + `ruff format` clean
- [ ] Deploy and verify Open Responses compliance tests still pass