### PR TITLE
fix(google): filter non-standard modality values from ModalityTokenCount

### DIFF
--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -75,7 +75,7 @@ def _modality_list_to_dict(modality_list: list[dict]) -> dict[str, int]:
     return result
 
 
-_GOOGLE_MODALITIES = {"TEXT", "IMAGE", "VIDEO", "AUDIO", "DOCUMENT"}
+_GOOGLE_MODALITIES = frozenset({"TEXT", "IMAGE", "VIDEO", "AUDIO", "DOCUMENT"})
 
 
 def _dict_to_modality_list(details: dict[str, int]) -> list[dict[str, Any]]:

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -75,8 +75,16 @@ def _modality_list_to_dict(modality_list: list[dict]) -> dict[str, int]:
     return result
 
 
+_GOOGLE_MODALITIES = {"TEXT", "IMAGE", "VIDEO", "AUDIO", "DOCUMENT"}
+
+
 def _dict_to_modality_list(details: dict[str, int]) -> list[dict[str, Any]]:
     """Convert IR ``dict[str, int]`` back to Google's ``list[ModalityTokenCount]``.
+
+    Only emits entries whose modality is in Google's ``Modality`` enum.
+    IR keys like ``cached_tokens`` or ``reasoning_tokens`` are handled by
+    dedicated fields (``cachedContentTokenCount``, ``thoughtsTokenCount``)
+    and must not appear as ``ModalityTokenCount`` entries.
 
     Example: ``{"text_tokens": 42}``
     → ``[{"modality": "TEXT", "tokenCount": 42}]``
@@ -84,6 +92,8 @@ def _dict_to_modality_list(details: dict[str, int]) -> list[dict[str, Any]]:
     result: list[dict[str, Any]] = []
     for key, count in details.items():
         modality = key.removesuffix("_tokens").upper()
+        if modality not in _GOOGLE_MODALITIES:
+            continue
         result.append({"modality": modality, "tokenCount": count})
     return result
 

--- a/tests/converters/google_genai/test_converter.py
+++ b/tests/converters/google_genai/test_converter.py
@@ -790,6 +790,57 @@ class TestGoogleGenAIConverter:
         assert comp_details[0]["modality"] == "TEXT"
         assert comp_details[0]["tokenCount"] == 20
 
+    def test_response_to_provider_modality_filters_non_standard(self):
+        """Non-standard modality keys (cached, reasoning) excluded from details array."""
+        ir_response = cast(
+            IRResponse,
+            {
+                "id": "resp_filter",
+                "object": "response",
+                "created": 1700000000,
+                "model": "gemini-2.0-flash",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Hi"}],
+                        },
+                        "finish_reason": {"reason": "stop"},
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                    "total_tokens": 150,
+                    "reasoning_tokens": 30,
+                    "cache_read_tokens": 20,
+                    "prompt_tokens_details": {
+                        "text_tokens": 80,
+                        "cached_tokens": 20,
+                    },
+                    "completion_tokens_details": {
+                        "text_tokens": 20,
+                        "reasoning_tokens": 30,
+                    },
+                },
+            },
+        )
+        result = self.converter.response_to_provider(ir_response)
+        usage = result["usageMetadata"]
+        # Dedicated fields should be present
+        assert usage["thoughtsTokenCount"] == 30
+        assert usage["cachedContentTokenCount"] == 20
+        # Details arrays should only have valid modalities
+        prompt_details = usage["promptTokensDetails"]
+        modalities = {d["modality"] for d in prompt_details}
+        assert "TEXT" in modalities
+        assert "CACHED" not in modalities
+        comp_details = usage["candidatesTokensDetails"]
+        modalities = {d["modality"] for d in comp_details}
+        assert "TEXT" in modalities
+        assert "REASONING" not in modalities
+
     def test_response_to_provider_finish_reasons(self):
         """Test finish reason mapping to provider."""
         reason_map = {


### PR DESCRIPTION
## Summary

- `_dict_to_modality_list()` was blindly uppercasing all IR detail keys into the Google `Modality` enum, producing invalid values like `CACHED` and `REASONING`
- Google's `Modality` enum only allows: `TEXT`, `IMAGE`, `VIDEO`, `AUDIO`, `DOCUMENT`
- `cached_tokens` and `reasoning_tokens` should only appear as dedicated top-level fields (`cachedContentTokenCount`, `thoughtsTokenCount`), not in the `ModalityTokenCount` array
- Now skips keys whose uppercased form is not a valid Google modality

## Test plan

- [x] `test_response_to_provider_modality_filters_non_standard` — verifies `CACHED`/`REASONING` excluded from details arrays while dedicated fields still present
- [x] Existing modality round-trip tests still pass
- [x] Full test suite: 2308 passed

Refs: #416