### PR TITLE
fix(google): include responseId and modelVersion in streaming chunks

### DIFF
--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -1072,6 +1072,22 @@ class GoogleGenAIConverter(BaseConverter):
 
     # --- to_provider ---
 
+    @staticmethod
+    def _inject_stream_metadata(
+        chunk: dict[str, Any], context: StreamContext | None
+    ) -> dict[str, Any]:
+        """Inject ``responseId`` and ``modelVersion`` into a non-empty chunk.
+
+        Google's streaming API includes these fields on every chunk.
+        """
+        if not chunk or context is None:
+            return chunk
+        if context.response_id:
+            chunk["responseId"] = context.response_id
+        if context.model:
+            chunk["modelVersion"] = context.model
+        return chunk
+
     def _handle_ir_stream_start_to_p(
         self, event: StreamStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
@@ -1113,34 +1129,40 @@ class GoogleGenAIConverter(BaseConverter):
         if not event["text"]:
             return {}
         choice_index = event.get("choice_index", 0)
-        return {
-            "candidates": [
-                {
-                    "index": choice_index,
-                    "content": {
-                        "role": "model",
-                        "parts": [{"text": event["text"]}],
-                    },
-                }
-            ]
-        }
+        return self._inject_stream_metadata(
+            {
+                "candidates": [
+                    {
+                        "index": choice_index,
+                        "content": {
+                            "role": "model",
+                            "parts": [{"text": event["text"]}],
+                        },
+                    }
+                ]
+            },
+            context,
+        )
 
     def _handle_ir_reasoning_delta_to_p(
         self, event: ReasoningDeltaEvent, context: StreamContext | None
     ) -> dict[str, Any]:
         """Handle ReasoningDeltaEvent → thought text part chunk."""
         choice_index = event.get("choice_index", 0)
-        return {
-            "candidates": [
-                {
-                    "index": choice_index,
-                    "content": {
-                        "role": "model",
-                        "parts": [{"thought": True, "text": event["reasoning"]}],
-                    },
-                }
-            ]
-        }
+        return self._inject_stream_metadata(
+            {
+                "candidates": [
+                    {
+                        "index": choice_index,
+                        "content": {
+                            "role": "model",
+                            "parts": [{"thought": True, "text": event["reasoning"]}],
+                        },
+                    }
+                ]
+            },
+            context,
+        )
 
     def _handle_ir_tool_call_start_to_p(
         self, event: ToolCallStartEvent, context: StreamContext | None
@@ -1217,7 +1239,7 @@ class GoogleGenAIConverter(BaseConverter):
                 usage_metadata["cachedContentTokenCount"] = usage["cache_read_tokens"]
             finish_chunk["usageMetadata"] = usage_metadata
 
-        chunks.append(finish_chunk)
+        chunks.append(self._inject_stream_metadata(finish_chunk, context))
 
         return chunks
 

--- a/tests/converters/google_genai/test_stream.py
+++ b/tests/converters/google_genai/test_stream.py
@@ -1245,3 +1245,103 @@ class TestStreamResponseToProviderWithContext:
         event = cast(StreamEndEvent, {"type": "stream_end"})
         result = cast(dict[str, Any], self.converter.stream_response_to_provider(event))
         assert result == {}
+
+    def test_text_delta_includes_response_id_and_model_version(self):
+        """Text delta chunks include responseId and modelVersion from context."""
+        context = StreamContext()
+        start = cast(
+            StreamStartEvent,
+            {
+                "type": "stream_start",
+                "response_id": "resp_abc",
+                "model": "gemini-3.5-flash",
+            },
+        )
+        self.converter.stream_response_to_provider(start, context=context)
+
+        delta = cast(
+            TextDeltaEvent,
+            {"type": "text_delta", "text": "Hello", "choice_index": 0},
+        )
+        result = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(delta, context=context),
+        )
+        assert result["responseId"] == "resp_abc"
+        assert result["modelVersion"] == "gemini-3.5-flash"
+        assert result["candidates"][0]["content"]["parts"][0]["text"] == "Hello"
+
+    def test_reasoning_delta_includes_response_id_and_model_version(self):
+        """Reasoning delta chunks include responseId and modelVersion."""
+        context = StreamContext()
+        start = cast(
+            StreamStartEvent,
+            {
+                "type": "stream_start",
+                "response_id": "resp_xyz",
+                "model": "gemini-2.5-flash",
+            },
+        )
+        self.converter.stream_response_to_provider(start, context=context)
+
+        delta = cast(
+            ReasoningDeltaEvent,
+            {"type": "reasoning_delta", "reasoning": "Let me think", "choice_index": 0},
+        )
+        result = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(delta, context=context),
+        )
+        assert result["responseId"] == "resp_xyz"
+        assert result["modelVersion"] == "gemini-2.5-flash"
+
+    def test_finish_chunk_includes_response_id_and_model_version(self):
+        """Finish chunk includes responseId and modelVersion."""
+        context = StreamContext()
+        start = cast(
+            StreamStartEvent,
+            {
+                "type": "stream_start",
+                "response_id": "resp_fin",
+                "model": "gemini-3.5-flash",
+            },
+        )
+        self.converter.stream_response_to_provider(start, context=context)
+
+        finish = cast(
+            FinishEvent,
+            {"type": "finish", "finish_reason": {"reason": "stop"}, "choice_index": 0},
+        )
+        results = self.converter.stream_response_to_provider(finish, context=context)
+        # _handle_ir_finish_to_p returns a list
+        assert isinstance(results, list)
+        chunk = results[0]
+        assert chunk["responseId"] == "resp_fin"
+        assert chunk["modelVersion"] == "gemini-3.5-flash"
+
+    def test_cross_format_stream_carries_metadata(self):
+        """IR from another provider (OpenAI) → Google streaming includes metadata."""
+        context = StreamContext()
+        # Simulate IR stream events that originated from an OpenAI response
+        start = cast(
+            StreamStartEvent,
+            {
+                "type": "stream_start",
+                "response_id": "chatcmpl-abc123",
+                "model": "gpt-4o",
+            },
+        )
+        self.converter.stream_response_to_provider(start, context=context)
+
+        delta = cast(
+            TextDeltaEvent,
+            {"type": "text_delta", "text": "Hi there", "choice_index": 0},
+        )
+        result = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(delta, context=context),
+        )
+        # Cross-format: responseId/modelVersion come from the original provider
+        assert result["responseId"] == "chatcmpl-abc123"
+        assert result["modelVersion"] == "gpt-4o"
+        assert result["candidates"][0]["content"]["parts"][0]["text"] == "Hi there"


### PR DESCRIPTION
## Summary

- Google's streaming API includes `responseId` and `modelVersion` on every chunk, but our to-provider streaming handlers only emitted `candidates` arrays
- Add `_inject_stream_metadata()` helper that injects these fields from `StreamContext` into every non-empty output chunk
- Applied to text delta, reasoning delta, and finish handlers
- Works for both same-format (Google→IR→Google) and cross-format (OpenAI→IR→Google) since `StreamStartEvent` always carries the source provider's metadata

## Test plan

- [x] `test_text_delta_includes_response_id_and_model_version`
- [x] `test_reasoning_delta_includes_response_id_and_model_version`
- [x] `test_finish_chunk_includes_response_id_and_model_version`
- [x] `test_cross_format_stream_carries_metadata` — OpenAI→IR→Google path
- [x] Full test suite: 2312 passed

Refs: #416