### PR TITLE
fix(openai-chat): always emit logprobs on response choices

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -277,10 +277,8 @@ class OpenAIChatConverter(BaseConverter):
             "index": choice.get("index", 0),
             "message": openai_message,
             "finish_reason": OPENAI_CHAT_REASON_TO_PROVIDER.get(reason, "stop"),
+            "logprobs": choice.get("logprobs"),
         }
-
-        if "logprobs" in choice:
-            openai_choice["logprobs"] = choice["logprobs"]
 
         return openai_choice
 


### PR DESCRIPTION
## Summary

- Always include `"logprobs": null` on response choice objects when IR has no logprobs data
- OpenAI spec marks `logprobs` as **required** (nullable) on `CreateChatCompletionResponse.choices[]` — previously the key was omitted entirely when absent from IR
- Note: streaming `logprobs` is **not** required per spec, so no streaming changes needed

Refs #413 (item #14)

## Test plan

- [x] `make test` — 2307 passed, 0 failed
- [x] `make lint` — clean