### PR TITLE
refactor(base): convert BaseConverter to template method pattern

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -15,11 +15,10 @@ Key Anthropic differences from OpenAI:
 """
 
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from typing import Any, cast
 
 from ...types.ir import (
-    IRInputItem,
     TextPart,
     is_text_part,
     is_tool_call_part,
@@ -71,6 +70,7 @@ class AnthropicConverter(BaseConverter):
     message_ops_class = AnthropicMessageOps
     config_ops_class = AnthropicConfigOps
     _CONVERTER_TAG = "anthropic"
+    _PASSTHROUGH_RESTORE_KEY = "content"
 
     def __init__(self):
         self.content_ops = self.content_ops_class()
@@ -80,24 +80,14 @@ class AnthropicConverter(BaseConverter):
 
     # ==================== Top-level Interfaces ====================
 
-    def request_to_provider(
+    def _do_request_to_provider(
         self,
         ir_request: IRRequest,
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
-    ) -> tuple[dict[str, Any], list[str]]:
-        """Convert IRRequest to Anthropic Messages API request parameters.
-
-        Orchestrates all Ops classes to build the complete provider request.
-
-        Args:
-            ir_request: IR request.
-
-        Returns:
-            Tuple of (provider request dict, warnings list).
-        """
-        ctx = context if context is not None else ConversionContext()
+    ) -> dict[str, Any]:
+        ctx = context
         result: dict[str, Any] = {"model": ir_request["model"]}
 
         # 1. System instruction → top-level system parameter
@@ -172,25 +162,15 @@ class AnthropicConverter(BaseConverter):
         if extensions:
             result.update(extensions)
 
-        return result, ctx.warnings
+        return result
 
-    def request_from_provider(
+    def _do_request_from_provider(
         self,
         provider_request: dict[str, Any],
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
-    ) -> IRRequest:
-        """Convert Anthropic Messages API request to IRRequest.
-
-        Args:
-            provider_request: Anthropic request dict (or SDK object).
-
-        Returns:
-            IR request.
-        """
-        provider_request = self._normalize(provider_request)
-
+    ) -> dict[str, Any]:
         ir_request: dict[str, Any] = {
             "model": provider_request.get("model", ""),
             "messages": [],
@@ -248,7 +228,7 @@ class AnthropicConverter(BaseConverter):
                 {"stream": stream}
             )
 
-        return self._validate_ir_request(ir_request)
+        return ir_request
 
     def _get_response_id_prefix(
         self, context: ConversionContext | StreamContext | None = None
@@ -260,25 +240,13 @@ class AnthropicConverter(BaseConverter):
                 return prefix
         return self._RESPONSE_ID_PREFIX
 
-    def response_from_provider(
+    def _do_response_from_provider(
         self,
         provider_response: dict[str, Any],
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
-    ) -> IRResponse:
-        """Convert Anthropic Messages API response to IRResponse.
-
-        Anthropic returns a single message (not choices list).
-        We wrap it as ``choices[0]``.
-
-        Args:
-            provider_response: Anthropic response dict (or SDK object).
-
-        Returns:
-            IR response.
-        """
-        provider_response = self._normalize(provider_response)
+    ) -> dict[str, Any]:
 
         # Convert the response message to IR
         ir_message = self.message_ops._p_message_to_ir(provider_response)
@@ -317,11 +285,11 @@ class AnthropicConverter(BaseConverter):
                 refusal_part["provider_metadata"] = {
                     "anthropic_refusal_category": category
                 }
-            msg_content = ir_message.get("content")  # ty: ignore[unresolved-attribute]
+            msg_content = ir_message.get("content")
             if isinstance(msg_content, list):
-                msg_content.append(refusal_part)  # ty: ignore[invalid-argument-type]
+                msg_content.append(refusal_part)
             else:
-                ir_message["content"] = [refusal_part]  # ty: ignore[invalid-assignment]
+                ir_message["content"] = [refusal_part]
 
         prefix = self._get_response_id_prefix(context)
         ir_response: dict[str, Any] = {
@@ -338,29 +306,15 @@ class AnthropicConverter(BaseConverter):
         p_usage = provider_response.get("usage") or {}
         ir_response["usage"] = self._build_p_usage_to_ir(p_usage)
 
-        # Preserve mode: capture extra fields for lossless round-trip
-        ctx = context if context is not None else ConversionContext()
-        if ctx.metadata_mode == "preserve":
-            self._capture_preserve_metadata(provider_response, ctx)
+        return ir_response
 
-        return self._validate_ir_response(ir_response)
-
-    def response_to_provider(
+    def _do_response_to_provider(
         self,
         ir_response: IRResponse,
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Convert IRResponse to Anthropic Messages API response.
-
-        Args:
-            ir_response: IR response.
-
-        Returns:
-            Anthropic response dict.
-        """
-        # Anthropic response is a single message
         prefix = self._get_response_id_prefix(context)
         provider_response: dict[str, Any] = {
             "id": self.add_response_id_prefix(ir_response.get("id", ""), prefix),
@@ -428,17 +382,6 @@ class AnthropicConverter(BaseConverter):
         # Usage (always present — Anthropic responses require usage field)
         ir_usage = ir_response.get("usage") or {}
         provider_response["usage"] = self._build_ir_usage_to_p(ir_usage)
-
-        # Preserve mode: inject captured extra fields
-        ctx = context if context is not None else ConversionContext()
-        if ctx.metadata_mode == "preserve":
-            self._apply_preserve_metadata(provider_response, ctx)
-        self._restore_response_passthrough_items(
-            provider_response,
-            ir_response,
-            output_key="content",
-            context=ctx,
-        )
 
         return provider_response
 
@@ -556,9 +499,10 @@ class AnthropicConverter(BaseConverter):
             "server_tool_use": None,
         }
 
-    @staticmethod
     def _capture_preserve_metadata(
+        self,
         provider_response: dict[str, Any],
+        ir_response: dict[str, Any],
         ctx: ConversionContext,
     ) -> None:
         """Capture extra fields from provider response for lossless round-trip."""
@@ -611,9 +555,10 @@ class AnthropicConverter(BaseConverter):
         if any(m for m in items_meta):
             ctx.store_output_items_meta(items_meta)
 
-    @staticmethod
     def _apply_preserve_metadata(
+        self,
         provider_response: dict[str, Any],
+        ir_response: dict[str, Any],
         ctx: ConversionContext,
     ) -> None:
         """Re-inject captured metadata fields in preserve mode."""
@@ -644,45 +589,6 @@ class AnthropicConverter(BaseConverter):
                 break
             for k, v in meta.items():
                 content[i][k] = v
-
-    def messages_to_provider(
-        self,
-        messages: Sequence[IRInputItem],
-        *,
-        context: ConversionContext | None = None,
-        **kwargs: Any,
-    ) -> tuple[list[Any], list[str]]:
-        """Convert IR message list to Anthropic message format.
-
-        Delegates to message_ops.
-
-        Args:
-            messages: IR messages (may contain ExtensionItems).
-
-        Returns:
-            Tuple of (converted messages, warnings).
-        """
-        kwargs["target_provider"] = self._CONVERTER_TAG
-        return self.message_ops.ir_messages_to_p(messages, **kwargs)
-
-    def messages_from_provider(
-        self,
-        provider_messages: list[Any],
-        *,
-        context: ConversionContext | None = None,
-        **kwargs: Any,
-    ) -> list[IRInputItem]:
-        """Convert Anthropic messages to IR message list.
-
-        Delegates to message_ops.
-
-        Args:
-            provider_messages: Anthropic messages.
-
-        Returns:
-            IR messages.
-        """
-        return self.message_ops.p_messages_to_ir(provider_messages, **kwargs)
 
     # ==================== Stream Support ====================
 

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -168,7 +168,7 @@ class AnthropicConverter(BaseConverter):
         self,
         provider_request: dict[str, Any],
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
     ) -> dict[str, Any]:
         ir_request: dict[str, Any] = {

--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -136,8 +136,9 @@ class BaseConverter(ABC):
         ``_do_request_from_provider``, and validates the IR output.
         """
         provider_request = self._normalize(provider_request)
+        ctx = context if context is not None else ConversionContext()
         ir_request = self._do_request_from_provider(
-            provider_request, context=context, **kwargs
+            provider_request, context=ctx, **kwargs
         )
         return self._validate_ir_request(ir_request)
 
@@ -159,7 +160,8 @@ class BaseConverter(ABC):
         ir_response = self._do_response_from_provider(
             provider_response, context=ctx, **kwargs
         )
-        self._capture_preserve_metadata(provider_response, ir_response, ctx)
+        if getattr(ctx, "metadata_mode", None) == "preserve":
+            self._capture_preserve_metadata(provider_response, ir_response, ctx)
         return self._validate_ir_response(ir_response)
 
     def response_to_provider(
@@ -179,9 +181,10 @@ class BaseConverter(ABC):
         provider_response = self._do_response_to_provider(
             ir_response, context=ctx, **kwargs
         )
-        self._apply_preserve_metadata(
-            provider_response, cast(dict[str, Any], ir_response), ctx
-        )
+        if getattr(ctx, "metadata_mode", None) == "preserve":
+            self._apply_preserve_metadata(
+                provider_response, cast(dict[str, Any], ir_response), ctx
+            )
         self._restore_response_passthrough_items(
             provider_response,
             ir_response,
@@ -241,13 +244,13 @@ class BaseConverter(ABC):
         self,
         provider_request: dict[str, Any],
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Format-specific provider → IR request conversion.
 
-        Input is already normalized. Do not call ``_normalize()`` or
-        ``_validate_ir_request()``.
+        Input is already normalized. Context is guaranteed non-None.
+        Do not call ``_normalize()`` or ``_validate_ir_request()``.
         """
         ...
 

--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -50,10 +50,15 @@ class BaseConverter(ABC):
     # Instance-level ops (set by subclass __init__).
     # Declared here so the type checker sees them on BaseConverter.
     tool_ops: Any
+    message_ops: Any
 
     # Converter identity tag for cache key namespacing.
     # Subclasses MUST set this to a unique string (e.g. "anthropic").
     _CONVERTER_TAG: str = ""
+
+    # Provider response list field for passthrough item restoration.
+    # Subclasses MUST set this (e.g. "choices", "output", "content", "candidates").
+    _PASSTHROUGH_RESTORE_KEY: str = ""
 
     # Enable/disable IR validation on from_provider output
     validate_output: bool = True
@@ -100,9 +105,8 @@ class BaseConverter(ABC):
             return f"{prefix}{stem}"
         return stem
 
-    # ==================== 顶层转换接口 Top-level conversion interface ====================
+    # ==================== Template methods (public API) ====================
 
-    @abstractmethod
     def request_to_provider(
         self,
         ir_request: IRRequest,
@@ -110,34 +114,15 @@ class BaseConverter(ABC):
         context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[dict[str, Any], list[str]]:
-        """将IRRequest转换为provider请求参数
-        Convert IRRequest to provider request parameters
+        """Convert IRRequest to provider request parameters.
 
-        这是最高层的转换方法，会调用各个功能域的ops类来完成转换：
-        - 使用message_ops处理messages字段
-        - 使用config_ops处理generation、stream等配置字段
-        - 使用tool_ops处理tools、tool_choice等工具字段
-
-        This is the highest-level conversion method that calls ops classes from various functional domains:
-        - Uses message_ops to handle messages field
-        - Uses config_ops to handle generation, stream and other config fields
-        - Uses tool_ops to handle tools, tool_choice and other tool fields
-
-        Subclass helper: call ``self._apply_tool_config(ir_request, result, ctx)``
-        to handle the tools / tool_choice / tool_config fields.
-
-        Args:
-            ir_request: IR格式的完整请求
-            context: Optional conversion context for carrying warnings,
-                options, and metadata through the pipeline.
-            **kwargs: 额外参数
-
-        Returns:
-            Tuple[转换后的请求参数, 警告信息列表]
+        Template method: creates a fallback ConversionContext, delegates to
+        ``_do_request_to_provider``, and returns ``(result, ctx.warnings)``.
         """
-        pass
+        ctx = context if context is not None else ConversionContext()
+        result = self._do_request_to_provider(ir_request, context=ctx, **kwargs)
+        return result, ctx.warnings
 
-    @abstractmethod
     def request_from_provider(
         self,
         provider_request: dict[str, Any],
@@ -145,23 +130,17 @@ class BaseConverter(ABC):
         context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> IRRequest:
-        """将provider请求转换为IRRequest
-        Convert provider request to IRRequest
+        """Convert provider request to IRRequest.
 
-        Subclass helper: call ``self._convert_p_tools_to_ir(tools)`` to convert
-        provider tool definitions to IR format.
-
-        Args:
-            provider_request: Provider格式的请求
-            context: Optional conversion context.
-            **kwargs: 额外参数
-
-        Returns:
-            IR格式的请求
+        Template method: normalizes input, delegates to
+        ``_do_request_from_provider``, and validates the IR output.
         """
-        pass
+        provider_request = self._normalize(provider_request)
+        ir_request = self._do_request_from_provider(
+            provider_request, context=context, **kwargs
+        )
+        return self._validate_ir_request(ir_request)
 
-    @abstractmethod
     def response_from_provider(
         self,
         provider_response: dict[str, Any],
@@ -169,23 +148,20 @@ class BaseConverter(ABC):
         context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> IRResponse:
-        """将provider响应转换为IRResponse
-        Convert provider response to IRResponse
+        """Convert provider response to IRResponse.
 
-        Subclass helper: call ``self._build_p_usage_to_ir(p_usage)`` to convert
-        provider usage to IR format.
-
-        Args:
-            provider_response: Provider格式的响应
-            context: Optional conversion context.
-            **kwargs: 额外参数
-
-        Returns:
-            IR格式的响应
+        Template method: normalizes input, delegates to
+        ``_do_response_from_provider``, runs preserve-mode capture,
+        and validates the IR output.
         """
-        pass
+        provider_response = self._normalize(provider_response)
+        ctx = context if context is not None else ConversionContext()
+        ir_response = self._do_response_from_provider(
+            provider_response, context=ctx, **kwargs
+        )
+        self._capture_preserve_metadata(provider_response, ir_response, ctx)
+        return self._validate_ir_response(ir_response)
 
-    @abstractmethod
     def response_to_provider(
         self,
         ir_response: IRResponse,
@@ -193,23 +169,27 @@ class BaseConverter(ABC):
         context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """将IRResponse转换为provider响应
-        Convert IRResponse to provider response
+        """Convert IRResponse to provider response.
 
-        Subclass helper: call ``self._build_ir_usage_to_p(ir_usage)`` to convert
-        IR usage to provider format.
-
-        Args:
-            ir_response: IR格式的响应
-            context: Optional conversion context.
-            **kwargs: 额外参数
-
-        Returns:
-            Provider格式的响应
+        Template method: creates a fallback ConversionContext, delegates to
+        ``_do_response_to_provider``, runs preserve-mode apply,
+        and restores passthrough items.
         """
-        pass
+        ctx = context if context is not None else ConversionContext()
+        provider_response = self._do_response_to_provider(
+            ir_response, context=ctx, **kwargs
+        )
+        self._apply_preserve_metadata(
+            provider_response, cast(dict[str, Any], ir_response), ctx
+        )
+        self._restore_response_passthrough_items(
+            provider_response,
+            ir_response,
+            output_key=self._PASSTHROUGH_RESTORE_KEY,
+            context=ctx,
+        )
+        return provider_response
 
-    @abstractmethod
     def messages_to_provider(
         self,
         messages: Sequence[IRInputItem],
@@ -217,23 +197,14 @@ class BaseConverter(ABC):
         context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
-        """将消息列表转换为provider消息格式
-        Convert message list to provider message format
+        """Convert IR messages to provider format.
 
-        这个方法通常会委托给message_ops_class来处理。
-        This method typically delegates to message_ops_class for processing.
-
-        Args:
-            messages: IR格式的消息列表（可包含扩展项）
-            context: Optional conversion context.
-            **kwargs: 额外参数
-
-        Returns:
-            Tuple[转换后的消息列表, 警告信息列表]
+        Default implementation delegates to ``message_ops.ir_messages_to_p``.
+        Override if the converter needs custom pre/post processing.
         """
-        pass
+        kwargs["target_provider"] = self._CONVERTER_TAG
+        return self.message_ops.ir_messages_to_p(messages, **kwargs)
 
-    @abstractmethod
     def messages_from_provider(
         self,
         provider_messages: list[Any],
@@ -241,18 +212,102 @@ class BaseConverter(ABC):
         context: ConversionContext | None = None,
         **kwargs: Any,
     ) -> list[IRInputItem]:
-        """将provider消息转换为IR消息列表
-        Convert provider messages to IR message list
+        """Convert provider messages to IR format.
 
-        Args:
-            provider_messages: Provider格式的消息列表
-            context: Optional conversion context.
-            **kwargs: 额外参数
-
-        Returns:
-            IR格式的消息列表
+        Default implementation delegates to ``message_ops.p_messages_to_ir``.
+        Override if the converter needs custom pre/post processing.
         """
-        pass
+        return self.message_ops.p_messages_to_ir(provider_messages, **kwargs)
+
+    # ==================== Abstract hooks (subclass implements) ====================
+
+    @abstractmethod
+    def _do_request_to_provider(
+        self,
+        ir_request: IRRequest,
+        *,
+        context: ConversionContext,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Format-specific IR → provider request conversion.
+
+        Context is guaranteed non-None. Warnings should be added to
+        ``context.warnings``. Return the provider request dict only.
+        """
+        ...
+
+    @abstractmethod
+    def _do_request_from_provider(
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Format-specific provider → IR request conversion.
+
+        Input is already normalized. Do not call ``_normalize()`` or
+        ``_validate_ir_request()``.
+        """
+        ...
+
+    @abstractmethod
+    def _do_response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Format-specific provider → IR response conversion.
+
+        Input is already normalized. Context is guaranteed non-None.
+        Do not call ``_normalize()`` or ``_validate_ir_response()``.
+        """
+        ...
+
+    @abstractmethod
+    def _do_response_to_provider(
+        self,
+        ir_response: IRResponse,
+        *,
+        context: ConversionContext,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Format-specific IR → provider response conversion.
+
+        Context is guaranteed non-None. Do not call
+        ``_restore_response_passthrough_items()`` or preserve-mode hooks.
+        """
+        ...
+
+    # ==================== Preserve-mode hooks (override in subclass) ====================
+
+    def _capture_preserve_metadata(
+        self,
+        provider_response: dict[str, Any],
+        ir_response: dict[str, Any],
+        ctx: ConversionContext,
+    ) -> None:
+        """Capture provider-specific fields for lossless round-trip.
+
+        Called by ``response_from_provider`` after the ``_do_*`` hook.
+        Override in converters that support preserve-mode metadata
+        (currently Anthropic and OpenAI Responses).
+        """
+
+    def _apply_preserve_metadata(
+        self,
+        provider_response: dict[str, Any],
+        ir_response: dict[str, Any],
+        ctx: ConversionContext,
+    ) -> None:
+        """Re-inject captured metadata for lossless round-trip.
+
+        Called by ``response_to_provider`` after the ``_do_*`` hook.
+        Override in converters that support preserve-mode metadata
+        (currently Anthropic and OpenAI Responses).
+        """
 
     # ==================== Stream转换接口 Stream conversion interface ====================
 
@@ -461,13 +516,6 @@ class BaseConverter(ABC):
         warnings to ``ctx`` for unsupported options.
         """
         ...
-
-    # Optional preserve-mode hooks (implement if provider supports lossless
-    # round-trip, currently anthropic and openai_responses):
-    #   _capture_preserve_metadata(provider_response: dict, ctx) -> None
-    #       Called in response_from_provider to capture non-core fields.
-    #   _apply_preserve_metadata(provider_response: dict, ctx) -> None
-    #       Called in response_to_provider to re-inject captured metadata.
 
     # ==================== Normalization ====================
 

--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -57,11 +57,19 @@ class BaseConverter(ABC):
     _CONVERTER_TAG: str = ""
 
     # Provider response list field for passthrough item restoration.
-    # Subclasses MUST set this (e.g. "choices", "output", "content", "candidates").
+    # Concrete subclasses MUST set this (enforced by __init_subclass__).
     _PASSTHROUGH_RESTORE_KEY: str = ""
 
     # Enable/disable IR validation on from_provider output
     validate_output: bool = True
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if (
+            not getattr(cls, "__abstractmethods__", set())
+            and not cls._PASSTHROUGH_RESTORE_KEY
+        ):
+            raise TypeError(f"{cls.__name__} must set _PASSTHROUGH_RESTORE_KEY")
 
     # Default dispatch table for stream_response_to_provider.
     # Maps IR stream event types to handler method names.

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -21,8 +21,8 @@ from typing import Any, cast
 
 
 from ...types.ir import (
-    IRInputItem,
     IRInput,
+    IRInputItem,
     TextPart,
     ToolChoice,
     ToolDefinition,
@@ -113,6 +113,7 @@ class GoogleGenAIConverter(BaseConverter):
     message_ops_class = GoogleGenAIMessageOps
     config_ops_class = GoogleGenAIConfigOps
     _CONVERTER_TAG = "google_genai"
+    _PASSTHROUGH_RESTORE_KEY = "candidates"
 
     def __init__(self):
         self.content_ops = self.content_ops_class()
@@ -206,30 +207,14 @@ class GoogleGenAIConverter(BaseConverter):
 
         return body
 
-    def request_to_provider(
+    def _do_request_to_provider(
         self,
         ir_request: IRRequest,
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
-    ) -> tuple[dict[str, Any], list[str]]:
-        """Convert IRRequest to Google GenAI request parameters.
-
-        Orchestrates all Ops classes to build the complete provider request.
-
-        Args:
-            ir_request: IR request.
-            **kwargs: Optional keyword arguments.
-
-                - ``output_format``: ``"sdk"`` (default) produces a dict with
-                  a nested ``config`` suitable for the Google GenAI Python SDK.
-                  ``"rest"`` flattens the config so the result can be sent
-                  directly to the Google REST API via ``httpx`` / ``requests``.
-
-        Returns:
-            Tuple of (provider request dict, warnings list).
-        """
-        ctx = context if context is not None else ConversionContext()
+    ) -> dict[str, Any]:
+        ctx = context
         output_format: str = kwargs.pop(
             "output_format",
             ctx.options.get("output_format", "sdk"),
@@ -313,27 +298,17 @@ class GoogleGenAIConverter(BaseConverter):
             config.update(extensions)
 
         if output_format == "rest":
-            return self._to_rest_body(result), ctx.warnings
+            return self._to_rest_body(result)
 
-        return result, ctx.warnings
+        return result
 
-    def request_from_provider(
+    def _do_request_from_provider(
         self,
         provider_request: dict[str, Any],
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
-    ) -> IRRequest:
-        """Convert Google GenAI request to IRRequest.
-
-        Args:
-            provider_request: Google request dict (or SDK object).
-
-        Returns:
-            IR request.
-        """
-        provider_request = self._normalize(provider_request)
-
+    ) -> dict[str, Any]:
         ir_request: dict[str, Any] = {
             "model": provider_request.get("model", ""),
             "messages": [],
@@ -402,7 +377,7 @@ class GoogleGenAIConverter(BaseConverter):
         if "thinking_config" in config or "thinkingConfig" in config:
             ir_request["reasoning"] = self.config_ops.p_reasoning_config_to_ir(config)
 
-        return self._validate_ir_request(ir_request)
+        return ir_request
 
     def _get_response_id_prefix(
         self, context: ConversionContext | StreamContext | None = None
@@ -414,23 +389,13 @@ class GoogleGenAIConverter(BaseConverter):
                 return prefix
         return self._RESPONSE_ID_PREFIX
 
-    def response_from_provider(
+    def _do_response_from_provider(
         self,
         provider_response: dict[str, Any],
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
-    ) -> IRResponse:
-        """Convert Google GenAI response to IRResponse.
-
-        Args:
-            provider_response: Google response dict (or SDK object).
-
-        Returns:
-            IR response.
-        """
-        provider_response = self._normalize(provider_response)
-
+    ) -> dict[str, Any]:
         choices = []
         candidates = provider_response.get("candidates", [])
 
@@ -498,23 +463,15 @@ class GoogleGenAIConverter(BaseConverter):
         if p_usage:
             ir_response["usage"] = self._build_p_usage_to_ir(p_usage)
 
-        return self._validate_ir_response(ir_response)
+        return ir_response
 
-    def response_to_provider(
+    def _do_response_to_provider(
         self,
         ir_response: IRResponse,
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Convert IRResponse to Google GenAI response.
-
-        Args:
-            ir_response: IR response.
-
-        Returns:
-            Google response dict.
-        """
         provider_response: dict[str, Any] = {
             "responseId": self.add_response_id_prefix(
                 ir_response.get("id", ""), self._get_response_id_prefix(context)
@@ -556,13 +513,6 @@ class GoogleGenAIConverter(BaseConverter):
         ir_usage = ir_response.get("usage")
         if ir_usage:
             provider_response["usageMetadata"] = self._build_ir_usage_to_p(ir_usage)
-        ctx = context if context is not None else ConversionContext()
-        self._restore_response_passthrough_items(
-            provider_response,
-            ir_response,
-            output_key="candidates",
-            context=ctx,
-        )
 
         return provider_response
 
@@ -698,45 +648,6 @@ class GoogleGenAIConverter(BaseConverter):
             ]
             return text_parts or None
         return None
-
-    def messages_to_provider(
-        self,
-        messages: Sequence[IRInputItem],
-        *,
-        context: ConversionContext | None = None,
-        **kwargs: Any,
-    ) -> tuple[list[Any], list[str]]:
-        """Convert IR message list to Google GenAI Content format.
-
-        Delegates to message_ops.
-
-        Args:
-            messages: IR messages (may contain ExtensionItems).
-
-        Returns:
-            Tuple of (converted Content list, warnings).
-        """
-        kwargs["target_provider"] = self._CONVERTER_TAG
-        return self.message_ops.ir_messages_to_p(messages, **kwargs)
-
-    def messages_from_provider(
-        self,
-        provider_messages: list[Any],
-        *,
-        context: ConversionContext | None = None,
-        **kwargs: Any,
-    ) -> list[IRInputItem]:
-        """Convert Google GenAI Content list to IR message list.
-
-        Delegates to message_ops.
-
-        Args:
-            provider_messages: Google Content list.
-
-        Returns:
-            IR messages.
-        """
-        return self.message_ops.p_messages_to_ir(provider_messages, **kwargs)
 
     # ==================== Backward Compatibility ====================
 

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -306,7 +306,7 @@ class GoogleGenAIConverter(BaseConverter):
         self,
         provider_request: dict[str, Any],
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
     ) -> dict[str, Any]:
         ir_request: dict[str, Any] = {

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -319,7 +319,7 @@ class OpenAIChatConverter(BaseConverter):
         self,
         provider_request: dict[str, Any],
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
     ) -> dict[str, Any]:
         ir_request: dict[str, Any] = {

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -7,11 +7,10 @@ conversion between IR and OpenAI Chat Completions API format.
 """
 
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from typing import Any, cast
 
 from ...types.ir import (
-    IRInputItem,
     TextPart,
     is_citation_part,
     is_reasoning_part,
@@ -62,6 +61,7 @@ class OpenAIChatConverter(BaseConverter):
     message_ops_class = OpenAIChatMessageOps
     config_ops_class = OpenAIChatConfigOps
     _CONVERTER_TAG = "openai_chat"
+    _PASSTHROUGH_RESTORE_KEY = "choices"
 
     def __init__(self):
         self.content_ops = self.content_ops_class()
@@ -71,24 +71,14 @@ class OpenAIChatConverter(BaseConverter):
 
     # ==================== Top-level Interfaces ====================
 
-    def request_to_provider(
+    def _do_request_to_provider(
         self,
         ir_request: IRRequest,
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
-    ) -> tuple[dict[str, Any], list[str]]:
-        """Convert IRRequest to OpenAI Chat Completions request parameters.
-
-        Orchestrates all Ops classes to build the complete provider request.
-
-        Args:
-            ir_request: IR request.
-
-        Returns:
-            Tuple of (provider request dict, warnings list).
-        """
-        ctx = context if context is not None else ConversionContext()
+    ) -> dict[str, Any]:
+        ctx = context
         result: dict[str, Any] = {"model": ir_request["model"]}
 
         # 1. System instruction → system message (structured content array)
@@ -168,7 +158,7 @@ class OpenAIChatConverter(BaseConverter):
         if extensions:
             result.update(extensions)
 
-        return result, ctx.warnings
+        return result
 
     @staticmethod
     def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> UsageInfo:
@@ -325,23 +315,13 @@ class OpenAIChatConverter(BaseConverter):
                     ir_messages.append(converted)
         return ir_messages, system_parts
 
-    def request_from_provider(
+    def _do_request_from_provider(
         self,
         provider_request: dict[str, Any],
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
-    ) -> IRRequest:
-        """Convert OpenAI Chat Completions request to IRRequest.
-
-        Args:
-            provider_request: OpenAI request dict (or SDK object).
-
-        Returns:
-            IR request.
-        """
-        provider_request = self._normalize(provider_request)
-
+    ) -> dict[str, Any]:
         ir_request: dict[str, Any] = {
             "model": provider_request.get("model", ""),
             "messages": [],
@@ -407,24 +387,15 @@ class OpenAIChatConverter(BaseConverter):
         if cache_fields:
             ir_request["cache"] = self.config_ops.p_cache_config_to_ir(cache_fields)
 
-        return self._validate_ir_request(ir_request)
+        return ir_request
 
-    def response_from_provider(
+    def _do_response_from_provider(
         self,
         provider_response: dict[str, Any],
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
-    ) -> IRResponse:
-        """Convert OpenAI Chat Completions response to IRResponse.
-
-        Args:
-            provider_response: OpenAI response dict (or SDK object).
-
-        Returns:
-            IR response.
-        """
-        provider_response = self._normalize(provider_response)
+    ) -> dict[str, Any]:
 
         choices = []
         for p_choice in provider_response.get("choices", []):
@@ -471,23 +442,15 @@ class OpenAIChatConverter(BaseConverter):
         if provider_response.get("system_fingerprint") is not None:
             ir_response["system_fingerprint"] = provider_response["system_fingerprint"]
 
-        return self._validate_ir_response(ir_response)
+        return ir_response
 
-    def response_to_provider(
+    def _do_response_to_provider(
         self,
         ir_response: IRResponse,
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Convert IRResponse to OpenAI Chat Completions response.
-
-        Args:
-            ir_response: IR response.
-
-        Returns:
-            OpenAI response dict.
-        """
         prefix = self._get_response_id_prefix(context)
         provider_response: dict[str, Any] = {
             "id": self.add_response_id_prefix(ir_response.get("id", ""), prefix),
@@ -512,13 +475,6 @@ class OpenAIChatConverter(BaseConverter):
 
         if "system_fingerprint" in ir_response:
             provider_response["system_fingerprint"] = ir_response["system_fingerprint"]
-        ctx = context if context is not None else ConversionContext()
-        self._restore_response_passthrough_items(
-            provider_response,
-            ir_response,
-            output_key="choices",
-            context=ctx,
-        )
 
         return provider_response
 
@@ -546,45 +502,6 @@ class OpenAIChatConverter(BaseConverter):
             )
 
         return usage
-
-    def messages_to_provider(
-        self,
-        messages: Sequence[IRInputItem],
-        *,
-        context: ConversionContext | None = None,
-        **kwargs: Any,
-    ) -> tuple[list[Any], list[str]]:
-        """Convert IR message list to OpenAI Chat message format.
-
-        Delegates to message_ops.
-
-        Args:
-            messages: IR messages (may contain ExtensionItems).
-
-        Returns:
-            Tuple of (converted messages, warnings).
-        """
-        kwargs["target_provider"] = self._CONVERTER_TAG
-        return self.message_ops.ir_messages_to_p(messages, **kwargs)
-
-    def messages_from_provider(
-        self,
-        provider_messages: list[Any],
-        *,
-        context: ConversionContext | None = None,
-        **kwargs: Any,
-    ) -> list[IRInputItem]:
-        """Convert OpenAI Chat messages to IR message list.
-
-        Delegates to message_ops.
-
-        Args:
-            provider_messages: OpenAI Chat messages.
-
-        Returns:
-            IR messages.
-        """
-        return self.message_ops.p_messages_to_ir(provider_messages, **kwargs)
 
     # ==================== Stream Support ====================
 

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -10,11 +10,10 @@ nested messages. The converter handles this structural difference.
 """
 
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from typing import Any, cast
 
 from ...types.ir import (
-    IRInputItem,
     TextPart,
     is_text_part,
     is_tool_call_part,
@@ -75,6 +74,7 @@ class OpenAIResponsesConverter(BaseConverter):
     message_ops_class = OpenAIResponsesMessageOps
     config_ops_class = OpenAIResponsesConfigOps
     _CONVERTER_TAG = "openai_responses"
+    _PASSTHROUGH_RESTORE_KEY = "output"
 
     # Default response ID prefix for the OpenAI Responses format.
     # Used as fallback when no shim-driven prefix is available in the
@@ -116,24 +116,14 @@ class OpenAIResponsesConverter(BaseConverter):
 
     # ==================== Top-level Interfaces ====================
 
-    def request_to_provider(
+    def _do_request_to_provider(
         self,
         ir_request: IRRequest,
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
-    ) -> tuple[dict[str, Any], list[str]]:
-        """Convert IRRequest to OpenAI Responses API request parameters.
-
-        Orchestrates all Ops classes to build the complete provider request.
-
-        Args:
-            ir_request: IR request.
-
-        Returns:
-            Tuple of (provider request dict, warnings list).
-        """
-        ctx = context if context is not None else ConversionContext()
+    ) -> dict[str, Any]:
+        ctx = context
         result: dict[str, Any] = {"model": ir_request["model"]}
 
         # 1. System instruction → instructions field (plain string)
@@ -197,25 +187,15 @@ class OpenAIResponsesConverter(BaseConverter):
         if extensions:
             result.update(extensions)
 
-        return result, ctx.warnings
+        return result
 
-    def request_from_provider(
+    def _do_request_from_provider(
         self,
         provider_request: dict[str, Any],
         *,
         context: ConversionContext | None = None,
         **kwargs: Any,
-    ) -> IRRequest:
-        """Convert OpenAI Responses API request to IRRequest.
-
-        Args:
-            provider_request: OpenAI Responses request dict (or SDK object).
-
-        Returns:
-            IR request.
-        """
-        provider_request = self._normalize(provider_request)
-
+    ) -> dict[str, Any]:
         ir_request: dict[str, Any] = {
             "model": provider_request.get("model", ""),
             "messages": [],
@@ -305,24 +285,15 @@ class OpenAIResponsesConverter(BaseConverter):
             if echo:
                 ctx.store_request_echo(echo)
 
-        return self._validate_ir_request(ir_request)
+        return ir_request
 
-    def response_from_provider(
+    def _do_response_from_provider(
         self,
         provider_response: dict[str, Any],
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
-    ) -> IRResponse:
-        """Convert OpenAI Responses API response to IRResponse.
-
-        Args:
-            provider_response: OpenAI Responses response dict (or SDK object).
-
-        Returns:
-            IR response.
-        """
-        provider_response = self._normalize(provider_response)
+    ) -> dict[str, Any]:
 
         choices = []
         output_items = provider_response.get("output", [])
@@ -406,28 +377,15 @@ class OpenAIResponsesConverter(BaseConverter):
         if provider_response.get("service_tier") is not None:
             ir_response["service_tier"] = provider_response["service_tier"]
 
-        # Preserve mode: capture extra fields for lossless round-trip
-        ctx = context if context is not None else ConversionContext()
-        if ctx.metadata_mode == "preserve":
-            self._capture_preserve_metadata(provider_response, ctx)
+        return ir_response
 
-        return self._validate_ir_response(ir_response)
-
-    def response_to_provider(
+    def _do_response_to_provider(
         self,
         ir_response: IRResponse,
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Convert IRResponse to OpenAI Responses API response.
-
-        Args:
-            ir_response: IR response.
-
-        Returns:
-            OpenAI Responses response dict.
-        """
         response_id_stem = ir_response.get("id", "")
         provider_response: dict[str, Any] = {
             "id": self.add_response_id_prefix(
@@ -514,17 +472,6 @@ class OpenAIResponsesConverter(BaseConverter):
             provider_response["completed_at"] = self._completion_timestamp()
         else:
             provider_response["completed_at"] = None
-
-        # Preserve mode: inject captured extra fields
-        ctx = context if context is not None else ConversionContext()
-        if ctx.metadata_mode == "preserve":
-            self._apply_preserve_metadata(provider_response, ctx)
-        self._restore_response_passthrough_items(
-            provider_response,
-            ir_response,
-            output_key="output",
-            context=ctx,
-        )
 
         return provider_response
 
@@ -620,9 +567,10 @@ class OpenAIResponsesConverter(BaseConverter):
         if cache_fields:
             ir_request["cache"] = self.config_ops.p_cache_config_to_ir(cache_fields)
 
-    @staticmethod
     def _capture_preserve_metadata(
+        self,
         provider_response: dict[str, Any],
+        ir_response: dict[str, Any],
         ctx: ConversionContext,
     ) -> None:
         """Capture extra fields from provider response for lossless round-trip."""
@@ -662,9 +610,10 @@ class OpenAIResponsesConverter(BaseConverter):
         if items_meta:
             ctx.store_output_items_meta(items_meta)
 
-    @staticmethod
     def _apply_preserve_metadata(
+        self,
         provider_response: dict[str, Any],
+        ir_response: dict[str, Any],
         ctx: ConversionContext,
     ) -> None:
         """Re-inject captured metadata fields in *preserve* mode."""
@@ -712,45 +661,6 @@ class OpenAIResponsesConverter(BaseConverter):
                     content[j]["annotations"] = pm["annotations"]
                 if "logprobs" in pm:
                     content[j]["logprobs"] = pm["logprobs"]
-
-    def messages_to_provider(
-        self,
-        messages: Sequence[IRInputItem],
-        *,
-        context: ConversionContext | None = None,
-        **kwargs: Any,
-    ) -> tuple[list[Any], list[str]]:
-        """Convert IR message list to OpenAI Responses input items.
-
-        Delegates to message_ops.
-
-        Args:
-            messages: IR messages (may contain ExtensionItems).
-
-        Returns:
-            Tuple of (converted items, warnings).
-        """
-        kwargs["target_provider"] = self._CONVERTER_TAG
-        return self.message_ops.ir_messages_to_p(messages, **kwargs)
-
-    def messages_from_provider(
-        self,
-        provider_messages: list[Any],
-        *,
-        context: ConversionContext | None = None,
-        **kwargs: Any,
-    ) -> list[IRInputItem]:
-        """Convert OpenAI Responses items to IR message list.
-
-        Delegates to message_ops.
-
-        Args:
-            provider_messages: OpenAI Responses items.
-
-        Returns:
-            IR messages.
-        """
-        return self.message_ops.p_messages_to_ir(provider_messages, **kwargs)
 
     # ==================== Backward Compatibility ====================
     # These methods maintain backward compatibility with the old API

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -193,7 +193,7 @@ class OpenAIResponsesConverter(BaseConverter):
         self,
         provider_request: dict[str, Any],
         *,
-        context: ConversionContext | None = None,
+        context: ConversionContext,
         **kwargs: Any,
     ) -> dict[str, Any]:
         ir_request: dict[str, Any] = {

--- a/tests/test_converters_base.py
+++ b/tests/test_converters_base.py
@@ -409,7 +409,11 @@ class MockConverter(BaseConverter):
         return provider_request
 
     def _do_request_from_provider(
-        self, provider_request: dict[str, Any], *, context=None, **kwargs: Any
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext,
+        **kwargs: Any,
     ) -> dict[str, Any]:
         ir_request: dict[str, Any] = {
             "model": provider_request["model"],

--- a/tests/test_converters_base.py
+++ b/tests/test_converters_base.py
@@ -376,27 +376,29 @@ class MockConfigOps(BaseConfigOps):
 class MockConverter(BaseConverter):
     """Mock implementation of BaseConverter for testing"""
 
-    # 指定使用的ops类
     content_ops_class = MockContentOps
     message_ops_class = MockMessageOps
     tool_ops_class = MockToolOps
     config_ops_class = MockConfigOps
+    _CONVERTER_TAG = "mock"
+    _PASSTHROUGH_RESTORE_KEY = "choices"
 
-    def request_to_provider(
-        self, ir_request: IRRequest, *, context=None, **kwargs: Any
-    ) -> tuple[dict[str, Any], list[str]]:
-        ctx = context if context is not None else ConversionContext()
+    def __init__(self):
+        self.message_ops = self.message_ops_class()
+        self.tool_ops = self.tool_ops_class()
+
+    def _do_request_to_provider(
+        self, ir_request: IRRequest, *, context: ConversionContext, **kwargs: Any
+    ) -> dict[str, Any]:
         provider_request: dict[str, Any] = {"model": ir_request["model"]}
 
-        # 转换消息
         if "messages" in ir_request:
             messages, msg_warnings = self.message_ops_class.ir_messages_to_p(
                 ir_request["messages"], **kwargs
             )
             provider_request["messages"] = messages
-            ctx.warnings.extend(msg_warnings)
+            context.warnings.extend(msg_warnings)
 
-        # 转换生成配置
         if "generation" in ir_request:
             provider_request.update(
                 self.config_ops_class.ir_generation_config_to_p(
@@ -404,26 +406,30 @@ class MockConverter(BaseConverter):
                 )
             )
 
-        return provider_request, ctx.warnings
+        return provider_request
 
-    def request_from_provider(
+    def _do_request_from_provider(
         self, provider_request: dict[str, Any], *, context=None, **kwargs: Any
-    ) -> IRRequest:
-        ir_request: IRRequest = {"model": provider_request["model"], "messages": []}
+    ) -> dict[str, Any]:
+        ir_request: dict[str, Any] = {
+            "model": provider_request["model"],
+            "messages": [],
+        }
 
         if "messages" in provider_request:
-            ir_request["messages"] = cast(
-                list[IRInputItem],
-                self.message_ops_class.p_messages_to_ir(
-                    provider_request["messages"], **kwargs
-                ),
+            ir_request["messages"] = self.message_ops_class.p_messages_to_ir(
+                provider_request["messages"], **kwargs
             )
 
         return ir_request
 
-    def response_from_provider(
-        self, provider_response: dict[str, Any], *, context=None, **kwargs: Any
-    ) -> IRResponse:
+    def _do_response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
         return {
             "id": provider_response.get("id", ""),
             "object": provider_response.get("object", ""),
@@ -433,8 +439,8 @@ class MockConverter(BaseConverter):
             "usage": provider_response.get("usage", {}),
         }
 
-    def response_to_provider(
-        self, ir_response: IRResponse, *, context=None, **kwargs: Any
+    def _do_response_to_provider(
+        self, ir_response: IRResponse, *, context: ConversionContext, **kwargs: Any
     ) -> dict[str, Any]:
         return {
             "id": ir_response["id"],
@@ -444,20 +450,6 @@ class MockConverter(BaseConverter):
             "choices": ir_response["choices"],
             "usage": ir_response["usage"],
         }
-
-    def messages_to_provider(
-        self,
-        messages: Sequence[IRInputItem],
-        *,
-        context=None,
-        **kwargs: Any,
-    ) -> tuple[list[Any], list[str]]:
-        return self.message_ops_class.ir_messages_to_p(messages, **kwargs)
-
-    def messages_from_provider(
-        self, provider_messages: list[Any], *, context=None, **kwargs: Any
-    ) -> list[IRInputItem]:
-        return self.message_ops_class.p_messages_to_ir(provider_messages, **kwargs)
 
     def stream_response_from_provider(
         self,


### PR DESCRIPTION
## Summary

- Convert `BaseConverter` from a pure interface (6 abstract methods) to template methods with `_do_*` hooks
- 4 abstract methods become concrete templates: `request_to/from_provider`, `response_to/from_provider`
- 2 abstract methods become concrete defaults: `messages_to/from_provider` (all 4 converters had identical one-liners)
- Add `_PASSTHROUGH_RESTORE_KEY` class attribute per converter (`"choices"`, `"output"`, `"content"`, `"candidates"`)
- Add no-op `_capture/_apply_preserve_metadata` defaults — Anthropic and Responses override, Chat and Google inherit
- Base template handles: `_normalize()`, `_validate_ir_request/response()`, `ConversionContext` fallback, `_restore_response_passthrough_items()`, preserve-mode capture/apply
- Net -316 lines: removed ~320 lines of duplicated boilerplate across 4 converters, added ~50 lines in base template

Closes #471
Part of #470 (enables clean insertion point for multimodal tool result patch)

### Design decisions (discussed in Matrix with @milo @elena @clementine)

1. `_do_*` naming — standard template method convention
2. `_do_request_to_provider` returns dict only, not tuple — base owns `ctx.warnings`
3. Preserve-mode: no-op defaults instead of `hasattr` checks
4. External subclass break: clean break, pre-1.0

## Test plan

- [x] `make lint` — clean (ruff + ruff format)
- [x] `make test` — 2372 passed, 4 skipped, 0 failed
- [x] Pre-commit hooks (ruff, ruff format, ty check) — all passed
- [x] All 4 converters load and report correct `_PASSTHROUGH_RESTORE_KEY`
- [x] Public API unchanged — callers use `converter.request_to_provider()` etc.