### PR TITLE
fix(openai-responses): preserve message phase through round-trip

### DIFF
--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -347,20 +347,29 @@ class OpenAIResponsesConverter(BaseConverter):
 
         # Collect all content parts into a single assistant message
         message_content: list[dict[str, Any]] = []
+        message_metadata: dict[str, Any] = {}
         for ir_item in ir_items:
             if isinstance(ir_item, dict) and "role" in ir_item:
-                # It's a message - extract content
                 content = ir_item.get("content", [])
                 message_content.extend(cast(list, content))
+                # Capture provider_metadata from first assistant message
+                pm = ir_item.get("provider_metadata")
+                if pm and not message_metadata:
+                    message_metadata = pm
             elif isinstance(ir_item, dict) and "type" in ir_item:
-                # It's an extension item (system_event etc.) - skip for choices
                 pass
 
         if message_content:
+            ir_msg: dict[str, Any] = {
+                "role": "assistant",
+                "content": message_content,
+            }
+            if message_metadata:
+                ir_msg["provider_metadata"] = message_metadata
             choices.append(
                 {
                     "index": 0,
-                    "message": {"role": "assistant", "content": message_content},
+                    "message": ir_msg,
                     "finish_reason": {"reason": finish_reason_val},
                 }
             )
@@ -471,16 +480,18 @@ class OpenAIResponsesConverter(BaseConverter):
 
             msg_insert_pos = len(provider_response["output"])
             if text_parts:
-                provider_response["output"].insert(
-                    msg_insert_pos,
-                    {
-                        "id": msg_item_id,
-                        "type": "message",
-                        "role": "assistant",
-                        "status": "completed",
-                        "content": text_parts,
-                    },
-                )
+                msg_item: dict[str, Any] = {
+                    "id": msg_item_id,
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": text_parts,
+                }
+                # Restore phase from IR message provider_metadata
+                phase = message.get("provider_metadata", {}).get("responses_phase")
+                if phase:
+                    msg_item["phase"] = phase
+                provider_response["output"].insert(msg_insert_pos, msg_item)
 
             # Set finish reason
             finish_reason = choice.get("finish_reason", {}).get("reason", "stop")
@@ -941,7 +952,11 @@ class OpenAIResponsesConverter(BaseConverter):
                 # own ``ContentBlockStartEvent``.  Emitting a
                 # ``ContentBlockStartEvent`` here would cause duplicate
                 # ``response.content_part.added`` events on round-trip.
-                pass
+                #
+                # Capture phase for streaming round-trip.
+                phase = item.get("phase")
+                if phase and context is not None:
+                    context.metadata["_responses_phase"] = phase
 
     def _handle_p_content_part_added_to_ir(
         self,
@@ -1651,6 +1666,10 @@ class OpenAIResponsesConverter(BaseConverter):
                 "role": "assistant",
                 "content": [{"type": "output_text", "text": accumulated}],
             }
+            # Restore phase from context if available
+            phase = context.metadata.get("_responses_phase")
+            if phase:
+                msg_item["phase"] = phase
             if context.metadata_mode == "preserve":
                 msg_item["status"] = "completed"
                 for part in msg_item.get("content", []):

--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -113,7 +113,12 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
         if role in ("system", "user", "developer"):
             return self._ir_input_message_to_p(role, content, warnings)
         elif role == "assistant":
-            return self._ir_assistant_to_p(content, warnings, metadata=metadata)
+            return self._ir_assistant_to_p(
+                content,
+                warnings,
+                metadata=metadata,
+                provider_metadata=message.get("provider_metadata"),
+            )
         elif role == "tool":
             return self._ir_tool_messages_to_p(content, warnings)
 
@@ -176,6 +181,7 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
         warnings: list[str],
         *,
         metadata: MessageMetadata | None = None,
+        provider_metadata: dict | None = None,
     ) -> tuple[list[dict[str, Any]], list[str]]:
         """Convert IR assistant message to Responses API items.
 
@@ -227,13 +233,17 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
 
         # Add assistant message if there are text content parts
         if content_parts:
-            result_items.append(
-                {
-                    "type": "message",
-                    "role": "assistant",
-                    "content": content_parts,
-                }
-            )
+            msg_item: dict[str, Any] = {
+                "type": "message",
+                "role": "assistant",
+                "content": content_parts,
+            }
+            # Restore phase from provider_metadata
+            if provider_metadata:
+                phase = provider_metadata.get("responses_phase")
+                if phase:
+                    msg_item["phase"] = phase
+            result_items.append(msg_item)
 
         # Add tool call items
         result_items.extend(tool_items)
@@ -480,7 +490,14 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
 
         # Empty messages are also created because subsequent tool calls
         # may need to be appended
-        return {"role": ir_role, "content": ir_content}
+        ir_msg: dict = {"role": ir_role, "content": ir_content}
+
+        # Preserve message phase for Responses round-trip
+        phase = provider_message.get("phase")
+        if phase:
+            ir_msg.setdefault("provider_metadata", {})["responses_phase"] = phase
+
+        return ir_msg
 
     def _p_content_part_to_ir(self, provider_part: Any) -> list[ContentPart]:
         """Convert a single Responses API content part to IR content part(s).

--- a/src/llm_rosetta/converters/openai_responses/utils.py
+++ b/src/llm_rosetta/converters/openai_responses/utils.py
@@ -33,6 +33,24 @@ def resolve_call_id(chunk: dict[str, Any], context: StreamContext | None) -> str
     return call_id
 
 
+def _build_message_item_skeleton(
+    item_id: str,
+    context: OpenAIResponsesStreamContext,
+) -> dict[str, Any]:
+    """Build message item dict for output_item.added, including phase if available."""
+    item: dict[str, Any] = {
+        "id": item_id,
+        "type": "message",
+        "role": "assistant",
+        "status": "in_progress",
+        "content": [],
+    }
+    phase = context.metadata.get("_responses_phase")
+    if phase:
+        item["phase"] = phase
+    return item
+
+
 def build_message_preamble_events(
     context: OpenAIResponsesStreamContext,
 ) -> list[dict[str, Any]]:
@@ -57,13 +75,7 @@ def build_message_preamble_events(
         {
             "type": ResponsesEventType.OUTPUT_ITEM_ADDED,
             "output_index": output_index,
-            "item": {
-                "id": item_id,
-                "type": "message",
-                "role": "assistant",
-                "status": "in_progress",
-                "content": [],
-            },
+            "item": _build_message_item_skeleton(item_id, context),
         },
         {
             "type": ResponsesEventType.CONTENT_PART_ADDED,

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -599,6 +599,12 @@ class StreamProcessor:
                 "_response_extras"
             ]
 
+        # Bridge message phase for Responses streaming round-trip
+        if "_responses_phase" in self._from_ctx.metadata:
+            self._to_ctx.metadata["_responses_phase"] = self._from_ctx.metadata[
+                "_responses_phase"
+            ]
+
         # IR → Source events
         result: list[dict[str, Any]] = []
         for ir_event in ir_events:

--- a/tests/converters/openai_responses/test_converter.py
+++ b/tests/converters/openai_responses/test_converter.py
@@ -1335,3 +1335,117 @@ class TestResponseIdPrefixFromContext:
         }
         result = self.converter.response_to_provider(ir_response, context=ctx)
         assert result["id"] == "plain_uuid_123"
+
+
+class TestMessagePhase:
+    """Tests for message phase preservation (#440)."""
+
+    def setup_method(self):
+        self.converter = OpenAIResponsesConverter()
+
+    def test_non_streaming_phase_round_trip(self):
+        """phase preserved through Responses → IR → Responses."""
+        response = {
+            "id": "resp_test",
+            "object": "response",
+            "model": "gpt-5.3-codex",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "Let me check."}],
+                },
+            ],
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        ir = self.converter.response_from_provider(response)
+        restored = self.converter.response_to_provider(ir)
+        msg = [i for i in restored["output"] if i.get("type") == "message"][0]
+        assert msg.get("phase") == "commentary"
+
+    def test_non_streaming_final_answer_phase(self):
+        """phase=final_answer preserved."""
+        response = {
+            "id": "resp_test",
+            "object": "response",
+            "model": "gpt-5.3-codex",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": "The answer is 42."}],
+                },
+            ],
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        ir = self.converter.response_from_provider(response)
+        restored = self.converter.response_to_provider(ir)
+        msg = [i for i in restored["output"] if i.get("type") == "message"][0]
+        assert msg.get("phase") == "final_answer"
+
+    def test_no_phase_does_not_add_phase(self):
+        """Messages without phase do not get a phase field."""
+        response = {
+            "id": "resp_test",
+            "object": "response",
+            "model": "gpt-5-nano",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "Hello."}],
+                },
+            ],
+            "usage": {"input_tokens": 5, "output_tokens": 3},
+        }
+        ir = self.converter.response_from_provider(response)
+        restored = self.converter.response_to_provider(ir)
+        msg = [i for i in restored["output"] if i.get("type") == "message"][0]
+        assert "phase" not in msg
+
+    def test_request_phase_round_trip(self):
+        """phase preserved on input assistant messages."""
+        request = {
+            "model": "gpt-5.3-codex",
+            "input": [
+                {"role": "user", "content": "Check weather"},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "Let me check."}],
+                },
+                {
+                    "type": "function_call",
+                    "name": "get_weather",
+                    "arguments": "{}",
+                    "call_id": "call_1",
+                    "id": "fc_1",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "sunny",
+                },
+            ],
+        }
+        ir = self.converter.request_from_provider(request)
+        restored = self.converter.request_to_provider(ir)
+        if isinstance(restored, tuple):
+            restored = restored[0]
+        # Find assistant message in restored input
+        assistant_msgs = [
+            i
+            for i in restored.get("input", [])
+            if isinstance(i, dict) and i.get("role") == "assistant"
+        ]
+        assert len(assistant_msgs) >= 1
+        assert assistant_msgs[0].get("phase") == "commentary"

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -2305,3 +2305,101 @@ class TestStreamingPrefixFromContext:
                 break
         assert completed is not None
         assert completed["response"]["id"] == "custom_ctx_test"
+
+
+class TestStreamingMessagePhase:
+    """Tests for message phase in streaming (#440)."""
+
+    def setup_method(self):
+        self.converter = OpenAIResponsesConverter()
+
+    def _run_stream(self, ir_events):
+        ctx = StreamContext()
+        ctx.response_id = "resp_test"
+        ctx.model = "test-model"
+        results = []
+        for ev in ir_events:
+            out = self.converter.stream_response_to_provider(ev, context=ctx)
+            if isinstance(out, list):
+                results.extend(out)
+            elif isinstance(out, dict) and out:
+                results.append(out)
+        return results, ctx
+
+    def test_p_to_ir_captures_phase_from_output_item_added(self):
+        """output_item.added with phase captures it into context."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.mark_started()
+        chunk = {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "type": "message",
+                "id": "msg_1",
+                "role": "assistant",
+                "phase": "commentary",
+                "status": "in_progress",
+                "content": [],
+            },
+        }
+        self.converter.stream_response_from_provider(chunk, context=ctx)
+        assert ctx.metadata.get("_responses_phase") == "commentary"
+
+    def test_ir_to_p_emits_phase_in_preamble(self):
+        """Streaming message preamble includes phase from context."""
+        ctx = OpenAIResponsesStreamContext()
+        ctx.response_id = "resp_test"
+        ctx.metadata["_responses_phase"] = "final_answer"
+
+        events, _ = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_test", "model": "m"},
+            ]
+        )
+        # Phase should not be in stream_start, but check context is set
+        assert ctx.metadata.get("_responses_phase") == "final_answer"
+
+    def test_streaming_same_format_phase_round_trip(self):
+        """Responses streaming → IR → Responses streaming preserves phase."""
+        from_ctx = OpenAIResponsesStreamContext()
+        from_ctx.mark_started()
+        from_ctx.response_id = "resp_test"
+
+        # Simulate upstream output_item.added with phase
+        chunk = {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "type": "message",
+                "id": "msg_1",
+                "role": "assistant",
+                "phase": "commentary",
+                "status": "in_progress",
+                "content": [],
+            },
+        }
+        self.converter.stream_response_from_provider(chunk, context=from_ctx)
+        assert from_ctx.metadata.get("_responses_phase") == "commentary"
+
+        # Now simulate ir→p with a to_ctx that has phase bridged
+        to_ctx = OpenAIResponsesStreamContext()
+        to_ctx.response_id = "resp_test"
+        to_ctx.metadata["_responses_phase"] = from_ctx.metadata["_responses_phase"]
+
+        # Emit a text delta which triggers message preamble
+        text_ev = {"type": "text_delta", "text": "Let me check."}
+        result = self.converter.stream_response_to_provider(text_ev, context=to_ctx)  # ty: ignore[invalid-argument-type]
+
+        if isinstance(result, list):
+            added = [
+                r
+                for r in result
+                if isinstance(r, dict) and r.get("type") == "response.output_item.added"
+            ]
+        else:
+            added = (
+                [result] if result.get("type") == "response.output_item.added" else []
+            )
+
+        assert len(added) == 1
+        assert added[0]["item"].get("phase") == "commentary"


### PR DESCRIPTION
Closes #440. Part of #397 workstream 4.

## Summary

Preserve the `phase` field (`commentary` / `final_answer`) on Responses API assistant messages through all conversion paths:

- **p→ir**: capture `phase` in `provider_metadata.responses_phase` (message_ops)
- **ir→p response**: restore `phase` on output message items (converter response_to_provider)
- **ir→p request**: restore `phase` on input assistant messages (message_ops _ir_assistant_to_p)
- **Streaming p→ir**: capture `phase` from `output_item.added` message into context metadata
- **Streaming ir→p**: emit `phase` in message preamble and finish output

Also fixes `response_from_provider` dropping `provider_metadata` from IR messages when collapsing output items into choices.

## What is `phase`?

Labels assistant messages as intermediate (`commentary`) or final (`final_answer`) in agentic workflows. GPT-5.5/5.4+ models use this to avoid early stopping when replaying conversation history.

## Test plan

- [x] 4 new tests: commentary round-trip, final_answer round-trip, no-phase passthrough, request round-trip
- [x] `make test` passes (2292 passed)