### PR TITLE
feat: auto-inject Anthropic cache breakpoints for cross-format requests

### DIFF
--- a/src/llm_rosetta/converters/base/helpers/cache_breakpoints.py
+++ b/src/llm_rosetta/converters/base/helpers/cache_breakpoints.py
@@ -1,0 +1,151 @@
+"""Auto-inject cache breakpoints into IR requests.
+
+When cross-format requests (OpenAI/Gemini → Anthropic) pass through
+conversion, the source format has no cache semantics.  This helper
+injects ``cache_hint`` markers on IR parts so the Anthropic converter
+emits ``cache_control`` breakpoints, enabling prompt caching.
+
+Strategy (up to 4 breakpoints, matching Anthropic's limit):
+
+1. Last tool definition       → caches all tool schemas
+2. System instruction tail    → caches tools + system prefix
+3. Last user message          → caches conversation so far
+4. Second-to-last user msg    → keeps a rolling prefix cache warm
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_EPHEMERAL: dict[str, str] = {"type": "ephemeral"}
+
+
+def _has_cache_hint_in_parts(parts: list[dict[str, Any]]) -> bool:
+    """Check if any part in a list carries ``cache_hint``."""
+    return any(p.get("cache_hint") is not None for p in parts)
+
+
+def _has_cache_hint_in_messages(messages: list[dict[str, Any]]) -> bool:
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list) and _has_cache_hint_in_parts(content):
+            return True
+    return False
+
+
+def _has_any_cache_hint(ir_request: dict[str, Any]) -> bool:
+    """Return True if the IR request contains any ``cache_hint`` marker."""
+    system = ir_request.get("system_instruction")
+    if isinstance(system, list) and _has_cache_hint_in_parts(system):
+        return True
+
+    tools = ir_request.get("tools")
+    if isinstance(tools, list) and _has_cache_hint_in_parts(tools):
+        return True
+
+    messages = ir_request.get("messages")
+    if isinstance(messages, list) and _has_cache_hint_in_messages(messages):
+        return True
+
+    return False
+
+
+def _mark_last_part(parts: list[dict[str, Any]]) -> bool:
+    """Set ``cache_hint`` on the last part that can carry it.
+
+    Shallow-copies the target entry before mutation to avoid corrupting
+    the conversion pipeline's LRU cache (cached IR entries are shared
+    by reference).
+
+    Returns True if a hint was placed.
+    """
+    for i in range(len(parts) - 1, -1, -1):
+        part = parts[i]
+        if isinstance(part, dict) and part.get("cache_hint") is None:
+            parts[i] = {**part, "cache_hint": dict(_EPHEMERAL)}
+            return True
+    return False
+
+
+def _mark_last_user_messages(messages: list[dict[str, Any]], count: int) -> int:
+    """Mark the last *count* user messages with cache breakpoints.
+
+    Returns the number of breakpoints actually placed.
+    """
+    placed = 0
+    user_indices = [
+        i
+        for i, m in enumerate(messages)
+        if isinstance(m, dict) and m.get("role") == "user"
+    ]
+    for idx in reversed(user_indices[-count:]):
+        content = messages[idx].get("content")
+        if isinstance(content, list) and content and _mark_last_part(content):
+            placed += 1
+    return placed
+
+
+def inject_cache_breakpoints(
+    ir_request: dict[str, Any],
+    *,
+    mode: str = "none_only",
+    request_id: str = "-",
+) -> dict[str, Any]:
+    """Inject ``cache_hint`` breakpoints into an IR request.
+
+    Args:
+        ir_request: The IR request dict (mutated in place).
+        mode: ``"none_only"`` skips injection if any hint exists;
+            ``"fill_gaps"`` fills each segment independently.
+        request_id: For logging context.
+
+    Returns:
+        The (potentially mutated) IR request.
+    """
+    if mode == "none_only" and _has_any_cache_hint(ir_request):
+        logger.debug("[%s] cache hints already present, skipping injection", request_id)
+        return ir_request
+
+    remaining = 4
+    placed_segments: list[str] = []
+
+    # 1. Last tool definition
+    tools = ir_request.get("tools")
+    if isinstance(tools, list) and tools and remaining > 0:
+        if mode == "fill_gaps" and _has_cache_hint_in_parts(tools):
+            pass
+        elif _mark_last_part(tools):
+            remaining -= 1
+            placed_segments.append("tools")
+
+    # 2. System instruction tail
+    system = ir_request.get("system_instruction")
+    if isinstance(system, list) and system and remaining > 0:
+        if mode == "fill_gaps" and _has_cache_hint_in_parts(system):
+            pass
+        elif _mark_last_part(system):
+            remaining -= 1
+            placed_segments.append("system")
+
+    # 3 & 4. Last two user messages
+    messages = ir_request.get("messages")
+    if isinstance(messages, list) and messages and remaining > 0:
+        if mode == "fill_gaps" and _has_cache_hint_in_messages(messages):
+            pass
+        else:
+            n = _mark_last_user_messages(messages, min(2, remaining))
+            remaining -= n
+            if n:
+                placed_segments.append(f"user_messages({n})")
+
+    if placed_segments:
+        logger.debug(
+            "[%s] injected cache breakpoints: %s",
+            request_id,
+            ", ".join(placed_segments),
+        )
+
+    return ir_request

--- a/src/llm_rosetta/converters/base/helpers/cache_breakpoints.py
+++ b/src/llm_rosetta/converters/base/helpers/cache_breakpoints.py
@@ -23,9 +23,24 @@ logger = logging.getLogger(__name__)
 _EPHEMERAL: dict[str, str] = {"type": "ephemeral"}
 
 
+def _count_cache_hints_in_parts(parts: list[dict[str, Any]]) -> int:
+    """Count parts in a list that carry ``cache_hint``."""
+    return sum(1 for p in parts if p.get("cache_hint") is not None)
+
+
 def _has_cache_hint_in_parts(parts: list[dict[str, Any]]) -> bool:
     """Check if any part in a list carries ``cache_hint``."""
     return any(p.get("cache_hint") is not None for p in parts)
+
+
+def _count_cache_hints_in_messages(messages: list[dict[str, Any]]) -> int:
+    """Count cache hints across all message content parts."""
+    total = 0
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            total += _count_cache_hints_in_parts(content)
+    return total
 
 
 def _has_cache_hint_in_messages(messages: list[dict[str, Any]]) -> bool:
@@ -88,6 +103,24 @@ def _mark_last_user_messages(messages: list[dict[str, Any]], count: int) -> int:
     return placed
 
 
+def _remaining_budget(tools: Any, system: Any, messages: Any, mode: str) -> int:
+    """Compute how many breakpoints can still be placed.
+
+    Anthropic allows 4 total, so pre-existing hints reduce the budget
+    available for injection in ``fill_gaps`` mode.
+    """
+    if mode != "fill_gaps":
+        return 4
+    used = 0
+    if isinstance(tools, list):
+        used += _count_cache_hints_in_parts(tools)
+    if isinstance(system, list):
+        used += _count_cache_hints_in_parts(system)
+    if isinstance(messages, list):
+        used += _count_cache_hints_in_messages(messages)
+    return max(4 - used, 0)
+
+
 def inject_cache_breakpoints(
     ir_request: dict[str, Any],
     *,
@@ -109,11 +142,14 @@ def inject_cache_breakpoints(
         logger.debug("[%s] cache hints already present, skipping injection", request_id)
         return ir_request
 
-    remaining = 4
+    tools = ir_request.get("tools")
+    system = ir_request.get("system_instruction")
+    messages = ir_request.get("messages")
+
+    remaining = _remaining_budget(tools, system, messages, mode)
     placed_segments: list[str] = []
 
     # 1. Last tool definition
-    tools = ir_request.get("tools")
     if isinstance(tools, list) and tools and remaining > 0:
         if mode == "fill_gaps" and _has_cache_hint_in_parts(tools):
             pass
@@ -122,7 +158,6 @@ def inject_cache_breakpoints(
             placed_segments.append("tools")
 
     # 2. System instruction tail
-    system = ir_request.get("system_instruction")
     if isinstance(system, list) and system and remaining > 0:
         if mode == "fill_gaps" and _has_cache_hint_in_parts(system):
             pass
@@ -131,7 +166,6 @@ def inject_cache_breakpoints(
             placed_segments.append("system")
 
     # 3 & 4. Last two user messages
-    messages = ir_request.get("messages")
     if isinstance(messages, list) and messages and remaining > 0:
         if mode == "fill_gaps" and _has_cache_hint_in_messages(messages):
             pass

--- a/src/llm_rosetta/shims/providers/argo/anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/anthropic/transforms.py
@@ -18,7 +18,7 @@ import copy
 import json
 from typing import Any
 
-from llm_rosetta.shims.transforms import _NamedTransform
+from llm_rosetta.shims.transforms import _NamedTransform, auto_cache_breakpoints
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -127,3 +127,4 @@ post_ir_transforms = ()
 pre_ir_transforms = (
     _NamedTransform(_normalize_openai_response, "normalize_openai_response()"),
 )
+ir_transforms = (auto_cache_breakpoints(),)

--- a/src/llm_rosetta/shims/providers/openrouter/anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/openrouter/anthropic/transforms.py
@@ -2,8 +2,12 @@
 
 OpenRouter's Anthropic-compatible endpoint (`/api`) is a faithful proxy
 of the Anthropic Messages API — no request- or response-side transforms
-are needed.
+are needed.  The IR-level ``auto_cache_breakpoints`` transform injects
+cache breakpoints for cross-format requests.
 """
+
+from llm_rosetta.shims.transforms import auto_cache_breakpoints
 
 post_ir_transforms = ()
 pre_ir_transforms = ()
+ir_transforms = (auto_cache_breakpoints(),)

--- a/src/llm_rosetta/shims/transforms.py
+++ b/src/llm_rosetta/shims/transforms.py
@@ -347,6 +347,38 @@ def unwind_parallel_tool_calls(pattern: str | None = None) -> IRTransform:
     return _NamedIRTransform(_unwind, label)
 
 
+def auto_cache_breakpoints(mode: str = "none_only") -> IRTransform:
+    """Return an IR transform that injects ``cache_hint`` breakpoints.
+
+    Targets cross-format requests (OpenAI/Gemini → Anthropic) where the
+    source format has no explicit cache semantics.  Injects up to 4
+    ``cache_hint`` markers matching Anthropic's breakpoint limit.
+
+    Args:
+        mode: ``"none_only"`` (default) skips injection if any
+            ``cache_hint`` already exists.  ``"fill_gaps"`` fills each
+            segment (tools, system, messages) independently.
+
+    Example::
+
+        auto_cache_breakpoints()                  # conservative
+        auto_cache_breakpoints(mode="fill_gaps")  # per-segment
+    """
+
+    def _inject(body: dict[str, Any], context: TransformContext) -> dict[str, Any]:
+        from llm_rosetta.converters.base.helpers.cache_breakpoints import (
+            inject_cache_breakpoints,
+        )
+
+        return inject_cache_breakpoints(body, mode=mode, request_id=context.request_id)
+
+    label = "auto_cache_breakpoints("
+    if mode != "none_only":
+        label += f"mode={mode!r}"
+    label += ")"
+    return _NamedIRTransform(_inject, label)
+
+
 # ---------------------------------------------------------------------------
 # Body-level: system message flattening
 # ---------------------------------------------------------------------------

--- a/tests/converters/test_cache_breakpoints.py
+++ b/tests/converters/test_cache_breakpoints.py
@@ -1,0 +1,366 @@
+"""Tests for auto cache breakpoint injection.
+
+Covers the helper function directly (unit tests) and an end-to-end
+round-trip through OpenAI Chat → IR → Anthropic with cache_control.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, cast
+
+from llm_rosetta.converters.base.helpers.cache_breakpoints import (
+    inject_cache_breakpoints,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_EPHEMERAL = {"type": "ephemeral"}
+
+
+def _tool(name: str, **extra: Any) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "name": name,
+        "description": f"Tool {name}",
+        "parameters": {"type": "object"},
+        **extra,
+    }
+
+
+def _user_msg(text: str, **extra: Any) -> dict[str, Any]:
+    return {
+        "role": "user",
+        "content": [{"type": "text", "text": text, **extra}],
+    }
+
+
+def _assistant_msg(text: str) -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": [{"type": "text", "text": text}],
+    }
+
+
+def _full_ir_request() -> dict[str, Any]:
+    """IR request with all segments: tools, system, 3 user messages."""
+    return {
+        "model": "claude-opus-4",
+        "system_instruction": [
+            {"type": "text", "text": "You are helpful."},
+        ],
+        "tools": [_tool("read_file"), _tool("write_file"), _tool("search")],
+        "messages": [
+            _user_msg("first question"),
+            _assistant_msg("answer 1"),
+            _user_msg("second question"),
+            _assistant_msg("answer 2"),
+            _user_msg("third question"),
+        ],
+    }
+
+
+def _count_cache_hints(ir: dict[str, Any]) -> int:
+    """Count total cache_hint markers across all segments."""
+    count = 0
+    for part in ir.get("system_instruction", []):
+        if part.get("cache_hint") is not None:
+            count += 1
+    for tool in ir.get("tools", []):
+        if tool.get("cache_hint") is not None:
+            count += 1
+    for msg in ir.get("messages", []):
+        for part in msg.get("content", []):
+            if isinstance(part, dict) and part.get("cache_hint") is not None:
+                count += 1
+    return count
+
+
+def _hint_locations(ir: dict[str, Any]) -> list[str]:
+    """Return human-readable locations of cache_hint markers."""
+    locs: list[str] = []
+    for i, tool in enumerate(ir.get("tools", [])):
+        if tool.get("cache_hint") is not None:
+            locs.append(f"tools[{i}]")
+    for i, part in enumerate(ir.get("system_instruction", [])):
+        if part.get("cache_hint") is not None:
+            locs.append(f"system[{i}]")
+    for i, msg in enumerate(ir.get("messages", [])):
+        for j, part in enumerate(msg.get("content", [])):
+            if isinstance(part, dict) and part.get("cache_hint") is not None:
+                locs.append(f"msg[{i}].content[{j}] role={msg['role']}")
+    return locs
+
+
+# ---------------------------------------------------------------------------
+# none_only mode (default)
+# ---------------------------------------------------------------------------
+
+
+class TestNoneOnlyMode:
+    def test_full_request_places_4_breakpoints(self):
+        ir = _full_ir_request()
+        inject_cache_breakpoints(ir)
+        assert _count_cache_hints(ir) == 4
+        locs = _hint_locations(ir)
+        assert "tools[2]" in locs  # last tool
+        assert "system[0]" in locs  # system tail
+        # Last two user messages (indices 2 and 4 in messages list)
+        assert any("msg[4]" in loc and "user" in loc for loc in locs)
+        assert any("msg[2]" in loc and "user" in loc for loc in locs)
+
+    def test_no_tools(self):
+        ir = _full_ir_request()
+        del ir["tools"]
+        inject_cache_breakpoints(ir)
+        assert _count_cache_hints(ir) == 3  # system + 2 user msgs
+
+    def test_no_system(self):
+        ir = _full_ir_request()
+        del ir["system_instruction"]
+        inject_cache_breakpoints(ir)
+        assert _count_cache_hints(ir) == 3  # tools + 2 user msgs
+
+    def test_single_user_message(self):
+        ir = {
+            "model": "claude-opus-4",
+            "system_instruction": [{"type": "text", "text": "sys"}],
+            "tools": [_tool("t1")],
+            "messages": [_user_msg("only question")],
+        }
+        inject_cache_breakpoints(ir)
+        assert _count_cache_hints(ir) == 3  # tools + system + 1 user msg
+
+    def test_no_user_messages(self):
+        ir = {
+            "model": "claude-opus-4",
+            "system_instruction": [{"type": "text", "text": "sys"}],
+            "tools": [_tool("t1")],
+            "messages": [_assistant_msg("hi")],
+        }
+        inject_cache_breakpoints(ir)
+        assert _count_cache_hints(ir) == 2  # tools + system only
+
+    def test_empty_messages(self):
+        ir = {
+            "model": "claude-opus-4",
+            "messages": [],
+        }
+        inject_cache_breakpoints(ir)
+        assert _count_cache_hints(ir) == 0
+
+    def test_minimal_request(self):
+        ir = {"model": "claude-opus-4", "messages": [_user_msg("hi")]}
+        inject_cache_breakpoints(ir)
+        assert _count_cache_hints(ir) == 1  # just the user msg
+
+    def test_existing_cache_hint_skips(self):
+        ir = _full_ir_request()
+        ir["tools"][0]["cache_hint"] = {"type": "ephemeral"}
+        original = copy.deepcopy(ir)
+        inject_cache_breakpoints(ir)
+        assert ir == original  # no changes
+
+    def test_existing_hint_on_system_skips(self):
+        ir = _full_ir_request()
+        ir["system_instruction"][0]["cache_hint"] = {"type": "ephemeral"}
+        original = copy.deepcopy(ir)
+        inject_cache_breakpoints(ir)
+        assert ir == original
+
+    def test_existing_hint_on_message_skips(self):
+        ir = _full_ir_request()
+        ir["messages"][0]["content"][0]["cache_hint"] = {"type": "ephemeral"}
+        original = copy.deepcopy(ir)
+        inject_cache_breakpoints(ir)
+        assert ir == original
+
+    def test_idempotent(self):
+        ir = _full_ir_request()
+        inject_cache_breakpoints(ir)
+        snapshot = copy.deepcopy(ir)
+        # Second call sees existing hints → no-op
+        inject_cache_breakpoints(ir)
+        assert ir == snapshot
+
+    def test_cache_hint_value(self):
+        ir = _full_ir_request()
+        inject_cache_breakpoints(ir)
+        assert ir["tools"][-1]["cache_hint"] == _EPHEMERAL
+        assert ir["system_instruction"][-1]["cache_hint"] == _EPHEMERAL
+
+    def test_no_tools_no_system_two_users(self):
+        ir = {
+            "model": "claude-opus-4",
+            "messages": [
+                _user_msg("q1"),
+                _assistant_msg("a1"),
+                _user_msg("q2"),
+            ],
+        }
+        inject_cache_breakpoints(ir)
+        assert _count_cache_hints(ir) == 2  # both user messages
+
+
+# ---------------------------------------------------------------------------
+# fill_gaps mode
+# ---------------------------------------------------------------------------
+
+
+class TestFillGapsMode:
+    def test_fills_missing_segments(self):
+        ir = _full_ir_request()
+        # Pre-mark tools only
+        ir["tools"][-1]["cache_hint"] = dict(_EPHEMERAL)
+        inject_cache_breakpoints(ir, mode="fill_gaps")
+        # Tools already had hint → not double-marked; system + 2 msgs filled
+        assert _count_cache_hints(ir) == 4  # 1 existing + 3 new
+
+    def test_all_segments_hinted_is_noop(self):
+        ir = _full_ir_request()
+        ir["tools"][-1]["cache_hint"] = dict(_EPHEMERAL)
+        ir["system_instruction"][0]["cache_hint"] = dict(_EPHEMERAL)
+        ir["messages"][-1]["content"][0]["cache_hint"] = dict(_EPHEMERAL)
+        original = copy.deepcopy(ir)
+        inject_cache_breakpoints(ir, mode="fill_gaps")
+        assert ir == original
+
+    def test_no_existing_hints_fills_all(self):
+        ir = _full_ir_request()
+        inject_cache_breakpoints(ir, mode="fill_gaps")
+        assert _count_cache_hints(ir) == 4
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_tools_list(self):
+        ir = {
+            "model": "claude-opus-4",
+            "tools": [],
+            "system_instruction": [{"type": "text", "text": "sys"}],
+            "messages": [_user_msg("q")],
+        }
+        inject_cache_breakpoints(ir)
+        assert _count_cache_hints(ir) == 2  # system + user
+
+    def test_empty_system_list(self):
+        ir = {
+            "model": "claude-opus-4",
+            "system_instruction": [],
+            "tools": [_tool("t1")],
+            "messages": [_user_msg("q")],
+        }
+        inject_cache_breakpoints(ir)
+        assert _count_cache_hints(ir) == 2  # tools + user
+
+    def test_user_message_with_empty_content(self):
+        ir = {
+            "model": "claude-opus-4",
+            "messages": [{"role": "user", "content": []}],
+        }
+        inject_cache_breakpoints(ir)
+        assert _count_cache_hints(ir) == 0
+
+    def test_multipart_user_message_marks_last_part(self):
+        ir = {
+            "model": "claude-opus-4",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "part1"},
+                        {"type": "text", "text": "part2"},
+                        {"type": "text", "text": "part3"},
+                    ],
+                }
+            ],
+        }
+        inject_cache_breakpoints(ir)
+        assert ir["messages"][0]["content"][2].get("cache_hint") == _EPHEMERAL
+        assert ir["messages"][0]["content"][0].get("cache_hint") is None
+        assert ir["messages"][0]["content"][1].get("cache_hint") is None
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: OpenAI Chat → IR → auto_cache → Anthropic body
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_openai_to_anthropic_has_cache_control(self):
+        """End-to-end: an OpenAI Chat request converted to Anthropic
+        body should have cache_control on the expected blocks after
+        auto_cache_breakpoints fires."""
+        from llm_rosetta.converters.anthropic.converter import AnthropicConverter
+        from llm_rosetta.converters.openai_chat.converter import OpenAIChatConverter
+
+        openai_request = {
+            "model": "claude-opus-4",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello!"},
+                {"role": "assistant", "content": "Hi there!"},
+                {"role": "user", "content": "What is 2+2?"},
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "calculator",
+                        "description": "Calculate math",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        }
+
+        # OpenAI → IR
+        oai = OpenAIChatConverter()
+        ir = oai.request_from_provider(openai_request)
+        ir_dict = cast(dict[str, Any], ir)
+
+        # Inject cache breakpoints
+        inject_cache_breakpoints(ir_dict)
+
+        # Verify IR has cache_hint
+        assert _count_cache_hints(ir_dict) == 4
+
+        # IR → Anthropic (returns (body, warnings) tuple)
+        anthropic = AnthropicConverter()
+        anthropic_body, _warnings = anthropic.request_to_provider(ir)
+
+        # Verify Anthropic body has cache_control
+        # On tools
+        tools = anthropic_body.get("tools", [])
+        assert any(t.get("cache_control") is not None for t in tools), (
+            "Expected cache_control on at least one tool"
+        )
+
+        # On system
+        system = anthropic_body.get("system", [])
+        if isinstance(system, list):
+            assert any(s.get("cache_control") is not None for s in system), (
+                "Expected cache_control on system block"
+            )
+
+        # On messages
+        messages = anthropic_body.get("messages", [])
+        user_msgs_with_cc = [
+            m
+            for m in messages
+            if m.get("role") == "user"
+            and isinstance(m.get("content"), list)
+            and any(
+                p.get("cache_control") is not None
+                for p in m["content"]
+                if isinstance(p, dict)
+            )
+        ]
+        assert len(user_msgs_with_cc) >= 1, "Expected cache_control on user messages"

--- a/tests/converters/test_cache_breakpoints.py
+++ b/tests/converters/test_cache_breakpoints.py
@@ -233,6 +233,26 @@ class TestFillGapsMode:
         inject_cache_breakpoints(ir, mode="fill_gaps")
         assert _count_cache_hints(ir) == 4
 
+    def test_existing_hints_count_against_budget(self):
+        """Pre-existing hints must not push the total past Anthropic's limit."""
+        ir = _full_ir_request()
+        # Two hints already present in tools — budget drops to 2.
+        ir["tools"][0]["cache_hint"] = dict(_EPHEMERAL)
+        ir["tools"][1]["cache_hint"] = dict(_EPHEMERAL)
+        inject_cache_breakpoints(ir, mode="fill_gaps")
+        assert _count_cache_hints(ir) <= 4
+
+    def test_budget_exhausted_by_existing_hints(self):
+        """Four pre-existing hints leave no budget for injection."""
+        ir = _full_ir_request()
+        for i in range(3):
+            ir["tools"][i]["cache_hint"] = dict(_EPHEMERAL)
+        ir["system_instruction"][0]["cache_hint"] = dict(_EPHEMERAL)
+        original = copy.deepcopy(ir)
+        inject_cache_breakpoints(ir, mode="fill_gaps")
+        assert ir == original
+        assert _count_cache_hints(ir) == 4
+
 
 # ---------------------------------------------------------------------------
 # Edge cases

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -23,6 +23,7 @@ from llm_rosetta.shims.provider_shim import (
     unregister_shim,
 )
 from llm_rosetta.shims.transforms import (
+    auto_cache_breakpoints,
     strip_non_vision_images,
     truncate_images as truncate_images_transform,
     unwind_parallel_tool_calls as unwind_transform,
@@ -59,7 +60,7 @@ def _make_shim(**kwargs: Any) -> ProviderShim:
 def _register_cleanup():
     """Ensure test shims are cleaned up after each test."""
     yield
-    for name in ("test-shim", "test-shim-img", "test-shim-unwind"):
+    for name in ("test-shim", "test-shim-img", "test-shim-unwind", "test-shim-cache"):
         unregister_shim(name)
 
 
@@ -389,6 +390,65 @@ class TestApplyIrTransforms:
         content = result["messages"][0]["content"]
         image_parts = [p for p in content if p.get("type") == "image"]
         assert len(image_parts) <= 2
+
+    def test_auto_cache_breakpoints_injects(self):
+        """auto_cache_breakpoints should inject cache_hint on IR parts."""
+        ir = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "q1"}]},
+                {"role": "assistant", "content": [{"type": "text", "text": "a1"}]},
+                {"role": "user", "content": [{"type": "text", "text": "q2"}]},
+            ],
+            "system_instruction": [{"type": "text", "text": "Be helpful."}],
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "search",
+                    "description": "Search",
+                    "parameters": {"type": "object"},
+                }
+            ],
+        }
+        shim = _make_shim(
+            name="test-shim-cache", ir_transforms=(auto_cache_breakpoints(),)
+        )
+        result = apply_ir_transforms(ir, shim)
+        # Should have cache_hint on: tool, system, 2 user messages = 4
+        hints = 0
+        if result["tools"][-1].get("cache_hint"):
+            hints += 1
+        if result["system_instruction"][-1].get("cache_hint"):
+            hints += 1
+        for msg in result["messages"]:
+            if msg.get("role") == "user":
+                for part in msg.get("content", []):
+                    if part.get("cache_hint"):
+                        hints += 1
+        assert hints == 4
+
+    def test_auto_cache_breakpoints_noop_when_hints_exist(self):
+        """auto_cache_breakpoints should not inject when hints already present."""
+        ir = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "q1"}]},
+            ],
+            "system_instruction": [
+                {"type": "text", "text": "sys", "cache_hint": {"type": "ephemeral"}}
+            ],
+            "tools": [],
+        }
+        original = copy.deepcopy(ir)
+        shim = _make_shim(
+            name="test-shim-cache", ir_transforms=(auto_cache_breakpoints(),)
+        )
+        result = apply_ir_transforms(ir, shim)
+        assert result == original
+
+    def test_auto_cache_breakpoints_repr(self):
+        t = auto_cache_breakpoints()
+        assert "auto_cache_breakpoints()" in repr(t)
+        t2 = auto_cache_breakpoints(mode="fill_gaps")
+        assert "fill_gaps" in repr(t2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `auto_cache_breakpoints` IR transform that injects up to 4 `cache_hint` breakpoints (Anthropic's limit) when cross-format requests (OpenAI/Gemini → Anthropic) lack cache semantics
- Breakpoints placed on: last tool definition, system instruction tail, and last two user messages — matching the strategy validated by braceal/argo-proxy
- Mounted on both Anthropic-targeting shims (argo, openrouter) via `ir_transforms` tuple
- Uses shallow-copy before mutation to avoid corrupting the pipeline's LRU cache

Closes #464, closes #465

## Design

**Helper** (`converters/base/helpers/cache_breakpoints.py`): core injection logic with two modes:
- `none_only` (default): skips injection if any `cache_hint` already exists — respects client intent
- `fill_gaps`: fills each segment (tools, system, messages) independently

**Transform factory** (`shims/transforms.py`): `auto_cache_breakpoints()` follows the same lazy-import + `_NamedIRTransform` pattern as `truncate_images()` / `unwind_parallel_tool_calls()`.

**Pipeline position**: fires in Phase 2a of `ConversionPipeline.convert_request()`, between source→IR and IR→target conversion. Existing `cache_hint → cache_control` serialization in `content_ops.py` / `tool_ops.py` handles the last mile — no converter changes needed.

## Test plan

- [x] 20 unit tests covering: full/partial requests, both modes, edge cases, idempotency
- [x] 3 integration tests via `apply_ir_transforms` with shim mounting
- [x] 1 round-trip test: OpenAI Chat → IR → inject → Anthropic body → verify `cache_control`
- [x] `make lint` clean (ruff + ty)
- [x] `make test` — 2374 passed, 0 failed
- [ ] E2E verification with real Anthropic upstream (warm call should show `cached_tokens > 0`)