### PR TITLE
feat(gateway): configurable root redirect

### DIFF
--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -546,6 +546,16 @@ def _flush_now(app: App) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _install_root_redirect(app: App, target: str | None) -> None:
+    """Register a GET / → *target* redirect when *target* is set."""
+    if not target:
+        return
+
+    @app.route("/", methods=["GET"])
+    async def root_redirect(request: Any) -> Response:
+        return Response(body=b"", status_code=307, headers={"Location": target})
+
+
 def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
     """Create the httpserver application."""
     global _config
@@ -577,6 +587,8 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
     app.route("/health", methods=["GET"])(handle_health)
     app.route("/health/live", methods=["GET"])(handle_health_live)
     app.route("/health/ready", methods=["GET"])(handle_health_ready)
+
+    _install_root_redirect(app, config.root_redirect)
 
     # --- Auth ---
     import secrets

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -288,6 +288,10 @@ class GatewayConfig:
         #   }
         self.admin_cors_origins: list[str] = _server.get("admin_cors_origins", []) or []
 
+        # Optional root redirect: when set, GET / returns a 307 to the given
+        # path (e.g. "/admin").  Disabled by default (no redirect).
+        self.root_redirect: str | None = _server.get("root_redirect")
+
         # Request-log retention knobs (consumed by setup_admin).  Kept as
         # a raw dict here so admin layer owns the resolution policy.
         self.request_log: dict[str, Any] = _server.get("request_log", {}) or {}

--- a/tests/gateway/test_root_redirect.py
+++ b/tests/gateway/test_root_redirect.py
@@ -1,0 +1,87 @@
+"""Tests for configurable root redirect (server.root_redirect)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from llm_rosetta.gateway.config import GatewayConfig
+
+
+def _minimal_raw(**server_overrides) -> dict:
+    raw = {
+        "providers": {
+            "test": {
+                "api_key": "sk-test",
+                "base_url": "https://api.example.com",
+                "type": "openai",
+            }
+        },
+        "models": {"gpt-test": "test"},
+        "server": {},
+    }
+    raw["server"].update(server_overrides)
+    return raw
+
+
+def _find_root_get_route(app):
+    for route in app._routes:
+        if route.pattern.fullmatch("/") and "GET" in route.methods:
+            return route
+    return None
+
+
+class TestRootRedirectConfig:
+    def test_default_none(self):
+        cfg = GatewayConfig(_minimal_raw())
+        assert cfg.root_redirect is None
+
+    def test_set_to_admin(self):
+        cfg = GatewayConfig(_minimal_raw(root_redirect="/admin"))
+        assert cfg.root_redirect == "/admin"
+
+    def test_set_to_custom_path(self):
+        cfg = GatewayConfig(_minimal_raw(root_redirect="/dashboard"))
+        assert cfg.root_redirect == "/dashboard"
+
+
+class TestRootRedirectRoute:
+    def test_root_route_registered_when_configured(self):
+        from llm_rosetta.gateway.app import create_app
+
+        cfg = GatewayConfig(_minimal_raw(root_redirect="/admin"))
+        app = create_app(cfg)
+        assert _find_root_get_route(app) is not None
+
+    def test_root_route_not_registered_when_disabled(self):
+        from llm_rosetta.gateway.app import create_app
+
+        cfg = GatewayConfig(_minimal_raw())
+        app = create_app(cfg)
+        assert _find_root_get_route(app) is None
+
+    def test_redirect_returns_307_to_admin(self):
+        from llm_rosetta.gateway.app import create_app
+
+        cfg = GatewayConfig(_minimal_raw(root_redirect="/admin"))
+        app = create_app(cfg)
+        route = _find_root_get_route(app)
+        assert route is not None
+
+        request = MagicMock()
+        resp = asyncio.run(route.handler(request))
+        assert resp.status_code == 307
+        assert resp.headers["Location"] == "/admin"
+
+    def test_redirect_to_custom_path(self):
+        from llm_rosetta.gateway.app import create_app
+
+        cfg = GatewayConfig(_minimal_raw(root_redirect="/dashboard"))
+        app = create_app(cfg)
+        route = _find_root_get_route(app)
+        assert route is not None
+
+        request = MagicMock()
+        resp = asyncio.run(route.handler(request))
+        assert resp.status_code == 307
+        assert resp.headers["Location"] == "/dashboard"


### PR DESCRIPTION
## Summary

- Add `server.root_redirect` config option — when set (e.g. `"/admin"`), `GET /` returns a 307 redirect to the configured path
- Disabled by default (no redirect, root returns 404 as before)
- Extracted `_install_root_redirect()` helper to keep `create_app` under the complexity limit

Ref: codex-rosetta `2a414550`, #398 item #8

## Config example

```jsonc
{
  "server": {
    "root_redirect": "/admin"
  }
}
```

## Test plan

- [x] Config parsing: default `None`, set to `/admin`, set to `/dashboard`
- [x] Route registration: present when configured, absent when not
- [x] Redirect response: 307 with correct `Location` header
- [x] Full test suite (2350 passed)
- [x] Lint clean (`ruff check` + `ruff format` + `ty check`)