### PR TITLE
fix(openai-responses): handle RefusalContent type

### DIFF
--- a/src/llm_rosetta/converters/openai_responses/content_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/content_ops.py
@@ -9,7 +9,6 @@ and input_file for files. Images and files are always input-only.
 """
 
 import re
-import warnings
 from typing import Any
 
 from ...types.ir import (
@@ -358,34 +357,32 @@ class OpenAIResponsesContentOps(BaseContentOps):
     # ==================== Refusal ====================
 
     @staticmethod
-    def ir_refusal_to_p(ir_refusal: RefusalPart, **kwargs: Any) -> dict | None:
-        """IR RefusalPart → OpenAI Responses refusal content.
-
-        OpenAI Responses API does not have a dedicated refusal format.
-        Returns None and emits a warning.
+    def ir_refusal_to_p(ir_refusal: RefusalPart, **kwargs: Any) -> dict:
+        """IR RefusalPart → OpenAI Responses RefusalContent.
 
         Args:
             ir_refusal: IR refusal part.
 
         Returns:
-            None (refusal is dropped with a warning).
+            OpenAI Responses RefusalContent dict.
         """
-        warnings.warn(
-            "Refusal content not directly supported in OpenAI Responses API, ignored",
-            stacklevel=2,
-        )
-        return None
+        return {"type": "refusal", "refusal": ir_refusal["refusal"]}
 
     @staticmethod
     def p_refusal_to_ir(provider_refusal: Any, **kwargs: Any) -> RefusalPart:
-        """OpenAI Responses refusal content → IR RefusalPart.
+        """OpenAI Responses RefusalContent → IR RefusalPart.
 
-        Raises:
-            NotImplementedError: OpenAI Responses API does not produce refusal parts.
+        Args:
+            provider_refusal: RefusalContent dict with type and refusal fields.
+
+        Returns:
+            IR RefusalPart.
         """
-        raise NotImplementedError(
-            "OpenAI Responses API does not produce refusal content parts."
-        )
+        if isinstance(provider_refusal, dict):
+            return RefusalPart(
+                type="refusal", refusal=provider_refusal.get("refusal", "")
+            )
+        return RefusalPart(type="refusal", refusal=str(provider_refusal))
 
     # ==================== Citation ====================
 

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -467,9 +467,7 @@ class OpenAIResponsesConverter(BaseConverter):
                     )
                     reasoning_index += 1
                 elif is_refusal_part(part):
-                    refusal_content = self.content_ops.ir_refusal_to_p(part)
-                    if refusal_content:
-                        text_parts.append(refusal_content)
+                    text_parts.append(self.content_ops.ir_refusal_to_p(part))
 
             if text_parts:
                 provider_response["output"].insert(

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -19,6 +19,7 @@ from ...types.ir import (
     is_text_part,
     is_tool_call_part,
     is_reasoning_part,
+    is_refusal_part,
 )
 from ...types.ir.passthrough import ProviderPassthroughItem
 from ...types.ir.request import IRRequest
@@ -465,6 +466,10 @@ class OpenAIResponsesConverter(BaseConverter):
                         )
                     )
                     reasoning_index += 1
+                elif is_refusal_part(part):
+                    refusal_content = self.content_ops.ir_refusal_to_p(part)
+                    if refusal_content:
+                        text_parts.append(refusal_content)
 
             if text_parts:
                 provider_response["output"].insert(

--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -506,6 +506,8 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
             return [self.content_ops.p_image_to_ir(provider_part)]
         elif part_type == "input_file":
             return [self.content_ops.p_file_to_ir(provider_part)]
+        elif part_type == "refusal":
+            return [self.content_ops.p_refusal_to_ir(provider_part)]
 
         # Slug-prefixed content part (e.g. "openai:summary_text") — preserve opaquely
         if isinstance(part_type, str) and ":" in part_type:

--- a/tests/converters/openai_responses/test_content_ops.py
+++ b/tests/converters/openai_responses/test_content_ops.py
@@ -10,6 +10,7 @@ from llm_rosetta.converters.openai_responses.content_ops import (
 from typing import cast
 
 from llm_rosetta.types.ir import (
+    RefusalPart,
     CitationPart,
     FilePart,
     ImagePart,
@@ -363,20 +364,27 @@ class TestOpenAIResponsesContentOps:
 
     # ==================== Refusal ====================
 
-    def test_ir_refusal_to_p_returns_none(self):
-        """Test ir_refusal_to_p returns None with warning."""
-        with pytest.warns(UserWarning, match="Refusal content not directly supported"):
-            result = OpenAIResponsesContentOps.ir_refusal_to_p(
-                {"type": "refusal", "refusal": "I cannot do that"}
-            )
-        assert result is None
+    def test_ir_refusal_to_p(self):
+        """Test ir_refusal_to_p produces RefusalContent."""
+        result = OpenAIResponsesContentOps.ir_refusal_to_p(
+            {"type": "refusal", "refusal": "I cannot do that"}
+        )
+        assert result == {"type": "refusal", "refusal": "I cannot do that"}
 
-    def test_p_refusal_to_ir_raises(self):
-        """Test p_refusal_to_ir raises NotImplementedError."""
-        with pytest.raises(
-            NotImplementedError, match="does not produce refusal content"
-        ):
-            OpenAIResponsesContentOps.p_refusal_to_ir("I cannot do that")
+    def test_p_refusal_to_ir(self):
+        """Test p_refusal_to_ir parses RefusalContent."""
+        result = OpenAIResponsesContentOps.p_refusal_to_ir(
+            {"type": "refusal", "refusal": "I cannot do that"}
+        )
+        assert result["type"] == "refusal"
+        assert result["refusal"] == "I cannot do that"
+
+    def test_refusal_round_trip(self):
+        """Test refusal round-trip: IR → Provider → IR."""
+        original = RefusalPart(type="refusal", refusal="Cannot help.")
+        provider = OpenAIResponsesContentOps.ir_refusal_to_p(original)
+        restored = OpenAIResponsesContentOps.p_refusal_to_ir(provider)
+        assert restored["refusal"] == original["refusal"]
 
     # ==================== Citation ====================
 


### PR DESCRIPTION
Closes #431.

## Summary

- `ir_refusal_to_p`: produces `RefusalContent` (`{type: "refusal", refusal: "..."}`) instead of returning `None` with a warning
- `p_refusal_to_ir`: parses `RefusalContent` dict into IR `RefusalPart`  
- `message_ops`: handles `type: "refusal"` in content part dispatch
- `converter`: processes `RefusalPart` in output item content loop

Streaming refusal events (`response.refusal.delta`/`response.refusal.done`) remain unhandled — these are very rare in practice and can be added later.

## Test plan

- [x] 3 new tests: ir_refusal_to_p, p_refusal_to_ir, round-trip
- [x] `make test` passes (2282 passed)
- [x] `ty check` passes (0 errors)