### PR TITLE
fix(gateway): strip _provider_metadata from outbound requests

### DIFF
--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -237,6 +237,26 @@ _default_metadata_store = ProviderMetadataStore()
 # ---------------------------------------------------------------------------
 
 
+def _strip_internal_metadata(body: dict) -> None:
+    """Recursively remove ``_provider_metadata`` from an outbound request body.
+
+    Converters attach ``_provider_metadata`` to provider-format objects
+    for cross-converter round-trip fidelity.  This must be stripped
+    before sending to upstream providers, which do not recognise it.
+
+    Operates in-place for zero-copy overhead.
+    """
+    for key in list(body.keys()):
+        if key == "_provider_metadata":
+            del body[key]
+        elif isinstance(body[key], dict):
+            _strip_internal_metadata(body[key])
+        elif isinstance(body[key], list):
+            for item in body[key]:
+                if isinstance(item, dict):
+                    _strip_internal_metadata(item)
+
+
 async def handle_non_streaming(
     route: ResolvedRoute,
     provider_info: ProviderInfo,
@@ -290,6 +310,7 @@ async def handle_non_streaming(
         target_body = flatten_system_content()(target_body)
 
     log_converted_request(target_body)
+    _strip_internal_metadata(target_body)
 
     # Phase 3: Forward to upstream via transport
     t_upstream = time.perf_counter()
@@ -542,6 +563,7 @@ async def handle_streaming(
         target_body = flatten_system_content()(target_body)
 
     log_converted_request(target_body)
+    _strip_internal_metadata(target_body)
 
     # Phase 3: Open upstream connection and check for immediate errors
     # *before* committing to a 200 StreamingResponse.

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -237,24 +237,25 @@ _default_metadata_store = ProviderMetadataStore()
 # ---------------------------------------------------------------------------
 
 
-def _strip_internal_metadata(body: dict) -> None:
+def _strip_internal_metadata(obj: dict | list) -> None:
     """Recursively remove ``_provider_metadata`` from an outbound request body.
 
     Converters attach ``_provider_metadata`` to provider-format objects
     for cross-converter round-trip fidelity.  This must be stripped
     before sending to upstream providers, which do not recognise it.
 
-    Operates in-place for zero-copy overhead.
+    Operates in-place for zero-copy overhead.  Accepts both dict and
+    list inputs for natural recursion through nested structures.
     """
-    for key in list(body.keys()):
-        if key == "_provider_metadata":
-            del body[key]
-        elif isinstance(body[key], dict):
-            _strip_internal_metadata(body[key])
-        elif isinstance(body[key], list):
-            for item in body[key]:
-                if isinstance(item, dict):
-                    _strip_internal_metadata(item)
+    if isinstance(obj, dict):
+        for key in list(obj.keys()):
+            if key == "_provider_metadata":
+                del obj[key]
+            else:
+                _strip_internal_metadata(obj[key])
+    elif isinstance(obj, list):
+        for item in obj:
+            _strip_internal_metadata(item)
 
 
 async def handle_non_streaming(

--- a/tests/gateway/test_strip_metadata.py
+++ b/tests/gateway/test_strip_metadata.py
@@ -77,3 +77,14 @@ class TestStripInternalMetadata:
         body = {}
         _strip_internal_metadata(body)
         assert body == {}
+
+    def test_list_of_list(self):
+        body = {"nested": [[{"_provider_metadata": {"x": 1}, "keep": 2}]]}
+        _strip_internal_metadata(body)
+        assert body["nested"][0][0] == {"keep": 2}
+
+    def test_non_dict_input(self):
+        items = [{"_provider_metadata": {"a": 1}, "id": "x"}, {"id": "y"}]
+        _strip_internal_metadata(items)
+        assert items[0] == {"id": "x"}
+        assert items[1] == {"id": "y"}

--- a/tests/gateway/test_strip_metadata.py
+++ b/tests/gateway/test_strip_metadata.py
@@ -1,0 +1,79 @@
+"""Tests for _strip_internal_metadata in proxy.py."""
+
+from llm_rosetta.gateway.proxy import _strip_internal_metadata
+
+
+class TestStripInternalMetadata:
+    def test_strips_top_level(self):
+        body = {"model": "gpt-4", "_provider_metadata": {"id": "x"}}
+        _strip_internal_metadata(body)
+        assert "_provider_metadata" not in body
+        assert body["model"] == "gpt-4"
+
+    def test_strips_nested_in_tool_calls(self):
+        body = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "function": {"name": "fn", "arguments": "{}"},
+                            "_provider_metadata": {"responses_item_id": "fc_1"},
+                        },
+                        {
+                            "id": "call_2",
+                            "function": {"name": "fn2", "arguments": "{}"},
+                            "_provider_metadata": {"responses_item_id": "fc_2"},
+                        },
+                    ],
+                }
+            ]
+        }
+        _strip_internal_metadata(body)
+        for tc in body["messages"][0]["tool_calls"]:
+            assert "_provider_metadata" not in tc
+            assert "id" in tc
+
+    def test_strips_in_content_blocks(self):
+        body = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "hi",
+                            "_provider_metadata": {"k": "v"},
+                        },
+                    ],
+                }
+            ]
+        }
+        _strip_internal_metadata(body)
+        assert "_provider_metadata" not in body["messages"][0]["content"][0]
+
+    def test_no_op_without_metadata(self):
+        body = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        original = body.copy()
+        _strip_internal_metadata(body)
+        assert body == original
+
+    def test_deeply_nested(self):
+        body = {"a": {"b": [{"c": {"_provider_metadata": {"deep": True}, "keep": 1}}]}}
+        _strip_internal_metadata(body)
+        assert body["a"]["b"][0]["c"] == {"keep": 1}
+
+    def test_preserves_other_underscore_fields(self):
+        body = {"_other_field": "keep", "_provider_metadata": "strip"}
+        _strip_internal_metadata(body)
+        assert "_other_field" in body
+        assert "_provider_metadata" not in body
+
+    def test_empty_body(self):
+        body = {}
+        _strip_internal_metadata(body)
+        assert body == {}


### PR DESCRIPTION
Closes #422

## Summary

- Add `_strip_internal_metadata()` recursive in-place strip function in `proxy.py`
- Called after `log_converted_request()` and before `transport.send_*()` in both streaming and non-streaming paths
- Logs retain full converted body for debugging, outbound HTTP requests are clean

## Test plan

- [x] 7 new tests covering: top-level strip, nested tool_calls, content blocks, deeply nested, no-op without metadata, preserves other underscore fields, empty body
- [x] `make test` passes (2259 passed)