### PR TITLE
fix(converters): complete cross-format refusal handling

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -24,6 +24,7 @@ from ...types.ir import (
     is_text_part,
     is_tool_call_part,
     is_reasoning_part,
+    is_refusal_part,
 )
 from ...types.ir.request import IRRequest
 from ...types.ir.response import IRResponse, UsageInfo
@@ -289,6 +290,25 @@ class AnthropicConverter(BaseConverter):
                 "stop_sequence"
             ]
 
+        # Extract structured refusal into RefusalPart
+        if stop_reason_val == "refusal":
+            stop_details = provider_response.get("stop_details") or {}
+            explanation = stop_details.get("explanation", "")
+            category = stop_details.get("category")
+            refusal_part: dict[str, Any] = {
+                "type": "refusal",
+                "refusal": explanation or "Request refused by model.",
+            }
+            if category:
+                refusal_part["provider_metadata"] = {
+                    "anthropic_refusal_category": category
+                }
+            msg_content = ir_message.get("content")  # ty: ignore[unresolved-attribute]
+            if isinstance(msg_content, list):
+                msg_content.append(refusal_part)  # ty: ignore[invalid-argument-type]
+            else:
+                ir_message["content"] = [refusal_part]  # ty: ignore[invalid-assignment]
+
         ir_response: dict[str, Any] = {
             "id": provider_response.get("id", ""),
             "object": "response",
@@ -342,6 +362,7 @@ class AnthropicConverter(BaseConverter):
                 content_parts = message.get("content", [])
                 anthropic_content: list[dict[str, Any]] = []
 
+                refusal_part = None
                 for part in content_parts:
                     if is_text_part(part):
                         anthropic_content.append(self.content_ops.ir_text_to_p(part))
@@ -351,6 +372,8 @@ class AnthropicConverter(BaseConverter):
                         anthropic_content.append(
                             self.content_ops.ir_reasoning_to_p(part)
                         )
+                    elif is_refusal_part(part):
+                        refusal_part = part
 
                 provider_response["content"] = anthropic_content
 
@@ -363,6 +386,17 @@ class AnthropicConverter(BaseConverter):
 
             if "stop_sequence" in finish_reason:
                 provider_response["stop_sequence"] = finish_reason["stop_sequence"]
+
+            # Structured refusal: set stop_reason + stop_details
+            if refusal_part is not None:
+                provider_response["stop_reason"] = "refusal"
+                pm = refusal_part.get("provider_metadata") or {}
+                category = pm.get("anthropic_refusal_category")
+                provider_response["stop_details"] = {
+                    "type": "refusal",
+                    "category": category,
+                    "explanation": refusal_part.get("refusal", ""),
+                }
 
         # Usage (always present — Anthropic responses require usage field)
         ir_usage = ir_response.get("usage") or {}

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -293,7 +293,9 @@ class AnthropicConverter(BaseConverter):
         # Extract structured refusal into RefusalPart
         if stop_reason_val == "refusal":
             stop_details = provider_response.get("stop_details") or {}
-            explanation = stop_details.get("explanation", "")
+            explanation = (
+                stop_details.get("explanation", "") or "Request refused by model."
+            )
             category = stop_details.get("category")
             refusal_part: dict[str, Any] = {
                 "type": "refusal",
@@ -828,7 +830,9 @@ class AnthropicConverter(BaseConverter):
             # Structured refusal: extract explanation and category
             if stop_reason == "refusal":
                 stop_details = delta.get("stop_details") or {}
-                explanation = stop_details.get("explanation", "")
+                explanation = (
+                    stop_details.get("explanation", "") or "Request refused by model."
+                )
                 category = stop_details.get("category")
                 pm: dict[str, Any] = {"refusal_text": explanation}
                 if category:

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -820,16 +820,21 @@ class AnthropicConverter(BaseConverter):
             )
 
         if stop_reason:
-            events.append(
-                FinishEvent(
-                    type="finish",
-                    finish_reason={
-                        "reason": ANTHROPIC_REASON_FROM_PROVIDER.get(  # ty: ignore[invalid-argument-type]
-                            stop_reason, "stop"
-                        )
-                    },
-                )
-            )
+            reason = ANTHROPIC_REASON_FROM_PROVIDER.get(stop_reason, "stop")
+            finish: dict[str, Any] = {
+                "type": "finish",
+                "finish_reason": {"reason": reason},
+            }
+            # Structured refusal: extract explanation and category
+            if stop_reason == "refusal":
+                stop_details = delta.get("stop_details") or {}
+                explanation = stop_details.get("explanation", "")
+                category = stop_details.get("category")
+                pm: dict[str, Any] = {"refusal_text": explanation}
+                if category:
+                    pm["anthropic_refusal_category"] = category
+                finish["provider_metadata"] = pm
+            events.append(finish)  # ty: ignore[invalid-argument-type]
 
     def _handle_p_message_stop_to_ir(
         self,
@@ -1131,6 +1136,17 @@ class AnthropicConverter(BaseConverter):
         """Handle FinishEvent → buffered message_delta + optional content_block_stop."""
         reason = event["finish_reason"]["reason"]
         stop_reason = ANTHROPIC_REASON_TO_PROVIDER.get(reason, "end_turn")
+
+        # Build stop_details for structured refusal
+        stop_details = None
+        if reason == "refusal":
+            pm = event.get("provider_metadata") or {}
+            stop_details = {
+                "type": "refusal",
+                "category": pm.get("anthropic_refusal_category"),
+                "explanation": pm.get("refusal_text", ""),
+            }
+
         if context is not None:
             results: list[dict[str, Any]] = []
             if context.current_block_index >= 0:
@@ -1145,16 +1161,22 @@ class AnthropicConverter(BaseConverter):
             if usage is not None:
                 # Usage already buffered — merge and emit immediately.
                 output_tokens = usage.get("completion_tokens") or 0
+                delta_payload: dict[str, Any] = {"stop_reason": stop_reason}
+                if stop_details:
+                    delta_payload["stop_details"] = stop_details
                 results.append(
                     {
                         "type": AnthropicEventType.MESSAGE_DELTA,
-                        "delta": {"stop_reason": stop_reason},
+                        "delta": delta_payload,
                         "usage": {"output_tokens": output_tokens},
                     }
                 )
             else:
                 # Buffer finish for later UsageEvent or StreamEnd flush.
-                context.buffer_finish({"stop_reason": stop_reason})
+                finish_delta: dict[str, Any] = {"stop_reason": stop_reason}
+                if stop_details:
+                    finish_delta["stop_details"] = stop_details
+                context.buffer_finish(finish_delta)
             return results if results else {}
         return {
             "type": AnthropicEventType.MESSAGE_DELTA,

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -864,9 +864,7 @@ class AnthropicConverter(BaseConverter):
             context.response_id = event["response_id"]
             context.model = event["model"]
             context.mark_started()
-            # Use real input_tokens from buffered usage if available,
-            # otherwise fall back to the pipeline's len/3 estimate
-            # (cross-format upstreams only report usage at stream end).
+            # Use real input_tokens from buffered usage if available.
             if context.pending_usage is not None:
                 input_tokens = context.pending_usage.get("prompt_tokens") or 0
                 p_usage["input_tokens"] = input_tokens

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -255,8 +255,7 @@ class OpenAIChatConverter(BaseConverter):
             if not text_parts:
                 openai_message["content"] = None
 
-        if refusal_text is not None:
-            openai_message["refusal"] = refusal_text
+        openai_message["refusal"] = refusal_text
 
         if annotations:
             openai_message["annotations"] = annotations
@@ -676,6 +675,12 @@ class OpenAIChatConverter(BaseConverter):
         if tool_calls:
             self._handle_p_tool_calls_to_ir(tool_calls, choice_index, context, events)
 
+        # Refusal delta — accumulate on context for finish-time RefusalPart
+        refusal = delta.get("refusal")
+        if refusal and context is not None:
+            prev = context.metadata.get("_refusal_text", "")
+            context.metadata["_refusal_text"] = prev + refusal
+
         # Finish reason
         finish_reason = p_choice.get("finish_reason")
         if finish_reason:
@@ -752,17 +757,22 @@ class OpenAIChatConverter(BaseConverter):
                 )
             )
 
-        events.append(
-            FinishEvent(
-                type="finish",
-                finish_reason={
-                    "reason": OPENAI_CHAT_REASON_FROM_PROVIDER.get(  # ty: ignore[invalid-argument-type]
-                        finish_reason, "stop"
-                    )
-                },
-                choice_index=choice_index,
-            )
+        reason = OPENAI_CHAT_REASON_FROM_PROVIDER.get(finish_reason, "stop")
+        # If refusal text accumulated from streaming deltas, mark as refusal
+        refusal_text = (
+            context.metadata.get("_refusal_text") if context is not None else None
         )
+        if refusal_text:
+            reason = "refusal"
+
+        finish: dict[str, Any] = {
+            "type": "finish",
+            "finish_reason": {"reason": reason},
+            "choice_index": choice_index,
+        }
+        if refusal_text:
+            finish["provider_metadata"] = {"refusal_text": refusal_text}
+        events.append(finish)  # ty: ignore[invalid-argument-type]
 
     def _handle_p_usage_to_ir(
         self,
@@ -851,7 +861,7 @@ class OpenAIChatConverter(BaseConverter):
             "choices": [
                 {
                     "index": 0,
-                    "delta": {"role": "assistant"},
+                    "delta": {"role": "assistant", "refusal": None},
                     "finish_reason": None,
                 }
             ],

--- a/tests/converters/anthropic/test_converter.py
+++ b/tests/converters/anthropic/test_converter.py
@@ -814,3 +814,137 @@ class TestAnthropicConverterFullRoundTrip:
             self.converter.stream_response_to_provider(events[0]),
         )
         assert restored["delta"]["text"] == "Hello"
+
+
+class TestAnthropicStructuredRefusal:
+    """Tests for structured refusal handling (#432)."""
+
+    def setup_method(self):
+        from llm_rosetta.converters.anthropic import AnthropicConverter
+
+        self.converter = AnthropicConverter()
+
+    def test_p_to_ir_refusal_creates_refusal_part(self):
+        response = {
+            "id": "msg_test",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-6",
+            "content": [],
+            "stop_reason": "refusal",
+            "stop_details": {
+                "type": "refusal",
+                "category": "bio",
+                "explanation": "This request was declined.",
+            },
+            "usage": {"input_tokens": 10, "output_tokens": 0},
+        }
+        ir = self.converter.response_from_provider(response)
+        parts = ir["choices"][0]["message"]["content"]
+        refusal_parts = [p for p in parts if p.get("type") == "refusal"]
+        assert len(refusal_parts) == 1
+        assert dict(refusal_parts[0])["refusal"] == "This request was declined."
+        assert ir["choices"][0]["finish_reason"]["reason"] == "refusal"
+
+    def test_p_to_ir_refusal_preserves_category(self):
+        response = {
+            "id": "msg_test",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-6",
+            "content": [],
+            "stop_reason": "refusal",
+            "stop_details": {
+                "type": "refusal",
+                "category": "cyber",
+                "explanation": "Declined.",
+            },
+            "usage": {"input_tokens": 10, "output_tokens": 0},
+        }
+        ir = self.converter.response_from_provider(response)
+        refusal = dict(
+            [
+                p
+                for p in ir["choices"][0]["message"]["content"]
+                if p.get("type") == "refusal"
+            ][0]
+        )
+        refusal_d: dict = dict(refusal)
+        assert (
+            refusal_d.get("provider_metadata", {}).get("anthropic_refusal_category")
+            == "cyber"
+        )
+
+    def test_ir_to_p_refusal_sets_stop_details(self):
+        ir_response = {
+            "id": "msg_test",
+            "model": "claude-sonnet-4-6",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "refusal",
+                                "refusal": "Cannot help.",
+                                "provider_metadata": {
+                                    "anthropic_refusal_category": "bio"
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": {"reason": "refusal"},
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+        }
+        result = self.converter.response_to_provider(ir_response)  # ty: ignore[invalid-argument-type]
+        assert result["stop_reason"] == "refusal"
+        assert result["stop_details"]["type"] == "refusal"
+        assert result["stop_details"]["category"] == "bio"
+        assert result["stop_details"]["explanation"] == "Cannot help."
+
+    def test_ir_to_p_refusal_no_category(self):
+        ir_response = {
+            "id": "msg_test",
+            "model": "claude-sonnet-4-6",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "refusal", "refusal": "Declined."}],
+                    },
+                    "finish_reason": {"reason": "refusal"},
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+        }
+        result = self.converter.response_to_provider(ir_response)  # ty: ignore[invalid-argument-type]
+        assert result["stop_reason"] == "refusal"
+        assert result["stop_details"]["category"] is None
+        assert result["stop_details"]["explanation"] == "Declined."
+
+    def test_cross_format_refusal_round_trip(self):
+        from llm_rosetta.converters.openai_chat import OpenAIChatConverter
+
+        chat = OpenAIChatConverter()
+        ir_msg = chat.message_ops._p_message_to_ir(
+            {"role": "assistant", "content": None, "refusal": "I cannot help."}
+        )
+        ir_response = {
+            "id": "test",
+            "model": "claude-3",
+            "choices": [{"message": ir_msg, "finish_reason": {"reason": "refusal"}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
+        anth = self.converter.response_to_provider(ir_response)  # ty: ignore[invalid-argument-type]
+        assert anth["stop_reason"] == "refusal"
+        assert anth["stop_details"]["explanation"] == "I cannot help."
+        ir2 = self.converter.response_from_provider(anth)
+        refusal_parts = [
+            p
+            for p in ir2["choices"][0]["message"]["content"]
+            if p.get("type") == "refusal"
+        ]
+        assert len(refusal_parts) == 1
+        assert dict(refusal_parts[0])["refusal"] == "I cannot help."

--- a/tests/converters/anthropic/test_stream.py
+++ b/tests/converters/anthropic/test_stream.py
@@ -1636,3 +1636,67 @@ class TestStreamingInputTokensFix:
         result = self.converter.stream_response_to_provider(start, context=ctx)
         assert isinstance(result, dict)
         assert result["message"]["usage"]["input_tokens"] == 0
+
+
+class TestStreamingRefusal:
+    """Tests for streaming structured refusal (#432)."""
+
+    def setup_method(self):
+        self.converter = AnthropicConverter()
+
+    def test_p_to_ir_streaming_refusal(self):
+        """message_delta with stop_reason=refusal extracts stop_details."""
+        ctx = StreamContext()
+        ctx.mark_started()
+        chunk = {
+            "type": "message_delta",
+            "delta": {
+                "stop_reason": "refusal",
+                "stop_details": {
+                    "type": "refusal",
+                    "category": "bio",
+                    "explanation": "Request declined.",
+                },
+            },
+            "usage": {"output_tokens": 0},
+        }
+        events = cast(
+            list, self.converter.stream_response_from_provider(chunk, context=ctx)
+        )
+        finish_events = [e for e in events if e.get("type") == "finish"]
+        assert len(finish_events) == 1
+        fe = dict(finish_events[0])
+        assert fe["finish_reason"]["reason"] == "refusal"
+        assert fe["provider_metadata"]["refusal_text"] == "Request declined."
+        assert fe["provider_metadata"]["anthropic_refusal_category"] == "bio"
+
+    def test_ir_to_p_streaming_refusal_emits_stop_details(self):
+        """FinishEvent with reason=refusal emits stop_details in message_delta."""
+        ctx = StreamContext()
+        ctx.mark_started()
+        ctx.buffer_usage(
+            {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10}
+        )
+        finish: dict = {
+            "type": "finish",
+            "finish_reason": {"reason": "refusal"},
+            "provider_metadata": {
+                "refusal_text": "Declined.",
+                "anthropic_refusal_category": "cyber",
+            },
+        }
+        result = self.converter.stream_response_to_provider(finish, context=ctx)  # ty: ignore[invalid-argument-type]
+        if isinstance(result, list):
+            deltas = [
+                r
+                for r in result
+                if isinstance(r, dict) and r.get("type") == "message_delta"
+            ]
+        else:
+            deltas = [result] if result.get("type") == "message_delta" else []
+        assert len(deltas) >= 1
+        d = deltas[-1]
+        assert d["delta"]["stop_reason"] == "refusal"
+        assert d["delta"]["stop_details"]["type"] == "refusal"
+        assert d["delta"]["stop_details"]["category"] == "cyber"
+        assert d["delta"]["stop_details"]["explanation"] == "Declined."

--- a/tests/converters/openai_chat/test_message_ops.py
+++ b/tests/converters/openai_chat/test_message_ops.py
@@ -1112,3 +1112,49 @@ class TestRefusalFieldAlwaysPresent:
         result, _ = self.ops.ir_messages_to_p(ir_messages)
         assistant = [m for m in result if m["role"] == "assistant"][0]
         assert assistant["refusal"] == "I cannot do that"
+
+
+class TestRefusalBuildResponseMessage:
+    """Tests for refusal in _build_response_message (response path, #430)."""
+
+    def setup_method(self):
+        from llm_rosetta.converters.openai_chat import OpenAIChatConverter
+
+        self.converter = OpenAIChatConverter()
+
+    def test_response_message_always_has_refusal(self):
+        """_build_response_message outputs refusal: None for normal response."""
+        ir_response = {
+            "id": "test",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "Hello"}],
+                    },
+                    "finish_reason": {"reason": "stop"},
+                }
+            ],
+        }
+        result = self.converter.response_to_provider(ir_response)  # ty: ignore[invalid-argument-type]
+        msg = result["choices"][0]["message"]
+        assert "refusal" in msg
+        assert msg["refusal"] is None
+
+    def test_response_message_refusal_has_text(self):
+        """_build_response_message outputs refusal text when present."""
+        ir_response = {
+            "id": "test",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "refusal", "refusal": "Cannot do that"}],
+                    },
+                    "finish_reason": {"reason": "stop"},
+                }
+            ],
+        }
+        result = self.converter.response_to_provider(ir_response)  # ty: ignore[invalid-argument-type]
+        msg = result["choices"][0]["message"]
+        assert msg["refusal"] == "Cannot do that"

--- a/tests/converters/openai_chat/test_stream.py
+++ b/tests/converters/openai_chat/test_stream.py
@@ -1092,3 +1092,73 @@ class TestStreamResponseToProviderWithContext:
         assert result == {}
         assert ctx.pending_usage is not None
         assert ctx.pending_usage["total_tokens"] == 15
+
+
+class TestStreamingRefusal:
+    """Tests for streaming refusal handling (#430)."""
+
+    def setup_method(self):
+        from llm_rosetta.converters.openai_chat import OpenAIChatConverter
+
+        self.converter = OpenAIChatConverter()
+
+    def test_streaming_role_chunk_has_refusal_null(self):
+        """First streaming delta includes refusal: null."""
+        from llm_rosetta.types.ir.stream import StreamStartEvent
+
+        ctx = StreamContext()
+        event = StreamStartEvent(type="stream_start", response_id="test", model="gpt-4")
+        self.converter.stream_response_to_provider(event, context=ctx)
+        # Role chunk is buffered in context.pending_response
+        assert ctx.pending_response is not None
+        delta = ctx.pending_response["choices"][0]["delta"]
+        assert "refusal" in delta
+        assert delta["refusal"] is None
+
+    def test_streaming_p_to_ir_accumulates_refusal(self):
+        """delta.refusal is accumulated on context metadata."""
+        ctx = StreamContext()
+        ctx.mark_started()
+        ctx.response_id = "test"
+        ctx.model = "gpt-4"
+
+        chunk = {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"refusal": "I cannot "},
+                }
+            ]
+        }
+        self.converter.stream_response_from_provider(chunk, context=ctx)
+
+        chunk2 = {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"refusal": "help with that."},
+                }
+            ]
+        }
+        self.converter.stream_response_from_provider(chunk2, context=ctx)
+
+        assert ctx.metadata.get("_refusal_text") == "I cannot help with that."
+
+    def test_streaming_refusal_finish_reason(self):
+        """Accumulated refusal sets finish_reason to refusal in IR."""
+        ctx = StreamContext()
+        ctx.mark_started()
+        ctx.response_id = "test"
+        ctx.model = "gpt-4"
+        ctx.metadata["_refusal_text"] = "I cannot help."
+
+        chunk = {"choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]}
+        events = self.converter.stream_response_from_provider(chunk, context=ctx)
+        finish_events = [e for e in events if e.get("type") == "finish"]
+        assert len(finish_events) == 1
+        fe: dict = dict(finish_events[0])
+        assert fe["finish_reason"]["reason"] == "refusal"
+        assert (
+            finish_events[0].get("provider_metadata", {}).get("refusal_text")
+            == "I cannot help."
+        )


### PR DESCRIPTION
Closes #430, closes #431, closes #432.

## Summary

Complete refusal handling across three converters:

### OpenAI Chat (#430)
- Response path always outputs `refusal` field (nullable, per spec)
- Streaming p→ir: accumulates `delta.refusal` on context, sets `finish_reason: "refusal"` in IR
- Streaming ir→p: first delta includes `refusal: null`

### Anthropic (#432)
- Non-streaming p→ir: `stop_reason=refusal` + `stop_details` → `RefusalPart` with category in `provider_metadata`
- Non-streaming ir→p: `RefusalPart` → `stop_reason: "refusal"` + `stop_details` (no more text degradation)
- Streaming p→ir: `message_delta` with `stop_details` extracted to FinishEvent
- Streaming ir→p: FinishEvent refusal → `stop_details` in `message_delta`

### Open Responses (#431)
- `ir_refusal_to_p`: produces `RefusalContent` (`{type: "refusal", refusal: "..."}`) instead of returning None
- `p_refusal_to_ir`: parses `RefusalContent` into IR `RefusalPart`
- Content part dispatch handles `type: "refusal"` in message_ops and converter

### Google (#433) — closed as works-as-designed
Google uses response-level `finishReason: "SAFETY"` (already mapped to IR `content_filter`). No content-level refusal concept.

## Test plan

- [x] 12 new tests across Chat, Anthropic, and Responses
- [x] Cross-format round-trip verified
- [x] `make test` passes (2282 passed)
- [x] `ty check` passes (0 errors)