### PR TITLE
fix(gateway): strip _provider_metadata from downstream responses

### DIFF
--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -425,6 +425,7 @@ async def handle_non_streaming(
             )
         )
 
+    _strip_internal_metadata(source_response)
     return JSONResponse(source_response), profile
 
 


### PR DESCRIPTION
## Summary

- Add `_strip_internal_metadata(source_response)` to the non-streaming response path before returning to the client
- Previously only upstream requests (client → provider) were stripped; cross-format responses (e.g. Anthropic → OpenAI Chat) could leak `_provider_metadata` in `tool_calls[]` objects back to the client
- The strip function is already used in both request paths (non-streaming line 314, streaming line 567) — this adds the missing downstream counterpart

Refs #413 (item #17)

## Test plan

- [x] `make test` — 2307 passed, 0 failed
- [x] `make lint` — clean