### PR TITLE
feat(openai): native custom tool support across Chat and Responses converters

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -711,23 +711,38 @@ class OpenAIChatConverter(BaseConverter):
     ) -> None:
         """Process tool call deltas from a choice."""
         for tc in tool_calls:
-            tc_func = tc.get("function", {})
+            tc_type = tc.get("type", "function")
             tc_id = tc.get("id")
             tc_index = tc.get("index")
+
+            if tc_type == "custom":
+                tc_custom = tc.get("custom", {})
+                tc_name = tc_custom.get("name", "")
+                tc_input = tc_custom.get("input", "")
+            else:
+                tc_func = tc.get("function", {})
+                tc_name = tc_func.get("name", "")
+                tc_input = tc_func.get("arguments", "")
 
             if tc_id:
                 start_event_tc = ToolCallStartEvent(
                     type="tool_call_start",
                     tool_call_id=tc_id,
-                    tool_name=tc_func.get("name", ""),
+                    tool_name=tc_name,
                     choice_index=choice_index,
                 )
+                if tc_type == "custom":
+                    start_event_tc["tool_type"] = "custom"
                 if tc_index is not None:
                     start_event_tc["tool_call_index"] = tc_index
                 events.append(start_event_tc)
 
                 if context is not None:
-                    context.register_tool_call(tc_id, tc_func.get("name", ""))
+                    context.register_tool_call(
+                        tc_id,
+                        tc_name,
+                        "custom" if tc_type == "custom" else "function",
+                    )
 
             # Resolve the effective call ID for delta-only chunks
             # (they carry index but no id).
@@ -737,12 +752,11 @@ class OpenAIChatConverter(BaseConverter):
                 if 0 <= tc_index < len(order):
                     effective_tc_id = order[tc_index]
 
-            arguments = tc_func.get("arguments")
-            if arguments:
+            if tc_input:
                 delta_event = ToolCallDeltaEvent(
                     type="tool_call_delta",
                     tool_call_id=effective_tc_id or "",
-                    arguments_delta=arguments,
+                    arguments_delta=tc_input,
                     choice_index=choice_index,
                 )
                 if tc_index is not None:
@@ -750,7 +764,7 @@ class OpenAIChatConverter(BaseConverter):
                 events.append(delta_event)
 
                 if context is not None and effective_tc_id:
-                    context.append_tool_call_args(effective_tc_id, arguments)
+                    context.append_tool_call_args(effective_tc_id, tc_input)
 
     def _handle_p_finish_reason_to_ir(
         self,
@@ -998,15 +1012,34 @@ class OpenAIChatConverter(BaseConverter):
         """Handle ToolCallStartEvent → tool_calls delta with id and name."""
         choice_index = event.get("choice_index", 0)
         tc_index = event.get("tool_call_index", 0)
-        tc_entry: dict[str, Any] = {
-            "index": tc_index,
-            "id": event["tool_call_id"],
-            "type": "function",
-            "function": {
-                "name": event["tool_name"],
-                "arguments": "",
-            },
-        }
+        tool_type = event.get("tool_type", "function")
+
+        if tool_type == "custom":
+            tc_entry: dict[str, Any] = {
+                "index": tc_index,
+                "id": event["tool_call_id"],
+                "type": "custom",
+                "custom": {
+                    "name": event["tool_name"],
+                    "input": "",
+                },
+            }
+        else:
+            tc_entry = {
+                "index": tc_index,
+                "id": event["tool_call_id"],
+                "type": "function",
+                "function": {
+                    "name": event["tool_name"],
+                    "arguments": "",
+                },
+            }
+
+        if context is not None:
+            context.register_tool_call(
+                event["tool_call_id"], event["tool_name"], tool_type
+            )
+
         chunk = {
             "choices": [
                 {
@@ -1024,12 +1057,22 @@ class OpenAIChatConverter(BaseConverter):
         """Handle ToolCallDeltaEvent → tool_calls delta with arguments."""
         choice_index = event.get("choice_index", 0)
         tc_index = event.get("tool_call_index", 0)
-        tc_delta_entry: dict[str, Any] = {
-            "index": tc_index,
-            "function": {
-                "arguments": event["arguments_delta"],
-            },
-        }
+
+        is_custom = (
+            context is not None
+            and context.get_tool_type(event["tool_call_id"]) == "custom"
+        )
+        if is_custom:
+            tc_delta_entry: dict[str, Any] = {
+                "index": tc_index,
+                "custom": {"input": event["arguments_delta"]},
+            }
+        else:
+            tc_delta_entry = {
+                "index": tc_index,
+                "function": {"arguments": event["arguments_delta"]},
+            }
+
         return {
             "choices": [
                 {

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -6,6 +6,7 @@ Composes ContentOps, ToolOps, MessageOps, and ConfigOps for full bidirectional
 conversion between IR and OpenAI Chat Completions API format.
 """
 
+import logging
 from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
@@ -41,6 +42,8 @@ from .config_ops import OpenAIChatConfigOps
 from .content_ops import OpenAIChatContentOps
 from .message_ops import OpenAIChatMessageOps
 from .tool_ops import OpenAIChatToolOps
+
+logger = logging.getLogger(__name__)
 
 
 class OpenAIChatConverter(BaseConverter):
@@ -1058,6 +1061,11 @@ class OpenAIChatConverter(BaseConverter):
         choice_index = event.get("choice_index", 0)
         tc_index = event.get("tool_call_index", 0)
 
+        if context is None:
+            logger.debug(
+                "tool_call_delta without context — cannot resolve tool_type for %s",
+                event["tool_call_id"],
+            )
         is_custom = (
             context is not None
             and context.get_tool_type(event["tool_call_id"]) == "custom"

--- a/src/llm_rosetta/converters/openai_chat/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/tool_ops.py
@@ -145,7 +145,22 @@ class OpenAIChatToolOps(BaseToolOps):
         Returns:
             OpenAI Chat tool definition dict.
         """
-        if ir_tool.get("type", "function") == "function":
+        tool_type = ir_tool.get("type", "function")
+        metadata = ir_tool.get("metadata") or {}
+
+        if tool_type == "custom" or metadata.get("provider_type") == "custom":
+            custom: dict[str, Any] = {
+                "name": ir_tool["name"],
+            }
+            desc = ir_tool.get("description", "")
+            if desc:
+                custom["description"] = desc
+            fmt = metadata.get("format")
+            if fmt:
+                custom["format"] = fmt
+            return {"type": "custom", "custom": custom}
+
+        if tool_type == "function":
             func_def: dict[str, Any] = {
                 "name": ir_tool["name"],
                 "description": ir_tool.get("description", ""),
@@ -157,9 +172,7 @@ class OpenAIChatToolOps(BaseToolOps):
                 func_def["parameters"] = parameters
             return {"type": "function", "function": func_def}
 
-        # Non-function tool types (e.g. Codex apply_patch with type="custom"):
-        # wrap as Chat Completions function, preserving the original name so
-        # the client can match tool_call responses back to the tool.
+        # Unknown tool types: wrap as Chat Completions function.
         raw_params = ir_tool.get("parameters", {})
         params = (
             sanitize_schema(raw_params) if isinstance(raw_params, dict) else raw_params
@@ -185,6 +198,24 @@ class OpenAIChatToolOps(BaseToolOps):
         Returns:
             IR ToolDefinition.
         """
+        if provider_tool.get("type") == "custom":
+            custom = provider_tool.get("custom", {})
+            metadata: dict[str, Any] = {}
+            fmt = custom.get("format")
+            if fmt:
+                metadata["format"] = fmt
+            return cast(
+                ToolDefinition,
+                {
+                    "type": "custom",
+                    "name": custom.get("name", ""),
+                    "description": custom.get("description", ""),
+                    "parameters": {},
+                    "required_parameters": [],
+                    "metadata": metadata,
+                },
+            )
+
         func = provider_tool.get("function", {})
         result: dict[str, Any] = {
             "type": "function",
@@ -232,6 +263,8 @@ class OpenAIChatToolOps(BaseToolOps):
         elif mode == "tool":
             tool_name = ir_tool_choice.get("tool_name")
             if tool_name:
+                if ir_tool_choice.get("tool_type") == "custom":
+                    return {"type": "custom", "custom": {"name": tool_name}}
                 return {"type": "function", "function": {"name": tool_name}}
             return "required"
 
@@ -263,6 +296,16 @@ class OpenAIChatToolOps(BaseToolOps):
             return cast(ToolChoice, {"mode": "auto", "tool_name": ""})
 
         if isinstance(provider_tool_choice, dict):
+            if provider_tool_choice.get("type") == "custom":
+                custom = provider_tool_choice.get("custom", {})
+                return cast(
+                    ToolChoice,
+                    {
+                        "mode": "tool",
+                        "tool_name": custom.get("name", ""),
+                        "tool_type": "custom",
+                    },
+                )
             if provider_tool_choice.get("type") == "function":
                 func = provider_tool_choice.get("function", {})
                 return cast(
@@ -285,12 +328,34 @@ class OpenAIChatToolOps(BaseToolOps):
         Returns:
             OpenAI Chat tool call dict.
         """
+        tool_type = ir_tool_call.get("tool_type", "function")
         tool_input = ir_tool_call.get("tool_input", {})
+
+        if tool_type == "custom":
+            if isinstance(tool_input, dict) and list(tool_input.keys()) == ["input"]:
+                input_str = str(tool_input["input"])
+            else:
+                input_str = (
+                    json.dumps(tool_input)
+                    if isinstance(tool_input, dict)
+                    else str(tool_input)
+                )
+            result: dict[str, Any] = {
+                "id": ir_tool_call["tool_call_id"],
+                "type": "custom",
+                "custom": {
+                    "name": ir_tool_call["tool_name"],
+                    "input": input_str,
+                },
+            }
+            if "provider_metadata" in ir_tool_call:
+                result["_provider_metadata"] = ir_tool_call["provider_metadata"]
+            return result
+
         arguments = (
             json.dumps(tool_input) if isinstance(tool_input, dict) else str(tool_input)
         )
-
-        result: dict[str, Any] = {
+        result = {
             "id": ir_tool_call["tool_call_id"],
             "type": "function",
             "function": {
@@ -314,6 +379,21 @@ class OpenAIChatToolOps(BaseToolOps):
         Returns:
             IR ToolCallPart.
         """
+        if provider_tool_call.get("type") == "custom":
+            custom = provider_tool_call.get("custom", {})
+            input_str = custom.get("input", "")
+            part = ToolCallPart(
+                type="tool_call",
+                tool_call_id=provider_tool_call.get("id", ""),
+                tool_name=custom.get("name", ""),
+                tool_input={"input": input_str},
+                tool_type="custom",
+            )
+            pm = provider_tool_call.get("_provider_metadata")
+            if pm:
+                part["provider_metadata"] = pm
+            return part
+
         func = provider_tool_call.get("function", {})
         arguments_str = func.get("arguments", "{}")
 

--- a/src/llm_rosetta/converters/openai_chat/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/tool_ops.py
@@ -332,7 +332,11 @@ class OpenAIChatToolOps(BaseToolOps):
         tool_input = ir_tool_call.get("tool_input", {})
 
         if tool_type == "custom":
-            if isinstance(tool_input, dict) and list(tool_input.keys()) == ["input"]:
+            if (
+                isinstance(tool_input, dict)
+                and len(tool_input) == 1
+                and "input" in tool_input
+            ):
                 input_str = str(tool_input["input"])
             else:
                 input_str = (

--- a/src/llm_rosetta/converters/openai_responses/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/tool_ops.py
@@ -146,13 +146,26 @@ class OpenAIResponsesToolOps(BaseToolOps):
         if passthrough is not None:
             return dict(passthrough)
 
-        # After #177, all non-function tools entering IR are coerced to
-        # type="function" and carry _passthrough (handled above).  Only
-        # genuine function tools reach here.
+        tool_type = ir_tool.get("type", "function")
+
+        if tool_type == "custom":
+            result: dict[str, Any] = {
+                "type": "custom",
+                "name": ir_tool["name"],
+            }
+            desc = ir_tool.get("description", "")
+            if desc:
+                result["description"] = desc
+            metadata = ir_tool.get("metadata") or {}
+            fmt = metadata.get("format")
+            if fmt:
+                result["format"] = fmt
+            return result
+
         parameters = ir_tool.get("parameters", {})
         if isinstance(parameters, dict):
             parameters = sanitize_schema(parameters)
-        result: dict[str, Any] = {
+        result = {
             "type": "function",
             "name": ir_tool["name"],
             "description": ir_tool.get("description", ""),
@@ -181,9 +194,7 @@ class OpenAIResponsesToolOps(BaseToolOps):
         Returns:
             IR ToolDefinition.
         """
-        # IR ToolDefinition.type is restricted to Literal["function", "mcp"];
-        # see types/ir/tools.py.
-        _IR_ALLOWED_TYPES = {"function", "mcp"}
+        _IR_ALLOWED_TYPES = {"function", "mcp", "custom"}
 
         # Handle nested format ({"type": "function", "function": {...}})
         if "function" in provider_tool and isinstance(provider_tool["function"], dict):
@@ -268,9 +279,13 @@ class OpenAIResponsesToolOps(BaseToolOps):
             result["required_parameters"] = []
 
         downgraded_from = result.pop("_downgraded_from", None)
-        result["metadata"] = (
+        meta: dict[str, Any] = (
             {"provider_type": downgraded_from} if downgraded_from else {}
         )
+        fmt = provider_tool.get("format")
+        if fmt:
+            meta["format"] = fmt
+        result["metadata"] = meta
         return cast(ToolDefinition, result)
 
     # ==================== Tool Choice ====================
@@ -308,8 +323,8 @@ class OpenAIResponsesToolOps(BaseToolOps):
             if not tool_name and "function" in ir_tool_choice:
                 tool_name = cast(dict, ir_tool_choice)["function"].get("name")
             if tool_name:
-                # Responses API format: {"type": "function", "name": "..."}
-                # (NOT Chat Completions format which nests under "function" key)
+                if ir_tool_choice.get("tool_type") == "custom":
+                    return {"type": "custom", "name": tool_name}
                 return {"type": "function", "name": tool_name}
             return "required"
 
@@ -341,9 +356,16 @@ class OpenAIResponsesToolOps(BaseToolOps):
             return cast(ToolChoice, {"mode": "auto", "tool_name": ""})
 
         if isinstance(provider_tool_choice, dict):
+            if provider_tool_choice.get("type") == "custom":
+                return cast(
+                    ToolChoice,
+                    {
+                        "mode": "tool",
+                        "tool_name": provider_tool_choice.get("name", ""),
+                        "tool_type": "custom",
+                    },
+                )
             if provider_tool_choice.get("type") == "function":
-                # Support both Responses format {"name": "..."} and
-                # Chat Completions format {"function": {"name": "..."}}
                 tool_name = provider_tool_choice.get("name", "")
                 if not tool_name:
                     func = provider_tool_choice.get("function", {})

--- a/src/llm_rosetta/types/ir/tools.py
+++ b/src/llm_rosetta/types/ir/tools.py
@@ -30,20 +30,23 @@ class ToolDefinition(TypedDict):
 
     Source converter contract:
     Provider tool types that fall outside the ``type`` Literal below
-    (e.g. OpenAI Responses' ``"custom"`` hosted tools, or unnamed hosted
-    tools like ``"web_search"``) MUST be coerced to ``"function"`` at the
-    provider→IR boundary so that runtime IR validation
-    (``validate_ir_request``) accepts the result.  Provider-specific
-    information may be retained in ``metadata`` (e.g.
-    ``{"provider_type": "custom"}``) or in the ``_passthrough`` extension
-    for round-tripping.  Target converters' downgrade fallbacks (e.g.
-    ``openai_chat/tool_ops.py``) are defensive only — IR is guaranteed
-    valid by validation.
+    (e.g. unnamed hosted tools like ``"web_search"``) MUST be coerced to
+    ``"function"`` at the provider→IR boundary so that runtime IR
+    validation (``validate_ir_request``) accepts the result.
+    Provider-specific information may be retained in ``metadata`` or in
+    the ``_passthrough`` extension for round-tripping.
+
+    ``"custom"`` is a first-class IR type supported natively by both
+    OpenAI Chat Completions and Responses APIs.  Custom tools accept
+    free-form text input (not JSON); ``parameters`` carries a synthesized
+    ``{"input": string}`` schema for providers that require JSON Schema.
+    Custom tool format info (text/grammar) is stored in ``metadata``.
     """
 
     type: Literal[
         "function",
         "mcp",
+        "custom",
         # 未来陆续支持 Future supports
         # "web_search",
         # "code_interpreter",
@@ -75,6 +78,7 @@ class ToolChoice(TypedDict):
 
     mode: Literal["none", "auto", "any", "tool"]
     tool_name: NotRequired[str]  # 当mode为"tool"时必需
+    tool_type: NotRequired[str]  # "function" (default) or "custom"
 
 
 # ============================================================================

--- a/tests/converters/openai_chat/test_tool_ops.py
+++ b/tests/converters/openai_chat/test_tool_ops.py
@@ -44,26 +44,45 @@ class TestOpenAIChatToolOps:
         assert result["function"]["description"] == "Get current weather"
         assert "parameters" in result["function"]
 
-    def test_ir_tool_definition_to_p_non_function_preserves_name(self):
-        """Non-function tool type preserves original name (no type prefix)."""
+    def test_ir_tool_definition_to_p_custom(self):
+        """Custom tool type emits native Chat custom format."""
         ir_tool = cast(
             ToolDefinition,
             {
                 "type": "custom",
                 "name": "apply_patch",
                 "description": "Apply a patch",
-                "parameters": {
-                    "type": "object",
-                    "properties": {"patch": {"type": "string"}},
-                },
+                "parameters": {},
                 "required_parameters": [],
-                "metadata": {},
+                "metadata": {
+                    "format": {
+                        "type": "grammar",
+                        "grammar": {"definition": "start: /.+/s", "syntax": "lark"},
+                    }
+                },
             },
         )
         result = OpenAIChatToolOps.ir_tool_definition_to_p(ir_tool)
-        assert result["type"] == "function"
-        assert result["function"]["name"] == "apply_patch"
-        assert result["function"]["description"] == "Apply a patch"
+        assert result["type"] == "custom"
+        assert result["custom"]["name"] == "apply_patch"
+        assert result["custom"]["description"] == "Apply a patch"
+        assert result["custom"]["format"]["type"] == "grammar"
+
+    def test_ir_tool_definition_to_p_custom_via_metadata(self):
+        """Custom tool detected from metadata.provider_type fallback."""
+        ir_tool = cast(
+            ToolDefinition,
+            {
+                "type": "function",
+                "name": "apply_patch",
+                "description": "",
+                "parameters": {},
+                "metadata": {"provider_type": "custom"},
+            },
+        )
+        result = OpenAIChatToolOps.ir_tool_definition_to_p(ir_tool)
+        assert result["type"] == "custom"
+        assert result["custom"]["name"] == "apply_patch"
 
     def test_p_tool_definition_to_ir(self):
         """Test OpenAI tool definition → IR ToolDefinition."""
@@ -385,3 +404,133 @@ class TestProviderMetadataPreservation:
         chat_call = OpenAIChatToolOps.ir_tool_call_to_p(ir_part)
         restored = OpenAIChatToolOps.p_tool_call_to_ir(chat_call)
         assert restored.get("provider_metadata") == {"responses_item_id": "fc_abc123"}
+
+
+class TestCustomToolSupport:
+    """Tests for native Chat Completions custom tool support."""
+
+    # --- Definition ---
+
+    def test_p_tool_definition_to_ir_custom(self):
+        """Chat CustomToolChatCompletions → IR custom ToolDefinition."""
+        provider_tool = {
+            "type": "custom",
+            "custom": {
+                "name": "apply_patch",
+                "description": "Apply a V4A patch",
+                "format": {
+                    "type": "grammar",
+                    "grammar": {"definition": "start: /.+/s", "syntax": "lark"},
+                },
+            },
+        }
+        result = OpenAIChatToolOps.p_tool_definition_to_ir(provider_tool)
+        assert result["type"] == "custom"
+        assert result["name"] == "apply_patch"
+        assert result["description"] == "Apply a V4A patch"
+        assert result["metadata"]["format"]["type"] == "grammar"
+
+    def test_p_tool_definition_to_ir_custom_minimal(self):
+        """Custom tool with only name."""
+        provider_tool = {"type": "custom", "custom": {"name": "my_tool"}}
+        result = OpenAIChatToolOps.p_tool_definition_to_ir(provider_tool)
+        assert result["type"] == "custom"
+        assert result["name"] == "my_tool"
+        assert result["parameters"] == {}
+
+    def test_custom_tool_definition_round_trip(self):
+        """Custom tool definition survives IR → Chat → IR."""
+        ir_tool = cast(
+            ToolDefinition,
+            {
+                "type": "custom",
+                "name": "apply_patch",
+                "description": "Apply a patch",
+                "parameters": {},
+                "metadata": {"format": {"type": "text"}},
+            },
+        )
+        provider = OpenAIChatToolOps.ir_tool_definition_to_p(ir_tool)
+        assert provider["type"] == "custom"
+        restored = OpenAIChatToolOps.p_tool_definition_to_ir(provider)
+        assert restored["type"] == "custom"
+        assert restored["name"] == "apply_patch"
+        assert restored["metadata"]["format"] == {"type": "text"}
+
+    # --- Tool Call ---
+
+    def test_ir_tool_call_to_p_custom(self):
+        """IR custom tool call → Chat ChatCompletionMessageCustomToolCall."""
+        ir_tc = ToolCallPart(
+            type="tool_call",
+            tool_call_id="call_1",
+            tool_name="apply_patch",
+            tool_input={"input": "*** Begin Patch\n+hi\n*** End Patch"},
+            tool_type="custom",
+        )
+        result = OpenAIChatToolOps.ir_tool_call_to_p(ir_tc)
+        assert result["type"] == "custom"
+        assert result["custom"]["name"] == "apply_patch"
+        assert result["custom"]["input"] == "*** Begin Patch\n+hi\n*** End Patch"
+        assert result["id"] == "call_1"
+
+    def test_p_tool_call_to_ir_custom(self):
+        """Chat ChatCompletionMessageCustomToolCall → IR custom tool call."""
+        provider_tc = {
+            "id": "call_1",
+            "type": "custom",
+            "custom": {
+                "name": "apply_patch",
+                "input": "*** Begin Patch\n+hi\n*** End Patch",
+            },
+        }
+        result = OpenAIChatToolOps.p_tool_call_to_ir(provider_tc)
+        assert result["tool_type"] == "custom"
+        assert result["tool_name"] == "apply_patch"
+        assert result["tool_input"] == {"input": "*** Begin Patch\n+hi\n*** End Patch"}
+        assert result["tool_call_id"] == "call_1"
+
+    def test_custom_tool_call_round_trip(self):
+        """Custom tool call survives IR → Chat → IR."""
+        ir_tc = ToolCallPart(
+            type="tool_call",
+            tool_call_id="call_rt",
+            tool_name="apply_patch",
+            tool_input={"input": "patch content"},
+            tool_type="custom",
+        )
+        provider = OpenAIChatToolOps.ir_tool_call_to_p(ir_tc)
+        restored = OpenAIChatToolOps.p_tool_call_to_ir(provider)
+        assert restored["tool_type"] == "custom"
+        assert restored["tool_name"] == "apply_patch"
+        assert restored["tool_input"] == {"input": "patch content"}
+
+    # --- Tool Choice ---
+
+    def test_ir_tool_choice_to_p_custom(self):
+        """IR tool choice with tool_type=custom → Chat custom tool choice."""
+        result = OpenAIChatToolOps.ir_tool_choice_to_p(
+            {"mode": "tool", "tool_name": "apply_patch", "tool_type": "custom"}
+        )
+        assert result == {"type": "custom", "custom": {"name": "apply_patch"}}
+
+    def test_p_tool_choice_to_ir_custom(self):
+        """Chat custom tool choice → IR with tool_type=custom."""
+        result = OpenAIChatToolOps.p_tool_choice_to_ir(
+            {"type": "custom", "custom": {"name": "apply_patch"}}
+        )
+        assert result["mode"] == "tool"
+        assert result["tool_name"] == "apply_patch"
+        assert result["tool_type"] == "custom"
+
+    def test_custom_tool_choice_round_trip(self):
+        """Custom tool choice survives IR → Chat → IR."""
+        ir = cast(
+            ToolChoice,
+            {"mode": "tool", "tool_name": "apply_patch", "tool_type": "custom"},
+        )
+        provider = OpenAIChatToolOps.ir_tool_choice_to_p(ir)
+        restored = OpenAIChatToolOps.p_tool_choice_to_ir(provider)
+        assert restored["mode"] == "tool"
+        assert restored["tool_name"] == "apply_patch"
+        assert restored["tool_type"] == "custom"

--- a/tests/converters/openai_responses/test_converter.py
+++ b/tests/converters/openai_responses/test_converter.py
@@ -194,11 +194,8 @@ class TestOpenAIResponsesConverter:
     def test_request_from_provider_codex_custom_tool_passes_validation(self):
         """End-to-end: a Codex ``"custom"`` apply_patch tool passes IR validation.
 
-        Regression test for the IR validator added in v0.3.0 (commit 5dc1b94)
-        rejecting ``tools[i].type == "custom"`` because IR's ToolDefinition
-        Literal only allows ``"function"`` and ``"mcp"``.  The source
-        converter must downgrade unknown provider tool types to ``"function"``
-        so the request reaches the target converter.
+        ``"custom"`` is now a first-class IR type, so the source converter
+        preserves it directly instead of downgrading to ``"function"``.
         """
         provider_request = {
             "model": "gpt-5.4",
@@ -228,16 +225,14 @@ class TestOpenAIResponsesConverter:
                 },
             ],
         }
-        # Must not raise — pre-fix this raised ValidationError with
-        # "Expected one of ('function', 'mcp') at 'tools[1].type', got 'custom'".
         result = self.converter.request_from_provider(provider_request)
         tools = list(result["tools"])
         assert len(tools) == 2
         assert tools[0]["type"] == "function"
         assert tools[0]["name"] == "shell"
-        assert tools[1]["type"] == "function"
+        assert tools[1]["type"] == "custom"
         assert tools[1]["name"] == "apply_patch"
-        assert tools[1]["metadata"]["provider_type"] == "custom"
+        assert tools[1]["metadata"]["format"]["type"] == "grammar"
 
     def test_request_from_provider_malformed_tool_raises_with_context(self):
         """Test that malformed tools raise clear errors with tool type/name context."""

--- a/tests/converters/openai_responses/test_tool_ops.py
+++ b/tests/converters/openai_responses/test_tool_ops.py
@@ -108,13 +108,11 @@ class TestOpenAIResponsesToolOps:
         assert result["required_parameters"] == ["query"]
 
     def test_p_tool_definition_to_ir_codex_custom_apply_patch(self):
-        """Codex ``"custom"`` tools (e.g. apply_patch) downgrade to IR function.
+        """Codex ``"custom"`` tools pass through as IR type ``"custom"``.
 
-        Regression test for the IR validation gap introduced in v0.3.0:
-        the IR ToolDefinition.type Literal only accepts ``"function"`` and
-        ``"mcp"``, so the source converter must coerce provider ``"custom"``
-        tools to ``"function"`` rather than carrying the provider type into
-        IR.  See ``types/ir/tools.py`` for the converter contract.
+        Since ``"custom"`` is now a first-class IR type, the source
+        converter preserves it directly.  Format info is stored in
+        ``metadata["format"]`` for cross-format round-trip.
         """
         provider_tool = {
             "type": "custom",
@@ -127,21 +125,15 @@ class TestOpenAIResponsesToolOps:
             },
         }
         result = OpenAIResponsesToolOps.p_tool_definition_to_ir(provider_tool)
-        assert result["type"] == "function"
+        assert result["type"] == "custom"
         assert result["name"] == "apply_patch"
-        # Description is enriched with format hint for cross-provider.
-        assert "Apply a unified-diff style patch." in result["description"]
-        assert "[Output format: grammar, syntax: lark]" in result["description"]
-        # Synthesized parameters for cross-provider degradation.
-        params = result["parameters"]
-        assert params["type"] == "object"
-        assert "input" in params["properties"]
-        assert params["properties"]["input"]["type"] == "string"
-        assert result["required_parameters"] == ["input"]
-        # provider_type is preserved in metadata for diagnostics.
-        assert result["metadata"]["provider_type"] == "custom"
-        assert cast(Any, result)["_passthrough"] == provider_tool
-        assert OpenAIResponsesToolOps.ir_tool_definition_to_p(result) == provider_tool
+        assert result["description"] == "Apply a unified-diff style patch."
+        assert result["metadata"]["format"] == provider_tool["format"]
+        # Round-trip: IR → provider restores original shape.
+        restored = OpenAIResponsesToolOps.ir_tool_definition_to_p(result)
+        assert restored["type"] == "custom"
+        assert restored["name"] == "apply_patch"
+        assert restored["format"] == provider_tool["format"]
 
     def test_tool_definition_round_trip(self):
         """Test tool definition round-trip."""


### PR DESCRIPTION
## Summary

- Chat Completions API natively supports custom tools (`CustomToolChatCompletions`, `ChatCompletionMessageCustomToolCall`, `ChatCompletionNamedToolChoiceCustom`) since spec v2.3.0 — our converter was treating Chat as function-only
- Add `"custom"` as first-class IR `ToolDefinition.type` (alongside `"function"` and `"mcp"`)
- Add `tool_type` to IR `ToolChoice` so `mode: "tool"` can distinguish forcing function vs custom
- `openai_chat` converter: full native custom tool support — definition, call, choice, streaming (both directions)
- `openai_responses` converter: stop unnecessarily downgrading custom tools to function with `metadata.provider_type` workaround — pass through as `type: "custom"` directly
- `openai_responses` converter: custom tool_choice support (`{"type": "custom", "name": "..."}`)

Closes #460
Part of #462, #397

### Why not PR #453?

PR #453 fixed the same symptom (Codex `apply_patch` broken through Chat upstream) but put all logic in `pipeline.py` — the pipeline was inspecting `metadata.provider_type`, rewriting `tool_type` fields, buffering streamed arguments, and JSON-parsing `{"input": "..."}` wrappers. Per the [Architecture Guide](https://llm-rosetta.readthedocs.io/en/latest/contributing/architecture/), these are converter concerns. This PR implements the correct converter-level approach, and discovers that Chat Completions actually supports custom tools natively — so no downgrade/restore is needed at all.

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 2360 passed, 4 skipped, 0 failed
- [x] Pre-commit hooks (ruff, ruff format, ty check) — all passed
- [x] Chat custom tool definition round-trip (IR → Chat → IR)
- [x] Chat custom tool call round-trip (IR → Chat → IR)
- [x] Chat custom tool choice round-trip (IR → Chat → IR)
- [x] Responses custom tool definition now preserves `type: "custom"` in IR
- [x] Responses custom tool_choice support
- [x] Existing 2360 tests pass with no regressions