### PR TITLE
fix(anthropic): always emit stop_sequence and stop_details

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -416,6 +416,10 @@ class AnthropicConverter(BaseConverter):
                     "explanation": refusal_part.get("refusal", ""),
                 }
 
+        # Ensure nullable required fields are always present (spec compliance)
+        provider_response.setdefault("stop_sequence", None)
+        provider_response.setdefault("stop_details", None)
+
         # Usage (always present — Anthropic responses require usage field)
         ir_usage = ir_response.get("usage") or {}
         provider_response["usage"] = self._build_ir_usage_to_p(ir_usage)
@@ -943,6 +947,8 @@ class AnthropicConverter(BaseConverter):
                 "model": event["model"],
                 "content": [],
                 "stop_reason": None,
+                "stop_sequence": None,
+                "stop_details": None,
                 "usage": p_usage,
             },
         }
@@ -1211,6 +1217,8 @@ class AnthropicConverter(BaseConverter):
                 delta_payload: dict[str, Any] = {"stop_reason": stop_reason}
                 if stop_details:
                     delta_payload["stop_details"] = stop_details
+                delta_payload.setdefault("stop_sequence", None)
+                delta_payload.setdefault("stop_details", None)
                 results.append(
                     {
                         "type": AnthropicEventType.MESSAGE_DELTA,
@@ -1223,11 +1231,17 @@ class AnthropicConverter(BaseConverter):
                 finish_delta: dict[str, Any] = {"stop_reason": stop_reason}
                 if stop_details:
                     finish_delta["stop_details"] = stop_details
+                finish_delta.setdefault("stop_sequence", None)
+                finish_delta.setdefault("stop_details", None)
                 context.buffer_finish(finish_delta)
             return results if results else {}
         return {
             "type": AnthropicEventType.MESSAGE_DELTA,
-            "delta": {"stop_reason": stop_reason},
+            "delta": {
+                "stop_reason": stop_reason,
+                "stop_sequence": None,
+                "stop_details": None,
+            },
             "usage": self._build_message_delta_usage(),
         }
 

--- a/tests/converters/anthropic/test_converter.py
+++ b/tests/converters/anthropic/test_converter.py
@@ -1228,3 +1228,138 @@ class TestAnthropicUsageRoundTrip:
         usage = anthropic_out["usage"]
         assert self._USAGE_REQUIRED_KEYS == set(usage.keys())
         assert usage["output_tokens_details"] == {"thinking_tokens": 80}
+
+
+class TestAnthropicStopFieldsCompliance:
+    """Tests for stop_sequence/stop_details always present (#414)."""
+
+    def setup_method(self):
+        self.converter = AnthropicConverter()
+
+    def test_response_to_provider_stop_fields_default_null(self):
+        """stop_sequence and stop_details default to null when not set."""
+        ir_response = cast(
+            IRResponse,
+            {
+                "id": "resp_stop",
+                "object": "response",
+                "created": 1700000000,
+                "model": "claude-3",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Hi"}],
+                        },
+                        "finish_reason": {"reason": "stop"},
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 3,
+                    "total_tokens": 8,
+                },
+            },
+        )
+        result = self.converter.response_to_provider(ir_response)
+        assert result["stop_sequence"] is None
+        assert result["stop_details"] is None
+
+    def test_response_to_provider_stop_sequence_preserved(self):
+        """stop_sequence is preserved when present in IR finish_reason."""
+        ir_response = cast(
+            IRResponse,
+            {
+                "id": "resp_seq",
+                "object": "response",
+                "created": 1700000000,
+                "model": "claude-3",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Hello"}],
+                        },
+                        "finish_reason": {"reason": "stop", "stop_sequence": "\n\n"},
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 3,
+                    "total_tokens": 8,
+                },
+            },
+        )
+        result = self.converter.response_to_provider(ir_response)
+        assert result["stop_sequence"] == "\n\n"
+        assert result["stop_details"] is None
+
+    def test_response_round_trip_stop_fields(self):
+        """A→IR→A: stop_sequence/stop_details always present."""
+        provider_response = {
+            "id": "msg_rt_stop",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3",
+            "content": [{"type": "text", "text": "Hello!"}],
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "stop_details": None,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        ir = self.converter.response_from_provider(provider_response)
+        restored = self.converter.response_to_provider(ir)
+        assert restored["stop_sequence"] is None
+        assert restored["stop_details"] is None
+
+    def test_cross_format_stop_fields_present(self):
+        """B→IR→A: stop_sequence/stop_details present even from OpenAI source."""
+        from llm_rosetta.converters.openai_chat import OpenAIChatConverter
+
+        openai = OpenAIChatConverter()
+        openai_response = {
+            "id": "chatcmpl-x",
+            "object": "chat.completion",
+            "model": "gpt-4",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hi"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+        }
+        ir = openai.response_from_provider(openai_response)
+        anthropic_out = self.converter.response_to_provider(ir)
+        assert anthropic_out["stop_sequence"] is None
+        assert anthropic_out["stop_details"] is None
+
+    def test_stream_message_start_has_stop_fields(self):
+        """message_start scaffold includes stop_sequence and stop_details."""
+        from llm_rosetta.types.ir import StreamStartEvent
+
+        event = cast(
+            StreamStartEvent,
+            {"type": "stream_start", "response_id": "msg_s", "model": "test"},
+        )
+        result = cast(dict[str, Any], self.converter.stream_response_to_provider(event))
+        msg = result["message"]
+        assert msg["stop_sequence"] is None
+        assert msg["stop_details"] is None
+
+    def test_stream_message_delta_has_stop_fields(self):
+        """message_delta delta includes stop_sequence and stop_details."""
+        event = cast(
+            FinishEvent,
+            {
+                "type": "finish",
+                "finish_reason": {"reason": "stop"},
+            },
+        )
+        result = cast(dict[str, Any], self.converter.stream_response_to_provider(event))
+        assert result["type"] == "message_delta"
+        assert result["delta"]["stop_sequence"] is None
+        assert result["delta"]["stop_details"] is None


### PR DESCRIPTION
## Summary

- Anthropic spec requires `stop_sequence` and `stop_details` as nullable fields on every response. Our converter only included them conditionally (stop_sequence when present in IR, stop_details only for refusal).
- Now uses `setdefault(None)` to ensure both fields are always present across non-streaming response, streaming `message_start.message`, and streaming `message_delta.delta`.
- Compatible with all conversion paths: A→IR→A, B→IR→A, A→IR→B→IR→A.

## Test plan

- [x] `make test` — 2332 passed
- [x] Non-streaming: stop_sequence/stop_details default to null
- [x] Non-streaming: stop_sequence preserved when present
- [x] A→IR→A round-trip: both fields present
- [x] B→IR→A cross-format: both fields present
- [x] Streaming message_start: scaffold has both fields
- [x] Streaming message_delta: delta has both fields

Ref: #414