### PR TITLE
fix(ir): allow RefusalPart in AssistantContentPart

### DIFF
--- a/src/llm_rosetta/types/ir/parts.py
+++ b/src/llm_rosetta/types/ir/parts.py
@@ -276,11 +276,14 @@ UserContentPart = Union[
     # AudioPart,
 ]
 
-# 助手消息内容类型 - 文本、工具调用、推理、引用，未来支持音频、图像
+# 助手消息内容类型 - 文本、工具调用、推理、拒绝、引用，未来支持音频、图像
+# Assistant message content types - text, tool calls, reasoning, refusal,
+# citations, future support for audio and images.
 AssistantContentPart = Union[
     TextPart,
     ToolCallPart,
     ReasoningPart,
+    RefusalPart,
     CitationPart,
     # 未来支持 Future support:
     # AudioPart,

--- a/tests/converters/openai_chat/test_message_ops.py
+++ b/tests/converters/openai_chat/test_message_ops.py
@@ -4,6 +4,7 @@ OpenAI Chat MessageOps unit tests.
 
 from typing import Any, Union, cast
 
+from llm_rosetta._vendor.validate import validate
 from llm_rosetta.converters.openai_chat.content_ops import OpenAIChatContentOps
 from llm_rosetta.converters.openai_chat.message_ops import (
     OpenAIChatMessageOps,
@@ -209,6 +210,27 @@ class TestOpenAIChatMessageOps:
         )
         result, warnings = self.message_ops.ir_messages_to_p(messages)
         assert result[0]["refusal"] == "I cannot do that"
+
+    def test_p_assistant_refusal_to_ir_validates(self):
+        """Provider refusal → IR must satisfy IR validation.
+
+        OpenAI returns `content: null` with a populated `refusal` field when a
+        request is declined. The converter turns that into a RefusalPart, so
+        the resulting message has to validate as an IR Message. Previously it
+        did not, and the gateway answered a plain refusal with a 502.
+        """
+        ir = self.message_ops._p_message_to_ir(
+            {
+                "role": "assistant",
+                "content": None,
+                "refusal": "I cannot help with that.",
+            }
+        )
+        assert ir["content"][0] == {
+            "type": "refusal",
+            "refusal": "I cannot help with that.",
+        }
+        validate(ir, Message)
 
     def test_tool_message_to_p(self):
         """Test IR tool message → OpenAI tool role message."""

--- a/tests/test_types/ir/test_validation.py
+++ b/tests/test_types/ir/test_validation.py
@@ -233,6 +233,43 @@ class TestValidateMessages:
         result = validate_messages([_user_message(), _assistant_message()])
         assert len(result) == 2
 
+    def test_assistant_message_accepts_refusal_part(self):
+        """A refusal is a valid assistant content part.
+
+        Converters emit RefusalPart whenever an upstream returns a refusal, so
+        it has to be a member of AssistantContentPart. When it was missing,
+        every refusal failed IR validation and the gateway turned a normal
+        safety refusal into a 502.
+        """
+        result = validate_messages(
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "refusal", "refusal": "I cannot help with that."}
+                    ],
+                }
+            ]
+        )
+        msg = cast(dict, result[0])
+        assert msg["content"][0]["type"] == "refusal"
+
+    def test_assistant_message_accepts_text_and_refusal(self):
+        """Partial output followed by a refusal must also validate."""
+        result = validate_messages(
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        _text_part("here is what I can say"),
+                        {"type": "refusal", "refusal": "but not the rest"},
+                    ],
+                }
+            ]
+        )
+        msg = cast(dict, result[0])
+        assert [part["type"] for part in msg["content"]] == ["text", "refusal"]
+
     def test_valid_system_message(self):
         result = validate_messages(
             [{"role": "system", "content": [_text_part("system prompt")]}]


### PR DESCRIPTION
## Summary

`RefusalPart` is missing from the `AssistantContentPart` union, so any response carrying a refusal fails IR validation:

```
Value at 'content[0]' does not match any variant of
TextPart | ToolCallPart | ReasoningPart | CitationPart
```

Through the gateway this surfaces as a **502 "Failed to parse upstream response"** — a normal safety refusal is reported to the client as a proxy failure rather than as the model's answer.

## Reproduction

On `main`:

```python
from llm_rosetta.converters.openai_chat import OpenAIChatConverter
from llm_rosetta._vendor.validate import validate
from llm_rosetta.types.ir.messages import Message

conv = OpenAIChatConverter()
ir = conv.message_ops._p_message_to_ir(
    {"role": "assistant", "content": None, "refusal": "I cannot help with that."}
)
# {'role': 'assistant', 'content': [{'type': 'refusal', 'refusal': '...'}]}
validate(ir, Message)   # ValidationError
```

## Why it happens

The refusal path is otherwise fully supported, which is what makes this look like an omission rather than missing functionality:

- `converters/openai_chat/message_ops.py:657` builds a `RefusalPart` from the provider `refusal` field
- `converters/openai_chat/content_ops.py:240` and `converters/anthropic/content_ops.py:352` also construct one
- the outbound direction already handles it (`content_ops.py:227` → `{"refusal": ...}`), and there is an existing IR→provider test for it
- `RefusalPart` is already a member of the general `ContentPart` union

Only `AssistantContentPart` — the one union where a refusal can actually appear — omitted it.

## Change

One line in `src/llm_rosetta/types/ir/parts.py`, adding `RefusalPart` to `AssistantContentPart`, plus a comment update.

## Tests

Three regression tests, all of which fail without the union change and pass with it:

- `tests/test_types/ir/test_validation.py` — assistant message with a refusal part, and with text followed by a refusal
- `tests/converters/openai_chat/test_message_ops.py` — provider→IR conversion of `content: null` + `refusal`, then validated

The gap in coverage was that existing tests exercised `RefusalPart` in isolation and in the IR→provider direction, but never validated an assistant message that contained one.

## Verification

- `pytest tests/ --ignore=tests/integration` — **2236 passed, 34 skipped**
- `ruff check src/ tests/` — clean
- `ruff format --check src/ tests/` — 253 files already formatted
- `ty check` — **28 diagnostics, identical to the baseline on `main`** (no new ones)

## Out of scope

While testing I noticed that cross-format refusal conversion drops the content — Anthropic→IR→Chat yields `{'role': 'assistant', 'content': ''}` with the refusal lost. That reproduces on `main` **without** this change, so I have left it alone rather than widen this PR. Happy to open a separate issue if useful.

## Note

Found while running a multi-model evaluation through a gateway, where three of thirteen models returned refusals and every one came back as a 502.

AI was used to assist with implementation.
