### PR TITLE
fix(google): flush pending usage on stream_end for cross-format streaming

### DIFF
--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -1088,6 +1088,24 @@ class GoogleGenAIConverter(BaseConverter):
             chunk["modelVersion"] = context.model
         return chunk
 
+    @staticmethod
+    def _build_stream_usage_metadata(usage: Mapping[str, Any]) -> dict[str, Any]:
+        """Build a Google ``usageMetadata`` dict from IR usage for streaming.
+
+        Lighter than ``_build_ir_usage_to_p`` — omits the details arrays
+        which are not typically present in streaming usage events.
+        """
+        usage_metadata: dict[str, Any] = {
+            "promptTokenCount": usage.get("prompt_tokens") or 0,
+            "candidatesTokenCount": usage.get("completion_tokens") or 0,
+            "totalTokenCount": usage.get("total_tokens") or 0,
+        }
+        if "reasoning_tokens" in usage:
+            usage_metadata["thoughtsTokenCount"] = usage["reasoning_tokens"]
+        if "cache_read_tokens" in usage:
+            usage_metadata["cachedContentTokenCount"] = usage["cache_read_tokens"]
+        return usage_metadata
+
     def _handle_ir_stream_start_to_p(
         self, event: StreamStartEvent, context: StreamContext | None
     ) -> dict[str, Any]:
@@ -1111,19 +1129,9 @@ class GoogleGenAIConverter(BaseConverter):
             usage = context.pop_pending_usage()
             context.mark_ended()
             if usage is not None:
-                usage_metadata: dict[str, Any] = {
-                    "promptTokenCount": usage.get("prompt_tokens") or 0,
-                    "candidatesTokenCount": usage.get("completion_tokens") or 0,
-                    "totalTokenCount": usage.get("total_tokens") or 0,
-                }
-                if "reasoning_tokens" in usage:
-                    usage_metadata["thoughtsTokenCount"] = usage["reasoning_tokens"]
-                if "cache_read_tokens" in usage:
-                    usage_metadata["cachedContentTokenCount"] = usage[
-                        "cache_read_tokens"
-                    ]
                 return self._inject_stream_metadata(
-                    {"usageMetadata": usage_metadata}, context
+                    {"usageMetadata": self._build_stream_usage_metadata(usage)},
+                    context,
                 )
         return {}
 
@@ -1249,16 +1257,7 @@ class GoogleGenAIConverter(BaseConverter):
         else:
             usage = None
         if usage is not None:
-            usage_metadata: dict[str, Any] = {
-                "promptTokenCount": usage.get("prompt_tokens") or 0,
-                "candidatesTokenCount": usage.get("completion_tokens") or 0,
-                "totalTokenCount": usage.get("total_tokens") or 0,
-            }
-            if "reasoning_tokens" in usage:
-                usage_metadata["thoughtsTokenCount"] = usage["reasoning_tokens"]
-            if "cache_read_tokens" in usage:
-                usage_metadata["cachedContentTokenCount"] = usage["cache_read_tokens"]
-            finish_chunk["usageMetadata"] = usage_metadata
+            finish_chunk["usageMetadata"] = self._build_stream_usage_metadata(usage)
 
         chunks.append(self._inject_stream_metadata(finish_chunk, context))
 
@@ -1278,18 +1277,7 @@ class GoogleGenAIConverter(BaseConverter):
         if context is not None:
             context.buffer_usage(usage)
             return {}
-        usage_metadata: dict[str, Any] = {
-            "promptTokenCount": usage.get("prompt_tokens") or 0,
-            "candidatesTokenCount": usage.get("completion_tokens") or 0,
-            "totalTokenCount": usage.get("total_tokens") or 0,
-        }
-
-        if "reasoning_tokens" in usage:
-            usage_metadata["thoughtsTokenCount"] = usage["reasoning_tokens"]
-        if "cache_read_tokens" in usage:
-            usage_metadata["cachedContentTokenCount"] = usage["cache_read_tokens"]
-
-        return {"usageMetadata": usage_metadata}
+        return {"usageMetadata": self._build_stream_usage_metadata(usage)}
 
 
 # Backward compatibility alias

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -1101,9 +1101,30 @@ class GoogleGenAIConverter(BaseConverter):
     def _handle_ir_stream_end_to_p(
         self, event: StreamEndEvent, context: StreamContext | None
     ) -> dict[str, Any]:
-        """Handle StreamEndEvent → mark ended, no output."""
+        """Handle StreamEndEvent → flush any buffered usage, mark ended.
+
+        When usage arrives after the finish chunk (e.g. OpenAI streaming
+        sends usage in a separate final chunk), pending_usage won't have
+        been merged into the finish chunk. Emit it here so it's not lost.
+        """
         if context is not None:
+            usage = context.pop_pending_usage()
             context.mark_ended()
+            if usage is not None:
+                usage_metadata: dict[str, Any] = {
+                    "promptTokenCount": usage.get("prompt_tokens") or 0,
+                    "candidatesTokenCount": usage.get("completion_tokens") or 0,
+                    "totalTokenCount": usage.get("total_tokens") or 0,
+                }
+                if "reasoning_tokens" in usage:
+                    usage_metadata["thoughtsTokenCount"] = usage["reasoning_tokens"]
+                if "cache_read_tokens" in usage:
+                    usage_metadata["cachedContentTokenCount"] = usage[
+                        "cache_read_tokens"
+                    ]
+                return self._inject_stream_metadata(
+                    {"usageMetadata": usage_metadata}, context
+                )
         return {}
 
     def _handle_ir_content_block_start_to_p(

--- a/tests/converters/google_genai/test_stream.py
+++ b/tests/converters/google_genai/test_stream.py
@@ -1345,3 +1345,76 @@ class TestStreamResponseToProviderWithContext:
         assert result["responseId"] == "chatcmpl-abc123"
         assert result["modelVersion"] == "gpt-4o"
         assert result["candidates"][0]["content"]["parts"][0]["text"] == "Hi there"
+
+    def test_stream_end_flushes_pending_usage(self):
+        """Usage buffered after finish is emitted on stream_end."""
+        context = StreamContext()
+        self.converter.stream_response_to_provider(
+            cast(
+                StreamStartEvent,
+                {"type": "stream_start", "response_id": "resp_u", "model": "gemini-x"},
+            ),
+            context=context,
+        )
+        # Finish without usage (usage hasn't arrived yet)
+        self.converter.stream_response_to_provider(
+            cast(
+                FinishEvent,
+                {
+                    "type": "finish",
+                    "finish_reason": {"reason": "stop"},
+                    "choice_index": 0,
+                },
+            ),
+            context=context,
+        )
+        # Usage arrives late (cross-format: OpenAI sends it after finish)
+        self.converter.stream_response_to_provider(
+            cast(
+                UsageEvent,
+                {
+                    "type": "usage",
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 5,
+                        "total_tokens": 15,
+                        "reasoning_tokens": 3,
+                    },
+                },
+            ),
+            context=context,
+        )
+        # stream_end should flush the buffered usage
+        result = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(
+                cast(StreamEndEvent, {"type": "stream_end"}),
+                context=context,
+            ),
+        )
+        assert result["usageMetadata"]["promptTokenCount"] == 10
+        assert result["usageMetadata"]["candidatesTokenCount"] == 5
+        assert result["usageMetadata"]["totalTokenCount"] == 15
+        assert result["usageMetadata"]["thoughtsTokenCount"] == 3
+        assert result["responseId"] == "resp_u"
+        assert result["modelVersion"] == "gemini-x"
+        assert context.pending_usage is None
+
+    def test_stream_end_no_usage_returns_empty(self):
+        """stream_end without pending usage returns empty dict."""
+        context = StreamContext()
+        self.converter.stream_response_to_provider(
+            cast(
+                StreamStartEvent,
+                {"type": "stream_start", "response_id": "r", "model": "m"},
+            ),
+            context=context,
+        )
+        result = cast(
+            dict[str, Any],
+            self.converter.stream_response_to_provider(
+                cast(StreamEndEvent, {"type": "stream_end"}),
+                context=context,
+            ),
+        )
+        assert result == {}


### PR DESCRIPTION
## Summary

- When converting OpenAI→IR→Google streaming, usage arrives in a separate chunk *after* `finish_reason`
- The Google converter buffers usage in `StreamContext.pending_usage` to merge with the finish chunk, but by the time usage arrives, the finish chunk has already been emitted
- The buffered usage was silently dropped — `_handle_ir_stream_end_to_p` just called `mark_ended()` and returned `{}`
- Now checks for `pending_usage` on `stream_end` and emits a `usageMetadata`-only chunk (with `responseId`/`modelVersion`) if present

## Root cause

OpenAI streaming event order: `[content deltas] → finish_reason → usage (separate chunk) → [DONE]`
Google streaming event order: `[content deltas] → finish_reason + usageMetadata (same chunk)`

The converter assumed usage would arrive before or with finish. When it arrives after (cross-format), it was lost.

## Test plan

- [x] Manual pipeline simulation: OpenAI chunks → IR → Google — `usageMetadata` now appears in stream_end output
- [x] Full test suite: 2326 passed

Follow-up to PR #452. Refs: #416