### PR TITLE
fix(openai-chat): include finish_reason: null on all streaming chunks

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -951,6 +951,7 @@ class OpenAIChatConverter(BaseConverter):
                 {
                     "index": choice_index,
                     "delta": {"content": event["text"]},
+                    "finish_reason": None,
                 }
             ]
         }
@@ -966,6 +967,7 @@ class OpenAIChatConverter(BaseConverter):
                 {
                     "index": choice_index,
                     "delta": {"reasoning_content": event["reasoning"]},
+                    "finish_reason": None,
                 }
             ]
         }
@@ -990,6 +992,7 @@ class OpenAIChatConverter(BaseConverter):
                 {
                     "index": choice_index,
                     "delta": {"tool_calls": [tc_entry]},
+                    "finish_reason": None,
                 }
             ]
         }
@@ -1012,6 +1015,7 @@ class OpenAIChatConverter(BaseConverter):
                 {
                     "index": choice_index,
                     "delta": {"tool_calls": [tc_delta_entry]},
+                    "finish_reason": None,
                 }
             ]
         }


### PR DESCRIPTION
## Summary

- Add `"finish_reason": null` to all interior streaming chunk choice dicts (text delta, reasoning delta, tool call start, tool call delta)
- OpenAI spec marks `finish_reason` as **required** (nullable) on every `choices[]` element in `CreateChatCompletionStreamResponse` — previously only the initial role chunk and final finish chunk included it

Closes #413 (item #31)

## Test plan

- [x] `make test` — 2303 passed, 0 failed
- [x] `make lint` — clean