### PR TITLE
fix(openai-chat): map IR refusal reason to stop explicitly

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/_constants.py
+++ b/src/llm_rosetta/converters/openai_chat/_constants.py
@@ -20,6 +20,7 @@ OPENAI_CHAT_REASON_TO_PROVIDER: dict[str, str] = {
     "length": "length",
     "tool_calls": "tool_calls",
     "content_filter": "content_filter",
+    "refusal": "stop",
 }
 
 # --- Tool content packing (Phase 2: multimodal tool result dual encoding) ---

--- a/tests/converters/openai_chat/test_constants.py
+++ b/tests/converters/openai_chat/test_constants.py
@@ -38,7 +38,16 @@ class TestOpenAIChatReasonMaps:
             f"FROM_PROVIDER produces {missing} but TO_PROVIDER has no mapping for them"
         )
 
-    def test_identity_mapping(self):
-        """TO_PROVIDER is an identity mapping since IR reasons match OpenAI Chat."""
+    def test_identity_or_valid_openai_reason(self):
+        """TO_PROVIDER values must be valid OpenAI Chat finish_reason enum values."""
+        valid_openai_reasons = {
+            "stop",
+            "length",
+            "tool_calls",
+            "content_filter",
+            "function_call",
+        }
         for key, val in OPENAI_CHAT_REASON_TO_PROVIDER.items():
-            assert key == val
+            assert val in valid_openai_reasons, (
+                f"'{key}' maps to '{val}' which is not a valid OpenAI Chat finish_reason"
+            )


### PR DESCRIPTION
## Summary

- Add explicit `"refusal": "stop"` entry to `OPENAI_CHAT_REASON_TO_PROVIDER` mapping
- IR uses `"refusal"` as a finish reason (from Anthropic's native `stop_reason: "refusal"`), but OpenAI Chat has no `"refusal"` enum value — the correct OpenAI behavior is `finish_reason: "stop"` with the refusal signal carried in `message.refusal`
- Previously this worked via silent `.get("refusal", "stop")` fallback, which was fragile and undocumented
- Update `test_constants` to validate output values are valid OpenAI Chat enum values rather than asserting identity mapping

Refs #413 (item #34)

## Test plan

- [x] `make test` — 2307 passed, 0 failed
- [x] `make lint` — clean