### PR TITLE
fix(google): normalize schema type case between Google and IR

### DIFF
--- a/src/llm_rosetta/converters/google_genai/tool_ops.py
+++ b/src/llm_rosetta/converters/google_genai/tool_ops.py
@@ -28,8 +28,6 @@ from ..base import BaseToolOps
 from ..base.helpers import sanitize_schema
 from ._constants import generate_tool_call_id
 
-_GOOGLE_SCHEMA_TYPES = {"STRING", "NUMBER", "INTEGER", "BOOLEAN", "ARRAY", "OBJECT"}
-
 
 def _normalize_schema_types(schema: Any, to_upper: bool = False) -> Any:
     """Recursively normalize ``type`` values in a JSON Schema dict.

--- a/src/llm_rosetta/converters/google_genai/tool_ops.py
+++ b/src/llm_rosetta/converters/google_genai/tool_ops.py
@@ -28,6 +28,37 @@ from ..base import BaseToolOps
 from ..base.helpers import sanitize_schema
 from ._constants import generate_tool_call_id
 
+_GOOGLE_SCHEMA_TYPES = {"STRING", "NUMBER", "INTEGER", "BOOLEAN", "ARRAY", "OBJECT"}
+
+
+def _normalize_schema_types(schema: Any, to_upper: bool = False) -> Any:
+    """Recursively normalize ``type`` values in a JSON Schema dict.
+
+    Google's API uses uppercase type names (``STRING``, ``OBJECT``, …)
+    while JSON Schema / other providers use lowercase.
+
+    Args:
+        schema: A JSON Schema dict (or sub-schema value).
+        to_upper: If True, convert to Google uppercase; otherwise lowercase.
+    """
+    if not isinstance(schema, dict):
+        return schema
+    result: dict[str, Any] = {}
+    for key, value in schema.items():
+        if key == "type" and isinstance(value, str):
+            result[key] = value.upper() if to_upper else value.lower()
+        elif key == "properties" and isinstance(value, dict):
+            result[key] = {
+                k: _normalize_schema_types(v, to_upper) for k, v in value.items()
+            }
+        elif key == "items":
+            result[key] = _normalize_schema_types(value, to_upper)
+        elif key in ("anyOf", "oneOf", "allOf") and isinstance(value, list):
+            result[key] = [_normalize_schema_types(v, to_upper) for v in value]
+        else:
+            result[key] = value
+    return result
+
 
 class GoogleGenAIToolOps(BaseToolOps):
     """Google GenAI tool conversion operations.
@@ -57,7 +88,7 @@ class GoogleGenAIToolOps(BaseToolOps):
         }
         parameters = ir_tool.get("parameters")
         if parameters:
-            func_decl["parameters"] = (
+            sanitized = (
                 sanitize_schema(
                     parameters,
                     extra_strip_keys={"additionalProperties", "title"},
@@ -65,6 +96,7 @@ class GoogleGenAIToolOps(BaseToolOps):
                 if isinstance(parameters, dict)
                 else parameters
             )
+            func_decl["parameters"] = _normalize_schema_types(sanitized, to_upper=True)
 
         return {"function_declarations": [func_decl]}
 
@@ -102,7 +134,7 @@ class GoogleGenAIToolOps(BaseToolOps):
         if func_decls:
             results: list[ToolDefinition] = []
             for func in func_decls:
-                parameters = func.get("parameters", {})
+                parameters = _normalize_schema_types(func.get("parameters", {}))
                 td: dict[str, Any] = {
                     "type": "function",
                     "name": func.get("name", ""),
@@ -123,7 +155,7 @@ class GoogleGenAIToolOps(BaseToolOps):
         func = provider_tool
         if not func.get("name"):
             return None
-        parameters = func.get("parameters", {})
+        parameters = _normalize_schema_types(func.get("parameters", {}))
         result: dict[str, Any] = {
             "type": "function",
             "name": func["name"],

--- a/tests/converters/google_genai/test_tool_ops.py
+++ b/tests/converters/google_genai/test_tool_ops.py
@@ -577,6 +577,98 @@ class TestGoogleGenAIToolOps:
         params = result["function_declarations"][0]["parameters"]
         assert params["properties"]["field"]["nullable"] is True
 
+    def test_p_tool_definition_uppercase_types_normalized(self):
+        """Google-native uppercase types (STRING, OBJECT) are lowercased to IR."""
+        provider_tool = {
+            "functionDeclarations": [
+                {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {
+                        "type": "OBJECT",
+                        "properties": {
+                            "location": {"type": "STRING"},
+                            "days": {"type": "INTEGER"},
+                            "detailed": {"type": "BOOLEAN"},
+                        },
+                        "required": ["location"],
+                    },
+                }
+            ]
+        }
+        result = GoogleGenAIToolOps.p_tool_definition_to_ir(provider_tool)
+        assert isinstance(result, dict)
+        params = result["parameters"]
+        assert params["type"] == "object"
+        assert params["properties"]["location"]["type"] == "string"
+        assert params["properties"]["days"]["type"] == "integer"
+        assert params["properties"]["detailed"]["type"] == "boolean"
+
+    def test_ir_tool_definition_uppercases_types_for_google(self):
+        """IR lowercase types are uppercased when emitting to Google format."""
+        ir_tool: ToolDefinition = {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": ["location"],
+            },
+        }
+        result = GoogleGenAIToolOps.ir_tool_definition_to_p(ir_tool)
+        params = result["function_declarations"][0]["parameters"]
+        assert params["type"] == "OBJECT"
+        assert params["properties"]["location"]["type"] == "STRING"
+        assert params["properties"]["tags"]["type"] == "ARRAY"
+        assert params["properties"]["tags"]["items"]["type"] == "STRING"
+
+    def test_schema_type_round_trip(self):
+        """Uppercase Google types → IR lowercase → Google uppercase round-trip."""
+        provider_tool = {
+            "functionDeclarations": [
+                {
+                    "name": "search",
+                    "description": "Search",
+                    "parameters": {
+                        "type": "OBJECT",
+                        "properties": {
+                            "query": {"type": "STRING"},
+                            "limit": {"type": "NUMBER"},
+                        },
+                    },
+                }
+            ]
+        }
+        ir = GoogleGenAIToolOps.p_tool_definition_to_ir(provider_tool)
+        assert isinstance(ir, dict)
+        assert ir["parameters"]["properties"]["query"]["type"] == "string"
+        restored = GoogleGenAIToolOps.ir_tool_definition_to_p(ir)
+        params = restored["function_declarations"][0]["parameters"]
+        assert params["properties"]["query"]["type"] == "STRING"
+        assert params["properties"]["limit"]["type"] == "NUMBER"
+
+    def test_p_tool_definition_bare_decl_uppercase_normalized(self):
+        """Bare function declaration with uppercase types also normalized."""
+        bare = {
+            "name": "lookup",
+            "description": "Look up",
+            "parameters": {
+                "type": "OBJECT",
+                "properties": {"id": {"type": "INTEGER"}},
+            },
+        }
+        result = GoogleGenAIToolOps.p_tool_definition_to_ir(bare)
+        assert isinstance(result, dict)
+        assert result["parameters"]["type"] == "object"
+        assert result["parameters"]["properties"]["id"]["type"] == "integer"
+
 
 class TestProviderMetadataPreservation:
     """Tests for generic provider_metadata round-trip through Google format.


### PR DESCRIPTION
## Summary

- Google's API uses uppercase schema type names (`STRING`, `OBJECT`, `INTEGER`, etc.) while JSON Schema and other providers use lowercase (`string`, `object`, `integer`)
- Previously, uppercase types from Google clients were passed through to IR as-is, causing downstream validation failures when converting to OpenAI/Anthropic formats
- Add bidirectional normalization via `_normalize_schema_types()`:
  - **from-provider**: lowercase type values when parsing Google tool definitions into IR
  - **to-provider**: uppercase type values when emitting IR tool definitions to Google format
- Handles nested schemas recursively (properties, items, anyOf/oneOf/allOf)

## Test plan

- [x] `test_p_tool_definition_uppercase_types_normalized` — Google uppercase types lowercased to IR
- [x] `test_ir_tool_definition_uppercases_types_for_google` — IR lowercase types uppercased for Google (including nested array items)
- [x] `test_schema_type_round_trip` — OBJECT/STRING → object/string → OBJECT/STRING
- [x] `test_p_tool_definition_bare_decl_uppercase_normalized` — bare declaration path also normalized
- [x] Full test suite: 2306 passed

Refs: #416