### PR TITLE
fix(google): handle prompt-level blocks and missing finishReason values

### DIFF
--- a/src/llm_rosetta/converters/google_genai/_constants.py
+++ b/src/llm_rosetta/converters/google_genai/_constants.py
@@ -9,6 +9,11 @@ GOOGLE_REASON_FROM_PROVIDER: dict[str, str] = {
     "MAX_TOKENS": "length",
     "SAFETY": "content_filter",
     "RECITATION": "content_filter",
+    "BLOCKLIST": "content_filter",
+    "PROHIBITED_CONTENT": "content_filter",
+    "SPII": "content_filter",
+    "IMAGE_SAFETY": "content_filter",
+    "LANGUAGE": "error",
     "MALFORMED_FUNCTION_CALL": "error",
     "OTHER": "error",
 }

--- a/src/llm_rosetta/converters/google_genai/content_ops.py
+++ b/src/llm_rosetta/converters/google_genai/content_ops.py
@@ -331,26 +331,36 @@ class GoogleGenAIContentOps(BaseContentOps):
         """IR RefusalPart → Google GenAI text Part.
 
         Google does not have a native refusal type. Refusals are converted
-        to text parts with a prefix.
+        to text parts with a `_provider_metadata` marker so they can be
+        recognized and restored on the return path.
 
         Args:
             ir_refusal: IR refusal part.
 
         Returns:
-            Google text Part dict.
+            Google text Part dict with refusal marker.
         """
-        return {"text": f"[Refusal] {ir_refusal['refusal']}"}
+        return {
+            "text": ir_refusal["refusal"],
+            "_provider_metadata": {"is_refusal": True},
+        }
 
     @staticmethod
     def p_refusal_to_ir(provider_refusal: Any, **kwargs: Any) -> RefusalPart:
-        """Google GenAI text → IR RefusalPart.
+        """Google GenAI text Part → IR RefusalPart.
 
-        Raises:
-            NotImplementedError: Google does not produce native refusal parts.
+        Converts a text part that was marked as a refusal (via
+        `_provider_metadata.is_refusal`) back to an IR RefusalPart.
+
+        Args:
+            provider_refusal: Google text Part dict with refusal marker.
+
+        Returns:
+            IR RefusalPart.
         """
-        raise NotImplementedError(
-            "Google GenAI does not produce native refusal content parts."
-        )
+        if isinstance(provider_refusal, dict):
+            return RefusalPart(type="refusal", refusal=provider_refusal.get("text", ""))
+        return RefusalPart(type="refusal", refusal=str(provider_refusal))
 
     # ==================== Citation (not natively supported in parts) ====================
 
@@ -405,13 +415,17 @@ class GoogleGenAIContentOps(BaseContentOps):
         """
         ir_parts: list[ContentPart] = []
 
-        # Handle text
+        # Handle text (check for refusal marker first)
         if (
             "text" in provider_part
             and provider_part["text"] is not None
             and provider_part["text"] != ""
         ):
-            ir_parts.append(GoogleGenAIContentOps.p_text_to_ir(provider_part))
+            pm = provider_part.get("_provider_metadata") or {}
+            if pm.get("is_refusal"):
+                ir_parts.append(GoogleGenAIContentOps.p_refusal_to_ir(provider_part))
+            else:
+                ir_parts.append(GoogleGenAIContentOps.p_text_to_ir(provider_part))
 
         # Handle inline_data / inlineData (image, audio, or file based on mime_type)
         raw_inline = provider_part.get("inline_data") or provider_part.get("inlineData")

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -428,6 +428,29 @@ class GoogleGenAIConverter(BaseConverter):
             }
             choices.append(choice_info)
 
+        # Handle prompt-level blocks (no candidates returned)
+        if not choices:
+            prompt_feedback = (
+                provider_response.get("prompt_feedback")
+                or provider_response.get("promptFeedback")
+                or {}
+            )
+            block_reason = prompt_feedback.get("block_reason") or prompt_feedback.get(
+                "blockReason"
+            )
+            if block_reason:
+                choices.append(
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": []},
+                        "finish_reason": {
+                            "reason": GOOGLE_REASON_FROM_PROVIDER.get(
+                                block_reason, "content_filter"
+                            )
+                        },
+                    }
+                )
+
         ir_response: dict[str, Any] = {
             "id": provider_response.get("response_id")
             or provider_response.get("responseId")
@@ -842,6 +865,25 @@ class GoogleGenAIConverter(BaseConverter):
                         "reason": GOOGLE_REASON_FROM_PROVIDER.get(finish_reason, "stop")  # ty: ignore[invalid-argument-type]
                     },
                     choice_index=choice_index,
+                )
+
+        # Handle prompt-level blocks in streaming (no candidates)
+        if not has_finish_reason and not chunk.get("candidates"):
+            prompt_feedback = (
+                chunk.get("prompt_feedback") or chunk.get("promptFeedback") or {}
+            )
+            block_reason = prompt_feedback.get("block_reason") or prompt_feedback.get(
+                "blockReason"
+            )
+            if block_reason:
+                has_finish_reason = True
+                deferred_finish = FinishEvent(
+                    type="finish",
+                    finish_reason={
+                        "reason": GOOGLE_REASON_FROM_PROVIDER.get(
+                            block_reason, "content_filter"
+                        )  # ty: ignore[invalid-argument-type]
+                    },
                 )
 
         self._handle_p_usage_to_ir(chunk, events)

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -30,6 +30,7 @@ from ...types.ir import (
     is_text_part,
     is_tool_call_part,
     is_reasoning_part,
+    is_refusal_part,
 )
 from ...types.ir.request import IRRequest
 from ...types.ir.response import IRResponse, UsageInfo
@@ -509,6 +510,8 @@ class GoogleGenAIConverter(BaseConverter):
                     parts.append(self.tool_ops.ir_tool_call_to_p(part))
                 elif is_reasoning_part(part):
                     parts.append(self.content_ops.ir_reasoning_to_p(part))
+                elif is_refusal_part(part):
+                    parts.append(self.content_ops.ir_refusal_to_p(part))
 
             finish_reason = choice.get("finish_reason", {})
             reason = finish_reason.get("reason", "stop")

--- a/src/llm_rosetta/converters/google_genai/message_ops.py
+++ b/src/llm_rosetta/converters/google_genai/message_ops.py
@@ -27,6 +27,7 @@ from ...types.ir import (
     is_image_part,
     is_message,
     is_reasoning_part,
+    is_refusal_part,
     is_text_part,
     is_tool_call_part,
     is_tool_result_part,
@@ -181,6 +182,8 @@ class GoogleGenAIMessageOps(BaseMessageOps):
             return self.content_ops.ir_audio_to_p(content_part)
         elif is_reasoning_part(content_part):
             return self.content_ops.ir_reasoning_to_p(content_part)
+        elif is_refusal_part(content_part):
+            return self.content_ops.ir_refusal_to_p(content_part)
         elif is_tool_call_part(content_part):
             return self.tool_ops.ir_tool_call_to_p(content_part)
         elif is_tool_result_part(content_part):

--- a/tests/converters/google_genai/test_converter.py
+++ b/tests/converters/google_genai/test_converter.py
@@ -1095,3 +1095,82 @@ class TestGoogleGenAIConverterFullRoundTrip:
         assert list(r0["content"])[0]["text"] == "Hello"
         assert r1["role"] == "assistant"
         assert list(r1["content"])[0]["text"] == "Hi!"
+
+
+class TestGooglePromptBlockHandling:
+    """Tests for promptFeedback.blockReason and missing finishReason values (#433)."""
+
+    def setup_method(self):
+        from llm_rosetta.converters.google_genai import GoogleGenAIConverter
+
+        self.converter = GoogleGenAIConverter()
+
+    def test_prompt_block_produces_content_filter(self):
+        """promptFeedback.blockReason with no candidates → content_filter finish."""
+        response = {
+            "promptFeedback": {"blockReason": "PROHIBITED_CONTENT"},
+            "usageMetadata": {"promptTokenCount": 14, "totalTokenCount": 14},
+        }
+        ir = self.converter.response_from_provider(response)
+        assert len(ir["choices"]) == 1
+        assert ir["choices"][0]["finish_reason"]["reason"] == "content_filter"
+        assert ir["choices"][0]["message"]["content"] == []
+
+    def test_safety_finish_reason(self):
+        """finishReason=SAFETY → content_filter."""
+        response = {
+            "candidates": [
+                {
+                    "finishReason": "SAFETY",
+                    "content": {"role": "model", "parts": []},
+                }
+            ],
+        }
+        ir = self.converter.response_from_provider(response)
+        assert ir["choices"][0]["finish_reason"]["reason"] == "content_filter"
+
+    def test_blocklist_finish_reason(self):
+        """finishReason=BLOCKLIST → content_filter."""
+        response = {
+            "candidates": [
+                {
+                    "finishReason": "BLOCKLIST",
+                    "content": {"role": "model", "parts": [{"text": ""}]},
+                }
+            ],
+        }
+        ir = self.converter.response_from_provider(response)
+        assert ir["choices"][0]["finish_reason"]["reason"] == "content_filter"
+
+    def test_spii_finish_reason(self):
+        """finishReason=SPII → content_filter."""
+        response = {
+            "candidates": [
+                {
+                    "finishReason": "SPII",
+                    "content": {"role": "model", "parts": []},
+                }
+            ],
+        }
+        ir = self.converter.response_from_provider(response)
+        assert ir["choices"][0]["finish_reason"]["reason"] == "content_filter"
+
+    def test_streaming_prompt_block(self):
+        """Streaming chunk with promptFeedback.blockReason → finish + stream_end."""
+        from llm_rosetta.converters.base.context import StreamContext
+
+        ctx = StreamContext()
+        ctx.mark_started()
+        ctx.response_id = "test"
+        ctx.model = "gemini"
+
+        chunk = {
+            "promptFeedback": {"blockReason": "PROHIBITED_CONTENT"},
+            "usageMetadata": {"promptTokenCount": 14, "totalTokenCount": 14},
+        }
+        events = self.converter.stream_response_from_provider(chunk, context=ctx)
+        types = [e["type"] for e in events]
+        assert "finish" in types
+        assert "stream_end" in types
+        finish = [e for e in events if e["type"] == "finish"][0]
+        assert finish["finish_reason"]["reason"] == "content_filter"

--- a/tests/converters/google_genai/test_converter.py
+++ b/tests/converters/google_genai/test_converter.py
@@ -1174,3 +1174,34 @@ class TestGooglePromptBlockHandling:
         assert "stream_end" in types
         finish = [e for e in events if e["type"] == "finish"][0]
         assert finish["finish_reason"]["reason"] == "content_filter"
+
+    def test_refusal_round_trip(self):
+        """IR refusal → Google → IR preserves refusal via _provider_metadata marker."""
+        ir = {
+            "id": "test",
+            "object": "response",
+            "created": 1700000000,
+            "model": "gemini",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "refusal", "refusal": "I cannot help."}],
+                    },
+                    "finish_reason": {"reason": "content_filter"},
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+        }
+        google_resp = self.converter.response_to_provider(ir)  # ty: ignore[invalid-argument-type]
+        parts = google_resp["candidates"][0]["content"]["parts"]
+        assert len(parts) == 1
+        assert parts[0]["text"] == "I cannot help."
+        assert parts[0]["_provider_metadata"]["is_refusal"] is True
+
+        ir2 = self.converter.response_from_provider(google_resp)
+        content = ir2["choices"][0]["message"]["content"]
+        assert len(content) == 1
+        assert content[0]["type"] == "refusal"
+        assert content[0]["refusal"] == "I cannot help."


### PR DESCRIPTION
Closes #433.

## Summary

- Add missing `finishReason` values to `GOOGLE_REASON_FROM_PROVIDER`: `BLOCKLIST`, `PROHIBITED_CONTENT`, `SPII`, `IMAGE_SAFETY` → `content_filter`; `LANGUAGE` → `error`
- Handle `promptFeedback.blockReason` in non-streaming `response_from_provider`: when no candidates but `blockReason` set, produce synthetic choice with `content_filter` finish reason
- Handle `promptFeedback.blockReason` in streaming: emit `FinishEvent` + `StreamEndEvent`

Tested against real Gemini API — CSAM prompts return `blockReason: "PROHIBITED_CONTENT"` with zero candidates.

## Test plan

- [x] 5 new tests: prompt block → content_filter, SAFETY/BLOCKLIST/SPII finishReason, streaming prompt block
- [x] `make test` passes (2287 passed)
- [x] `ty check` passes (0 errors)