### PR TITLE
fix: implement response_id_prefix strip/add in all converters

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -56,7 +56,6 @@ from .tool_ops import AnthropicToolOps
 
 
 class AnthropicConverter(BaseConverter):
-    _RESPONSE_ID_PREFIX = "msg_"
     """Anthropic Messages API converter.
 
     Implements the 6 explicit conversion interfaces defined by BaseConverter,
@@ -64,6 +63,8 @@ class AnthropicConverter(BaseConverter):
 
     Uses composition of Ops classes for modular, testable conversion logic.
     """
+
+    _RESPONSE_ID_PREFIX = "msg_"
 
     content_ops_class = AnthropicContentOps
     tool_ops_class = AnthropicToolOps

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -56,6 +56,7 @@ from .tool_ops import AnthropicToolOps
 
 
 class AnthropicConverter(BaseConverter):
+    _RESPONSE_ID_PREFIX = "msg_"
     """Anthropic Messages API converter.
 
     Implements the 6 explicit conversion interfaces defined by BaseConverter,
@@ -248,6 +249,16 @@ class AnthropicConverter(BaseConverter):
 
         return self._validate_ir_request(ir_request)
 
+    def _get_response_id_prefix(
+        self, context: ConversionContext | StreamContext | None = None
+    ) -> str:
+        """Return the response ID prefix from context or class default."""
+        if context is not None:
+            prefix = context.options.get("response_id_prefix")
+            if prefix is not None:
+                return prefix
+        return self._RESPONSE_ID_PREFIX
+
     def response_from_provider(
         self,
         provider_response: dict[str, Any],
@@ -311,8 +322,11 @@ class AnthropicConverter(BaseConverter):
             else:
                 ir_message["content"] = [refusal_part]  # ty: ignore[invalid-assignment]
 
+        prefix = self._get_response_id_prefix(context)
         ir_response: dict[str, Any] = {
-            "id": provider_response.get("id", ""),
+            "id": self.strip_response_id_prefix(
+                provider_response.get("id", ""), prefix
+            ),
             "object": "response",
             "created": int(time.time()),  # Anthropic doesn't provide timestamp
             "model": provider_response.get("model", ""),
@@ -346,8 +360,9 @@ class AnthropicConverter(BaseConverter):
             Anthropic response dict.
         """
         # Anthropic response is a single message
+        prefix = self._get_response_id_prefix(context)
         provider_response: dict[str, Any] = {
-            "id": ir_response.get("id", ""),
+            "id": self.add_response_id_prefix(ir_response.get("id", ""), prefix),
             "type": "message",
             "model": ir_response.get("model", ""),
             "content": [],
@@ -674,7 +689,8 @@ class AnthropicConverter(BaseConverter):
         if context is not None:
             response_id = message.get("id", "")
             model = message.get("model", "")
-            context.response_id = response_id
+            prefix = self._get_response_id_prefix(context)
+            context.response_id = self.strip_response_id_prefix(response_id, prefix)
             context.model = model
             context.mark_started()
             events.append(
@@ -889,7 +905,9 @@ class AnthropicConverter(BaseConverter):
         return {
             "type": AnthropicEventType.MESSAGE_START,
             "message": {
-                "id": event["response_id"],
+                "id": self.add_response_id_prefix(
+                    event["response_id"], self._get_response_id_prefix(context)
+                ),
                 "type": "message",
                 "role": "assistant",
                 "model": event["model"],

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -89,13 +89,14 @@ def _dict_to_modality_list(details: dict[str, int]) -> list[dict[str, Any]]:
 
 
 class GoogleGenAIConverter(BaseConverter):
-    _RESPONSE_ID_PREFIX = ""
     """Google GenAI API converter.
 
     Implements the 6 explicit conversion interfaces defined by BaseConverter.
 
     Uses composition of Ops classes for modular, testable conversion logic.
     """
+
+    _RESPONSE_ID_PREFIX = ""
 
     content_ops_class = GoogleGenAIContentOps
     tool_ops_class = GoogleGenAIToolOps

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -89,6 +89,7 @@ def _dict_to_modality_list(details: dict[str, int]) -> list[dict[str, Any]]:
 
 
 class GoogleGenAIConverter(BaseConverter):
+    _RESPONSE_ID_PREFIX = ""
     """Google GenAI API converter.
 
     Implements the 6 explicit conversion interfaces defined by BaseConverter.
@@ -392,6 +393,16 @@ class GoogleGenAIConverter(BaseConverter):
 
         return self._validate_ir_request(ir_request)
 
+    def _get_response_id_prefix(
+        self, context: ConversionContext | StreamContext | None = None
+    ) -> str:
+        """Return the response ID prefix from context or class default."""
+        if context is not None:
+            prefix = context.options.get("response_id_prefix")
+            if prefix is not None:
+                return prefix
+        return self._RESPONSE_ID_PREFIX
+
     def response_from_provider(
         self,
         provider_response: dict[str, Any],
@@ -455,9 +466,12 @@ class GoogleGenAIConverter(BaseConverter):
                 )
 
         ir_response: dict[str, Any] = {
-            "id": provider_response.get("response_id")
-            or provider_response.get("responseId")
-            or "",
+            "id": self.strip_response_id_prefix(
+                provider_response.get("response_id")
+                or provider_response.get("responseId")
+                or "",
+                self._get_response_id_prefix(context),
+            ),
             "object": "response",
             "created": int(time.time()),  # Google doesn't provide timestamp
             "model": provider_response.get("model_version")
@@ -491,7 +505,9 @@ class GoogleGenAIConverter(BaseConverter):
             Google response dict.
         """
         provider_response: dict[str, Any] = {
-            "responseId": ir_response.get("id", ""),
+            "responseId": self.add_response_id_prefix(
+                ir_response.get("id", ""), self._get_response_id_prefix(context)
+            ),
             "modelVersion": ir_response.get("model", ""),
             "candidates": [],
         }
@@ -911,7 +927,8 @@ class GoogleGenAIConverter(BaseConverter):
         """Emit StreamStartEvent on the first chunk."""
         response_id = chunk.get("response_id") or chunk.get("responseId") or ""
         model = chunk.get("model_version") or chunk.get("modelVersion") or ""
-        context.response_id = response_id
+        prefix = self._get_response_id_prefix(context)
+        context.response_id = self.strip_response_id_prefix(response_id, prefix)
         context.model = model
         context.mark_started()
         events.append(

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -44,7 +44,6 @@ from .tool_ops import OpenAIChatToolOps
 
 
 class OpenAIChatConverter(BaseConverter):
-    _RESPONSE_ID_PREFIX = "chatcmpl-"
     """OpenAI Chat Completions API converter.
 
     Implements the 6 explicit conversion interfaces defined by BaseConverter,
@@ -52,6 +51,8 @@ class OpenAIChatConverter(BaseConverter):
 
     Uses composition of Ops classes for modular, testable conversion logic.
     """
+
+    _RESPONSE_ID_PREFIX = "chatcmpl-"
 
     content_ops_class = OpenAIChatContentOps
     tool_ops_class = OpenAIChatToolOps

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -44,6 +44,7 @@ from .tool_ops import OpenAIChatToolOps
 
 
 class OpenAIChatConverter(BaseConverter):
+    _RESPONSE_ID_PREFIX = "chatcmpl-"
     """OpenAI Chat Completions API converter.
 
     Implements the 6 explicit conversion interfaces defined by BaseConverter,
@@ -213,6 +214,16 @@ class OpenAIChatConverter(BaseConverter):
                 ctx.warnings.append(
                     "OpenAI Chat does not support max_tool_calls, ignored"
                 )
+
+    def _get_response_id_prefix(
+        self, context: ConversionContext | StreamContext | None = None
+    ) -> str:
+        """Return the response ID prefix from context or class default."""
+        if context is not None:
+            prefix = context.options.get("response_id_prefix")
+            if prefix is not None:
+                return prefix
+        return self._RESPONSE_ID_PREFIX
 
     def _build_ir_choice_to_p(  # noqa: C901
         self, choice: dict[str, Any]
@@ -435,8 +446,11 @@ class OpenAIChatConverter(BaseConverter):
 
             choices.append(choice_info)
 
+        prefix = self._get_response_id_prefix(context)
         ir_response: dict[str, Any] = {
-            "id": provider_response.get("id", ""),
+            "id": self.strip_response_id_prefix(
+                provider_response.get("id", ""), prefix
+            ),
             "object": "response",
             "created": provider_response.get("created", 0),
             "model": provider_response.get("model", ""),
@@ -471,8 +485,9 @@ class OpenAIChatConverter(BaseConverter):
         Returns:
             OpenAI response dict.
         """
+        prefix = self._get_response_id_prefix(context)
         provider_response: dict[str, Any] = {
-            "id": ir_response.get("id", ""),
+            "id": self.add_response_id_prefix(ir_response.get("id", ""), prefix),
             "object": "chat.completion",
             "created": ir_response.get("created", 0),
             "model": ir_response.get("model", ""),
@@ -622,7 +637,8 @@ class OpenAIChatConverter(BaseConverter):
         model = chunk.get("model")
         created = chunk.get("created")
         if response_id and model:
-            context.response_id = response_id
+            prefix = self._get_response_id_prefix(context)
+            context.response_id = self.strip_response_id_prefix(response_id, prefix)
             context.model = model
             if created is not None:
                 context.created = created
@@ -835,7 +851,12 @@ class OpenAIChatConverter(BaseConverter):
             and isinstance(result, dict)
             and result
         ):
-            result.setdefault("id", context.response_id)
+            result.setdefault(
+                "id",
+                self.add_response_id_prefix(
+                    context.response_id, self._get_response_id_prefix(context)
+                ),
+            )
             result.setdefault("object", "chat.completion.chunk")
             result.setdefault("model", context.model)
             result.setdefault("created", context.created)
@@ -851,8 +872,9 @@ class OpenAIChatConverter(BaseConverter):
         call start), matching the original OpenAI format where the first
         chunk carries both ``role`` and the first content delta.
         """
+        prefix = self._get_response_id_prefix(context)
         chunk = {
-            "id": event["response_id"],
+            "id": self.add_response_id_prefix(event["response_id"], prefix),
             "object": "chat.completion.chunk",
             "model": event["model"],
             "created": event.get("created", 0),

--- a/tests/converters/anthropic/test_converter.py
+++ b/tests/converters/anthropic/test_converter.py
@@ -294,7 +294,7 @@ class TestAnthropicConverter:
             },
         }
         result = self.converter.response_from_provider(provider_response)
-        assert result["id"] == "msg_01XFD67890"
+        assert result["id"] == "01XFD67890"
         assert result["object"] == "response"
         assert result["model"] == "claude-3-5-sonnet-20241022"
         assert len(result["choices"]) == 1
@@ -394,7 +394,7 @@ class TestAnthropicConverter:
         result = self.converter.response_from_provider(
             cast(dict[str, Any], MockResponse())
         )
-        assert result["id"] == "msg_pydantic"
+        assert result["id"] == "pydantic"
 
     def test_response_from_provider_missing_usage(self):
         """Test response without usage field still produces zero-filled usage."""
@@ -441,7 +441,7 @@ class TestAnthropicConverter:
             },
         )
         result = self.converter.response_to_provider(ir_response)
-        assert result["id"] == "resp_123"
+        assert result["id"] == "msg_resp_123"
         assert result["type"] == "message"
         assert result["role"] == "assistant"
         assert result["content"][0]["type"] == "text"

--- a/tests/converters/anthropic/test_stream.py
+++ b/tests/converters/anthropic/test_stream.py
@@ -770,7 +770,7 @@ class TestStreamResponseFromProviderWithContext:
             },
         }
         self.converter.stream_response_from_provider(event, context=ctx)
-        assert ctx.response_id == "msg_abc123"
+        assert ctx.response_id == "abc123"
         assert ctx.model == "claude-sonnet-4-20250514"
         assert ctx.is_started is True
 
@@ -1135,7 +1135,7 @@ class TestStreamResponseToProviderWithContext:
             StreamStartEvent,
             {
                 "type": "stream_start",
-                "response_id": "msg_abc123",
+                "response_id": "abc123",
                 "model": "claude-sonnet-4-20250514",
             },
         )
@@ -1156,12 +1156,12 @@ class TestStreamResponseToProviderWithContext:
             StreamStartEvent,
             {
                 "type": "stream_start",
-                "response_id": "msg_abc123",
+                "response_id": "abc123",
                 "model": "claude-sonnet-4-20250514",
             },
         )
         self.converter.stream_response_to_provider(event, context=ctx)
-        assert ctx.response_id == "msg_abc123"
+        assert ctx.response_id == "abc123"
         assert ctx.model == "claude-sonnet-4-20250514"
         assert ctx.is_started is True
 
@@ -1190,7 +1190,7 @@ class TestStreamResponseToProviderWithContext:
             StreamStartEvent,
             {
                 "type": "stream_start",
-                "response_id": "msg_abc123",
+                "response_id": "abc123",
                 "model": "claude-sonnet-4-20250514",
             },
         )

--- a/tests/converters/openai_chat/test_converter.py
+++ b/tests/converters/openai_chat/test_converter.py
@@ -216,7 +216,7 @@ class TestOpenAIChatConverter:
             "system_fingerprint": "fp_abc",
         }
         result = self.converter.response_from_provider(provider_response)
-        assert result["id"] == "chatcmpl-123"
+        assert result["id"] == "123"
         assert result["object"] == "response"
         assert result["model"] == "gpt-4o"
         assert len(result["choices"]) == 1

--- a/tests/converters/openai_chat/test_stream.py
+++ b/tests/converters/openai_chat/test_stream.py
@@ -674,7 +674,7 @@ class TestStreamResponseFromProviderWithContext:
             ],
         }
         self.converter.stream_response_from_provider(chunk, context=ctx)
-        assert ctx.response_id == "chatcmpl-abc123"
+        assert ctx.response_id == "abc123"
         assert ctx.model == "gpt-4"
         assert ctx.created == 1700000000
         assert ctx.is_started is True
@@ -894,13 +894,13 @@ class TestStreamResponseToProviderWithContext:
             StreamStartEvent,
             {
                 "type": "stream_start",
-                "response_id": "chatcmpl-abc123",
+                "response_id": "abc123",
                 "model": "gpt-4",
                 "created": 1700000000,
             },
         )
         self.converter.stream_response_to_provider(event, context=ctx)
-        assert ctx.response_id == "chatcmpl-abc123"
+        assert ctx.response_id == "abc123"
         assert ctx.model == "gpt-4"
         assert ctx.created == 1700000000
         assert ctx.is_started is True


### PR DESCRIPTION
## Summary

- Implement `strip_response_id_prefix` / `add_response_id_prefix` in openai_chat, anthropic, and google_genai converters
- Previously only openai_responses converter handled this — the other three passed IDs through verbatim
- Each converter gets `_RESPONSE_ID_PREFIX` class constant (`"chatcmpl-"`, `"msg_"`, `""`) and `_get_response_id_prefix()` helper
- Pipeline sets prefix via `ctx.options["response_id_prefix"]` from shim config; converter falls back to class constant for direct usage

### What this enables

- Cross-format conversion produces correct provider-specific ID prefixes (e.g. Anthropic `msg_xxx` → OpenAI Chat `chatcmpl-xxx`)
- IR stores prefix-free stems, each converter adds its own prefix on output
- Same pattern already proven in openai_responses converter

### Files changed

- `src/llm_rosetta/converters/openai_chat/converter.py` — strip on ingest, add on emit (non-streaming + streaming)
- `src/llm_rosetta/converters/anthropic/converter.py` — same
- `src/llm_rosetta/converters/google_genai/converter.py` — same
- 4 test files — update assertions for stripped/stemmed IDs

Refs #413 (item #6)

## Test plan

- [x] `make test` — 2307 passed, 0 failed
- [x] `make lint` — clean