### PR TITLE
fix(openai-responses): emit response.in_progress streaming event

### DIFF
--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -842,8 +842,10 @@ class OpenAIResponsesConverter(BaseConverter):
         if handler_name is not None:
             getattr(self, handler_name)(chunk, context, events)
 
-        # All other event types (response.in_progress,
-        # response.output_text.done, etc.) are ignored.
+        # All other event types (response.in_progress, response.queued,
+        # response.output_text.done, etc.) are dropped — response.in_progress
+        # is redundant with response.created and is re-synthesised by
+        # _handle_ir_stream_start_to_p on the to_provider side.
 
         return events
 
@@ -1162,7 +1164,6 @@ class OpenAIResponsesConverter(BaseConverter):
             events.append(StreamEndEvent(type="stream_end"))
 
     _P_TO_IR_DISPATCH: dict[str, str] = {
-        ResponsesEventType.RESPONSE_IN_PROGRESS: "_handle_p_passthrough_to_ir",
         ResponsesEventType.RESPONSE_CREATED: "_handle_p_response_created_to_ir",
         ResponsesEventType.OUTPUT_TEXT_DELTA: "_handle_p_output_text_delta_to_ir",
         ResponsesEventType.REASONING_SUMMARY_TEXT_DELTA: "_handle_p_reasoning_delta_to_ir",
@@ -1226,7 +1227,7 @@ class OpenAIResponsesConverter(BaseConverter):
         self,
         event: StreamStartEvent,
         context: StreamContext | None,
-    ) -> dict[str, Any]:
+    ) -> list[dict[str, Any]]:
         response_id_stem = event["response_id"]
 
         # Store metadata in context if provided (stem, without prefix)
@@ -1270,10 +1271,18 @@ class OpenAIResponsesConverter(BaseConverter):
             # response.created must include usage: null (not yet available)
             response.setdefault("usage", None)
 
-        return {
-            "type": ResponsesEventType.RESPONSE_CREATED,
-            "response": response,
-        }
+        # Both events share the same response snapshot — safe because
+        # nothing between here and json.dumps serialisation mutates it.
+        return [
+            {
+                "type": ResponsesEventType.RESPONSE_CREATED,
+                "response": response,
+            },
+            {
+                "type": ResponsesEventType.RESPONSE_IN_PROGRESS,
+                "response": response,
+            },
+        ]
 
     def _handle_ir_stream_end_to_p(
         self,

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -261,17 +261,11 @@ class TestStreamResponseFromProvider:
         events = self.converter.stream_response_from_provider(event)
         assert events == []
 
-    def test_response_in_progress_passthrough(self):
-        """response.in_progress is preserved as a passthrough event."""
+    def test_response_in_progress_dropped(self):
+        """response.in_progress is dropped (re-synthesised on the to_provider side)."""
         event = {"type": "response.in_progress", "response": {}}
         events = self.converter.stream_response_from_provider(event)
-        assert events == [
-            {
-                "type": "provider_passthrough",
-                "provider": "openai_responses",
-                "payload": event,
-            }
-        ]
+        assert events == []
 
     def test_output_item_done_ignored(self):
         """response.output_item.done produces no events."""
@@ -875,7 +869,7 @@ class TestStreamResponseToProviderWithContext:
         self.converter = OpenAIResponsesConverter()
 
     def test_stream_start_event(self):
-        """StreamStartEvent → response.created."""
+        """StreamStartEvent → [response.created, response.in_progress]."""
         ctx = OpenAIResponsesStreamContext()
         event = cast(
             StreamStartEvent,
@@ -885,21 +879,22 @@ class TestStreamResponseToProviderWithContext:
                 "model": "gpt-4o",
             },
         )
-        result = cast(
-            dict[str, Any],
-            self.converter.stream_response_to_provider(event, context=ctx),
-        )
-        assert result["type"] == "response.created"
-        assert result["response"]["id"] == "resp_abc123"
-        assert result["response"]["model"] == "gpt-4o"
-        assert result["response"]["status"] == "in_progress"
-        assert result["response"]["output"] == []
+        result = self.converter.stream_response_to_provider(event, context=ctx)
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["type"] == "response.created"
+        assert result[0]["response"]["id"] == "resp_abc123"
+        assert result[0]["response"]["model"] == "gpt-4o"
+        assert result[0]["response"]["status"] == "in_progress"
+        assert result[0]["response"]["output"] == []
+        assert result[1]["type"] == "response.in_progress"
+        assert result[1]["response"] is result[0]["response"]
         assert ctx.response_id == "resp_abc123"
         assert ctx.model == "gpt-4o"
         assert ctx.is_started is True
 
     def test_stream_start_without_context(self):
-        """StreamStartEvent without context still produces response.created."""
+        """StreamStartEvent without context still produces [created, in_progress]."""
         event = cast(
             StreamStartEvent,
             {
@@ -908,9 +903,12 @@ class TestStreamResponseToProviderWithContext:
                 "model": "gpt-4o",
             },
         )
-        result = cast(dict[str, Any], self.converter.stream_response_to_provider(event))
-        assert result["type"] == "response.created"
-        assert result["response"]["id"] == "resp_abc123"
+        result = self.converter.stream_response_to_provider(event)
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["type"] == "response.created"
+        assert result[0]["response"]["id"] == "resp_abc123"
+        assert result[1]["type"] == "response.in_progress"
 
     def test_stream_end_event(self):
         """StreamEndEvent → empty dict."""
@@ -1142,22 +1140,22 @@ class TestStreamResponseToProviderWithContext:
         """Full stream sequence produces correct events with no duplicates."""
         ctx = OpenAIResponsesStreamContext()
 
-        # 1. StreamStartEvent
-        start_result = cast(
-            dict[str, Any],
-            self.converter.stream_response_to_provider(
-                cast(
-                    StreamStartEvent,
-                    {
-                        "type": "stream_start",
-                        "response_id": "resp_123",
-                        "model": "gpt-4o",
-                    },
-                ),
-                context=ctx,
+        # 1. StreamStartEvent → [response.created, response.in_progress]
+        start_results = self.converter.stream_response_to_provider(
+            cast(
+                StreamStartEvent,
+                {
+                    "type": "stream_start",
+                    "response_id": "resp_123",
+                    "model": "gpt-4o",
+                },
             ),
+            context=ctx,
         )
-        assert start_result["type"] == "response.created"
+        assert isinstance(start_results, list)
+        assert len(start_results) == 2
+        assert start_results[0]["type"] == "response.created"
+        assert start_results[1]["type"] == "response.in_progress"
 
         # 2. ContentBlockStartEvent — with context, first text block emits
         # both output_item.added and content_part.added as a list.
@@ -1251,7 +1249,7 @@ class TestStreamResponseToProviderWithContext:
 
         # Verify: only ONE response.completed was produced in the entire sequence
         all_results: list[Any] = [
-            start_result,
+            *start_results,
             usage_result,
             end_result,
         ]
@@ -2167,8 +2165,10 @@ class TestStreamingResponseIdPrefix:
             "created": 1700000000,
         }
         result = self.converter.stream_response_to_provider(ir_event, context=ctx)
-        assert isinstance(result, dict)
-        assert result["response"]["id"] == "resp_abc123"
+        assert isinstance(result, list)
+        assert result[0]["type"] == "response.created"
+        assert result[0]["response"]["id"] == "resp_abc123"
+        assert result[1]["type"] == "response.in_progress"
         # Context stores the stem (without prefix)
         assert ctx.response_id == "abc123"
 
@@ -2275,8 +2275,8 @@ class TestStreamingPrefixFromContext:
             "created": 1700000000,
         }
         result = self.converter.stream_response_to_provider(ir_event, context=ctx)
-        assert isinstance(result, dict)
-        assert result["response"]["id"] == "custom_abc123"
+        assert isinstance(result, list)
+        assert result[0]["response"]["id"] == "custom_abc123"
 
     def test_finish_uses_context_prefix(self):
         """Finish response uses prefix from context."""

--- a/tests/converters/test_provider_passthrough.py
+++ b/tests/converters/test_provider_passthrough.py
@@ -94,22 +94,15 @@ class TestStreamPassthrough:
         passthrough = cast(ProviderPassthroughEvent, events[0])
         assert passthrough["payload"] is not chunk
 
-    def test_responses_in_progress_emits_passthrough(self):
+    def test_responses_in_progress_dropped(self):
+        """response.in_progress is dropped (re-synthesised on the to_provider side)."""
         chunk = {
             "type": "response.in_progress",
             "sequence_number": 3,
             "response": {"id": "resp_1", "status": "in_progress"},
         }
         events = OpenAIResponsesConverter().stream_response_from_provider(chunk)
-        assert events == [
-            {
-                "type": "provider_passthrough",
-                "provider": "openai_responses",
-                "payload": chunk,
-            }
-        ]
-        passthrough = cast(ProviderPassthroughEvent, events[0])
-        assert passthrough["payload"] is not chunk
+        assert events == []
 
     def test_same_format_restores_copy(self):
         converter = AnthropicConverter()
@@ -410,23 +403,17 @@ class TestNonStreamPassthroughHelpers:
 
 class TestStreamProcessorPassthrough:
     def test_same_format_forwards_passthrough(self):
-        target = OpenAIResponsesConverter()
-        source = OpenAIResponsesConverter()
+        """Anthropic ping events pass through same-format round-trip."""
+        target = AnthropicConverter()
+        source = AnthropicConverter()
         processor = StreamProcessor(
             target_converter=target,
             source_converter=source,
             from_ctx=target.create_stream_context(),
             to_ctx=source.create_stream_context(),
         )
-        result = processor.process_chunk(
-            {
-                "type": "response.in_progress",
-                "sequence_number": 8,
-                "response": {"id": "resp_1", "status": "in_progress"},
-            }
-        )
-        assert result[0]["type"] == "response.in_progress"
-        assert result[0]["sequence_number"] == 1
+        result = processor.process_chunk({"type": "ping"})
+        assert result[0]["type"] == "ping"
 
     def test_cross_format_drops_passthrough(self):
         target = OpenAIResponsesConverter()

--- a/tests/converters/test_roundtrip_inflation.py
+++ b/tests/converters/test_roundtrip_inflation.py
@@ -461,6 +461,17 @@ OPENAI_RESPONSES_BASIC: list[dict[str, Any]] = [
         },
     },
     {
+        "type": "response.in_progress",
+        "response": {
+            "id": "resp_001",
+            "object": "response",
+            "model": "gpt-4o",
+            "status": "in_progress",
+            "output": [],
+            "usage": None,
+        },
+    },
+    {
         "type": "response.output_item.added",
         "output_index": 0,
         "item": {
@@ -558,6 +569,17 @@ OPENAI_RESPONSES_BASIC: list[dict[str, Any]] = [
 OPENAI_RESPONSES_TOOL_CALL: list[dict[str, Any]] = [
     {
         "type": "response.created",
+        "response": {
+            "id": "resp_002",
+            "object": "response",
+            "model": "gpt-4o",
+            "status": "in_progress",
+            "output": [],
+            "usage": None,
+        },
+    },
+    {
+        "type": "response.in_progress",
         "response": {
             "id": "resp_002",
             "object": "response",


### PR DESCRIPTION
## Summary

- Emit `response.in_progress` streaming event after `response.created`, per Open Responses spec (v2026-04-24)
- Last remaining non-compaction spec violation from #412 audit

## Design

Three conversion paths must be correct:

1. **Responses→IR→Responses**: from_provider drops original `response.in_progress` (redundant with `response.created`), to_provider synthesises a new one → no inflation
2. **Chat/Anthropic/Google→IR→Responses**: to_provider synthesises `response.in_progress` → cross-format gap filled
3. **Responses→IR→Chat**: `response.in_progress` not emitted → no leak

## Changes

- `converter.py`: `_handle_ir_stream_start_to_p` returns `[response.created, response.in_progress]`; `response.in_progress` removed from `_P_TO_IR_DISPATCH` (dropped instead of passthrough)
- 4 test files updated to match

## Test plan

- [x] 2312 unit tests pass, 0 failures
- [x] All three conversion paths verified (same-format round-trip, cross-format synthesis, no-leak)
- [ ] llm-comply re-run against gateway

Closes the `response.in_progress` item in #412.