### PR TITLE
fix(gateway): surface in-band upstream errors on the streaming path

### DIFF
--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -46,6 +46,8 @@ from .transport import (
 from .transport.sse_format import (
     SSE_FORMATTERS,
     build_stream_error_events,
+    extract_upstream_error_message,
+    is_upstream_error_chunk,
     format_sse_done,
 )
 
@@ -482,26 +484,6 @@ def _terminal_error_sse(
         return []
 
 
-def _is_upstream_error_chunk(chunk: Any) -> bool:
-    """True if *chunk* is an in-band upstream error rather than content.
-
-    Only treats a chunk as an error when it carries no payload of its own, so
-    a provider that legitimately ships an ``error`` field alongside content is
-    left alone.
-    """
-    if not isinstance(chunk, dict) or not chunk.get("error"):
-        return False
-    return not any(k in chunk for k in ("choices", "delta", "candidates", "type"))
-
-
-def _upstream_error_message(chunk: dict[str, Any]) -> str:
-    """Pull a human-readable message out of an upstream error envelope."""
-    err = chunk.get("error")
-    if isinstance(err, dict):
-        return str(err.get("message") or err)
-    return str(err)
-
-
 async def _stream_event_generator(
     *,
     source_provider: ProviderType,
@@ -540,8 +522,8 @@ async def _stream_event_generator(
                 if upstream_chunks is not None:
                     upstream_chunks.append(chunk)
 
-                if _is_upstream_error_chunk(chunk):
-                    stream_error = _upstream_error_message(chunk)
+                if is_upstream_error_chunk(chunk):
+                    stream_error = extract_upstream_error_message(chunk)
                     log_upstream_error(
                         getattr(stream, "status_code", 200),
                         json.dumps(chunk)[:2000],

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -15,6 +15,7 @@ Downstream SSE formatting lives in :mod:`transport.sse_format`.
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -481,6 +482,26 @@ def _terminal_error_sse(
         return []
 
 
+def _is_upstream_error_chunk(chunk: Any) -> bool:
+    """True if *chunk* is an in-band upstream error rather than content.
+
+    Only treats a chunk as an error when it carries no payload of its own, so
+    a provider that legitimately ships an ``error`` field alongside content is
+    left alone.
+    """
+    if not isinstance(chunk, dict) or not chunk.get("error"):
+        return False
+    return not any(k in chunk for k in ("choices", "delta", "candidates", "type"))
+
+
+def _upstream_error_message(chunk: dict[str, Any]) -> str:
+    """Pull a human-readable message out of an upstream error envelope."""
+    err = chunk.get("error")
+    if isinstance(err, dict):
+        return str(err.get("message") or err)
+    return str(err)
+
+
 async def _stream_event_generator(
     *,
     source_provider: ProviderType,
@@ -518,6 +539,21 @@ async def _stream_event_generator(
                 chunk_count += 1
                 if upstream_chunks is not None:
                     upstream_chunks.append(chunk)
+
+                if _is_upstream_error_chunk(chunk):
+                    stream_error = _upstream_error_message(chunk)
+                    log_upstream_error(
+                        getattr(stream, "status_code", 200),
+                        json.dumps(chunk)[:2000],
+                        endpoint=model,
+                        is_streaming=True,
+                    )
+                    for event in build_stream_error_events(
+                        source_provider, stream_error
+                    ):
+                        yield format_sse(event)
+                    break
+
                 for source_event in processor.process_chunk(chunk):
                     yield format_sse(source_event)
 

--- a/src/llm_rosetta/gateway/transport/sse_format.py
+++ b/src/llm_rosetta/gateway/transport/sse_format.py
@@ -106,3 +106,32 @@ def build_stream_error_events(
         return [{"error": {"code": 500, "message": message, "status": "INTERNAL"}}]
 
     return []
+
+
+# ---------------------------------------------------------------------------
+# In-band upstream error detection
+# ---------------------------------------------------------------------------
+
+
+def is_upstream_error_chunk(chunk: Any) -> bool:
+    """True if *chunk* is an in-band upstream error rather than content.
+
+    Some upstreams report request errors inside a 200 SSE stream rather than
+    by HTTP status.  Such a chunk converts to zero source events, leaving the
+    client a successful but empty response.
+
+    Only treats a chunk as an error when it carries no payload of its own, so
+    a provider that legitimately ships an ``error`` field alongside content is
+    left alone.
+    """
+    if not isinstance(chunk, dict) or not chunk.get("error"):
+        return False
+    return not any(k in chunk for k in ("choices", "delta", "candidates", "type"))
+
+
+def extract_upstream_error_message(chunk: dict[str, Any]) -> str:
+    """Pull a human-readable message out of an upstream error envelope."""
+    err = chunk.get("error")
+    if isinstance(err, dict):
+        return str(err.get("message") or err)
+    return str(err)

--- a/tests/gateway/test_stream_upstream_error.py
+++ b/tests/gateway/test_stream_upstream_error.py
@@ -12,11 +12,11 @@ import asyncio
 
 import pytest
 
-from llm_rosetta.gateway.proxy import (
-    _is_upstream_error_chunk,
-    _stream_event_generator,
+from llm_rosetta.gateway.proxy import _stream_event_generator
+from llm_rosetta.gateway.transport.sse_format import (
+    build_stream_error_events,
+    is_upstream_error_chunk,
 )
-from llm_rosetta.gateway.transport.sse_format import build_stream_error_events
 
 ERROR_CHUNK = {
     "error": {
@@ -80,7 +80,7 @@ async def _collect(chunks, source_provider="openai_responses"):
 
 
 def test_detects_bare_error_envelope():
-    assert _is_upstream_error_chunk(ERROR_CHUNK)
+    assert is_upstream_error_chunk(ERROR_CHUNK)
 
 
 @pytest.mark.parametrize(
@@ -95,7 +95,7 @@ def test_detects_bare_error_envelope():
     ],
 )
 def test_content_chunks_are_not_errors(chunk):
-    assert not _is_upstream_error_chunk(chunk)
+    assert not is_upstream_error_chunk(chunk)
 
 
 def test_error_event_uses_source_envelope():

--- a/tests/test_stream_upstream_error.py
+++ b/tests/test_stream_upstream_error.py
@@ -1,0 +1,137 @@
+"""Tests for in-band upstream errors on the streaming path.
+
+Some upstreams report a request error inside a 200 SSE stream rather than by
+HTTP status.  ARGO answers an over-limit `tools` array with `event: error` on
+a 200.  Such a chunk converts to zero source events, so without explicit
+handling the client receives a successful but completely empty stream.
+"""
+
+import json
+
+import asyncio
+
+import pytest
+
+from llm_rosetta.gateway.proxy import (
+    _is_upstream_error_chunk,
+    _stream_event_generator,
+)
+from llm_rosetta.gateway.transport.sse_format import build_stream_error_events
+
+ERROR_CHUNK = {
+    "error": {
+        "message": "Invalid 'tools': array too long. Expected an array with "
+        "maximum length 128, but got an array with length 129 instead.",
+        "type": "BadRequestError",
+        "code": "internal_error",
+    }
+}
+
+
+class _FakeStream:
+    """Minimal stand-in for an upstream SSE stream."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+        self.status_code = 200
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self.closed = True
+        return False
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeProcessor:
+    """Converts content chunks; an error chunk yields nothing, as in real life."""
+
+    def process_chunk(self, chunk):
+        if "error" in chunk:
+            return []
+        return [{"type": "response.output_text.delta", "delta": chunk.get("text", "")}]
+
+
+def _format_sse(event):
+    return f"data: {json.dumps(event)}\n\n"
+
+
+async def _collect(chunks, source_provider="openai_responses"):
+    out = []
+    async for piece in _stream_event_generator(
+        source_provider=source_provider,
+        stream=_FakeStream(chunks),
+        processor=_FakeProcessor(),
+        model="gpt-5.6-sol",
+        format_sse=_format_sse,
+    ):
+        out.append(piece)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+def test_detects_bare_error_envelope():
+    assert _is_upstream_error_chunk(ERROR_CHUNK)
+
+
+@pytest.mark.parametrize(
+    "chunk",
+    [
+        {"choices": [{"delta": {"content": "hi"}}]},
+        {"choices": [], "error": None},
+        # A provider shipping content alongside an error field is not an error.
+        {"error": {"message": "x"}, "choices": [{"delta": {}}]},
+        {"type": "response.output_text.delta", "error": {"message": "x"}},
+        "not a dict",
+    ],
+)
+def test_content_chunks_are_not_errors(chunk):
+    assert not _is_upstream_error_chunk(chunk)
+
+
+def test_error_event_uses_source_envelope():
+    assert (
+        build_stream_error_events("anthropic", "boom")[0]["error"]["type"]
+        == "api_error"
+    )
+    assert build_stream_error_events("google", "boom")[0]["error"]["code"] == 500
+    assert (
+        build_stream_error_events("openai_responses", "boom")[0]["type"]
+        == "response.failed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Generator behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_in_band_error_reaches_the_client():
+    out = asyncio.run(_collect([ERROR_CHUNK]))
+    assert out, "an upstream error must not produce an empty stream"
+    payload = json.loads(out[0].removeprefix("data: ").strip())
+    assert payload["type"] == "response.failed"
+    assert "array too long" in payload["response"]["error"]["message"]
+
+
+def test_stream_stops_after_an_error_but_stays_well_formed():
+    out = asyncio.run(_collect([ERROR_CHUNK, {"text": "should not appear"}]))
+    # The error, then the terminator. Content after the error is dropped.
+    assert len(out) == 2
+    assert "should not appear" not in "".join(out)
+    assert out[-1] == "data: [DONE]\n\n"
+
+
+def test_healthy_stream_is_unaffected():
+    out = asyncio.run(_collect([{"text": "a"}, {"text": "b"}]))
+    assert len(out) == 3  # two deltas plus the [DONE] terminator
+    assert "error" not in out[0]


### PR DESCRIPTION
## Summary

- An upstream that reports a request error inside a 200 SSE stream, rather than by HTTP status, leaves the client with a successful but completely empty response. The error chunk converts to zero source events, so nothing is ever written and the stream simply ends
- `handle_streaming` already covers the header-level case before the `StreamingResponse` is built. The in-band case cannot change the status code, but it can still tell the client why the stream stopped
- Detect the error envelope, log it through the existing `log_upstream_error` path, emit an error event in the client's own envelope, and stop
- Detection is deliberately narrow: a chunk only counts as an error when it carries no payload keys of its own (`choices`, `delta`, `candidates`, `type`), so a provider that ships an `error` field alongside content is untouched
- The stream still terminates normally, so the client gets the error followed by the usual `[DONE]` rather than a truncated stream

## Test plan

- [x] `make test` — 2292 passed, 34 skipped, 0 failed
- [x] `make lint` — clean
- [x] `ty check` — no new diagnostics
- [x] `test_in_band_error_reaches_the_client`
- [x] `test_stream_stops_after_an_error_but_stays_well_formed`
- [x] `test_healthy_stream_is_unaffected`
- [x] `test_content_chunks_are_not_errors` — 5 parametrized negative cases
- [x] Live Chat upstream that answers an over-limit `tools` array with `event: error` on a 200. Client previously received 0 bytes; it now receives the upstream message plus the terminator. A normal streaming request is unaffected

Note: while testing this I hit an unrelated flake in `test_pipeline_profile.py::test_profile_populated_after_convert_request`. It compares a rounded total against a sum of rounded parts, so at sub-millisecond speeds it can fail on rounding alone (`assert 0.05 >= 0.054`). This PR does not touch `pipeline.py`. Left alone to keep the change focused.

AI was used to assist with investigation and implementation.
