### PR TITLE
fix(openai-chat): stop duplicating packed image bytes in tool messages

### DIFF
--- a/src/llm_rosetta/converters/base/helpers/multimodal_tool_patch.py
+++ b/src/llm_rosetta/converters/base/helpers/multimodal_tool_patch.py
@@ -47,7 +47,7 @@ def pack_multimodal_tool_result(
     multimodal_packs: dict[str, list[dict[str, Any]]],
     call_id: str,
     warnings: list[str],
-) -> None:
+) -> list[Any]:
     """Extract visual content blocks from a multimodal tool result.
 
     Converted blocks are stored in ``multimodal_packs[call_id]`` for
@@ -59,31 +59,45 @@ def pack_multimodal_tool_result(
         multimodal_packs: Accumulator mapping call_id → provider content blocks.
         call_id: The tool call ID.
         warnings: Warning accumulator.
+
+    Returns:
+        The residual result with successfully packed blocks removed. Callers
+        should serialize this instead of ``result`` so packed payloads (which
+        may be multi-megabyte base64 images) are not also emitted as inert
+        text in the tool message.
     """
     packed_parts: list[dict[str, Any]] = []
+    residual: list[Any] = []
 
     for block in result:
         if not isinstance(block, dict):
+            residual.append(block)
             continue
         block_type = block.get("type")
         if block_type == "text":
             packed_parts.append(content_ops.ir_text_to_p(block))
+            residual.append(block)
         elif block_type == "image":
             try:
                 packed_parts.append(content_ops.ir_image_to_p(block))
             except ValueError as e:
                 warnings.append(f"Skipped image in tool result packing: {e}")
+                residual.append(block)
         elif block_type == "file":
             warnings.append(
                 "File content not supported in tool result packing, skipped"
             )
+            residual.append(block)
         else:
             warnings.append(
                 f"Unsupported block type in tool result packing: {block_type}"
             )
+            residual.append(block)
 
     if packed_parts:
         multimodal_packs[call_id] = packed_parts
+
+    return residual
 
 
 def inject_packed_tool_content(

--- a/src/llm_rosetta/converters/openai_chat/message_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/message_ops.py
@@ -417,6 +417,11 @@ class OpenAIChatMessageOps(BaseMessageOps):
         multimodal extraction; text-only results go straight through
         ``tool_ops.ir_tool_result_to_p()``.
 
+        Blocks that were successfully packed into the synthetic user message
+        are dropped from the tool message body. Re-serializing them here would
+        emit the same bytes twice — and for base64 images that inert copy can
+        be megabytes the model cannot even read.
+
         Args:
             part: IR tool result part.
             multimodal_packs: Accumulator mapping call_id → provider content blocks.
@@ -428,10 +433,10 @@ class OpenAIChatMessageOps(BaseMessageOps):
         result = part.get("result", "")
         if not has_multimodal_content(result):
             return self.tool_ops.ir_tool_result_to_p(part)
-        pack_multimodal_tool_result(
+        residual = pack_multimodal_tool_result(
             result, self.content_ops, multimodal_packs, part["tool_call_id"], warnings
         )
-        return self.tool_ops.ir_tool_result_to_p(part)
+        return self.tool_ops.ir_tool_result_to_p({**part, "result": residual})
 
     # ==================== Provider → IR ====================
 

--- a/tests/converters/openai_chat/test_message_ops.py
+++ b/tests/converters/openai_chat/test_message_ops.py
@@ -738,7 +738,7 @@ class TestMultimodalToolResultPacking:
         assert result[2]["content"] == "plain text result"
 
     def test_image_only_packing(self):
-        """Image-only tool result → json.dumps in tool msg + synthetic user msg."""
+        """Image-only tool result → image lives only in the synthetic user msg."""
         tr = ToolResultPart(
             type="tool_result",
             tool_call_id="call_img",
@@ -752,11 +752,10 @@ class TestMultimodalToolResultPacking:
         roles = [m["role"] for m in result]
         assert roles == ["user", "assistant", "tool", "user"]
 
-        # Tool message has json.dumps fallback
+        # Packed image is stripped from the tool message, not re-serialized there
         import json
 
-        tool_content = json.loads(result[2]["content"])
-        assert tool_content[0]["type"] == "image"
+        assert json.loads(result[2]["content"]) == []
 
         # Synthetic user message has tagged image_url
         synthetic = result[3]
@@ -1036,6 +1035,67 @@ class TestMultimodalToolResultPacking:
         assert "text" in types
         # No file-related part type in synthetic
         assert "file" not in types
+
+    def test_packed_image_bytes_not_duplicated(self):
+        """Base64 image payload appears exactly once in the converted messages.
+
+        Regression for #480: the tool message used to carry a json.dumps copy
+        of the same base64 alongside the synthetic user message, doubling
+        payload size and tripping upstream request-size limits.
+        """
+        import json
+
+        b64 = "A" * 4096
+        data_url = f"data:image/png;base64,{b64}"
+        tr = ToolResultPart(
+            type="tool_result",
+            tool_call_id="call_big",
+            result=[
+                {"type": "text", "text": "rendered page"},
+                {
+                    "type": "image",
+                    "image_data": {"media_type": "image/png", "data": b64},
+                },
+            ],
+        )
+        ir_msgs = self._make_ir_conversation([tr])
+        result, _ = self.message_ops.ir_messages_to_p(ir_msgs)
+
+        assert json.dumps(result).count(b64) == 1
+
+        # The surviving copy is the real image block in the synthetic message
+        synthetic = result[-1]
+        assert synthetic["role"] == "user"
+        images = [p for p in synthetic["content"] if p.get("type") == "image_url"]
+        assert len(images) == 1
+        assert images[0]["image_url"]["url"] == data_url
+
+        # Text is still readable in the tool slot
+        assert json.loads(result[2]["content"]) == [
+            {"type": "text", "text": "rendered page"}
+        ]
+
+    def test_unpackable_image_stays_in_tool_message(self):
+        """An image that fails to pack is not dropped from the tool message.
+
+        Stripping only applies to blocks that actually made it into the
+        synthetic message; otherwise the content would be lost entirely.
+        """
+        import json
+
+        tr = ToolResultPart(
+            type="tool_result",
+            tool_call_id="call_bad",
+            result=[
+                {"type": "image", "detail": "auto"},  # no url and no data
+            ],
+        )
+        ir_msgs = self._make_ir_conversation([tr])
+        result, warnings = self.message_ops.ir_messages_to_p(ir_msgs)
+
+        assert any("Skipped image in tool result packing" in w for w in warnings)
+        tool_msg = [m for m in result if m["role"] == "tool"][0]
+        assert json.loads(tool_msg["content"]) == [{"type": "image", "detail": "auto"}]
 
     def test_has_multimodal_content_helper(self):
         """has_multimodal_content correctly detects multimodal vs text-only."""


### PR DESCRIPTION
Closes #480

## Summary

When targeting `openai_chat`, a tool result containing images was transmitted **twice**: once as a real `image_url` block in the injected synthetic user message, and once as inert base64 text via `json.dumps(result)` in the `role: "tool"` message body. For image-bearing tool results this exactly doubled the payload.

`pack_multimodal_tool_result` now returns the residual result with successfully packed blocks removed; the caller serializes that instead of the original. Blocks that fail to pack (e.g. an image with neither URL nor data, or an unsupported type) are retained so nothing is silently dropped.

## Measured effect

Converting an `openai_responses` request with a single ~300KB PNG in a tool result:

| | before | after |
|---|---|---|
| output size | 800,654 B (2.00x) | 400,553 B (1.00x) |
| base64 occurrences | 2 | 1 |
| `role: "tool"` bytes | 400,164 | 46 |

## Why this matters

Reported downstream via argo-proxy 3.2.3 (pins `llm-rosetta>=0.7.1`): Codex CLI crashes with `Stream disconnected before completion: stream closed before response.completed` when returning PDF pages rendered as PNG through tool results, with the proxy logging a message-size-exceeded error.

argo-proxy's own image compression guards cannot mitigate this — `_collect_openai_image_urls_from_message` only scans messages whose `content` is a list, and the duplicate lived in a `role: "tool"` message with **string** content. So it was invisible to compression while still counting against the upstream size limit.

The duplicated copy was also useless on its own terms: a model cannot read base64 nested inside a JSON string, so those bytes were pure token and bandwidth waste even when they fit.

## Behavior notes

- Text blocks stay in both places by design — they are small, and keeping them means the tool slot still reads sensibly on its own.
- The reverse path is unaffected: `_p_tool_to_ir` already reconstructs multimodal results exclusively from the synthetic message and ignores the tool message body.
- Only fires when `openai_chat` is the target format; `anthropic` / `openai_responses` routes were never affected.

## Testing

- `make lint` clean, full suite green (2374 passed, 4 skipped).
- Updated `test_image_only_packing`, which asserted the old duplicating behavior.
- Added `test_packed_image_bytes_not_duplicated` (base64 appears exactly once) and `test_unpackable_image_stays_in_tool_message` (failed packs are not lost).

---

Disclosure: AI was used to help investigate and draft this change.