### PR TITLE
fix: address multimodal tool result review nits

### DIFF
--- a/src/llm_rosetta/converters/base/converter.py
+++ b/src/llm_rosetta/converters/base/converter.py
@@ -62,7 +62,7 @@ class BaseConverter(ABC):
 
     # Whether the provider format supports multimodal content in tool results.
     # Chat Completions overrides to False (tool messages are text-only).
-    SUPPORTS_MULTIMODAL_TOOL_RESULT: bool = True
+    _SUPPORTS_MULTIMODAL_TOOL_RESULT: bool = True
 
     # Enable/disable IR validation on from_provider output
     validate_output: bool = True
@@ -218,6 +218,10 @@ class BaseConverter(ABC):
         Override if the converter needs custom pre/post processing.
         """
         kwargs["target_provider"] = self._CONVERTER_TAG
+        kwargs.setdefault(
+            "supports_multimodal_tool_result",
+            self._supports_multimodal_tool_result(context),
+        )
         return self.message_ops.ir_messages_to_p(messages, **kwargs)
 
     def messages_from_provider(
@@ -338,7 +342,7 @@ class BaseConverter(ABC):
             override = context.options.get("multimodal_tool_result")
             if override is not None:
                 return bool(override)
-        return self.SUPPORTS_MULTIMODAL_TOOL_RESULT
+        return self._SUPPORTS_MULTIMODAL_TOOL_RESULT
 
     # ==================== Stream转换接口 Stream conversion interface ====================
 

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -62,7 +62,7 @@ class OpenAIChatConverter(BaseConverter):
     config_ops_class = OpenAIChatConfigOps
     _CONVERTER_TAG = "openai_chat"
     _PASSTHROUGH_RESTORE_KEY = "choices"
-    SUPPORTS_MULTIMODAL_TOOL_RESULT = False
+    _SUPPORTS_MULTIMODAL_TOOL_RESULT = False
 
     def __init__(self):
         self.content_ops = self.content_ops_class()

--- a/src/llm_rosetta/converters/openai_chat/message_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/message_ops.py
@@ -36,7 +36,6 @@ from ..base import BaseMessageOps
 from ..base.helpers.multimodal_tool_patch import (
     has_multimodal_content,
     inject_packed_tool_content,
-    is_synthetic_tool_content_msg,
     pack_multimodal_tool_result,
     unpack_tool_content,
 )
@@ -109,8 +108,10 @@ class OpenAIChatMessageOps(BaseMessageOps):
                 warnings.extend(ext_warnings)
 
         messages = self._reorder_tool_messages(messages, warnings)
-        if multimodal_packs:
-            messages = self._inject_packed_tool_content(messages, multimodal_packs)
+        if multimodal_packs and not kwargs.get(
+            "supports_multimodal_tool_result", False
+        ):
+            messages = inject_packed_tool_content(messages, multimodal_packs)
         return messages, warnings
 
     @staticmethod
@@ -432,11 +433,6 @@ class OpenAIChatMessageOps(BaseMessageOps):
         )
         return self.tool_ops.ir_tool_result_to_p(part)
 
-    @staticmethod
-    def _inject_packed_tool_content(messages, multimodal_packs):
-        """Thin wrapper around shared ``inject_packed_tool_content``."""
-        return inject_packed_tool_content(messages, multimodal_packs)
-
     # ==================== Provider → IR ====================
 
     def p_messages_to_ir(
@@ -455,7 +451,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
         Returns:
             List of IR messages.
         """
-        unpacked_content, clean_messages = self._unpack_tool_content(provider_messages)
+        unpacked_content, clean_messages = unpack_tool_content(provider_messages)
 
         ir_messages: list[IRInputItem] = []
         for msg in clean_messages:
@@ -639,18 +635,6 @@ class OpenAIChatMessageOps(BaseMessageOps):
                 )
             ],
         }
-
-    # ==================== Multimodal Unpacking ====================
-
-    @staticmethod
-    def _is_synthetic_tool_content_msg(msg):
-        """Thin wrapper around shared ``is_synthetic_tool_content_msg``."""
-        return is_synthetic_tool_content_msg(msg)
-
-    @staticmethod
-    def _unpack_tool_content(messages):
-        """Thin wrapper around shared ``unpack_tool_content``."""
-        return unpack_tool_content(messages)
 
     def _p_content_part_to_ir(self, provider_part: Any) -> list[ContentPart]:
         """Convert a single OpenAI content part to IR content part(s).

--- a/tests/converters/openai_chat/test_message_ops.py
+++ b/tests/converters/openai_chat/test_message_ops.py
@@ -7,6 +7,7 @@ from typing import Any, Union, cast
 from llm_rosetta._vendor.validate import validate
 from llm_rosetta.converters.base.helpers.multimodal_tool_patch import (
     has_multimodal_content,
+    is_synthetic_tool_content_msg,
 )
 from llm_rosetta.converters.openai_chat.content_ops import OpenAIChatContentOps
 from llm_rosetta.converters.openai_chat.message_ops import OpenAIChatMessageOps
@@ -1003,13 +1004,10 @@ class TestMultimodalToolResultPacking:
         }
         assistant = {"role": "assistant", "content": "Hi!"}
 
-        assert OpenAIChatMessageOps._is_synthetic_tool_content_msg(synthetic) is True
-        assert OpenAIChatMessageOps._is_synthetic_tool_content_msg(normal_user) is False
-        assert (
-            OpenAIChatMessageOps._is_synthetic_tool_content_msg(normal_user_list)
-            is False
-        )
-        assert OpenAIChatMessageOps._is_synthetic_tool_content_msg(assistant) is False
+        assert is_synthetic_tool_content_msg(synthetic) is True
+        assert is_synthetic_tool_content_msg(normal_user) is False
+        assert is_synthetic_tool_content_msg(normal_user_list) is False
+        assert is_synthetic_tool_content_msg(assistant) is False
 
     def test_file_part_skipped_with_warning(self):
         """File parts in multimodal tool result produce warning, skipped during packing."""


### PR DESCRIPTION
## Summary

Follow-up to PR #476, addresses all three reviewer nits:

1. **Wire the flag** — `_supports_multimodal_tool_result()` is now called: base `messages_to_provider` passes `supports_multimodal_tool_result` via kwargs, Chat `ir_messages_to_p` skips packing when the target supports multimodal natively
2. **Naming consistency** — `SUPPORTS_MULTIMODAL_TOOL_RESULT` → `_SUPPORTS_MULTIMODAL_TOOL_RESULT` (underscore-prefixed like `_CONVERTER_TAG`, `_PASSTHROUGH_RESTORE_KEY`)
3. **Remove thin wrappers** — `_inject_packed_tool_content`, `_is_synthetic_tool_content_msg`, `_unpack_tool_content` removed from Chat `message_ops.py`, callers use shared helpers directly

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 2372 passed, 0 failed
- [x] Pre-commit hooks — all passed