### PR TITLE
feat(gateway): configurable upstream and read timeouts

### DIFF
--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -572,9 +572,9 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
     from .transport import HttpTransport
 
     metadata_store = ProviderMetadataStore()
-    transport = HttpTransport()
+    transport = HttpTransport(timeout=config.upstream_timeout)
 
-    app = App(max_body_size=50_000_000, read_timeout=300.0)
+    app = App(max_body_size=50_000_000, read_timeout=config.read_timeout)
 
     # --- Routes ---
     app.route("/v1/chat/completions", methods=["POST"])(handle_openai_chat)

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -292,6 +292,13 @@ class GatewayConfig:
         # path (e.g. "/admin").  Disabled by default (no redirect).
         self.root_redirect: str | None = _server.get("root_redirect")
 
+        # Timeout settings (seconds).  upstream_timeout governs the entire
+        # upstream HTTP lifecycle: connect, header-read, and per-chunk
+        # streaming reads.  read_timeout governs how long the inbound
+        # httpserver waits for the client to send a complete request.
+        self.upstream_timeout: float = float(_server.get("upstream_timeout", 300.0))
+        self.read_timeout: float = float(_server.get("read_timeout", 300.0))
+
         # Request-log retention knobs (consumed by setup_admin).  Kept as
         # a raw dict here so admin layer owns the resolution policy.
         self.request_log: dict[str, Any] = _server.get("request_log", {}) or {}

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -296,8 +296,10 @@ class GatewayConfig:
         # upstream HTTP lifecycle: connect, header-read, and per-chunk
         # streaming reads.  read_timeout governs how long the inbound
         # httpserver waits for the client to send a complete request.
-        self.upstream_timeout: float = float(_server.get("upstream_timeout", 300.0))
-        self.read_timeout: float = float(_server.get("read_timeout", 300.0))
+        self.upstream_timeout: float = max(
+            1.0, float(_server.get("upstream_timeout", 300.0))
+        )
+        self.read_timeout: float = max(1.0, float(_server.get("read_timeout", 300.0)))
 
         # Request-log retention knobs (consumed by setup_admin).  Kept as
         # a raw dict here so admin layer owns the resolution policy.

--- a/tests/gateway/test_timeout_config.py
+++ b/tests/gateway/test_timeout_config.py
@@ -50,6 +50,16 @@ class TestTimeoutConfig:
         assert cfg.upstream_timeout == 450.0
         assert cfg.read_timeout == 90.0
 
+    def test_clamp_zero(self):
+        cfg = GatewayConfig(_minimal_raw(upstream_timeout=0, read_timeout=0))
+        assert cfg.upstream_timeout == 1.0
+        assert cfg.read_timeout == 1.0
+
+    def test_clamp_negative(self):
+        cfg = GatewayConfig(_minimal_raw(upstream_timeout=-10, read_timeout=-5))
+        assert cfg.upstream_timeout == 1.0
+        assert cfg.read_timeout == 1.0
+
 
 class TestTimeoutWiring:
     def test_transport_receives_upstream_timeout(self):

--- a/tests/gateway/test_timeout_config.py
+++ b/tests/gateway/test_timeout_config.py
@@ -1,0 +1,81 @@
+"""Tests for configurable gateway timeouts (server.upstream_timeout, server.read_timeout)."""
+
+from __future__ import annotations
+
+from llm_rosetta.gateway.config import GatewayConfig
+
+
+def _minimal_raw(**server_overrides) -> dict:
+    raw = {
+        "providers": {
+            "test": {
+                "api_key": "sk-test",
+                "base_url": "https://api.example.com",
+                "type": "openai",
+            }
+        },
+        "models": {"gpt-test": "test"},
+        "server": {},
+    }
+    raw["server"].update(server_overrides)
+    return raw
+
+
+class TestTimeoutConfig:
+    def test_defaults(self):
+        cfg = GatewayConfig(_minimal_raw())
+        assert cfg.upstream_timeout == 300.0
+        assert cfg.read_timeout == 300.0
+
+    def test_custom_upstream_timeout(self):
+        cfg = GatewayConfig(_minimal_raw(upstream_timeout=600))
+        assert cfg.upstream_timeout == 600.0
+
+    def test_custom_read_timeout(self):
+        cfg = GatewayConfig(_minimal_raw(read_timeout=120))
+        assert cfg.read_timeout == 120.0
+
+    def test_both_custom(self):
+        cfg = GatewayConfig(_minimal_raw(upstream_timeout=900, read_timeout=60))
+        assert cfg.upstream_timeout == 900.0
+        assert cfg.read_timeout == 60.0
+
+    def test_float_coercion_from_int(self):
+        cfg = GatewayConfig(_minimal_raw(upstream_timeout=10, read_timeout=20))
+        assert isinstance(cfg.upstream_timeout, float)
+        assert isinstance(cfg.read_timeout, float)
+
+    def test_float_coercion_from_string(self):
+        cfg = GatewayConfig(_minimal_raw(upstream_timeout="450", read_timeout="90"))
+        assert cfg.upstream_timeout == 450.0
+        assert cfg.read_timeout == 90.0
+
+
+class TestTimeoutWiring:
+    def test_transport_receives_upstream_timeout(self):
+        from llm_rosetta.gateway.app import create_app
+
+        cfg = GatewayConfig(_minimal_raw(upstream_timeout=600))
+        app = create_app(cfg)
+        assert app.transport._pool._timeout == 600.0  # ty: ignore[unresolved-attribute]
+
+    def test_transport_receives_default_timeout(self):
+        from llm_rosetta.gateway.app import create_app
+
+        cfg = GatewayConfig(_minimal_raw())
+        app = create_app(cfg)
+        assert app.transport._pool._timeout == 300.0  # ty: ignore[unresolved-attribute]
+
+    def test_app_receives_read_timeout(self):
+        from llm_rosetta.gateway.app import create_app
+
+        cfg = GatewayConfig(_minimal_raw(read_timeout=120))
+        app = create_app(cfg)
+        assert app.read_timeout == 120.0
+
+    def test_app_receives_default_read_timeout(self):
+        from llm_rosetta.gateway.app import create_app
+
+        cfg = GatewayConfig(_minimal_raw())
+        app = create_app(cfg)
+        assert app.read_timeout == 300.0


### PR DESCRIPTION
## Summary

- Add `server.upstream_timeout` config option (default 300s) — governs the full upstream HTTP lifecycle: connect, header-read, and per-chunk streaming reads
- Add `server.read_timeout` config option (default 300s) — governs how long the inbound httpserver waits for the client to send a complete request
- Both were previously hardcoded at 300s; now configurable for slow-model deployments (e.g. thinking/reasoning models that take minutes to start streaming)

Ref: codex-rosetta `ccf7766b` + `da0b98a0`, #398 item #10

## Config example

```jsonc
{
  "server": {
    "upstream_timeout": 600,
    "read_timeout": 300
  }
}
```

## Note on stream open vs idle timeout

The vendored `AsyncClient` uses a single timeout value for the entire HTTP lifecycle (connect, headers, per-chunk reads). True separation of stream-open and stream-idle timeouts would require modifying `_vendor/`, which is out of scope. This PR exposes the existing single timeout as configurable — a future `_vendor` update could enable finer-grained control.

## Test plan

- [x] Config parsing: defaults, custom values, float coercion from int/string
- [x] Wiring: `HttpTransport` and `App` receive configured values from `create_app`
- [x] Full test suite (2360 passed)
- [x] Lint clean (`ruff check` + `ruff format` + `ty check`)