### PR TITLE
fix(anthropic): add caller, citations, and container fields

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -393,6 +393,10 @@ class AnthropicConverter(BaseConverter):
                     elif is_refusal_part(part):
                         refusal_part = part
 
+                # Add citations: null to text blocks (spec requires it on ResponseTextBlock)
+                for block in anthropic_content:
+                    if block.get("type") == "text":
+                        block.setdefault("citations", None)
                 provider_response["content"] = anthropic_content
 
             # Map finish_reason back to stop_reason
@@ -419,6 +423,7 @@ class AnthropicConverter(BaseConverter):
         # Ensure nullable required fields are always present (spec compliance)
         provider_response.setdefault("stop_sequence", None)
         provider_response.setdefault("stop_details", None)
+        provider_response.setdefault("container", None)
 
         # Usage (always present — Anthropic responses require usage field)
         ir_usage = ir_response.get("usage") or {}
@@ -566,6 +571,8 @@ class AnthropicConverter(BaseConverter):
             "model",
             "stop_reason",
             "stop_sequence",
+            "stop_details",
+            "container",
             "usage",
         }
         extras = {
@@ -622,6 +629,8 @@ class AnthropicConverter(BaseConverter):
             "model",
             "stop_reason",
             "stop_sequence",
+            "stop_details",
+            "container",
             "usage",
         }
         for k, v in echo.items():
@@ -949,6 +958,7 @@ class AnthropicConverter(BaseConverter):
                 "stop_reason": None,
                 "stop_sequence": None,
                 "stop_details": None,
+                "container": None,
                 "usage": p_usage,
             },
         }
@@ -1219,6 +1229,7 @@ class AnthropicConverter(BaseConverter):
                     delta_payload["stop_details"] = stop_details
                 delta_payload.setdefault("stop_sequence", None)
                 delta_payload.setdefault("stop_details", None)
+                delta_payload.setdefault("container", None)
                 results.append(
                     {
                         "type": AnthropicEventType.MESSAGE_DELTA,
@@ -1233,6 +1244,7 @@ class AnthropicConverter(BaseConverter):
                     finish_delta["stop_details"] = stop_details
                 finish_delta.setdefault("stop_sequence", None)
                 finish_delta.setdefault("stop_details", None)
+                finish_delta.setdefault("container", None)
                 context.buffer_finish(finish_delta)
             return results if results else {}
         return {
@@ -1241,6 +1253,7 @@ class AnthropicConverter(BaseConverter):
                 "stop_reason": stop_reason,
                 "stop_sequence": None,
                 "stop_details": None,
+                "container": None,
             },
             "usage": self._build_message_delta_usage(),
         }

--- a/src/llm_rosetta/converters/anthropic/tool_ops.py
+++ b/src/llm_rosetta/converters/anthropic/tool_ops.py
@@ -332,6 +332,12 @@ class AnthropicToolOps(BaseToolOps):
         if "provider_metadata" in ir_tool_call:
             result["_provider_metadata"] = ir_tool_call["provider_metadata"]
 
+        # Restore caller from provider_metadata or default to direct
+        pm = ir_tool_call.get("provider_metadata") or {}
+        caller = pm.get("anthropic_caller", {"type": "direct"})
+        if result["type"] == "tool_use":
+            result["caller"] = caller
+
         # Preserve cache_hint → cache_control
         cache_hint = ir_tool_call.get("cache_hint")
         if cache_hint is not None:
@@ -371,6 +377,11 @@ class AnthropicToolOps(BaseToolOps):
         pm = provider_tool_call.get("_provider_metadata")
         if pm:
             part["provider_metadata"] = pm
+
+        # Preserve non-default caller for Anthropic round-trip
+        caller = provider_tool_call.get("caller")
+        if isinstance(caller, dict) and caller.get("type") != "direct":
+            part.setdefault("provider_metadata", {})["anthropic_caller"] = caller
 
         # Read cache_control → cache_hint
         cache_control = provider_tool_call.get("cache_control")

--- a/tests/converters/anthropic/test_converter.py
+++ b/tests/converters/anthropic/test_converter.py
@@ -1363,3 +1363,234 @@ class TestAnthropicStopFieldsCompliance:
         assert result["type"] == "message_delta"
         assert result["delta"]["stop_sequence"] is None
         assert result["delta"]["stop_details"] is None
+
+
+class TestAnthropicContentBlockCompliance:
+    """Tests for caller, citations, container spec compliance (#414)."""
+
+    def setup_method(self):
+        self.converter = AnthropicConverter()
+
+    # --- ToolUseBlock.caller ---
+
+    def test_tool_use_has_caller_default(self):
+        """IR→A: tool_use block includes caller: {"type": "direct"} by default."""
+        ir_response = cast(
+            IRResponse,
+            {
+                "id": "resp_caller",
+                "object": "response",
+                "created": 1700000000,
+                "model": "claude-3",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "tool_call",
+                                    "tool_call_id": "toolu_123",
+                                    "tool_name": "get_weather",
+                                    "tool_input": {"city": "Tokyo"},
+                                }
+                            ],
+                        },
+                        "finish_reason": {"reason": "tool_calls"},
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                },
+            },
+        )
+        result = self.converter.response_to_provider(ir_response)
+        tool_block = result["content"][0]
+        assert tool_block["caller"] == {"type": "direct"}
+
+    def test_caller_round_trip_direct(self):
+        """A→IR→A: direct caller round-trips."""
+        provider_response = {
+            "id": "msg_caller_rt",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_abc",
+                    "name": "search",
+                    "input": {"q": "hello"},
+                    "caller": {"type": "direct"},
+                }
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        ir = self.converter.response_from_provider(provider_response)
+        restored = self.converter.response_to_provider(ir)
+        assert restored["content"][0]["caller"] == {"type": "direct"}
+
+    def test_caller_round_trip_code_execution(self):
+        """A→IR→A: non-direct caller preserved via provider_metadata."""
+        provider_response = {
+            "id": "msg_caller_ce",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_xyz",
+                    "name": "run_code",
+                    "input": {},
+                    "caller": {
+                        "type": "code_execution_20250825",
+                        "tool_id": "srvtoolu_abc123",
+                    },
+                }
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+        ir = self.converter.response_from_provider(provider_response)
+        restored = self.converter.response_to_provider(ir)
+        assert restored["content"][0]["caller"] == {
+            "type": "code_execution_20250825",
+            "tool_id": "srvtoolu_abc123",
+        }
+
+    def test_cross_format_tool_use_has_caller(self):
+        """B→IR→A: OpenAI tool call gets default caller."""
+        from llm_rosetta.converters.openai_chat import OpenAIChatConverter
+
+        openai = OpenAIChatConverter()
+        openai_response = {
+            "id": "chatcmpl-c",
+            "object": "chat.completion",
+            "model": "gpt-4",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "search",
+                                    "arguments": '{"q":"hi"}',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+        }
+        ir = openai.response_from_provider(openai_response)
+        anthropic_out = self.converter.response_to_provider(ir)
+        tool_block = [b for b in anthropic_out["content"] if b["type"] == "tool_use"][0]
+        assert tool_block["caller"] == {"type": "direct"}
+
+    # --- TextBlock.citations ---
+
+    def test_text_block_has_citations_null(self):
+        """IR→A: text block includes citations: null."""
+        ir_response = cast(
+            IRResponse,
+            {
+                "id": "resp_cite",
+                "object": "response",
+                "created": 1700000000,
+                "model": "claude-3",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Hello"}],
+                        },
+                        "finish_reason": {"reason": "stop"},
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 2,
+                    "total_tokens": 7,
+                },
+            },
+        )
+        result = self.converter.response_to_provider(ir_response)
+        assert result["content"][0]["citations"] is None
+
+    def test_citations_round_trip_null(self):
+        """A→IR→A: citations: null round-trips."""
+        provider_response = {
+            "id": "msg_cite_rt",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3",
+            "content": [{"type": "text", "text": "Hi"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 5, "output_tokens": 2},
+        }
+        ir = self.converter.response_from_provider(provider_response)
+        restored = self.converter.response_to_provider(ir)
+        assert restored["content"][0]["citations"] is None
+
+    # --- container ---
+
+    def test_response_has_container_null(self):
+        """IR→A: response includes container: null."""
+        ir_response = cast(
+            IRResponse,
+            {
+                "id": "resp_cont",
+                "object": "response",
+                "created": 1700000000,
+                "model": "claude-3",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Hi"}],
+                        },
+                        "finish_reason": {"reason": "stop"},
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 2,
+                    "total_tokens": 7,
+                },
+            },
+        )
+        result = self.converter.response_to_provider(ir_response)
+        assert result["container"] is None
+
+    def test_stream_message_start_has_container(self):
+        """message_start scaffold includes container: null."""
+        from llm_rosetta.types.ir import StreamStartEvent
+
+        event = cast(
+            StreamStartEvent,
+            {"type": "stream_start", "response_id": "msg_c", "model": "test"},
+        )
+        result = cast(dict[str, Any], self.converter.stream_response_to_provider(event))
+        assert result["message"]["container"] is None
+
+    def test_stream_message_delta_has_container(self):
+        """message_delta delta includes container: null."""
+        event = cast(
+            FinishEvent,
+            {"type": "finish", "finish_reason": {"reason": "stop"}},
+        )
+        result = cast(dict[str, Any], self.converter.stream_response_to_provider(event))
+        assert result["delta"]["container"] is None


### PR DESCRIPTION
## Summary

Closes the remaining Anthropic spec compliance gaps from #414:

- **`ToolUseBlock.caller`**: always emits `{"type": "direct"}` by default. Non-direct callers (e.g. `code_execution_20250825`) preserved via `provider_metadata["anthropic_caller"]` for A→IR→A round-trip.
- **`TextBlock.citations`**: `null` on response content blocks. Applied at response-level, not `ir_text_to_p`, so system instruction text blocks are unaffected.
- **`Message.container`**: `null` on response, `message_start.message`, and `message_delta.delta`.

All conversion paths verified: A→IR→A, B→IR→A, A→IR→B→IR→A.

## Test plan

- [x] `make test` — 2343 passed
- [x] caller: default `{"type": "direct"}` on tool_use blocks
- [x] caller: direct round-trip (A→IR→A)
- [x] caller: code_execution round-trip via provider_metadata (A→IR→A)
- [x] caller: cross-format gets default (B→IR→A)
- [x] citations: null on text blocks
- [x] citations: null round-trip (A→IR→A)
- [x] container: null on response
- [x] container: null on streaming message_start
- [x] container: null on streaming message_delta

Ref: #414