### PR TITLE
refactor: generalize multimodal tool result dual-encoding

### DIFF
--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -60,6 +60,10 @@ class BaseConverter(ABC):
     # Concrete subclasses MUST set this (enforced by __init_subclass__).
     _PASSTHROUGH_RESTORE_KEY: str = ""
 
+    # Whether the provider format supports multimodal content in tool results.
+    # Chat Completions overrides to False (tool messages are text-only).
+    SUPPORTS_MULTIMODAL_TOOL_RESULT: bool = True
+
     # Enable/disable IR validation on from_provider output
     validate_output: bool = True
 
@@ -319,6 +323,22 @@ class BaseConverter(ABC):
         Override in converters that support preserve-mode metadata
         (currently Anthropic and OpenAI Responses).
         """
+
+    # ==================== Capability queries ====================
+
+    def _supports_multimodal_tool_result(
+        self, context: ConversionContext | None = None
+    ) -> bool:
+        """Whether this converter's target format supports multimodal tool results.
+
+        Checks shim override in context.options first, then falls back to
+        the class-level ``SUPPORTS_MULTIMODAL_TOOL_RESULT`` default.
+        """
+        if context is not None:
+            override = context.options.get("multimodal_tool_result")
+            if override is not None:
+                return bool(override)
+        return self.SUPPORTS_MULTIMODAL_TOOL_RESULT
 
     # ==================== Stream转换接口 Stream conversion interface ====================
 

--- a/src/llm_rosetta/converters/base/helpers/multimodal_tool_patch.py
+++ b/src/llm_rosetta/converters/base/helpers/multimodal_tool_patch.py
@@ -1,0 +1,206 @@
+"""Multimodal tool result dual-encoding helpers.
+
+When a provider format does not support multimodal content in tool result
+messages (e.g. OpenAI Chat Completions ``role: "tool"`` only accepts text),
+these helpers implement a dual-encoding strategy:
+
+**Packing (IR → provider)**: multimodal blocks (images, files) are extracted
+from the tool result and stored in a ``multimodal_packs`` dict keyed by
+``call_id``.  After all messages are converted, ``inject_packed_tool_content``
+inserts a synthetic ``role: "user"`` message containing the visual content
+wrapped in ``<tool-content call-id="...">`` XML tags.  The original tool
+message keeps ``json.dumps(result)`` as a fallback.
+
+**Unpacking (provider → IR)**: ``unpack_tool_content`` detects synthetic user
+messages, parses the XML tags, and extracts ``call_id → content blocks``
+mappings so the consuming converter can reconstruct the multimodal IR result.
+
+Originally implemented in ``openai_chat/message_ops.py`` (PR #108).  Extracted
+here so any text-only converter can reuse the protocol.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..content import BaseContentOps
+
+TOOL_CONTENT_OPEN_TAG_RE = re.compile(r'^<tool-content\s+call-id="([^"]+)">$')
+TOOL_CONTENT_CLOSE_TAG = "</tool-content>"
+
+
+def has_multimodal_content(result: Any) -> bool:
+    """Check if a tool result contains non-text content blocks."""
+    if not isinstance(result, list):
+        return False
+    return any(
+        isinstance(block, dict) and block.get("type") not in ("text", None)
+        for block in result
+    )
+
+
+def pack_multimodal_tool_result(
+    result: list[Any],
+    content_ops: BaseContentOps,
+    multimodal_packs: dict[str, list[dict[str, Any]]],
+    call_id: str,
+    warnings: list[str],
+) -> None:
+    """Extract visual content blocks from a multimodal tool result.
+
+    Converted blocks are stored in ``multimodal_packs[call_id]`` for
+    later injection by ``inject_packed_tool_content``.
+
+    Args:
+        result: The IR tool result content (list of content blocks).
+        content_ops: Provider content ops for converting blocks.
+        multimodal_packs: Accumulator mapping call_id → provider content blocks.
+        call_id: The tool call ID.
+        warnings: Warning accumulator.
+    """
+    packed_parts: list[dict[str, Any]] = []
+
+    for block in result:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            packed_parts.append(content_ops.ir_text_to_p(block))
+        elif block_type == "image":
+            try:
+                packed_parts.append(content_ops.ir_image_to_p(block))
+            except ValueError as e:
+                warnings.append(f"Skipped image in tool result packing: {e}")
+        elif block_type == "file":
+            warnings.append(
+                "File content not supported in tool result packing, skipped"
+            )
+        else:
+            warnings.append(
+                f"Unsupported block type in tool result packing: {block_type}"
+            )
+
+    if packed_parts:
+        multimodal_packs[call_id] = packed_parts
+
+
+def inject_packed_tool_content(
+    messages: list[dict[str, Any]],
+    multimodal_packs: dict[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    """Insert synthetic user messages with packed multimodal tool content.
+
+    After each group of consecutive ``role: "tool"`` messages, inserts a
+    synthetic ``role: "user"`` message containing ``<tool-content>`` tagged
+    blocks for any tool results that have multimodal content.
+    """
+    if not multimodal_packs:
+        return messages
+
+    result: list[dict[str, Any]] = []
+    i = 0
+
+    while i < len(messages):
+        msg = messages[i]
+        result.append(msg)
+        i += 1
+
+        if msg.get("role") != "tool":
+            continue
+
+        tool_call_ids = [msg.get("tool_call_id")]
+        while i < len(messages) and messages[i].get("role") == "tool":
+            result.append(messages[i])
+            tool_call_ids.append(messages[i].get("tool_call_id"))
+            i += 1
+
+        synthetic_parts: list[dict[str, Any]] = []
+        for tcid in tool_call_ids:
+            if tcid and tcid in multimodal_packs:
+                synthetic_parts.append(
+                    {"type": "text", "text": f'<tool-content call-id="{tcid}">'}
+                )
+                synthetic_parts.extend(multimodal_packs[tcid])
+                synthetic_parts.append({"type": "text", "text": TOOL_CONTENT_CLOSE_TAG})
+
+        if synthetic_parts:
+            result.append({"role": "user", "content": synthetic_parts})
+
+    return result
+
+
+def is_synthetic_tool_content_msg(msg: dict[str, Any]) -> bool:
+    """Check if a user message is a synthetic tool content message."""
+    if msg.get("role") != "user":
+        return False
+    content = msg.get("content")
+    if not isinstance(content, list) or not content:
+        return False
+    first = content[0]
+    if isinstance(first, dict) and first.get("type") == "text":
+        return bool(TOOL_CONTENT_OPEN_TAG_RE.match(first.get("text", "")))
+    return False
+
+
+def unpack_tool_content(
+    messages: list[dict[str, Any]],
+) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]]]:
+    """Extract multimodal content from synthetic user messages.
+
+    Returns:
+        Tuple of (unpacked_content mapping, clean message list).
+    """
+    unpacked: dict[str, list[dict[str, Any]]] = {}
+    clean: list[dict[str, Any]] = []
+
+    for msg in messages:
+        if not is_synthetic_tool_content_msg(msg):
+            clean.append(msg)
+            continue
+
+        content = msg.get("content", [])
+        current_call_id: str | None = None
+        current_blocks: list[dict[str, Any]] = []
+
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+
+            if part.get("type") == "text":
+                text = part.get("text", "")
+
+                open_match = TOOL_CONTENT_OPEN_TAG_RE.match(text)
+                if open_match:
+                    if current_call_id and current_blocks:
+                        unpacked[current_call_id] = current_blocks
+                    current_call_id = open_match.group(1)
+                    current_blocks = []
+                    continue
+
+                if text == TOOL_CONTENT_CLOSE_TAG:
+                    if current_call_id and current_blocks:
+                        unpacked[current_call_id] = current_blocks
+                    current_call_id = None
+                    current_blocks = []
+                    continue
+
+            if current_call_id is not None:
+                current_blocks.append(part)
+
+        if current_call_id and current_blocks:
+            unpacked[current_call_id] = current_blocks
+
+    return unpacked, clean
+
+
+__all__ = [
+    "TOOL_CONTENT_CLOSE_TAG",
+    "TOOL_CONTENT_OPEN_TAG_RE",
+    "has_multimodal_content",
+    "inject_packed_tool_content",
+    "is_synthetic_tool_content_msg",
+    "pack_multimodal_tool_result",
+    "unpack_tool_content",
+]

--- a/src/llm_rosetta/converters/openai_chat/_constants.py
+++ b/src/llm_rosetta/converters/openai_chat/_constants.py
@@ -1,6 +1,9 @@
 """OpenAI Chat converter constants — reason mappings and tool content packing."""
 
-import re
+from ..base.helpers.multimodal_tool_patch import (  # noqa: F401  # re-export
+    TOOL_CONTENT_CLOSE_TAG,
+    TOOL_CONTENT_OPEN_TAG_RE,
+)
 
 # --- Reason mappings ---
 
@@ -22,8 +25,3 @@ OPENAI_CHAT_REASON_TO_PROVIDER: dict[str, str] = {
     "content_filter": "content_filter",
     "refusal": "stop",
 }
-
-# --- Tool content packing (Phase 2: multimodal tool result dual encoding) ---
-
-TOOL_CONTENT_OPEN_TAG_RE = re.compile(r'^<tool-content\s+call-id="([^"]+)">$')
-TOOL_CONTENT_CLOSE_TAG = "</tool-content>"

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -62,6 +62,7 @@ class OpenAIChatConverter(BaseConverter):
     config_ops_class = OpenAIChatConfigOps
     _CONVERTER_TAG = "openai_chat"
     _PASSTHROUGH_RESTORE_KEY = "choices"
+    SUPPORTS_MULTIMODAL_TOOL_RESULT = False
 
     def __init__(self):
         self.content_ops = self.content_ops_class()

--- a/src/llm_rosetta/converters/openai_chat/message_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/message_ops.py
@@ -33,25 +33,17 @@ from ...types.ir import (
     is_tool_result_part,
 )
 from ..base import BaseMessageOps
-from ._constants import TOOL_CONTENT_CLOSE_TAG, TOOL_CONTENT_OPEN_TAG_RE
+from ..base.helpers.multimodal_tool_patch import (
+    has_multimodal_content,
+    inject_packed_tool_content,
+    is_synthetic_tool_content_msg,
+    pack_multimodal_tool_result,
+    unpack_tool_content,
+)
 from .content_ops import OpenAIChatContentOps
 from .tool_ops import OpenAIChatToolOps
 
 logger = logging.getLogger(__name__)
-
-
-def _has_multimodal_content(result: Any) -> bool:
-    """Check if a tool result contains multimodal content blocks.
-
-    Returns True if ``result`` is a list containing at least one
-    non-text content block (image, file, etc.).
-    """
-    if not isinstance(result, list):
-        return False
-    return any(
-        isinstance(block, dict) and block.get("type") not in ("text", None)
-        for block in result
-    )
 
 
 class OpenAIChatMessageOps(BaseMessageOps):
@@ -420,12 +412,9 @@ class OpenAIChatMessageOps(BaseMessageOps):
     ) -> dict[str, Any]:
         """Convert an IR ToolResultPart, packing multimodal content for dual encoding.
 
-        If the result contains multimodal content (images, files, etc.), the
-        visual content blocks are extracted and stored in ``multimodal_packs``
-        for later injection as a synthetic user message. The tool message itself
-        keeps ``json.dumps(result)`` as content (Phase 1 fallback).
-
-        Text-only results delegate directly to ``tool_ops.ir_tool_result_to_p()``.
+        Delegates to the shared ``pack_multimodal_tool_result`` helper for
+        multimodal extraction; text-only results go straight through
+        ``tool_ops.ir_tool_result_to_p()``.
 
         Args:
             part: IR tool result part.
@@ -436,97 +425,17 @@ class OpenAIChatMessageOps(BaseMessageOps):
             OpenAI tool role message dict.
         """
         result = part.get("result", "")
-        if not _has_multimodal_content(result):
+        if not has_multimodal_content(result):
             return self.tool_ops.ir_tool_result_to_p(part)
-
-        # Multimodal: extract visual content for synthetic user message
-        call_id = part["tool_call_id"]
-        packed_parts: list[dict[str, Any]] = []
-
-        for block in result:
-            if not isinstance(block, dict):
-                continue
-            block_type = block.get("type")
-            if block_type == "text":
-                packed_parts.append(self.content_ops.ir_text_to_p(block))
-            elif block_type == "image":
-                try:
-                    packed_parts.append(self.content_ops.ir_image_to_p(block))
-                except ValueError as e:
-                    warnings.append(f"Skipped image in tool result packing: {e}")
-            elif block_type == "file":
-                warnings.append(
-                    "File content not supported in OpenAI Chat tool result packing, "
-                    "skipped"
-                )
-            else:
-                warnings.append(
-                    f"Unsupported block type in tool result packing: {block_type}"
-                )
-
-        if packed_parts:
-            multimodal_packs[call_id] = packed_parts
-
-        # Tool message keeps json.dumps fallback (existing Phase 1 behavior)
+        pack_multimodal_tool_result(
+            result, self.content_ops, multimodal_packs, part["tool_call_id"], warnings
+        )
         return self.tool_ops.ir_tool_result_to_p(part)
 
     @staticmethod
-    def _inject_packed_tool_content(
-        messages: list[dict[str, Any]],
-        multimodal_packs: dict[str, list[dict[str, Any]]],
-    ) -> list[dict[str, Any]]:
-        """Inject synthetic user message with packed multimodal tool content.
-
-        Walks the reordered message list and, after each group of consecutive
-        tool messages following an assistant, inserts a synthetic user message
-        containing ``<tool-content call-id="...">`` tagged content blocks for
-        any tool results that have multimodal content.
-
-        Args:
-            messages: Reordered OpenAI Chat messages.
-            multimodal_packs: Mapping of call_id → provider content blocks.
-
-        Returns:
-            Messages list with synthetic user messages injected.
-        """
-        if not multimodal_packs:
-            return messages
-
-        result: list[dict[str, Any]] = []
-        i = 0
-
-        while i < len(messages):
-            msg = messages[i]
-            result.append(msg)
-            i += 1
-
-            # After tool messages group, check for packed content
-            if msg.get("role") != "tool":
-                continue
-
-            # Collect consecutive tool messages (already appended first one)
-            tool_call_ids = [msg.get("tool_call_id")]
-            while i < len(messages) and messages[i].get("role") == "tool":
-                result.append(messages[i])
-                tool_call_ids.append(messages[i].get("tool_call_id"))
-                i += 1
-
-            # Build synthetic user message for packed call_ids
-            synthetic_parts: list[dict[str, Any]] = []
-            for tcid in tool_call_ids:
-                if tcid and tcid in multimodal_packs:
-                    synthetic_parts.append(
-                        {"type": "text", "text": f'<tool-content call-id="{tcid}">'}
-                    )
-                    synthetic_parts.extend(multimodal_packs[tcid])
-                    synthetic_parts.append(
-                        {"type": "text", "text": TOOL_CONTENT_CLOSE_TAG}
-                    )
-
-            if synthetic_parts:
-                result.append({"role": "user", "content": synthetic_parts})
-
-        return result
+    def _inject_packed_tool_content(messages, multimodal_packs):
+        """Thin wrapper around shared ``inject_packed_tool_content``."""
+        return inject_packed_tool_content(messages, multimodal_packs)
 
     # ==================== Provider → IR ====================
 
@@ -734,91 +643,14 @@ class OpenAIChatMessageOps(BaseMessageOps):
     # ==================== Multimodal Unpacking ====================
 
     @staticmethod
-    def _is_synthetic_tool_content_msg(msg: dict[str, Any]) -> bool:
-        """Check if a user message is a synthetic tool content message.
-
-        A synthetic message has ``role: "user"`` and its content list starts
-        with a text part matching the ``<tool-content call-id="...">`` tag.
-
-        Args:
-            msg: OpenAI message dict.
-
-        Returns:
-            True if the message is a synthetic tool content message.
-        """
-        if msg.get("role") != "user":
-            return False
-        content = msg.get("content")
-        if not isinstance(content, list) or not content:
-            return False
-        first = content[0]
-        if isinstance(first, dict) and first.get("type") == "text":
-            return bool(TOOL_CONTENT_OPEN_TAG_RE.match(first.get("text", "")))
-        return False
+    def _is_synthetic_tool_content_msg(msg):
+        """Thin wrapper around shared ``is_synthetic_tool_content_msg``."""
+        return is_synthetic_tool_content_msg(msg)
 
     @staticmethod
-    def _unpack_tool_content(
-        messages: list[dict[str, Any]],
-    ) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]]]:
-        """Extract multimodal content from synthetic user messages.
-
-        Scans for synthetic user messages containing ``<tool-content>`` tags,
-        parses the tags to extract ``call_id → content blocks`` mapping, and
-        removes the synthetic messages from the message list.
-
-        Args:
-            messages: OpenAI Chat messages (may contain synthetic user messages).
-
-        Returns:
-            Tuple of (unpacked_content mapping, clean message list).
-        """
-        unpacked: dict[str, list[dict[str, Any]]] = {}
-        clean: list[dict[str, Any]] = []
-
-        for msg in messages:
-            if not OpenAIChatMessageOps._is_synthetic_tool_content_msg(msg):
-                clean.append(msg)
-                continue
-
-            # Parse <tool-content call-id="..."> sections
-            content = msg.get("content", [])
-            current_call_id: str | None = None
-            current_blocks: list[dict[str, Any]] = []
-
-            for part in content:
-                if not isinstance(part, dict):
-                    continue
-
-                if part.get("type") == "text":
-                    text = part.get("text", "")
-
-                    # Check for open tag
-                    open_match = TOOL_CONTENT_OPEN_TAG_RE.match(text)
-                    if open_match:
-                        # Save previous section if any
-                        if current_call_id and current_blocks:
-                            unpacked[current_call_id] = current_blocks
-                        current_call_id = open_match.group(1)
-                        current_blocks = []
-                        continue
-
-                    # Check for close tag
-                    if text == TOOL_CONTENT_CLOSE_TAG:
-                        if current_call_id and current_blocks:
-                            unpacked[current_call_id] = current_blocks
-                        current_call_id = None
-                        current_blocks = []
-                        continue
-
-                # Content block within a section
-                if current_call_id is not None:
-                    current_blocks.append(part)
-
-            # Handle unclosed section
-            if current_call_id and current_blocks:
-                unpacked[current_call_id] = current_blocks
-
-        return unpacked, clean
+    def _unpack_tool_content(messages):
+        """Thin wrapper around shared ``unpack_tool_content``."""
+        return unpack_tool_content(messages)
 
     def _p_content_part_to_ir(self, provider_part: Any) -> list[ContentPart]:
         """Convert a single OpenAI content part to IR content part(s).

--- a/tests/converters/openai_chat/test_message_ops.py
+++ b/tests/converters/openai_chat/test_message_ops.py
@@ -5,11 +5,11 @@ OpenAI Chat MessageOps unit tests.
 from typing import Any, Union, cast
 
 from llm_rosetta._vendor.validate import validate
-from llm_rosetta.converters.openai_chat.content_ops import OpenAIChatContentOps
-from llm_rosetta.converters.openai_chat.message_ops import (
-    OpenAIChatMessageOps,
-    _has_multimodal_content,
+from llm_rosetta.converters.base.helpers.multimodal_tool_patch import (
+    has_multimodal_content,
 )
+from llm_rosetta.converters.openai_chat.content_ops import OpenAIChatContentOps
+from llm_rosetta.converters.openai_chat.message_ops import OpenAIChatMessageOps
 from llm_rosetta.converters.openai_chat.tool_ops import OpenAIChatToolOps
 from llm_rosetta.types.ir import Message, ToolCallPart, ToolResultPart
 from llm_rosetta.types.ir.extensions_experimental import ExtensionItem
@@ -1040,18 +1040,18 @@ class TestMultimodalToolResultPacking:
         assert "file" not in types
 
     def test_has_multimodal_content_helper(self):
-        """_has_multimodal_content correctly detects multimodal vs text-only."""
-        assert _has_multimodal_content("just a string") is False
-        assert _has_multimodal_content([{"type": "text", "text": "hi"}]) is False
-        assert _has_multimodal_content([{"type": "image", "image_url": "x"}]) is True
+        """has_multimodal_content correctly detects multimodal vs text-only."""
+        assert has_multimodal_content("just a string") is False
+        assert has_multimodal_content([{"type": "text", "text": "hi"}]) is False
+        assert has_multimodal_content([{"type": "image", "image_url": "x"}]) is True
         assert (
-            _has_multimodal_content(
+            has_multimodal_content(
                 [{"type": "text", "text": "hi"}, {"type": "image", "image_url": "x"}]
             )
             is True
         )
-        assert _has_multimodal_content([]) is False
-        assert _has_multimodal_content(None) is False
+        assert has_multimodal_content([]) is False
+        assert has_multimodal_content(None) is False
 
 
 class TestRefusalFieldAlwaysPresent:


### PR DESCRIPTION
## Summary

- Extract multimodal tool result dual-encoding from `openai_chat/message_ops.py` into shared `base/helpers/multimodal_tool_patch.py`
- Add `SUPPORTS_MULTIMODAL_TOOL_RESULT` capability flag to `BaseConverter` (default `True`, Chat overrides to `False`)
- Add `_supports_multimodal_tool_result(context)` lookup with shim override via `context.options`
- Chat `message_ops.py`: ~200 lines of inline pack/unpack/inject code replaced with thin wrappers
- Chat `_constants.py`: moved constants re-exported for backward compat
- Net -149 lines, all protocol behavior unchanged

Any future text-only converter can reuse the dual-encoding protocol by setting `SUPPORTS_MULTIMODAL_TOOL_RESULT = False` and calling the shared helpers.

Closes #474
Part of #470

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 2372 passed, 4 skipped, 0 failed
- [x] Pre-commit hooks (ruff, ruff format, ty check) — all passed
- [x] PR #108's multimodal tool result tests still pass (pack/unpack/round-trip)
- [x] `SUPPORTS_MULTIMODAL_TOOL_RESULT` flag correct on all 4 converters