### PR TITLE
fix(openai-responses): unified output_index and reasoning item lifecycle

### DIFF
--- a/src/llm_rosetta/converters/openai_responses/_constants.py
+++ b/src/llm_rosetta/converters/openai_responses/_constants.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import uuid
 from typing import Any
 
 # --- SSE event types ---
@@ -22,6 +24,9 @@ class ResponsesEventType:
     OUTPUT_TEXT_DELTA = "response.output_text.delta"
     OUTPUT_TEXT_DONE = "response.output_text.done"
     REASONING_SUMMARY_TEXT_DELTA = "response.reasoning_summary_text.delta"
+    REASONING_SUMMARY_TEXT_DONE = "response.reasoning_summary_text.done"
+    REASONING_SUMMARY_PART_ADDED = "response.reasoning_summary.part.added"
+    REASONING_SUMMARY_PART_DONE = "response.reasoning_summary.part.done"
     FUNCTION_CALL_ARGS_DELTA = "response.function_call_arguments.delta"
     FUNCTION_CALL_ARGS_DONE = "response.function_call_arguments.done"
     CUSTOM_TOOL_CALL_INPUT_DELTA = "response.custom_tool_call_input.delta"
@@ -67,6 +72,21 @@ RESPONSES_REASON_TO_INCOMPLETE_REASON: dict[str, str] = {
 def generate_message_id(response_id: str) -> str:
     """Generate a message item ID from the response ID."""
     return f"msg_{response_id or ''}"
+
+
+def generate_reasoning_id(response_id: str, index: int = 0) -> str:
+    """Generate a deterministic reasoning item ID.
+
+    Uses SHA-256 to derive a stable ID from the response ID and
+    reasoning item position, ensuring idempotent output across
+    repeated conversions of the same IR response.
+
+    Falls back to a random UUID when no response_id is available.
+    """
+    if response_id:
+        seed = f"{response_id}:reasoning:{index}"
+        return f"rs_{hashlib.sha256(seed.encode()).hexdigest()[:24]}"
+    return f"rs_{uuid.uuid4().hex[:24]}"
 
 
 # --- Preserve-mode echo fields ---

--- a/src/llm_rosetta/converters/openai_responses/content_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/content_ops.py
@@ -23,6 +23,7 @@ from ...types.ir import (
     TextPart,
 )
 from ..base import BaseContentOps
+from ._constants import generate_reasoning_id
 
 
 class OpenAIResponsesContentOps(BaseContentOps):
@@ -260,8 +261,12 @@ class OpenAIResponsesContentOps(BaseContentOps):
         # Recover the original reasoning item id for round-trip fidelity.
         metadata = ir_reasoning.get("provider_metadata") or {}
         item_id = metadata.get("responses_reasoning_id")
-        if item_id:
-            result["id"] = item_id
+        if not item_id:
+            response_id = kwargs.get("response_id", "")
+            reasoning_index = kwargs.get("reasoning_index", 0)
+            item_id = generate_reasoning_id(response_id, reasoning_index)
+        result["id"] = item_id
+        result["status"] = "completed"
 
         # Recover structured summary if available, otherwise use flat content.
         summary = metadata.get("responses_reasoning_summary")

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -49,6 +49,7 @@ from ._constants import (
     RESPONSES_STATUS_TO_REASON,
     ResponsesEventType,
     generate_message_id,
+    generate_reasoning_id,
 )
 from .config_ops import OpenAIResponsesConfigOps
 from .content_ops import OpenAIResponsesContentOps
@@ -405,6 +406,7 @@ class OpenAIResponsesConverter(BaseConverter):
 
             content_parts = message.get("content", [])
             text_parts: list[dict[str, Any]] = []
+            reasoning_index = 0
 
             for part in content_parts:
                 if is_text_part(part):
@@ -422,8 +424,13 @@ class OpenAIResponsesConverter(BaseConverter):
                     )
                 elif is_reasoning_part(part):
                     provider_response["output"].append(
-                        self.content_ops.ir_reasoning_to_p(part)
+                        self.content_ops.ir_reasoning_to_p(
+                            part,
+                            response_id=ir_response.get("id", ""),
+                            reasoning_index=reasoning_index,
+                        )
                     )
+                    reasoning_index += 1
 
             if text_parts:
                 provider_response["output"].insert(
@@ -1236,14 +1243,15 @@ class OpenAIResponsesConverter(BaseConverter):
             # and mark the item as emitted so the first TextDelta doesn't
             # re-emit them.
             if context is not None and not context.output_item_emitted:
-                return build_message_preamble_events(context, output_index=0)
+                return build_message_preamble_events(context)
             # Fallback: just emit content_part.added (e.g. no context, or
             # output item already emitted by a prior ContentBlockStartEvent)
             item_id = context.item_id if context is not None else ""
+            msg_idx = context._message_output_index if context is not None else 0
             return {
                 "type": ResponsesEventType.CONTENT_PART_ADDED,
                 "item_id": item_id,
-                "output_index": 0,
+                "output_index": msg_idx,
                 "content_index": 0,
                 "part": {
                     "type": "output_text",
@@ -1266,11 +1274,12 @@ class OpenAIResponsesConverter(BaseConverter):
             # Emit output_text.done before content_part.done (matches
             # OpenAI's event ordering)
             item_id = context.item_id
+            msg_idx = context._message_output_index
             return [
                 {
                     "type": ResponsesEventType.OUTPUT_TEXT_DONE,
                     "item_id": item_id,
-                    "output_index": 0,
+                    "output_index": msg_idx,
                     "content_index": 0,
                     "text": accumulated,
                     "logprobs": [],
@@ -1278,7 +1287,7 @@ class OpenAIResponsesConverter(BaseConverter):
                 {
                     "type": ResponsesEventType.CONTENT_PART_DONE,
                     "item_id": item_id,
-                    "output_index": 0,
+                    "output_index": msg_idx,
                     "content_index": 0,
                     "part": {
                         "type": "output_text",
@@ -1300,39 +1309,85 @@ class OpenAIResponsesConverter(BaseConverter):
         event: TextDeltaEvent,
         context: OpenAIResponsesStreamContext | None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
-        choice_index = event.get("choice_index", 0)
         text = event["text"]
-        item_id = context.item_id if context is not None else ""
-        delta_event: dict[str, Any] = {
-            "type": ResponsesEventType.OUTPUT_TEXT_DELTA,
-            "item_id": item_id,
-            "output_index": choice_index,
-            "content_index": 0,
-            "delta": text,
-            "logprobs": [],
-        }
+
+        # Emit output_item.added + content_part.added before the first
+        # text delta so clients (e.g. Codex CLI) can register the item.
+        preamble: list[dict[str, Any]] = []
+        if context is not None and not context.output_item_emitted:
+            preamble = build_message_preamble_events(context)
 
         # Accumulate text in context for response.completed output
         if context is not None:
             context.accumulated_text += text
 
-        # Emit output_item.added + content_part.added before the first
-        # text delta so clients (e.g. Codex CLI) can register the item.
-        if context is not None and not context.output_item_emitted:
-            preamble = build_message_preamble_events(context, output_index=choice_index)
-            return preamble + [delta_event]
+        msg_idx = context._message_output_index if context is not None else 0
+        item_id = context.item_id if context is not None else ""
+        delta_event: dict[str, Any] = {
+            "type": ResponsesEventType.OUTPUT_TEXT_DELTA,
+            "item_id": item_id,
+            "output_index": msg_idx,
+            "content_index": 0,
+            "delta": text,
+            "logprobs": [],
+        }
 
+        if preamble:
+            return preamble + [delta_event]
         return delta_event
 
     def _handle_ir_reasoning_delta_to_p(
         self,
         event: ReasoningDeltaEvent,
         context: StreamContext | None,
-    ) -> dict[str, Any]:
-        return {
-            "type": ResponsesEventType.REASONING_SUMMARY_TEXT_DELTA,
-            "delta": event["reasoning"],
-        }
+    ) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        ctx = context if isinstance(context, OpenAIResponsesStreamContext) else None
+
+        if ctx is not None and ctx._reasoning_item_id == "":
+            output_index = ctx.next_output_index()
+            ctx._reasoning_output_index = output_index
+            item_id = generate_reasoning_id(ctx.response_id, output_index)
+            ctx._reasoning_item_id = item_id
+
+            results.append(
+                {
+                    "type": ResponsesEventType.OUTPUT_ITEM_ADDED,
+                    "output_index": output_index,
+                    "item": {
+                        "id": item_id,
+                        "type": "reasoning",
+                        "summary": [],
+                        "status": "in_progress",
+                    },
+                }
+            )
+            results.append(
+                {
+                    "type": ResponsesEventType.REASONING_SUMMARY_PART_ADDED,
+                    "item_id": item_id,
+                    "output_index": output_index,
+                    "summary_index": 0,
+                    "part": {"type": "summary_text", "text": ""},
+                }
+            )
+
+        reasoning_text = event["reasoning"]
+        if ctx is not None:
+            ctx._reasoning_accumulated_text += reasoning_text
+
+        item_id = ctx._reasoning_item_id if ctx is not None else ""
+        r_idx = ctx._reasoning_output_index if ctx is not None else 0
+        results.append(
+            {
+                "type": ResponsesEventType.REASONING_SUMMARY_TEXT_DELTA,
+                "item_id": item_id,
+                "output_index": r_idx,
+                "summary_index": 0,
+                "delta": reasoning_text,
+            }
+        )
+        return results
 
     def _handle_ir_tool_call_start_to_p(
         self,
@@ -1350,8 +1405,12 @@ class OpenAIResponsesConverter(BaseConverter):
             context.register_tool_call(call_id, tool_name, tool_type)
             context.register_tool_call_item(call_id, item_id)
 
-        tc_index = event.get("tool_call_index")
-        output_index = tc_index if tc_index is not None else 0
+        if isinstance(context, OpenAIResponsesStreamContext):
+            output_index = context.next_output_index()
+            context._tool_call_output_indices[call_id] = output_index
+        else:
+            tc_index = event.get("tool_call_index")
+            output_index = tc_index if tc_index is not None else 0
 
         if tool_type == "custom":
             item: dict[str, Any] = {
@@ -1406,7 +1465,10 @@ class OpenAIResponsesConverter(BaseConverter):
         if not item_id and call_id:
             item_id = call_id
 
-        output_index = tc_index if tc_index is not None else 0
+        if isinstance(context, OpenAIResponsesStreamContext) and call_id:
+            output_index = context._tool_call_output_indices.get(call_id, 0)
+        else:
+            output_index = tc_index if tc_index is not None else 0
 
         # Determine event type based on tool type (custom vs function)
         tool_type = (
@@ -1442,6 +1504,7 @@ class OpenAIResponsesConverter(BaseConverter):
         results: list[dict[str, Any]] = []
 
         if context is not None:
+            self._emit_reasoning_done_events(context, results)
             self._emit_text_done_events(context, results)
             self._emit_tool_call_done_events(context, results)
 
@@ -1503,6 +1566,22 @@ class OpenAIResponsesConverter(BaseConverter):
         output: list[dict[str, Any]] = []
         if context is None:
             return output
+
+        # Reasoning item comes first in output array
+        if context._reasoning_item_id:
+            output.append(
+                {
+                    "id": context._reasoning_item_id,
+                    "type": "reasoning",
+                    "summary": [
+                        {
+                            "type": "summary_text",
+                            "text": context._reasoning_accumulated_text,
+                        }
+                    ],
+                    "status": "completed",
+                }
+            )
 
         accumulated = context.accumulated_text
         if accumulated:
@@ -1589,6 +1668,49 @@ class OpenAIResponsesConverter(BaseConverter):
             if k not in core_keys:
                 response[k] = v
 
+    def _emit_reasoning_done_events(
+        self,
+        context: OpenAIResponsesStreamContext,
+        results: list[dict[str, Any]],
+    ) -> None:
+        """Emit reasoning lifecycle done events."""
+        if not context._reasoning_item_id:
+            return
+        item_id = context._reasoning_item_id
+        output_index = context._reasoning_output_index
+        accumulated = context._reasoning_accumulated_text
+
+        results.append(
+            {
+                "type": ResponsesEventType.REASONING_SUMMARY_TEXT_DONE,
+                "item_id": item_id,
+                "output_index": output_index,
+                "summary_index": 0,
+                "text": accumulated,
+            }
+        )
+        results.append(
+            {
+                "type": ResponsesEventType.REASONING_SUMMARY_PART_DONE,
+                "item_id": item_id,
+                "output_index": output_index,
+                "summary_index": 0,
+                "part": {"type": "summary_text", "text": accumulated},
+            }
+        )
+        results.append(
+            {
+                "type": ResponsesEventType.OUTPUT_ITEM_DONE,
+                "output_index": output_index,
+                "item": {
+                    "id": item_id,
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": accumulated}],
+                    "status": "completed",
+                },
+            }
+        )
+
     def _emit_text_done_events(
         self,
         context: OpenAIResponsesStreamContext,
@@ -1600,6 +1722,7 @@ class OpenAIResponsesConverter(BaseConverter):
 
         accumulated = context.accumulated_text
         item_id = context.item_id
+        msg_idx = context._message_output_index
 
         # Only emit output_text.done + content_part.done if not
         # already emitted by a prior ContentBlockEndEvent
@@ -1608,7 +1731,7 @@ class OpenAIResponsesConverter(BaseConverter):
                 {
                     "type": ResponsesEventType.OUTPUT_TEXT_DONE,
                     "item_id": item_id,
-                    "output_index": 0,
+                    "output_index": msg_idx,
                     "content_index": 0,
                     "text": accumulated,
                     "logprobs": [],
@@ -1618,7 +1741,7 @@ class OpenAIResponsesConverter(BaseConverter):
                 {
                     "type": ResponsesEventType.CONTENT_PART_DONE,
                     "item_id": item_id,
-                    "output_index": 0,
+                    "output_index": msg_idx,
                     "content_index": 0,
                     "part": {
                         "type": "output_text",
@@ -1631,7 +1754,7 @@ class OpenAIResponsesConverter(BaseConverter):
         results.append(
             {
                 "type": ResponsesEventType.OUTPUT_ITEM_DONE,
-                "output_index": 0,
+                "output_index": msg_idx,
                 "item": {
                     "id": item_id,
                     "type": "message",
@@ -1659,7 +1782,7 @@ class OpenAIResponsesConverter(BaseConverter):
             tool_name = context.get_tool_name(call_id)
             arguments = context._tool_call_args.get(call_id, "")
             item_id = context.get_tool_call_item_id(call_id) or call_id
-            output_index = tc_idx + (1 if context.output_item_emitted else 0)
+            output_index = context._tool_call_output_indices.get(call_id, tc_idx)
             tool_type = context.get_tool_type(call_id)
 
             if tool_type == "custom":

--- a/src/llm_rosetta/converters/openai_responses/stream_context.py
+++ b/src/llm_rosetta/converters/openai_responses/stream_context.py
@@ -18,8 +18,8 @@ class OpenAIResponsesStreamContext(StreamContext):
     Attributes:
         item_id_to_call_id: Reverse mapping from Responses item_id to
             tool call_id for function call argument delta resolution.
-        output_item_emitted: Whether the initial output_item.added and
-            content_part.added events have been emitted.
+        output_item_emitted: Whether the initial message output_item.added
+            and content_part.added events have been emitted.
         item_id: Current output item ID for the response message.
         accumulated_text: Accumulated text deltas for the final
             response.completed payload.
@@ -27,12 +27,37 @@ class OpenAIResponsesStreamContext(StreamContext):
             emitted (prevents duplicate emission).
     """
 
+    # Message item tracking
     item_id_to_call_id: dict[str, str] = field(default_factory=dict)
     output_item_emitted: bool = False
     item_id: str = ""
     accumulated_text: str = ""
     content_part_done_emitted: bool = False
     _sequence_number: int = 0
+
+    # Unified output item counter — allocates output_index for all item
+    # types (reasoning, message, tool call).  Call next_output_index()
+    # ONLY when emitting output_item.added.
+    _output_item_counter: int = 0
+    _message_output_index: int = -1
+
+    # Tool call output_index storage (call_id → assigned index)
+    _tool_call_output_indices: dict[str, int] = field(default_factory=dict, repr=False)
+
+    # Reasoning item tracking
+    _reasoning_item_id: str = ""
+    _reasoning_output_index: int = -1
+    _reasoning_accumulated_text: str = ""
+
+    def next_output_index(self) -> int:
+        """Allocate the next output_index.
+
+        Call ONLY when emitting an output_item.added event.  Delta and
+        done events must reference the index stored at added-time.
+        """
+        idx = self._output_item_counter
+        self._output_item_counter += 1
+        return idx
 
     @classmethod
     def from_base(cls, base: StreamContext) -> OpenAIResponsesStreamContext:

--- a/src/llm_rosetta/converters/openai_responses/utils.py
+++ b/src/llm_rosetta/converters/openai_responses/utils.py
@@ -35,22 +35,22 @@ def resolve_call_id(chunk: dict[str, Any], context: StreamContext | None) -> str
 
 def build_message_preamble_events(
     context: OpenAIResponsesStreamContext,
-    output_index: int = 0,
 ) -> list[dict[str, Any]]:
     """Build output_item.added + content_part.added for a new message item.
 
-    Marks the context as having emitted the output item and generates
-    the item_id.  Must only be called when ``context.output_item_emitted``
-    is ``False``.
+    Allocates the next output_index from the unified counter and marks
+    the context as having emitted the message output item.  Must only
+    be called when ``context.output_item_emitted`` is ``False``.
 
     Args:
         context: Responses stream context.
-        output_index: The output array index for the item.
 
     Returns:
         Two-element list of SSE event dicts.
     """
     context.output_item_emitted = True
+    output_index = context.next_output_index()
+    context._message_output_index = output_index
     item_id = generate_message_id(context.response_id)
     context.item_id = item_id
     return [

--- a/tests/converters/openai_responses/test_content_ops.py
+++ b/tests/converters/openai_responses/test_content_ops.py
@@ -444,3 +444,56 @@ class TestOpenAIResponsesContentOps:
             restored["url_citation"]["start_index"]
             == original["url_citation"]["start_index"]
         )
+
+
+class TestReasoningIdGeneration:
+    """Tests for reasoning item id and status generation (#407)."""
+
+    def test_generates_id_without_provider_metadata(self):
+        ir_reasoning = ReasoningPart(type="reasoning", reasoning="thinking...")
+        result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
+        assert "id" in result
+        assert result["id"].startswith("rs_")
+
+    def test_generates_status(self):
+        ir_reasoning = ReasoningPart(type="reasoning", reasoning="thinking...")
+        result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
+        assert result["status"] == "completed"
+
+    def test_preserves_original_id(self):
+        ir_reasoning = ReasoningPart(
+            type="reasoning",
+            reasoning="thinking...",
+            provider_metadata={"responses_reasoning_id": "rs_original_123"},
+        )
+        result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
+        assert result["id"] == "rs_original_123"
+        assert result["status"] == "completed"
+
+    def test_deterministic_with_response_id(self):
+        ir = ReasoningPart(type="reasoning", reasoning="test")
+        r1 = OpenAIResponsesContentOps.ir_reasoning_to_p(
+            ir, response_id="resp_abc", reasoning_index=0
+        )
+        r2 = OpenAIResponsesContentOps.ir_reasoning_to_p(
+            ir, response_id="resp_abc", reasoning_index=0
+        )
+        assert r1["id"] == r2["id"]
+
+    def test_different_index_different_id(self):
+        ir = ReasoningPart(type="reasoning", reasoning="test")
+        r0 = OpenAIResponsesContentOps.ir_reasoning_to_p(
+            ir, response_id="resp_abc", reasoning_index=0
+        )
+        r1 = OpenAIResponsesContentOps.ir_reasoning_to_p(
+            ir, response_id="resp_abc", reasoning_index=1
+        )
+        assert r0["id"] != r1["id"]
+
+    def test_uuid_fallback_without_response_id(self):
+        ir = ReasoningPart(type="reasoning", reasoning="test")
+        r1 = OpenAIResponsesContentOps.ir_reasoning_to_p(ir)
+        r2 = OpenAIResponsesContentOps.ir_reasoning_to_p(ir)
+        assert r1["id"].startswith("rs_")
+        assert r2["id"].startswith("rs_")
+        assert r1["id"] != r2["id"]

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -4,6 +4,7 @@ OpenAI Responses API stream converter unit tests.
 
 from typing import Any, cast
 
+from llm_rosetta.converters.base.context import StreamContext
 from llm_rosetta.converters.openai_responses import OpenAIResponsesConverter
 from llm_rosetta.converters.openai_responses.stream_context import (
     OpenAIResponsesStreamContext,
@@ -341,14 +342,17 @@ class TestStreamResponseToProvider:
         assert result["delta"] == "Hello"
 
     def test_reasoning_delta(self):
-        """ReasoningDeltaEvent → response.reasoning_summary_text.delta."""
+        """ReasoningDeltaEvent → response.reasoning_summary_text.delta with lifecycle."""
         event = cast(
             ReasoningDeltaEvent,
             {"type": "reasoning_delta", "reasoning": "thinking..."},
         )
-        result = cast(dict[str, Any], self.converter.stream_response_to_provider(event))
-        assert result["type"] == "response.reasoning_summary_text.delta"
-        assert result["delta"] == "thinking..."
+        result = self.converter.stream_response_to_provider(event)
+        assert isinstance(result, list)
+        # Without context: just the delta event
+        delta = result[-1]
+        assert delta["type"] == "response.reasoning_summary_text.delta"
+        assert delta["delta"] == "thinking..."
 
     def test_tool_call_start(self):
         """ToolCallStartEvent → response.output_item.added."""
@@ -558,11 +562,11 @@ class TestStreamRoundTrip:
             "delta": "step 1",
         }
         events = cast(list[Any], self.converter.stream_response_from_provider(original))
-        restored = cast(
-            dict[str, Any], self.converter.stream_response_to_provider(events[0])
-        )
-        assert restored["type"] == "response.reasoning_summary_text.delta"
-        assert restored["delta"] == "step 1"
+        result = self.converter.stream_response_to_provider(events[0])
+        assert isinstance(result, list)
+        delta = result[-1]
+        assert delta["type"] == "response.reasoning_summary_text.delta"
+        assert delta["delta"] == "step 1"
 
     def test_tool_call_start_round_trip(self):
         """Tool call start round-trip preserves id and name."""
@@ -1815,3 +1819,314 @@ class TestFunctionCallItemIdPreservation:
         assert len(fc_items) == 1
         assert fc_items[0]["id"] == "fc_abc123"
         assert fc_items[0]["call_id"] == "call_xyz789"
+
+
+class TestUnifiedOutputIndex:
+    """Tests for unified output_index management (#418)."""
+
+    def setup_method(self):
+        self.converter = OpenAIResponsesConverter()
+
+    def _run_stream(self, ir_events):
+        """Run a sequence of IR events through the converter and collect output."""
+        ctx = StreamContext()
+        ctx.response_id = "resp_test"
+        ctx.model = "test-model"
+        results = []
+        for ev in ir_events:
+            out = self.converter.stream_response_to_provider(ev, context=ctx)
+            if isinstance(out, list):
+                results.extend(out)
+            elif isinstance(out, dict) and out:
+                results.append(out)
+        return results
+
+    def _get_output_indices(self, events):
+        """Extract (type, output_index) from output_item.added events."""
+        return [
+            (ev["item"]["type"], ev["output_index"])
+            for ev in events
+            if ev.get("type") == "response.output_item.added"
+        ]
+
+    def test_message_only(self):
+        """[message] → output_index [0]."""
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "text_delta", "text": "hi"},
+            ]
+        )
+        indices = self._get_output_indices(events)
+        assert indices == [("message", 0)]
+
+    def test_reasoning_then_message(self):
+        """[reasoning, message] → output_index [0, 1]."""
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "reasoning_delta", "reasoning": "think"},
+                {"type": "text_delta", "text": "hi"},
+            ]
+        )
+        indices = self._get_output_indices(events)
+        assert indices == [("reasoning", 0), ("message", 1)]
+
+    def test_reasoning_then_tool_call(self):
+        """[reasoning, fc] → output_index [0, 1]."""
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "reasoning_delta", "reasoning": "think"},
+                {
+                    "type": "tool_call_start",
+                    "tool_call_id": "call_1",
+                    "tool_name": "search",
+                    "tool_call_index": 0,
+                },
+            ]
+        )
+        indices = self._get_output_indices(events)
+        assert indices == [("reasoning", 0), ("function_call", 1)]
+
+    def test_reasoning_then_parallel_tools(self):
+        """[reasoning, fc, fc, fc] → output_index [0, 1, 2, 3]."""
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "reasoning_delta", "reasoning": "think"},
+                {
+                    "type": "tool_call_start",
+                    "tool_call_id": "call_1",
+                    "tool_name": "fn1",
+                    "tool_call_index": 0,
+                },
+                {
+                    "type": "tool_call_start",
+                    "tool_call_id": "call_2",
+                    "tool_name": "fn2",
+                    "tool_call_index": 1,
+                },
+                {
+                    "type": "tool_call_start",
+                    "tool_call_id": "call_3",
+                    "tool_name": "fn3",
+                    "tool_call_index": 2,
+                },
+            ]
+        )
+        indices = self._get_output_indices(events)
+        assert indices == [
+            ("reasoning", 0),
+            ("function_call", 1),
+            ("function_call", 2),
+            ("function_call", 3),
+        ]
+
+    def test_reasoning_message_then_tools(self):
+        """[reasoning, message, fc, fc] → output_index [0, 1, 2, 3]."""
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "reasoning_delta", "reasoning": "think"},
+                {"type": "text_delta", "text": "hi"},
+                {
+                    "type": "tool_call_start",
+                    "tool_call_id": "call_1",
+                    "tool_name": "fn1",
+                    "tool_call_index": 0,
+                },
+                {
+                    "type": "tool_call_start",
+                    "tool_call_id": "call_2",
+                    "tool_name": "fn2",
+                    "tool_call_index": 1,
+                },
+            ]
+        )
+        indices = self._get_output_indices(events)
+        assert indices == [
+            ("reasoning", 0),
+            ("message", 1),
+            ("function_call", 2),
+            ("function_call", 3),
+        ]
+
+    def test_no_reasoning_backward_compat(self):
+        """[message, fc, fc] → output_index [0, 1, 2] (no reasoning)."""
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "text_delta", "text": "hi"},
+                {
+                    "type": "tool_call_start",
+                    "tool_call_id": "call_1",
+                    "tool_name": "fn1",
+                    "tool_call_index": 0,
+                },
+                {
+                    "type": "tool_call_start",
+                    "tool_call_id": "call_2",
+                    "tool_name": "fn2",
+                    "tool_call_index": 1,
+                },
+            ]
+        )
+        indices = self._get_output_indices(events)
+        assert indices == [
+            ("message", 0),
+            ("function_call", 1),
+            ("function_call", 2),
+        ]
+
+    def test_tools_only_no_message(self):
+        """[fc, fc] → output_index [0, 1]."""
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {
+                    "type": "tool_call_start",
+                    "tool_call_id": "call_1",
+                    "tool_name": "fn1",
+                    "tool_call_index": 0,
+                },
+                {
+                    "type": "tool_call_start",
+                    "tool_call_id": "call_2",
+                    "tool_name": "fn2",
+                    "tool_call_index": 1,
+                },
+            ]
+        )
+        indices = self._get_output_indices(events)
+        assert indices == [
+            ("function_call", 0),
+            ("function_call", 1),
+        ]
+
+
+class TestReasoningStreamingLifecycle:
+    """Tests for reasoning streaming lifecycle events (#408)."""
+
+    def setup_method(self):
+        self.converter = OpenAIResponsesConverter()
+
+    def _run_stream(self, ir_events):
+        ctx = StreamContext()
+        ctx.response_id = "resp_test"
+        ctx.model = "test-model"
+        results = []
+        for ev in ir_events:
+            out = self.converter.stream_response_to_provider(ev, context=ctx)
+            if isinstance(out, list):
+                results.extend(out)
+            elif isinstance(out, dict) and out:
+                results.append(out)
+        return results
+
+    def test_reasoning_delta_has_lifecycle_preamble(self):
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "reasoning_delta", "reasoning": "step 1"},
+            ]
+        )
+        types = [e.get("type") for e in events]
+        assert "response.output_item.added" in types
+        assert "response.reasoning_summary.part.added" in types
+        assert "response.reasoning_summary_text.delta" in types
+
+    def test_reasoning_item_added_has_id_and_status(self):
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "reasoning_delta", "reasoning": "step 1"},
+            ]
+        )
+        added = [e for e in events if e.get("type") == "response.output_item.added"]
+        assert len(added) == 1
+        item = added[0]["item"]
+        assert item["type"] == "reasoning"
+        assert item["id"].startswith("rs_")
+        assert item["status"] == "in_progress"
+
+    def test_reasoning_delta_has_required_fields(self):
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "reasoning_delta", "reasoning": "step 1"},
+            ]
+        )
+        deltas = [
+            e
+            for e in events
+            if e.get("type") == "response.reasoning_summary_text.delta"
+        ]
+        assert len(deltas) == 1
+        d = deltas[0]
+        assert "item_id" in d
+        assert d["item_id"].startswith("rs_")
+        assert "output_index" in d
+        assert d["summary_index"] == 0
+        assert d["delta"] == "step 1"
+
+    def test_reasoning_done_events_at_finish(self):
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "reasoning_delta", "reasoning": "step 1"},
+                {"type": "text_delta", "text": "result"},
+                {
+                    "type": "finish",
+                    "finish_reason": {"reason": "stop"},
+                },
+            ]
+        )
+        types = [e.get("type") for e in events]
+        assert "response.reasoning_summary_text.done" in types
+        assert "response.reasoning_summary.part.done" in types
+        # output_item.done should appear for both reasoning and message
+        done_events = [
+            e for e in events if e.get("type") == "response.output_item.done"
+        ]
+        done_types = [e["item"]["type"] for e in done_events]
+        assert "reasoning" in done_types
+        assert "message" in done_types
+
+    def test_reasoning_in_response_completed_output(self):
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "reasoning_delta", "reasoning": "thinking"},
+                {"type": "text_delta", "text": "answer"},
+                {
+                    "type": "finish",
+                    "finish_reason": {"reason": "stop"},
+                },
+                {"type": "stream_end"},
+            ]
+        )
+        completed = [e for e in events if e.get("type") == "response.completed"]
+        assert len(completed) == 1
+        output = completed[0]["response"]["output"]
+        output_types = [item["type"] for item in output]
+        assert "reasoning" in output_types
+        assert "message" in output_types
+
+    def test_second_reasoning_delta_no_duplicate_preamble(self):
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "reasoning_delta", "reasoning": "step 1"},
+                {"type": "reasoning_delta", "reasoning": "step 2"},
+            ]
+        )
+        added = [e for e in events if e.get("type") == "response.output_item.added"]
+        assert len(added) == 1
+        deltas = [
+            e
+            for e in events
+            if e.get("type") == "response.reasoning_summary_text.delta"
+        ]
+        assert len(deltas) == 2
+        assert deltas[0]["item_id"] == deltas[1]["item_id"]

--- a/tests/converters/openai_responses/test_utils.py
+++ b/tests/converters/openai_responses/test_utils.py
@@ -87,12 +87,19 @@ class TestBuildMessagePreambleEvents:
         build_message_preamble_events(self.ctx)
         assert self.ctx.item_id == "msg_resp_123"
 
-    def test_respects_output_index(self):
-        events = build_message_preamble_events(self.ctx, output_index=2)
-        assert events[0]["output_index"] == 2
-        assert events[1]["output_index"] == 2
+    def test_output_index_from_counter(self):
+        # Simulate reasoning item already allocated index 0
+        self.ctx.next_output_index()  # reasoning takes 0
+        events = build_message_preamble_events(self.ctx)
+        assert events[0]["output_index"] == 1
+        assert events[1]["output_index"] == 1
 
     def test_default_output_index_is_zero(self):
         events = build_message_preamble_events(self.ctx)
         assert events[0]["output_index"] == 0
         assert events[1]["output_index"] == 0
+
+    def test_stores_message_output_index(self):
+        self.ctx.next_output_index()  # reasoning takes 0
+        build_message_preamble_events(self.ctx)
+        assert self.ctx._message_output_index == 1


### PR DESCRIPTION
## Summary

- Replace fragmented `output_index` calculation with a single monotonic counter on `OpenAIResponsesStreamContext` — all output item types (reasoning, message, tool call) now allocate indices through `next_output_index()`, fixing incorrect indices when reasoning items precede messages or tool calls
- Add full streaming lifecycle for reasoning items: `output_item.added` → `reasoning_summary.part.added` → `reasoning_summary_text.delta` → `part.done` → `output_item.done`
- Generate deterministic reasoning item IDs via SHA-256 hash of `(response_id, index)` with three-level fallback, and add required `id`/`status` fields to non-streaming reasoning output

Closes #407, closes #408, closes #418.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (2226 passed, 0 failed)
- [x] New tests cover all output_index combinations: `[msg]`, `[reasoning, msg]`, `[reasoning, fc]`, `[reasoning, fc, fc, fc]`, `[reasoning, msg, fc, fc]`, `[msg, fc, fc]`, `[fc, fc]`
- [x] New tests verify reasoning streaming lifecycle events (preamble, delta fields, done events, response.completed output)
- [x] New tests verify deterministic reasoning ID generation and round-trip preservation