### PR TITLE
fix(openai-chat): nest annotations under url_citation and always emit field

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/content_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/content_ops.py
@@ -258,10 +258,12 @@ class OpenAIChatContentOps(BaseContentOps):
         if url_citation:
             return {
                 "type": "url_citation",
-                "start_index": url_citation.get("start_index", 0),
-                "end_index": url_citation.get("end_index", 0),
-                "title": url_citation.get("title", ""),
-                "url": url_citation.get("url", ""),
+                "url_citation": {
+                    "start_index": url_citation.get("start_index", 0),
+                    "end_index": url_citation.get("end_index", 0),
+                    "title": url_citation.get("title", ""),
+                    "url": url_citation.get("url", ""),
+                },
             }
         return None
 
@@ -277,13 +279,14 @@ class OpenAIChatContentOps(BaseContentOps):
         """
         citation_type = provider_citation.get("type", "")
         if citation_type == "url_citation":
+            nested = provider_citation.get("url_citation", {})
             return CitationPart(
                 type="citation",
                 url_citation={
-                    "start_index": provider_citation.get("start_index", 0),
-                    "end_index": provider_citation.get("end_index", 0),
-                    "title": provider_citation.get("title", ""),
-                    "url": provider_citation.get("url", ""),
+                    "start_index": nested.get("start_index", 0),
+                    "end_index": nested.get("end_index", 0),
+                    "title": nested.get("title", ""),
+                    "url": nested.get("url", ""),
                 },
             )
         # Fallback: store raw data

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -269,8 +269,7 @@ class OpenAIChatConverter(BaseConverter):
 
         openai_message["refusal"] = refusal_text
 
-        if annotations:
-            openai_message["annotations"] = annotations
+        openai_message["annotations"] = annotations
 
         if reasoning_parts:
             openai_message["reasoning_content"] = "\n".join(reasoning_parts)

--- a/tests/converters/openai_chat/test_content_ops.py
+++ b/tests/converters/openai_chat/test_content_ops.py
@@ -200,7 +200,7 @@ class TestOpenAIChatContentOps:
         result = OpenAIChatContentOps.ir_citation_to_p(ir_citation)
         assert result is not None
         assert result["type"] == "url_citation"
-        assert result["url"] == "https://example.com"
+        assert result["url_citation"]["url"] == "https://example.com"
 
     def test_ir_citation_to_p_no_url(self):
         """Test ir_citation_to_p returns None when no url_citation."""
@@ -211,10 +211,12 @@ class TestOpenAIChatContentOps:
         """Test OpenAI annotation → IR CitationPart."""
         provider = {
             "type": "url_citation",
-            "start_index": 5,
-            "end_index": 15,
-            "title": "Source",
-            "url": "https://example.com/source",
+            "url_citation": {
+                "start_index": 5,
+                "end_index": 15,
+                "title": "Source",
+                "url": "https://example.com/source",
+            },
         }
         result = OpenAIChatContentOps.p_citation_to_ir(provider)
         assert result["type"] == "citation"


### PR DESCRIPTION
## Summary

- Fix annotation structure: wrap citation fields under nested `url_citation` key to match OpenAI spec
  - Before: `{"type": "url_citation", "start_index": 0, ...}` (flat, spec-invalid)
  - After: `{"type": "url_citation", "url_citation": {"start_index": 0, ...}}` (nested, spec-compliant)
- Always emit `"annotations": []` on assistant messages, matching OpenAI's real API behavior
- Fix both directions: `ir_citation_to_p` (output) and `p_citation_to_ir` (ingest)
- Verified against live OpenAI API (`gpt-4o-search-preview` with web search)

Refs #413 (item #15)

## Test plan

- [x] `make test` — 2307 passed, 0 failed
- [x] `make lint` — clean
- [x] Verified annotation structure matches live OpenAI API response