### PR TITLE
fix(gateway): emit terminal event when upstream stream aborts

### DIFF
--- a/src/llm_rosetta/converters/base/context.py
+++ b/src/llm_rosetta/converters/base/context.py
@@ -275,6 +275,33 @@ class StreamContext(ConversionContext):
         """Whether the stream has been ended."""
         return self._ended
 
+    @property
+    def next_sequence_number(self) -> int | None:
+        """The sequence number a synthesized event should carry, if any.
+
+        Only formats that number their stream events (OpenAI Responses)
+        override this; everywhere else there is no sequence to continue.
+        """
+        return None
+
+    @property
+    def outbound_response_id(self) -> str:
+        """The response ID as the client sees it, prefix included.
+
+        ``response_id`` holds the bare stem: the source prefix is stripped
+        on ingest and re-added by the converter on the way out. Anything
+        synthesizing an event outside the converter must use this instead,
+        or it will emit a second, differently-shaped ID for the same
+        response.
+        """
+        stem = self.response_id
+        if not stem:
+            return ""
+        prefix = self.options.get("response_id_prefix", "")
+        if prefix and not stem.startswith(prefix):
+            return f"{prefix}{stem}"
+        return stem
+
     # Buffer convenience methods
 
     def buffer_usage(self, usage: Mapping[str, Any]) -> None:

--- a/src/llm_rosetta/converters/openai_responses/stream_context.py
+++ b/src/llm_rosetta/converters/openai_responses/stream_context.py
@@ -59,6 +59,16 @@ class OpenAIResponsesStreamContext(StreamContext):
         self._output_item_counter += 1
         return idx
 
+    @property
+    def next_sequence_number(self) -> int:
+        """The sequence number the next emitted event should carry.
+
+        Responses numbers its stream events monotonically, so a
+        synthesized terminal event has to continue the run the client
+        has already consumed rather than restart it.
+        """
+        return self._sequence_number + 1
+
     @classmethod
     def from_base(cls, base: StreamContext) -> OpenAIResponsesStreamContext:
         """Create from a base StreamContext, preserving existing state.

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -14,6 +14,7 @@ Downstream SSE formatting lives in :mod:`transport.sse_format`.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -41,7 +42,11 @@ from .transport import (
     UpstreamConnectionError,
     UpstreamTransport,
 )
-from .transport.sse_format import SSE_FORMATTERS, format_sse_done
+from .transport.sse_format import (
+    SSE_FORMATTERS,
+    build_stream_error_events,
+    format_sse_done,
+)
 
 logger = get_logger()
 
@@ -429,6 +434,52 @@ async def handle_non_streaming(
     return JSONResponse(source_response), profile
 
 
+def _terminal_error_sse(
+    source_provider: ProviderType,
+    processor: Any,
+    format_sse: Any,
+    exc: BaseException,
+) -> list[str]:
+    """Build SSE text announcing that the upstream stream died mid-flight.
+
+    Without this the socket simply closes and clients that wait for a
+    terminal event (Codex waits for ``response.completed``) report a bare
+    "stream closed before response.completed" with no upstream reason.
+
+    Never raises: a failure to synthesize the notice must not replace the
+    original exception, which carries the real diagnosis.
+
+    Returns:
+        SSE strings to yield, or an empty list if no notice applies.
+    """
+    # Unreachable while the caller catches Exception, since CancelledError
+    # derives from BaseException. Kept so widening that clause later cannot
+    # silently start writing to a client that has already hung up.
+    if isinstance(exc, asyncio.CancelledError):
+        return []
+
+    try:
+        ctx = getattr(processor, "source_context", None)
+        if ctx is not None and ctx.is_ended:
+            # Stream already reached its terminal event — the failure
+            # happened during teardown, so a second one would corrupt it.
+            return []
+
+        events = build_stream_error_events(
+            source_provider,
+            str(exc) or exc.__class__.__name__,
+            response_id=getattr(ctx, "outbound_response_id", "") or "",
+            sequence_number=getattr(ctx, "next_sequence_number", None),
+        )
+        out = [format_sse(event) for event in events]
+        if source_provider in ("openai_chat", "openai_responses", "open_responses"):
+            out.append(format_sse_done())
+        return out
+    except Exception:
+        logger.debug("Failed to build terminal error event", exc_info=True)
+        return []
+
+
 async def _stream_event_generator(
     *,
     source_provider: ProviderType,
@@ -479,6 +530,10 @@ async def _stream_event_generator(
         )
     except Exception as exc:
         stream_error = str(exc)
+        for sse_text in _terminal_error_sse(
+            source_provider, processor, format_sse, exc
+        ):
+            yield sse_text
         raise
     finally:
         # Write back stream profile to request log entry

--- a/src/llm_rosetta/gateway/transport/sse_format.py
+++ b/src/llm_rosetta/gateway/transport/sse_format.py
@@ -50,3 +50,59 @@ SSE_FORMATTERS: dict[str, Any] = {
     "anthropic": _format_sse_anthropic,
     "google": _format_sse_google,
 }
+
+
+# ---------------------------------------------------------------------------
+# Terminal error events
+# ---------------------------------------------------------------------------
+
+_TERMINAL_ERROR_MESSAGE = "Upstream stream ended before completion: {reason}"
+
+
+def build_stream_error_events(
+    source_provider: str,
+    reason: str,
+    *,
+    response_id: str = "",
+    sequence_number: int | None = None,
+) -> list[dict[str, Any]]:
+    """Build terminal events announcing that a stream failed mid-flight.
+
+    Clients that wait for a format-specific terminal event (Codex waits for
+    ``response.completed``) otherwise see only an abrupt socket close, which
+    is indistinguishable from a network fault and hides the upstream reason.
+
+    Args:
+        source_provider: Client-facing format.
+        reason: Short description of the upstream failure.
+        response_id: Response ID already advertised to the client, if any.
+        sequence_number: Next sequence number for Responses events.
+
+    Returns:
+        Event dicts to format and yield. Empty for formats with no terminal
+        event convention.
+    """
+    message = _TERMINAL_ERROR_MESSAGE.format(reason=reason)
+
+    if source_provider in ("openai_responses", "open_responses"):
+        response: dict[str, Any] = {
+            "id": response_id,
+            "object": "response",
+            "status": "failed",
+            "error": {"code": "server_error", "message": message},
+        }
+        event: dict[str, Any] = {"type": "response.failed", "response": response}
+        if sequence_number is not None:
+            event["sequence_number"] = sequence_number
+        return [event]
+
+    if source_provider == "openai_chat":
+        return [{"error": {"message": message, "type": "server_error", "code": None}}]
+
+    if source_provider == "anthropic":
+        return [{"type": "error", "error": {"type": "api_error", "message": message}}]
+
+    if source_provider == "google":
+        return [{"error": {"code": 500, "message": message, "status": "INTERNAL"}}]
+
+    return []

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -574,6 +574,16 @@ class StreamProcessor:
         self._pre_ir_transforms = pre_ir_transforms
         self._on_ir_event = on_ir_event
 
+    @property
+    def source_context(self) -> Any:
+        """The IR→source StreamContext.
+
+        Exposed so transports can inspect stream state (e.g. whether the
+        stream already ended, the assigned response ID) when synthesizing
+        a terminal event after an upstream failure.
+        """
+        return self._to_ctx
+
     def process_chunk(self, chunk: dict[str, Any]) -> list[dict[str, Any]]:
         """Convert one upstream chunk to source-format events.
 

--- a/tests/gateway/test_stream_abort.py
+++ b/tests/gateway/test_stream_abort.py
@@ -1,0 +1,373 @@
+"""Tests for terminal event emission when an upstream stream dies mid-flight.
+
+Regression coverage for #481: the generator used to re-raise without telling
+the downstream client anything, so clients waiting on a terminal event saw
+only an abrupt socket close.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, cast
+
+import pytest
+
+from llm_rosetta.auto_detect import ProviderType
+from llm_rosetta.gateway.proxy import _stream_event_generator
+from llm_rosetta.gateway.transport.sse_format import (
+    SSE_FORMATTERS,
+    build_stream_error_events,
+    format_sse_done,
+)
+from llm_rosetta.pipeline import ConversionPipeline
+
+UPSTREAM_MESSAGE = "connection reset by peer"
+
+
+class _AbortingStream:
+    """Yields some chunks, then fails the way a dropped upstream would."""
+
+    def __init__(self, chunks: list[dict[str, Any]], exc: BaseException):
+        self._chunks = list(chunks)
+        self._exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc: object):
+        pass
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> dict[str, Any]:
+        if self._chunks:
+            return self._chunks.pop(0)
+        raise self._exc
+
+
+class _FakeContext:
+    """Mirrors the real StreamContext surface.
+
+    ``is_ended``, ``next_sequence_number`` and ``outbound_response_id``
+    are properties on the real class; defining them as methods here would
+    let a call-vs-attribute mismatch in the production code pass unnoticed.
+    ``response_id`` holds the bare stem, as it does in production.
+    """
+
+    def __init__(self, *, ended: bool = False, response_id: str = "abc"):
+        self._ended = ended
+        self.response_id = response_id
+        self.options = {"response_id_prefix": "resp_"}
+        self._sequence_number = 7
+
+    @property
+    def is_ended(self) -> bool:
+        return self._ended
+
+    @property
+    def next_sequence_number(self) -> int:
+        return self._sequence_number + 1
+
+    @property
+    def outbound_response_id(self) -> str:
+        prefix = self.options.get("response_id_prefix", "")
+        stem = self.response_id
+        if prefix and stem and not stem.startswith(prefix):
+            return f"{prefix}{stem}"
+        return stem
+
+
+class _FakeProcessor:
+    def __init__(self, ctx: Any = None):
+        self._ctx = ctx if ctx is not None else _FakeContext()
+
+    @property
+    def source_context(self) -> Any:
+        return self._ctx
+
+    def process_chunk(self, chunk: dict[str, Any]) -> list[dict[str, Any]]:
+        return [chunk]
+
+
+async def _drain(
+    provider: ProviderType,
+    *,
+    exc: BaseException,
+    ctx: Any = None,
+) -> tuple[list[str], BaseException | None]:
+    """Run the generator to failure, returning emitted SSE and the exception."""
+    gen = _stream_event_generator(
+        source_provider=provider,
+        stream=_AbortingStream([{"type": "response.output_text.delta"}], exc),
+        processor=_FakeProcessor(ctx),
+        model="test-model",
+        format_sse=SSE_FORMATTERS[provider],
+    )
+    events: list[str] = []
+    raised: BaseException | None = None
+    try:
+        async for event in gen:
+            events.append(event)
+    except BaseException as e:  # noqa: BLE001 - we assert on what propagated
+        raised = e
+    return events, raised
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ["openai_chat", "openai_responses", "open_responses", "anthropic", "google"],
+)
+def test_terminal_event_emitted_on_abort(provider: str) -> None:
+    """Every format gets a terminal notice carrying the upstream reason."""
+    events, raised = asyncio.run(
+        _drain(cast(ProviderType, provider), exc=ConnectionError(UPSTREAM_MESSAGE))
+    )
+
+    assert isinstance(raised, ConnectionError)
+    joined = "".join(events)
+    assert UPSTREAM_MESSAGE in joined
+    assert "Upstream stream ended before completion" in joined
+
+
+def test_responses_emits_response_failed() -> None:
+    """Responses clients get `response.failed`, the event Codex waits on."""
+    events, _ = asyncio.run(
+        _drain(
+            cast(ProviderType, "openai_responses"),
+            exc=ConnectionError(UPSTREAM_MESSAGE),
+        )
+    )
+
+    failed = [e for e in events if e.startswith("event: response.failed")]
+    assert len(failed) == 1
+
+    payload = json.loads(failed[0].split("data: ", 1)[1].strip())
+    assert payload["response"]["status"] == "failed"
+    assert payload["response"]["id"] == "resp_abc"
+    assert UPSTREAM_MESSAGE in payload["response"]["error"]["message"]
+    # Continues the sequence the client has already been consuming
+    assert payload["sequence_number"] == 8
+
+    assert events[-1] == format_sse_done()
+
+
+def test_no_terminal_event_when_stream_already_ended() -> None:
+    """A failure during teardown must not append a second terminal event."""
+    events, raised = asyncio.run(
+        _drain(
+            cast(ProviderType, "openai_responses"),
+            exc=ConnectionError("late failure"),
+            ctx=_FakeContext(ended=True),
+        )
+    )
+
+    assert isinstance(raised, ConnectionError)
+    assert not any("response.failed" in e for e in events)
+
+
+def test_cancellation_emits_nothing() -> None:
+    """Client disconnects leave nobody to notify, and must stay cancellations."""
+    events, raised = asyncio.run(
+        _drain(
+            cast(ProviderType, "openai_responses"),
+            exc=asyncio.CancelledError(),
+        )
+    )
+
+    assert isinstance(raised, asyncio.CancelledError)
+    assert not any("response.failed" in e for e in events)
+
+
+def test_original_exception_survives_builder_failure() -> None:
+    """A broken context must not replace the real upstream error."""
+
+    class _ExplodingContext:
+        @property
+        def is_ended(self) -> bool:
+            raise RuntimeError("context is broken")
+
+    events, raised = asyncio.run(
+        _drain(
+            cast(ProviderType, "openai_responses"),
+            exc=ConnectionError(UPSTREAM_MESSAGE),
+            ctx=_ExplodingContext(),
+        )
+    )
+
+    assert isinstance(raised, ConnectionError)
+    assert str(raised) == UPSTREAM_MESSAGE
+    assert not any("response.failed" in e for e in events)
+
+
+def test_builder_returns_empty_for_unknown_format() -> None:
+    """Unknown source formats have no terminal convention to honour."""
+    assert build_stream_error_events("mystery", "boom") == []
+
+
+# ---------------------------------------------------------------------------
+# Real pipeline — no test doubles
+# ---------------------------------------------------------------------------
+
+
+def _real_processor(source: str, target: str) -> Any:
+    pipeline = ConversionPipeline(source, target)
+    pipeline.convert_request(
+        {
+            "model": "test-model",
+            "input": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        }
+        if source in ("openai_responses", "open_responses")
+        else {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        }
+    )
+    return pipeline.create_stream_processor()
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ["openai_chat", "openai_responses", "anthropic", "google"],
+)
+def test_terminal_event_with_real_pipeline_context(provider: str) -> None:
+    """The real StreamContext must satisfy what the abort path expects.
+
+    The fakes above can drift from the production interface — `is_ended`
+    and `next_sequence_number` are properties, and calling one as a method
+    would raise inside the swallow-all guard, silently emitting nothing.
+    Only a real context proves the path actually fires.
+    """
+    processor = _real_processor(provider, provider)
+    gen = _stream_event_generator(
+        source_provider=cast(ProviderType, provider),
+        stream=_AbortingStream([], ConnectionError(UPSTREAM_MESSAGE)),
+        processor=processor,
+        model="test-model",
+        format_sse=SSE_FORMATTERS[provider],
+    )
+
+    events: list[str] = []
+    raised: BaseException | None = None
+
+    async def run() -> None:
+        nonlocal raised
+        try:
+            async for event in gen:
+                events.append(event)
+        except BaseException as e:  # noqa: BLE001
+            raised = e
+
+    asyncio.run(run())
+
+    assert isinstance(raised, ConnectionError)
+    assert events, "real context produced no terminal event"
+    assert UPSTREAM_MESSAGE in "".join(events)
+
+
+def test_real_responses_context_supplies_sequence_number() -> None:
+    """`next_sequence_number` resolves on the real Responses context."""
+    processor = _real_processor("openai_responses", "openai_responses")
+    gen = _stream_event_generator(
+        source_provider=cast(ProviderType, "openai_responses"),
+        stream=_AbortingStream([], ConnectionError(UPSTREAM_MESSAGE)),
+        processor=processor,
+        model="test-model",
+        format_sse=SSE_FORMATTERS["openai_responses"],
+    )
+
+    events: list[str] = []
+
+    async def run() -> None:
+        try:
+            async for event in gen:
+                events.append(event)
+        except ConnectionError:
+            pass
+
+    asyncio.run(run())
+
+    failed = [e for e in events if e.startswith("event: response.failed")]
+    assert len(failed) == 1
+    payload = json.loads(failed[0].split("data: ", 1)[1].strip())
+    assert payload["response"]["status"] == "failed"
+    assert isinstance(payload["sequence_number"], int)
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ["openai_chat", "openai_responses", "anthropic", "google"],
+)
+def test_base_context_exposes_abort_path_attributes(provider: str) -> None:
+    """Guards against a converter context drifting from the expected surface.
+
+    `_terminal_error_sse` reads these through a swallow-all try, so a
+    missing or renamed attribute degrades to "emit nothing" rather than
+    failing loudly. Assert the shape here instead.
+    """
+    from llm_rosetta import get_converter_for_provider
+
+    ctx = get_converter_for_provider(provider).create_stream_context()
+
+    assert isinstance(ctx.is_ended, bool)
+    seq = ctx.next_sequence_number
+    assert seq is None or isinstance(seq, int)
+    assert isinstance(ctx.outbound_response_id, str)
+
+    ctx.mark_ended()
+    assert ctx.is_ended is True
+
+    # The stem is stored bare; the client-facing value re-applies the prefix.
+    ctx.response_id = "xyz"
+    ctx.options["response_id_prefix"] = "pfx_"
+    assert ctx.outbound_response_id == "pfx_xyz"
+
+
+def test_terminal_event_id_matches_the_stream_it_ends() -> None:
+    """The synthesized event must carry the same ID as the events before it.
+
+    ``response_id`` on the context is the bare stem — the source prefix is
+    stripped on ingest and re-added by the converter on output. Reading it
+    directly emitted ``real1`` while every earlier event in the same stream
+    said ``resp_real1``, i.e. two IDs for one response.
+    """
+    upstream_created = {
+        "type": "response.created",
+        "response": {
+            "id": "resp_real1",
+            "object": "response",
+            "status": "in_progress",
+            "model": "m",
+            "output": [],
+        },
+    }
+
+    processor = _real_processor("openai_responses", "openai_responses")
+    gen = _stream_event_generator(
+        source_provider=cast(ProviderType, "openai_responses"),
+        stream=_AbortingStream([upstream_created], ConnectionError(UPSTREAM_MESSAGE)),
+        processor=processor,
+        model="test-model",
+        format_sse=SSE_FORMATTERS["openai_responses"],
+    )
+
+    events: list[str] = []
+
+    async def run() -> None:
+        try:
+            async for event in gen:
+                events.append(event)
+        except ConnectionError:
+            pass
+
+    asyncio.run(run())
+
+    ids = {
+        json.loads(e.split("data: ", 1)[1].strip())["response"]["id"]
+        for e in events
+        if "data: " in e and '"response"' in e
+    }
+    assert ids == {"resp_real1"}, f"inconsistent response ids across stream: {ids}"


### PR DESCRIPTION
Closes #481

## Summary

When the upstream connection dropped mid-stream, `_stream_event_generator` re-raised without yielding anything to the downstream client. The SSE socket simply closed — and because the chunked terminator is written inside the same `try`, even that was skipped. Clients waiting on a terminal event had no way to distinguish an upstream failure from a network fault, and no visibility into the cause.

The generator now emits a format-appropriate terminal event before re-raising:

| source format | terminal event |
|---|---|
| `openai_responses` / `open_responses` | `response.failed` + `[DONE]` |
| `openai_chat` | error chunk + `[DONE]` |
| `anthropic` | `event: error` |
| `google` | error object |

The message embeds the upstream reason, e.g. `Upstream stream ended before completion: connection reset by peer`.

## Guards

Three cases where emitting would be wrong, all covered by tests:

- **Stream already ended** — if the context is marked ended, the failure happened during teardown; appending a second terminal event would corrupt an otherwise valid stream.
- **`CancelledError`** — the client disconnected, so there is nobody to notify, and the cancellation must propagate unchanged.
- **Builder failure** — any exception while synthesizing the notice is swallowed and logged at debug. The original exception carries the real diagnosis and must not be replaced.

## Implementation notes

- `build_stream_error_events` lives in `transport/sse_format.py`, alongside the existing per-format SSE dispatch.
- `StreamProcessor` gains a `source_context` property so the transport can read `is_ended()`, `response_id`, and the sequence counter without reaching into privates from another module.
- Responses events continue the client's existing `sequence_number` rather than restarting, so a client tracking ordering does not see a gap.

## Not changed

Pre-stream errors (upstream 4xx/5xx before SSE begins) were already handled correctly — `handle_streaming` checks `stream.is_error` and returns a proper HTTP error response. Only the mid-stream path was affected.

## Testing

- `make lint` clean, full suite green (2384 passed, 4 skipped).
- New `tests/gateway/test_stream_abort.py` (10 tests): terminal event across all five source formats, `response.failed` payload shape and sequence continuity, the already-ended guard, the cancellation guard, original-exception survival when the context is broken, and the unknown-format fallback.

---

Disclosure: AI was used to help investigate and draft this change.