### PR TITLE
fix(openai-chat): always include refusal field on assistant messages

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/message_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/message_ops.py
@@ -351,9 +351,8 @@ class OpenAIChatMessageOps(BaseMessageOps):
         if not text_parts and not tool_calls:
             openai_message["content"] = ""
 
-        # Set refusal if present
-        if refusal_text is not None:
-            openai_message["refusal"] = refusal_text
+        # OpenAI spec requires refusal field on assistant messages (nullable)
+        openai_message["refusal"] = refusal_text
 
         return openai_message, warnings
 

--- a/tests/converters/openai_chat/test_message_ops.py
+++ b/tests/converters/openai_chat/test_message_ops.py
@@ -1052,3 +1052,63 @@ class TestMultimodalToolResultPacking:
         )
         assert _has_multimodal_content([]) is False
         assert _has_multimodal_content(None) is False
+
+
+class TestRefusalFieldAlwaysPresent:
+    """Tests for refusal field always present on assistant messages (#427 follow-up)."""
+
+    def setup_method(self):
+        content_ops = OpenAIChatContentOps()
+        tool_ops = OpenAIChatToolOps()
+        self.ops = OpenAIChatMessageOps(content_ops, tool_ops)
+
+    def test_normal_response_has_refusal_null(self):
+        """Normal assistant message includes refusal: None."""
+        ir_messages = cast(
+            list,
+            [
+                {"role": "assistant", "content": [{"type": "text", "text": "Hello"}]},
+            ],
+        )
+        result, _ = self.ops.ir_messages_to_p(ir_messages)
+        assistant = [m for m in result if m["role"] == "assistant"][0]
+        assert "refusal" in assistant
+        assert assistant["refusal"] is None
+
+    def test_tool_call_response_has_refusal_null(self):
+        """Assistant with tool calls includes refusal: None."""
+        ir_messages = cast(
+            list,
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_call",
+                            "tool_call_id": "call_1",
+                            "tool_name": "fn",
+                            "tool_input": {},
+                        }
+                    ],
+                },
+            ],
+        )
+        result, _ = self.ops.ir_messages_to_p(ir_messages)
+        assistant = [m for m in result if m["role"] == "assistant"][0]
+        assert "refusal" in assistant
+        assert assistant["refusal"] is None
+
+    def test_refusal_response_has_refusal_text(self):
+        """Assistant with refusal includes the refusal text."""
+        ir_messages = cast(
+            list,
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "refusal", "refusal": "I cannot do that"}],
+                },
+            ],
+        )
+        result, _ = self.ops.ir_messages_to_p(ir_messages)
+        assistant = [m for m in result if m["role"] == "assistant"][0]
+        assert assistant["refusal"] == "I cannot do that"


### PR DESCRIPTION
Follow-up to #427.

## Summary

OpenAI Chat spec requires `refusal` on `ChatCompletionResponseMessage` (`required: ['role', 'content', 'refusal']`, `nullable: true`). Our converter only set it when a refusal was present, causing llm-comply compliance failures (4/8 tests).

One-line fix: always set `refusal` (defaults to `None` when no refusal).

## Evidence

Spec (`openai_chat.json`): `ChatCompletionResponseMessage.required = ['role', 'content', 'refusal']`

Real API probe — OpenAI always returns `refusal: null`:
```
OpenAI gpt-5-nano:  message keys = ['annotations', 'content', 'refusal', 'role']
DeepSeek:           message keys = ['content', 'role']  (no refusal — non-compliant)
OpenRouter:         message keys = ['content', 'reasoning', 'refusal', 'role']
```

## Test plan

- [x] 3 new tests: normal response has `refusal: null`, tool call has `refusal: null`, refusal has text
- [x] `make test` passes (2269 passed)