### PR TITLE
fix(anthropic): emit all spec-required usage fields

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -487,7 +487,7 @@ class AnthropicConverter(BaseConverter):
         otd = p_usage.get("output_tokens_details")
         if isinstance(otd, dict):
             thinking = otd.get("thinking_tokens")
-            if thinking:
+            if thinking is not None:
                 usage_info["reasoning_tokens"] = thinking
         return cast(UsageInfo, usage_info)
 

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -484,20 +484,52 @@ class AnthropicConverter(BaseConverter):
             usage_info["cache_read_tokens"] = p_usage["cache_read_input_tokens"]
         if "cache_creation_input_tokens" in p_usage:
             usage_info["cache_creation_tokens"] = p_usage["cache_creation_input_tokens"]
+        otd = p_usage.get("output_tokens_details")
+        if isinstance(otd, dict):
+            thinking = otd.get("thinking_tokens")
+            if thinking:
+                usage_info["reasoning_tokens"] = thinking
         return cast(UsageInfo, usage_info)
 
     @staticmethod
     def _build_ir_usage_to_p(ir_usage: Mapping[str, Any]) -> dict[str, Any]:
         """Build Anthropic usage dict from IR usage."""
+        reasoning = ir_usage.get("reasoning_tokens")
         usage: dict[str, Any] = {
             "input_tokens": ir_usage.get("prompt_tokens") or 0,
             "output_tokens": ir_usage.get("completion_tokens") or 0,
+            "cache_read_input_tokens": ir_usage.get("cache_read_tokens") or 0,
+            "cache_creation_input_tokens": ir_usage.get("cache_creation_tokens") or 0,
+            "cache_creation": None,
+            "output_tokens_details": (
+                {"thinking_tokens": reasoning} if reasoning else None
+            ),
+            "service_tier": None,
+            "inference_geo": None,
+            "server_tool_use": None,
         }
-        if "cache_read_tokens" in ir_usage:
-            usage["cache_read_input_tokens"] = ir_usage["cache_read_tokens"]
-        if "cache_creation_tokens" in ir_usage:
-            usage["cache_creation_input_tokens"] = ir_usage["cache_creation_tokens"]
         return usage
+
+    @staticmethod
+    def _build_message_delta_usage(
+        ir_usage: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Build Anthropic MessageDeltaUsage dict from IR usage."""
+        if ir_usage is None:
+            ir_usage = {}
+        output_tokens = ir_usage.get("completion_tokens") or 0
+        reasoning = ir_usage.get("reasoning_tokens")
+        return {
+            "output_tokens": output_tokens,
+            "input_tokens": ir_usage.get("prompt_tokens") or None,
+            "cache_creation_input_tokens": ir_usage.get("cache_creation_tokens")
+            or None,
+            "cache_read_input_tokens": ir_usage.get("cache_read_tokens") or None,
+            "output_tokens_details": (
+                {"thinking_tokens": reasoning} if reasoning else None
+            ),
+            "server_tool_use": None,
+        }
 
     @staticmethod
     def _capture_preserve_metadata(
@@ -523,6 +555,12 @@ class AnthropicConverter(BaseConverter):
             "input_tokens",
             "output_tokens",
             "cache_read_input_tokens",
+            "cache_creation_input_tokens",
+            "cache_creation",
+            "output_tokens_details",
+            "service_tier",
+            "inference_geo",
+            "server_tool_use",
         }
         if p_usage:
             usage_extras = {
@@ -867,24 +905,15 @@ class AnthropicConverter(BaseConverter):
         self, event: StreamStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle StreamStartEvent → message_start."""
-        input_tokens = 0
-        p_usage: dict[str, Any] = {"input_tokens": 0, "output_tokens": 0}
+        ir_usage: Mapping[str, Any] = {}
         if context is not None:
             context.response_id = event["response_id"]
             context.model = event["model"]
             context.mark_started()
-            # Use real input_tokens from buffered usage if available.
             if context.pending_usage is not None:
-                input_tokens = context.pending_usage.get("prompt_tokens") or 0
-                p_usage["input_tokens"] = input_tokens
-                if "cache_read_tokens" in context.pending_usage:
-                    p_usage["cache_read_input_tokens"] = context.pending_usage[
-                        "cache_read_tokens"
-                    ]
-                if "cache_creation_tokens" in context.pending_usage:
-                    p_usage["cache_creation_input_tokens"] = context.pending_usage[
-                        "cache_creation_tokens"
-                    ]
+                ir_usage = context.pending_usage
+
+        p_usage = self._build_ir_usage_to_p(ir_usage)
 
         return {
             "type": AnthropicEventType.MESSAGE_START,
@@ -908,15 +937,12 @@ class AnthropicConverter(BaseConverter):
             # Flush any buffered finish that never got a UsageEvent
             finish = context.pop_pending_finish()
             if finish is not None:
-                output_tokens = 0
                 usage = context.pop_pending_usage()
-                if usage is not None:
-                    output_tokens = usage.get("completion_tokens") or 0
                 results.append(
                     {
                         "type": AnthropicEventType.MESSAGE_DELTA,
                         "delta": finish,
-                        "usage": {"output_tokens": output_tokens},
+                        "usage": self._build_message_delta_usage(usage),
                     }
                 )
             context.mark_ended()
@@ -1163,8 +1189,6 @@ class AnthropicConverter(BaseConverter):
                 context.current_block_index = -1
             usage = context.pop_pending_usage()
             if usage is not None:
-                # Usage already buffered — merge and emit immediately.
-                output_tokens = usage.get("completion_tokens") or 0
                 delta_payload: dict[str, Any] = {"stop_reason": stop_reason}
                 if stop_details:
                     delta_payload["stop_details"] = stop_details
@@ -1172,7 +1196,7 @@ class AnthropicConverter(BaseConverter):
                     {
                         "type": AnthropicEventType.MESSAGE_DELTA,
                         "delta": delta_payload,
-                        "usage": {"output_tokens": output_tokens},
+                        "usage": self._build_message_delta_usage(usage),
                     }
                 )
             else:
@@ -1185,7 +1209,7 @@ class AnthropicConverter(BaseConverter):
         return {
             "type": AnthropicEventType.MESSAGE_DELTA,
             "delta": {"stop_reason": stop_reason},
-            "usage": {"output_tokens": 0},
+            "usage": self._build_message_delta_usage(),
         }
 
     def _handle_ir_usage_to_p(
@@ -1202,19 +1226,16 @@ class AnthropicConverter(BaseConverter):
         if context is not None:
             delta = context.pop_pending_finish()
             if delta is not None:
-                # Merge with buffered finish and emit.
-                output_tokens = usage.get("completion_tokens") or 0
                 return {
                     "type": AnthropicEventType.MESSAGE_DELTA,
                     "delta": delta,
-                    "usage": {"output_tokens": output_tokens},
+                    "usage": self._build_message_delta_usage(usage),
                 }
             # No pending finish — buffer for later merge.
             context.buffer_usage(usage)
             return {}
-        output_tokens = usage.get("completion_tokens") or 0
         return {
             "type": AnthropicEventType.MESSAGE_DELTA,
             "delta": {},
-            "usage": {"output_tokens": output_tokens},
+            "usage": self._build_message_delta_usage(usage),
         }

--- a/tests/converters/anthropic/test_converter.py
+++ b/tests/converters/anthropic/test_converter.py
@@ -1089,3 +1089,142 @@ class TestAnthropicUsageCompliance:
         assert result["type"] == "message_delta"
         assert self._DELTA_USAGE_REQUIRED_KEYS == set(result["usage"].keys())
         assert result["usage"]["output_tokens"] == 20
+
+
+class TestAnthropicUsageRoundTrip:
+    """Usage field preservation across A→IR→A and cross-format conversions (#414)."""
+
+    def setup_method(self):
+        self.anthropic = AnthropicConverter()
+        from llm_rosetta.converters.openai_chat import OpenAIChatConverter
+
+        self.openai_chat = OpenAIChatConverter()
+
+    _ANTHROPIC_RESPONSE = {
+        "id": "msg_usage_rt",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-haiku-4-5-20251001",
+        "content": [
+            {"type": "thinking", "thinking": "Let me think...", "signature": "sig123"},
+            {"type": "text", "text": "The answer is 4."},
+        ],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "stop_details": None,
+        "usage": {
+            "input_tokens": 43,
+            "output_tokens": 37,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 0,
+            },
+            "output_tokens_details": {"thinking_tokens": 22},
+            "service_tier": "standard",
+            "inference_geo": "not_available",
+        },
+    }
+
+    _USAGE_REQUIRED_KEYS = {
+        "input_tokens",
+        "output_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+        "cache_creation",
+        "output_tokens_details",
+        "service_tier",
+        "inference_geo",
+        "server_tool_use",
+    }
+
+    def test_anthropic_to_ir_to_anthropic_usage(self):
+        """A→IR→A: usage fields survive round-trip."""
+        ir = self.anthropic.response_from_provider(self._ANTHROPIC_RESPONSE)
+        restored = self.anthropic.response_to_provider(ir)
+
+        usage = restored["usage"]
+        assert self._USAGE_REQUIRED_KEYS == set(usage.keys())
+        assert usage["input_tokens"] == 43
+        assert usage["output_tokens"] == 37
+        assert usage["cache_read_input_tokens"] == 0
+        assert usage["cache_creation_input_tokens"] == 0
+        assert usage["output_tokens_details"] == {"thinking_tokens": 22}
+
+    def test_anthropic_to_ir_to_anthropic_thinking_tokens_preserved(self):
+        """A→IR→A: thinking_tokens round-trips through IR reasoning_tokens."""
+        ir = self.anthropic.response_from_provider(self._ANTHROPIC_RESPONSE)
+        assert ir["usage"]["reasoning_tokens"] == 22
+
+        restored = self.anthropic.response_to_provider(ir)
+        assert restored["usage"]["output_tokens_details"] == {"thinking_tokens": 22}
+
+    def test_openai_chat_to_ir_to_anthropic_usage_complete(self):
+        """B→IR→A: OpenAI Chat response converted to Anthropic has all required usage fields."""
+        openai_response = {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "model": "gpt-4",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hello!"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+                "prompt_tokens_details": {"cached_tokens": 3},
+            },
+        }
+        ir = self.openai_chat.response_from_provider(openai_response)
+        anthropic_out = self.anthropic.response_to_provider(ir)
+
+        usage = anthropic_out["usage"]
+        assert self._USAGE_REQUIRED_KEYS == set(usage.keys())
+        assert usage["input_tokens"] == 10
+        assert usage["output_tokens"] == 5
+        assert usage["cache_read_input_tokens"] == 3
+        assert usage["cache_creation_input_tokens"] == 0
+        assert usage["output_tokens_details"] is None
+
+    def test_anthropic_to_ir_to_openai_chat_usage(self):
+        """A→IR→B: Anthropic usage maps correctly to OpenAI Chat format."""
+        ir = self.anthropic.response_from_provider(self._ANTHROPIC_RESPONSE)
+        openai_out = self.openai_chat.response_to_provider(ir)
+
+        usage = openai_out["usage"]
+        assert usage["prompt_tokens"] == 43
+        assert usage["completion_tokens"] == 37
+        assert "prompt_tokens_details" in usage
+        assert usage["prompt_tokens_details"]["cached_tokens"] == 0
+
+    def test_openai_chat_reasoning_to_anthropic_thinking_tokens(self):
+        """B→IR→A: OpenAI reasoning_tokens maps to output_tokens_details.thinking_tokens."""
+        openai_response = {
+            "id": "chatcmpl-456",
+            "object": "chat.completion",
+            "model": "o1",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "42"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 20,
+                "completion_tokens": 100,
+                "total_tokens": 120,
+                "completion_tokens_details": {"reasoning_tokens": 80},
+            },
+        }
+        ir = self.openai_chat.response_from_provider(openai_response)
+        anthropic_out = self.anthropic.response_to_provider(ir)
+
+        usage = anthropic_out["usage"]
+        assert self._USAGE_REQUIRED_KEYS == set(usage.keys())
+        assert usage["output_tokens_details"] == {"thinking_tokens": 80}

--- a/tests/converters/anthropic/test_converter.py
+++ b/tests/converters/anthropic/test_converter.py
@@ -948,3 +948,144 @@ class TestAnthropicStructuredRefusal:
         ]
         assert len(refusal_parts) == 1
         assert dict(refusal_parts[0])["refusal"] == "I cannot help."
+
+
+class TestAnthropicUsageCompliance:
+    """Tests for Anthropic spec-required usage fields (#414)."""
+
+    def setup_method(self):
+        self.converter = AnthropicConverter()
+
+    _USAGE_REQUIRED_KEYS = {
+        "input_tokens",
+        "output_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+        "cache_creation",
+        "output_tokens_details",
+        "service_tier",
+        "inference_geo",
+        "server_tool_use",
+    }
+
+    def test_build_ir_usage_to_p_all_keys_present(self):
+        """_build_ir_usage_to_p must emit all 9 spec-required keys."""
+        result = self.converter._build_ir_usage_to_p({})
+        assert self._USAGE_REQUIRED_KEYS == set(result.keys())
+
+    def test_build_ir_usage_to_p_minimal(self):
+        """Minimal IR usage produces zeros for token counts, None for nullable."""
+        result = self.converter._build_ir_usage_to_p(
+            {"prompt_tokens": 10, "completion_tokens": 5}
+        )
+        assert result["input_tokens"] == 10
+        assert result["output_tokens"] == 5
+        assert result["cache_read_input_tokens"] == 0
+        assert result["cache_creation_input_tokens"] == 0
+        assert result["cache_creation"] is None
+        assert result["output_tokens_details"] is None
+        assert result["service_tier"] is None
+        assert result["inference_geo"] is None
+        assert result["server_tool_use"] is None
+
+    def test_build_ir_usage_to_p_with_cache_and_thinking(self):
+        """Cache and reasoning tokens map to Anthropic-specific fields."""
+        result = self.converter._build_ir_usage_to_p(
+            {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "cache_read_tokens": 10,
+                "cache_creation_tokens": 5,
+                "reasoning_tokens": 22,
+            }
+        )
+        assert result["cache_read_input_tokens"] == 10
+        assert result["cache_creation_input_tokens"] == 5
+        assert result["output_tokens_details"] == {"thinking_tokens": 22}
+
+    def test_thinking_tokens_round_trip(self):
+        """output_tokens_details.thinking_tokens survives p→IR→p round-trip."""
+        p_usage = {
+            "input_tokens": 43,
+            "output_tokens": 37,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "output_tokens_details": {"thinking_tokens": 22},
+        }
+        ir = self.converter._build_p_usage_to_ir(p_usage)
+        assert ir["reasoning_tokens"] == 22
+
+        back = self.converter._build_ir_usage_to_p(ir)
+        assert back["output_tokens_details"] == {"thinking_tokens": 22}
+
+    def test_thinking_tokens_zero_preserved(self):
+        """thinking_tokens: 0 should NOT be dropped."""
+        p_usage = {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "output_tokens_details": {"thinking_tokens": 0},
+        }
+        ir = self.converter._build_p_usage_to_ir(p_usage)
+        assert ir["reasoning_tokens"] == 0
+
+    _DELTA_USAGE_REQUIRED_KEYS = {
+        "output_tokens",
+        "input_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "output_tokens_details",
+        "server_tool_use",
+    }
+
+    def test_build_message_delta_usage_all_keys(self):
+        """_build_message_delta_usage must emit all MessageDeltaUsage keys."""
+        result = self.converter._build_message_delta_usage()
+        assert self._DELTA_USAGE_REQUIRED_KEYS == set(result.keys())
+
+    def test_build_message_delta_usage_with_values(self):
+        """MessageDeltaUsage uses real values from IR when available."""
+        result = self.converter._build_message_delta_usage(
+            {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "cache_read_tokens": 10,
+                "cache_creation_tokens": 5,
+                "reasoning_tokens": 20,
+            }
+        )
+        assert result["output_tokens"] == 50
+        assert result["input_tokens"] == 100
+        assert result["cache_read_input_tokens"] == 10
+        assert result["cache_creation_input_tokens"] == 5
+        assert result["output_tokens_details"] == {"thinking_tokens": 20}
+
+    def test_stream_message_start_has_complete_usage(self):
+        """message_start event must contain all spec-required usage fields."""
+        from llm_rosetta.types.ir import StreamStartEvent
+
+        event = cast(
+            StreamStartEvent,
+            {"type": "stream_start", "response_id": "msg_123", "model": "test"},
+        )
+        result = cast(dict[str, Any], self.converter.stream_response_to_provider(event))
+        assert result["type"] == "message_start"
+        usage = result["message"]["usage"]
+        assert self._USAGE_REQUIRED_KEYS == set(usage.keys())
+
+    def test_stream_usage_event_has_delta_usage_fields(self):
+        """UsageEvent → message_delta must have all MessageDeltaUsage fields."""
+        event = cast(
+            UsageEvent,
+            {
+                "type": "usage",
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 20,
+                    "total_tokens": 30,
+                },
+            },
+        )
+        result = cast(dict[str, Any], self.converter.stream_response_to_provider(event))
+        assert result["type"] == "message_delta"
+        assert self._DELTA_USAGE_REQUIRED_KEYS == set(result["usage"].keys())
+        assert result["usage"]["output_tokens"] == 20


### PR DESCRIPTION
## Summary

- Anthropic Messages API spec marks 9 usage fields as required (nullable with defaults). Our converter was conditionally omitting cache fields and entirely missing `cache_creation`, `output_tokens_details`, `service_tier`, `inference_geo`, and `server_tool_use`.
- Verified against live Anthropic API that these fields are always present in real responses.
- `_build_ir_usage_to_p` now always emits all 9 required fields; new `_build_message_delta_usage` helper handles `MessageDeltaUsage` schema for streaming; `_build_p_usage_to_ir` now captures `output_tokens_details.thinking_tokens` → IR `reasoning_tokens` for round-trip.

## Test plan

- [x] `make test` — 2307 passed, 0 failed
- [x] Manual verification: `_build_ir_usage_to_p` output matches spec for both full and minimal IR usage
- [x] Manual verification: `_build_message_delta_usage` output matches `MessageDeltaUsage` schema
- [x] Round-trip: Anthropic thinking response → IR → Anthropic preserves `thinking_tokens`
- [ ] Run llm-comply against updated dev build to confirm schema validation passes

Ref: #414