### PR TITLE
fix(gateway): accept Bearer token as fallback for all auth strategies

### DIFF
--- a/src/llm_rosetta/gateway/auth.py
+++ b/src/llm_rosetta/gateway/auth.py
@@ -51,21 +51,23 @@ def _extract_key(request: Any) -> str | None:
             strategy = strat
             break
 
+    # Always extract Bearer token as a fallback — gateway clients may
+    # use a single Authorization header regardless of API format.
+    auth = request.headers.get("authorization", "")
+    bearer_key = auth[7:] if auth.startswith("Bearer ") else None
+
     if strategy == "anthropic":
-        return request.headers.get("x-api-key")
+        return request.headers.get("x-api-key") or bearer_key
     elif strategy == "google":
-        # Google uses x-goog-api-key header or ?key= query param
         google_key = request.headers.get("x-goog-api-key")
         if google_key:
             return google_key
         vals = request.query_params.get("key")
-        return vals[0] if vals else None
+        if vals:
+            return vals[0]
+        return bearer_key
     else:
-        # OpenAI-style Bearer token
-        auth = request.headers.get("authorization", "")
-        if auth.startswith("Bearer "):
-            return auth[7:]
-        return None
+        return bearer_key
 
 
 def _is_admin_path(path: str) -> bool:


### PR DESCRIPTION
## Summary
- Gateway clients using a proxy may send `Authorization: Bearer` regardless of API format
- Anthropic and Google GenAI routes now fall back to Bearer token when their native auth headers (`x-api-key`, `x-goog-api-key`, `?key=`) are absent
- Fixes 401 errors when testing Google GenAI or Anthropic format through llm-comply or other tools that use unified Bearer auth

## Test plan
- [x] `make test` passes (2288 passed)
- [ ] Verify Google GenAI compliance tests pass through rosetta-dev with Bearer auth
- [ ] Verify Anthropic compliance tests still work with both `x-api-key` and Bearer auth