### PR TITLE
fix(openai-responses): preserve reasoning item order in response_to_provider

### DIFF
--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -469,9 +469,10 @@ class OpenAIResponsesConverter(BaseConverter):
                 elif is_refusal_part(part):
                     text_parts.append(self.content_ops.ir_refusal_to_p(part))
 
+            msg_insert_pos = len(provider_response["output"])
             if text_parts:
                 provider_response["output"].insert(
-                    0,
+                    msg_insert_pos,
                     {
                         "id": msg_item_id,
                         "type": "message",


### PR DESCRIPTION
Closes #437.

## Summary

One-line fix: replace `insert(0, msg_item)` with `insert(msg_insert_pos, msg_item)` where `msg_insert_pos = len(output)` is captured after the content loop. This places the message after any preceding reasoning items.

Before: `[reasoning, text]` → output `[message, reasoning]` (wrong)
After: `[reasoning, text]` → output `[reasoning, message]` (correct)

## Verification

Ran full cross-format round-trip audit — all 64 paths (4 scenarios × 16 A→B paths) now pass:

| Scenario | Result |
|----------|--------|
| text | 16/16 ✅ |
| tool_call | 16/16 ✅ |
| reasoning | 16/16 ✅ |
| refusal | 16/16 ✅ |

## Test plan

- [x] `make test` passes (2288 passed)
- [x] Cross-format round-trip audit: all paths pass