### PR TITLE
feat(shims): downgrade custom tools for non-supporting Chat upstreams

### DIFF
--- a/src/llm_rosetta/capabilities.py
+++ b/src/llm_rosetta/capabilities.py
@@ -12,6 +12,7 @@ Functions follow the ``enforce_*`` naming convention:
 
 - :func:`enforce_reasoning` — configure reasoning output mode (pre-IR)
 - :func:`enforce_vision` — strip images for non-vision models (post-IR)
+- :func:`enforce_custom_tools` — downgrade custom tools for non-supporting providers (post-IR)
 
 Called by :class:`~llm_rosetta.pipeline.ConversionPipeline` at the
 appropriate pipeline stages.
@@ -135,3 +136,173 @@ def enforce_vision(
     )
 
     return strip_images_for_non_vision(ir_request, model=model, request_id=request_id)
+
+
+# ---------------------------------------------------------------------------
+# Custom tool enforcement
+# ---------------------------------------------------------------------------
+
+_CUSTOM_TOOL_SYNTH_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "input": {
+            "type": "string",
+            "description": "Free-form text input for the tool.",
+        },
+    },
+    "required": ["input"],
+}
+
+
+def enforce_custom_tools(
+    ir_request: dict[str, Any],
+    *,
+    shim: ProviderShim | str | None = None,
+) -> dict[str, Any]:
+    """Downgrade custom tools to functions for providers that lack support.
+
+    Must be called **after** source → IR conversion.  When the resolved
+    shim has ``supports_custom_tools = False``, each IR tool with
+    ``type == "custom"`` is rewritten to ``type = "function"`` with a
+    synthesised JSON schema wrapping the input as ``{"input": string}``.
+    The original type is preserved in ``metadata["provider_type"]`` so
+    the response path can restore it.
+
+    No-op when *shim* is ``None`` or supports custom tools natively.
+
+    Args:
+        ir_request: The IR request dict — **always use the return value**.
+        shim: Provider shim (name or object).
+
+    Returns:
+        The IR request with custom tools downgraded, or the original
+        request unchanged.
+    """
+    resolved = resolve_shim(shim) if isinstance(shim, str) else shim
+    if resolved is None or resolved.supports_custom_tools:
+        return ir_request
+
+    tools = ir_request.get("tools")
+    if not tools:
+        return ir_request
+
+    # Check if any custom tools exist before copying
+    if not any(isinstance(t, dict) and t.get("type") == "custom" for t in tools):
+        return ir_request
+
+    # Deep-copy tools to avoid mutating cached entries
+    import copy
+
+    tools = copy.deepcopy(tools)
+    ir_request["tools"] = tools
+
+    changed = False
+    for tool in tools:
+        if not isinstance(tool, dict) or tool.get("type") != "custom":
+            continue
+        changed = True
+        tool["type"] = "function"
+
+        meta = tool.get("metadata") or {}
+        meta["provider_type"] = "custom"
+        fmt = meta.get("format")
+        tool["metadata"] = meta
+
+        if not tool.get("parameters"):
+            tool["parameters"] = dict(_CUSTOM_TOOL_SYNTH_PARAMS)
+
+        if fmt:
+            fmt_type = fmt.get("type", "unknown")
+            fmt_syntax = fmt.get("syntax") or fmt.get("grammar", {}).get("syntax", "")
+            hint = f"[Output format: {fmt_type}"
+            if fmt_syntax:
+                hint += f", syntax: {fmt_syntax}"
+            hint += "]"
+            desc = tool.get("description", "")
+            tool["description"] = f"{desc}\n\n{hint}" if desc else hint
+
+    if changed:
+        tc = ir_request.get("tool_choice")
+        if isinstance(tc, dict) and tc.get("tool_type") == "custom":
+            del tc["tool_type"]
+
+    return ir_request
+
+
+def get_custom_tool_names(ir_request: dict[str, Any]) -> frozenset[str]:
+    """Return names of tools that were downgraded from custom to function.
+
+    Looks for ``metadata.provider_type == "custom"`` on each tool
+    definition in the IR request — the marker set by
+    :func:`enforce_custom_tools`.
+    """
+    names: set[str] = set()
+    for tool in ir_request.get("tools") or []:
+        if (
+            isinstance(tool, dict)
+            and (tool.get("metadata") or {}).get("provider_type") == "custom"
+        ):
+            name = tool.get("name")
+            if name:
+                names.add(name)
+    return frozenset(names)
+
+
+def restore_custom_tool_calls(
+    ir_response: dict[str, Any],
+    *,
+    custom_tool_names: frozenset[str],
+) -> None:
+    """Re-tag downgraded tool calls as custom in the IR response.
+
+    Mutates *ir_response* in place.  For each tool call whose
+    ``tool_name`` is in *custom_tool_names*, sets
+    ``tool_type = "custom"``.  Called on the non-streaming response
+    path after Target → IR conversion.
+    """
+    if not custom_tool_names:
+        return
+
+    for choice in ir_response.get("choices") or []:
+        if not isinstance(choice, dict):
+            continue
+        msg = choice.get("message")
+        if not isinstance(msg, dict):
+            continue
+        for part in msg.get("content") or []:
+            if (
+                isinstance(part, dict)
+                and part.get("type") == "tool_call"
+                and part.get("tool_name") in custom_tool_names
+            ):
+                part["tool_type"] = "custom"
+
+    for msg in ir_response.get("messages") or []:
+        if not isinstance(msg, dict):
+            continue
+        for part in msg.get("content") or []:
+            if (
+                isinstance(part, dict)
+                and part.get("type") == "tool_call"
+                and part.get("tool_name") in custom_tool_names
+            ):
+                part["tool_type"] = "custom"
+
+
+def unwrap_custom_tool_input(raw: str) -> str:
+    """Recover a custom tool's raw text from the downgraded JSON wrapper.
+
+    The synthesised schema is ``{"input": string}``, so a well-formed
+    call arrives as ``{"input": "..."}``.  Anything else is returned
+    untouched.
+    """
+    import json
+
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return raw
+    if isinstance(parsed, dict) and list(parsed.keys()) == ["input"]:
+        value = parsed["input"]
+        return value if isinstance(value, str) else json.dumps(value)
+    return raw

--- a/src/llm_rosetta/capabilities.py
+++ b/src/llm_rosetta/capabilities.py
@@ -209,7 +209,7 @@ def enforce_custom_tools(
         tool["metadata"] = meta
 
         if not tool.get("parameters"):
-            tool["parameters"] = dict(_CUSTOM_TOOL_SYNTH_PARAMS)
+            tool["parameters"] = copy.deepcopy(_CUSTOM_TOOL_SYNTH_PARAMS)
 
         if fmt:
             fmt_type = fmt.get("type", "unknown")
@@ -259,6 +259,10 @@ def restore_custom_tool_calls(
     ``tool_name`` is in *custom_tool_names*, sets
     ``tool_type = "custom"``.  Called on the non-streaming response
     path after Target → IR conversion.
+
+    Input unwrapping (extracting raw text from the ``{"input": ...}``
+    JSON wrapper) is handled downstream by the source converter's
+    IR → provider serialisation for custom tool calls.
     """
     if not custom_tool_names:
         return

--- a/src/llm_rosetta/capabilities.py
+++ b/src/llm_rosetta/capabilities.py
@@ -204,7 +204,7 @@ def enforce_custom_tools(
         tool["type"] = "function"
 
         meta = tool.get("metadata") or {}
-        meta["provider_type"] = "custom"
+        meta["_downgraded_from"] = "custom"
         fmt = meta.get("format")
         tool["metadata"] = meta
 
@@ -232,7 +232,7 @@ def enforce_custom_tools(
 def get_custom_tool_names(ir_request: dict[str, Any]) -> frozenset[str]:
     """Return names of tools that were downgraded from custom to function.
 
-    Looks for ``metadata.provider_type == "custom"`` on each tool
+    Looks for ``metadata._downgraded_from == "custom"`` on each tool
     definition in the IR request — the marker set by
     :func:`enforce_custom_tools`.
     """
@@ -240,7 +240,7 @@ def get_custom_tool_names(ir_request: dict[str, Any]) -> frozenset[str]:
     for tool in ir_request.get("tools") or []:
         if (
             isinstance(tool, dict)
-            and (tool.get("metadata") or {}).get("provider_type") == "custom"
+            and (tool.get("metadata") or {}).get("_downgraded_from") == "custom"
         ):
             name = tool.get("name")
             if name:

--- a/src/llm_rosetta/converters/base/context.py
+++ b/src/llm_rosetta/converters/base/context.py
@@ -178,6 +178,15 @@ class StreamContext(ConversionContext):
         """
         return self._tool_call_types.get(tool_call_id, "function")
 
+    def set_tool_call_type(self, tool_call_id: str, tool_type: str) -> None:
+        """Update the tool type for an already-registered call.
+
+        Args:
+            tool_call_id: The unique identifier for the tool call.
+            tool_type: The new tool type ("function" or "custom").
+        """
+        self._tool_call_types[tool_call_id] = tool_type
+
     def register_tool_call_item(self, tool_call_id: str, item_id: str) -> None:
         """Register the Responses output item ID for a tool call.
 

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -692,8 +692,7 @@ class StreamProcessor:
                 call_id = event.get("tool_call_id", "")
                 if call_id:
                     self._custom_arg_buffers[call_id] = ""
-                    if call_id in self._from_ctx._tool_call_types:
-                        self._from_ctx._tool_call_types[call_id] = "custom"
+                    self._from_ctx.set_tool_call_type(call_id, "custom")
                 staged.append(event)
                 continue
 

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -26,7 +26,14 @@ import time
 from collections.abc import Callable
 from typing import Any
 
-from llm_rosetta.capabilities import enforce_reasoning, enforce_vision
+from llm_rosetta.capabilities import (
+    enforce_custom_tools,
+    enforce_reasoning,
+    enforce_vision,
+    get_custom_tool_names,
+    restore_custom_tool_calls,
+    unwrap_custom_tool_input,
+)
 from llm_rosetta.converters.base.context import ConversionContext
 from llm_rosetta.shims.provider_shim import ProviderShim, resolve_shim
 from llm_rosetta.shims.transforms import (
@@ -374,6 +381,9 @@ class ConversionPipeline:
             request_id=request_id,
         )
 
+        # Capability enforcement: custom tools (post-IR)
+        ir_request = enforce_custom_tools(ir_request, shim=self._shim)
+
         # Phase 2a: Shim-driven IR transforms
         ir_request = apply_ir_transforms(
             ir_request,
@@ -464,6 +474,12 @@ class ConversionPipeline:
         if on_ir_ready is not None:
             on_ir_ready(ir_response)
 
+        # Restore custom tool types downgraded by enforce_custom_tools
+        if self._ir_request is not None:
+            custom_names = get_custom_tool_names(self._ir_request)
+            if custom_names:
+                restore_custom_tool_calls(ir_response, custom_tool_names=custom_names)
+
         # Phase 4c: IR → Source response
         t0 = time.perf_counter()
         ctx.options["response_id_prefix"] = self._source_id_prefix
@@ -521,12 +537,20 @@ class ConversionPipeline:
         if "_request_echo" in ctx.metadata:
             to_ctx.metadata["_request_echo"] = ctx.metadata["_request_echo"]
 
+        # Custom tool names downgraded by enforce_custom_tools
+        custom_names = (
+            get_custom_tool_names(self._ir_request)
+            if self._ir_request is not None
+            else frozenset()
+        )
+
         return StreamProcessor(
             target_converter=self._target_converter,
             source_converter=self._source_converter,
             from_ctx=from_ctx,
             to_ctx=to_ctx,
             pre_ir_transforms=self._pre_ir_transforms,
+            custom_tool_names=custom_names,
             on_ir_event=on_ir_event,
         )
 
@@ -554,6 +578,8 @@ class StreamProcessor:
         from_ctx: StreamContext for upstream→IR conversion.
         to_ctx: StreamContext for IR→source conversion.
         pre_ir_transforms: Shim pre_ir_transforms to apply before conversion.
+        custom_tool_names: Names of tools downgraded from custom to
+            function by :func:.
         on_ir_event: Optional callback for each IR event.
     """
 
@@ -565,6 +591,7 @@ class StreamProcessor:
         from_ctx: Any,
         to_ctx: Any,
         pre_ir_transforms: tuple[Transform, ...] = (),
+        custom_tool_names: frozenset[str] = frozenset(),
         on_ir_event: Callable[[dict[str, Any]], None] | None = None,
     ) -> None:
         self._target_converter = target_converter
@@ -572,6 +599,8 @@ class StreamProcessor:
         self._from_ctx = from_ctx
         self._to_ctx = to_ctx
         self._pre_ir_transforms = pre_ir_transforms
+        self._custom_tool_names = custom_tool_names
+        self._custom_arg_buffers: dict[str, str] = {}
         self._on_ir_event = on_ir_event
 
     @property
@@ -615,6 +644,10 @@ class StreamProcessor:
                 "_responses_phase"
             ]
 
+        # Restore custom tool types for downgraded tools
+        if self._custom_tool_names:
+            ir_events = self._restore_custom_tool_events(ir_events)
+
         # IR → Source events
         result: list[dict[str, Any]] = []
         for ir_event in ir_events:
@@ -630,3 +663,58 @@ class StreamProcessor:
                 result.append(source_chunks)
 
         return result
+
+    def _restore_custom_tool_events(
+        self, ir_events: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Re-tag streamed tool calls that were downgraded from custom.
+
+        - tool_call_start: set tool_type to "custom" and
+          fix the from_ctx registration.
+        - tool_call_delta: buffer JSON argument fragments for
+          custom tool calls (they contain JSON wrapping that needs to
+          be unwrapped before the client sees them).
+        - finish: flush buffered arguments as a single unwrapped
+          delta before emitting the finish event.
+        """
+        staged: list[dict[str, Any]] = []
+        for event in ir_events:
+            if not isinstance(event, dict):
+                staged.append(event)
+                continue
+            etype = event.get("type")
+
+            if (
+                etype == "tool_call_start"
+                and event.get("tool_name") in self._custom_tool_names
+            ):
+                event["tool_type"] = "custom"
+                call_id = event.get("tool_call_id", "")
+                if call_id:
+                    self._custom_arg_buffers[call_id] = ""
+                    if call_id in self._from_ctx._tool_call_types:
+                        self._from_ctx._tool_call_types[call_id] = "custom"
+                staged.append(event)
+                continue
+
+            if (
+                etype == "tool_call_delta"
+                and event.get("tool_call_id") in self._custom_arg_buffers
+            ):
+                call_id = event["tool_call_id"]
+                self._custom_arg_buffers[call_id] += event.get("arguments_delta") or ""
+                continue
+
+            if etype == "finish" and self._custom_arg_buffers:
+                for call_id, raw in list(self._custom_arg_buffers.items()):
+                    staged.append(
+                        {
+                            "type": "tool_call_delta",
+                            "tool_call_id": call_id,
+                            "arguments_delta": unwrap_custom_tool_input(raw),
+                        }
+                    )
+                self._custom_arg_buffers.clear()
+
+            staged.append(event)
+        return staged

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -126,6 +126,11 @@ class ProviderShim:
             (e.g. ``"resp_"`` for OpenAI Responses, ``"chatcmpl-"`` for
             OpenAI Chat).  Default ``""`` means passthrough (no
             prefix stripping or adding).
+        supports_custom_tools: Whether the provider's API natively
+            accepts custom tool definitions (``{type: "custom"}``).
+            Default ``False`` — only OpenAI's official API supports
+            this.  When ``False``, custom tools are downgraded to
+            function wrappers.
     """
 
     name: str
@@ -140,6 +145,7 @@ class ProviderShim:
     reasoning: ReasoningCapability | None = None
     model_reasoning: dict[str, ReasoningCapability] | None = None
     response_id_prefix: str = ""
+    supports_custom_tools: bool = False
 
     def __init__(self, **kwargs: Any) -> None:  # type: ignore[override]
         """Accept both new and legacy kwarg names.
@@ -185,6 +191,7 @@ class ProviderShim:
             "reasoning": None,
             "model_reasoning": None,
             "response_id_prefix": "",
+            "supports_custom_tools": False,
         }
         _VALID_FIELDS = {"name", "base"} | _FIELD_DEFAULTS.keys()
         for k, v in _FIELD_DEFAULTS.items():

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -201,6 +201,7 @@ def _load_single_provider(
         reasoning=reasoning_cap,
         model_reasoning=model_reasoning,
         response_id_prefix=cfg.get("response_id_prefix", ""),
+        supports_custom_tools=cfg.get("supports_custom_tools", False),
     )
     register_shim(shim)
     logger.debug("Registered provider shim: %s (base=%s)", shim.name, shim.base)

--- a/src/llm_rosetta/shims/providers/argo/openai_chat/provider.yaml
+++ b/src/llm_rosetta/shims/providers/argo/openai_chat/provider.yaml
@@ -13,3 +13,5 @@ reasoning:
     high: high
     xhigh: xhigh
     max: max
+
+supports_custom_tools: true

--- a/src/llm_rosetta/shims/providers/openai/provider.yaml
+++ b/src/llm_rosetta/shims/providers/openai/provider.yaml
@@ -15,3 +15,5 @@ reasoning:
     high: high
     xhigh: high
     max: high
+
+supports_custom_tools: true

--- a/src/llm_rosetta/shims/providers/openai_responses/provider.yaml
+++ b/src/llm_rosetta/shims/providers/openai_responses/provider.yaml
@@ -15,3 +15,5 @@ reasoning:
     high: high
     xhigh: high
     max: high
+
+supports_custom_tools: true

--- a/tests/test_custom_tool_downgrade.py
+++ b/tests/test_custom_tool_downgrade.py
@@ -1,0 +1,473 @@
+"""Tests for custom tool downgrade/restore across non-supporting upstreams.
+
+When a provider does not support custom tools (``supports_custom_tools=False``),
+the pipeline downgrades them to functions on the request path and restores
+them on the response path.
+"""
+
+import copy
+import json
+from typing import Any
+
+import pytest
+
+from llm_rosetta.capabilities import (
+    enforce_custom_tools,
+    get_custom_tool_names,
+    restore_custom_tool_calls,
+    unwrap_custom_tool_input,
+)
+from llm_rosetta.pipeline import ConversionPipeline
+from llm_rosetta.shims.provider_shim import (
+    ProviderShim,
+    register_shim,
+    unregister_shim,
+)
+
+PATCH_TEXT = "*** Begin Patch\n*** Add File: a.txt\n+hi\n*** End Patch"
+
+CUSTOM_TOOL_IR = {
+    "type": "custom",
+    "name": "apply_patch",
+    "description": "Apply a V4A patch.",
+    "parameters": {},
+    "metadata": {
+        "format": {"type": "grammar", "syntax": "lark"},
+    },
+}
+
+FUNCTION_TOOL_IR = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get weather.",
+    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+}
+
+
+def _make_shim(supports: bool, name: str = "__test_custom_tool__") -> ProviderShim:
+    return ProviderShim(
+        name=name,
+        base="openai_chat",
+        supports_custom_tools=supports,
+    )
+
+
+# ---------------------------------------------------------------------------
+# enforce_custom_tools
+# ---------------------------------------------------------------------------
+
+
+class TestEnforceCustomTools:
+    def test_noop_when_shim_supports(self):
+        shim = _make_shim(supports=True)
+        ir = {"tools": [dict(CUSTOM_TOOL_IR)]}
+        result = enforce_custom_tools(ir, shim=shim)
+        assert result["tools"][0]["type"] == "custom"
+
+    def test_noop_when_shim_is_none(self):
+        ir = {"tools": [dict(CUSTOM_TOOL_IR)]}
+        result = enforce_custom_tools(ir, shim=None)
+        assert result["tools"][0]["type"] == "custom"
+
+    def test_noop_when_no_custom_tools(self):
+        shim = _make_shim(supports=False)
+        ir = {"tools": [dict(FUNCTION_TOOL_IR)]}
+        result = enforce_custom_tools(ir, shim=shim)
+        assert result["tools"][0]["type"] == "function"
+        assert "provider_type" not in (result["tools"][0].get("metadata") or {})
+
+    def test_downgrades_custom_to_function(self):
+        shim = _make_shim(supports=False)
+        tool = dict(CUSTOM_TOOL_IR)
+        tool["metadata"] = copy.deepcopy(CUSTOM_TOOL_IR.get("metadata", {}))
+        ir = {"tools": [tool]}
+        result = enforce_custom_tools(ir, shim=shim)
+
+        t = result["tools"][0]
+        assert t["type"] == "function"
+        assert t["metadata"]["provider_type"] == "custom"
+        assert t["parameters"]["properties"]["input"]["type"] == "string"
+        assert t["parameters"]["required"] == ["input"]
+
+    def test_preserves_existing_parameters(self):
+        shim = _make_shim(supports=False)
+        tool = dict(CUSTOM_TOOL_IR)
+        tool["metadata"] = copy.deepcopy(CUSTOM_TOOL_IR.get("metadata", {}))
+        custom_params = {"type": "object", "properties": {"code": {"type": "string"}}}
+        tool["parameters"] = custom_params
+        ir = {"tools": [tool]}
+        result = enforce_custom_tools(ir, shim=shim)
+
+        assert result["tools"][0]["parameters"] == custom_params
+
+    def test_description_includes_format_hint(self):
+        shim = _make_shim(supports=False)
+        tool = dict(CUSTOM_TOOL_IR)
+        tool["metadata"] = copy.deepcopy(CUSTOM_TOOL_IR.get("metadata", {}))
+        ir = {"tools": [tool]}
+        result = enforce_custom_tools(ir, shim=shim)
+
+        assert (
+            "[Output format: grammar, syntax: lark]"
+            in result["tools"][0]["description"]
+        )
+
+    def test_downgrades_tool_choice(self):
+        shim = _make_shim(supports=False)
+        tool = dict(CUSTOM_TOOL_IR)
+        tool["metadata"] = copy.deepcopy(CUSTOM_TOOL_IR.get("metadata", {}))
+        ir = {
+            "tools": [tool],
+            "tool_choice": {
+                "mode": "tool",
+                "tool_name": "apply_patch",
+                "tool_type": "custom",
+            },
+        }
+        result = enforce_custom_tools(ir, shim=shim)
+
+        assert "tool_type" not in result["tool_choice"]
+        assert result["tool_choice"]["tool_name"] == "apply_patch"
+
+    def test_mixed_tools_only_downgrades_custom(self):
+        shim = _make_shim(supports=False)
+        custom = dict(CUSTOM_TOOL_IR)
+        custom["metadata"] = copy.deepcopy(CUSTOM_TOOL_IR.get("metadata", {}))
+        func = dict(FUNCTION_TOOL_IR)
+        ir = {"tools": [custom, func]}
+        result = enforce_custom_tools(ir, shim=shim)
+
+        assert result["tools"][0]["type"] == "function"
+        assert result["tools"][0]["metadata"]["provider_type"] == "custom"
+        assert result["tools"][1]["type"] == "function"
+        assert "provider_type" not in (result["tools"][1].get("metadata") or {})
+
+
+# ---------------------------------------------------------------------------
+# get_custom_tool_names
+# ---------------------------------------------------------------------------
+
+
+class TestGetCustomToolNames:
+    def test_returns_downgraded_names(self):
+        ir = {
+            "tools": [
+                {"name": "apply_patch", "metadata": {"provider_type": "custom"}},
+                {"name": "get_weather", "metadata": {}},
+            ]
+        }
+        assert get_custom_tool_names(ir) == frozenset({"apply_patch"})
+
+    def test_empty_when_no_custom(self):
+        ir = {"tools": [{"name": "fn", "metadata": {}}]}
+        assert get_custom_tool_names(ir) == frozenset()
+
+    def test_empty_when_no_tools(self):
+        assert get_custom_tool_names({}) == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# restore_custom_tool_calls
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreCustomToolCalls:
+    def test_restores_tool_type(self):
+        ir_response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_call",
+                                "tool_name": "apply_patch",
+                                "tool_type": "function",
+                                "tool_input": {"input": PATCH_TEXT},
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        restore_custom_tool_calls(
+            ir_response, custom_tool_names=frozenset({"apply_patch"})
+        )
+        assert (
+            ir_response["choices"][0]["message"]["content"][0]["tool_type"] == "custom"
+        )
+
+    def test_noop_when_empty_set(self):
+        ir_response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_call",
+                                "tool_name": "apply_patch",
+                                "tool_type": "function",
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        restore_custom_tool_calls(ir_response, custom_tool_names=frozenset())
+        assert (
+            ir_response["choices"][0]["message"]["content"][0]["tool_type"]
+            == "function"
+        )
+
+    def test_only_restores_matching_names(self):
+        ir_response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_call",
+                                "tool_name": "apply_patch",
+                                "tool_type": "function",
+                            },
+                            {
+                                "type": "tool_call",
+                                "tool_name": "get_weather",
+                                "tool_type": "function",
+                            },
+                        ]
+                    }
+                }
+            ]
+        }
+        restore_custom_tool_calls(
+            ir_response, custom_tool_names=frozenset({"apply_patch"})
+        )
+        assert (
+            ir_response["choices"][0]["message"]["content"][0]["tool_type"] == "custom"
+        )
+        assert (
+            ir_response["choices"][0]["message"]["content"][1]["tool_type"]
+            == "function"
+        )
+
+
+# ---------------------------------------------------------------------------
+# unwrap_custom_tool_input
+# ---------------------------------------------------------------------------
+
+
+class TestUnwrapCustomToolInput:
+    def test_unwraps_input_key(self):
+        assert unwrap_custom_tool_input(json.dumps({"input": PATCH_TEXT})) == PATCH_TEXT
+
+    def test_passthrough_non_json(self):
+        assert unwrap_custom_tool_input("not json") == "not json"
+
+    def test_passthrough_multi_key_dict(self):
+        raw = json.dumps({"input": "a", "other": "b"})
+        assert unwrap_custom_tool_input(raw) == raw
+
+    def test_passthrough_non_input_key(self):
+        raw = json.dumps({"code": "print(1)"})
+        assert unwrap_custom_tool_input(raw) == raw
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration: non-streaming
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineNonStreamingRoundtrip:
+    """Full request + response through pipeline with a non-supporting shim."""
+
+    @pytest.fixture(autouse=True)
+    def _register_shim(self):
+        shim = _make_shim(supports=False, name="__test_ns_custom__")
+        register_shim(shim)
+        yield
+        unregister_shim("__test_ns_custom__")
+
+    def _request(self) -> dict[str, Any]:
+        return {
+            "model": "test-model",
+            "tools": [
+                {
+                    "type": "custom",
+                    "name": "apply_patch",
+                    "description": "Apply a V4A patch.",
+                    "format": {
+                        "type": "grammar",
+                        "grammar": {"definition": "start: /.+/s", "syntax": "lark"},
+                    },
+                }
+            ],
+            "tool_choice": {"type": "custom", "custom": {"name": "apply_patch"}},
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "create a.txt"}],
+                }
+            ],
+        }
+
+    def _chat_completion(self) -> dict[str, Any]:
+        return {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "apply_patch",
+                                    "arguments": json.dumps({"input": PATCH_TEXT}),
+                                },
+                            }
+                        ],
+                    },
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+
+    def test_custom_tool_call_roundtrip(self):
+        pipe = ConversionPipeline(
+            "openai_responses", "openai_chat", shim="__test_ns_custom__"
+        )
+        pipe.convert_request(self._request())
+        out = pipe.convert_response(self._chat_completion())
+
+        items = out.get("output", [])
+        custom_items = [i for i in items if i.get("type") == "custom_tool_call"]
+        assert len(custom_items) == 1
+        assert custom_items[0]["input"] == PATCH_TEXT
+        assert custom_items[0]["name"] == "apply_patch"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration: streaming
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineStreamingRoundtrip:
+    """Streaming request + response through pipeline with a non-supporting shim."""
+
+    @pytest.fixture(autouse=True)
+    def _register_shim(self):
+        shim = _make_shim(supports=False, name="__test_stream_custom__")
+        register_shim(shim)
+        yield
+        unregister_shim("__test_stream_custom__")
+
+    def _request(self) -> dict[str, Any]:
+        return {
+            "model": "test-model",
+            "tools": [
+                {
+                    "type": "custom",
+                    "name": "apply_patch",
+                    "description": "Apply a V4A patch.",
+                    "format": {
+                        "type": "grammar",
+                        "grammar": {"definition": "start: /.+/s", "syntax": "lark"},
+                    },
+                }
+            ],
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "create a.txt"}],
+                }
+            ],
+        }
+
+    def _chat_chunks(self) -> list[dict[str, Any]]:
+        def chunk(delta: dict, finish: str | None = None) -> dict[str, Any]:
+            return {
+                "id": "chatcmpl-test",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": "test-model",
+                "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+            }
+
+        args = json.dumps({"input": PATCH_TEXT})
+        half = len(args) // 2
+        return [
+            chunk(
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "apply_patch", "arguments": ""},
+                        }
+                    ],
+                }
+            ),
+            chunk(
+                {"tool_calls": [{"index": 0, "function": {"arguments": args[:half]}}]}
+            ),
+            chunk(
+                {"tool_calls": [{"index": 0, "function": {"arguments": args[half:]}}]}
+            ),
+            chunk({}, finish="tool_calls"),
+        ]
+
+    def test_streaming_emits_custom_tool_call(self):
+        pipe = ConversionPipeline(
+            "openai_responses", "openai_chat", shim="__test_stream_custom__"
+        )
+        pipe.convert_request(self._request())
+        proc = pipe.create_stream_processor()
+
+        events: list[dict[str, Any]] = []
+        for chunk in self._chat_chunks():
+            events.extend(proc.process_chunk(chunk))
+
+        done_items = [
+            e["item"]
+            for e in events
+            if isinstance(e, dict) and e.get("type", "").endswith("output_item.done")
+        ]
+        custom_items = [d for d in done_items if d.get("type") == "custom_tool_call"]
+        assert len(custom_items) == 1
+        assert custom_items[0]["input"] == PATCH_TEXT
+
+        event_types = {e.get("type") for e in events if isinstance(e, dict)}
+        assert "response.custom_tool_call_input.done" in event_types
+        assert "response.function_call_arguments.done" not in event_types
+
+
+# ---------------------------------------------------------------------------
+# ProviderShim field
+# ---------------------------------------------------------------------------
+
+
+class TestProviderShimCustomToolField:
+    def test_default_false(self):
+        shim = ProviderShim(name="test", base="openai_chat")
+        assert shim.supports_custom_tools is False
+
+    def test_explicit_true(self):
+        shim = ProviderShim(name="test", base="openai_chat", supports_custom_tools=True)
+        assert shim.supports_custom_tools is True
+
+    def test_explicit_false(self):
+        shim = ProviderShim(
+            name="test", base="openai_chat", supports_custom_tools=False
+        )
+        assert shim.supports_custom_tools is False

--- a/tests/test_custom_tool_downgrade.py
+++ b/tests/test_custom_tool_downgrade.py
@@ -74,7 +74,7 @@ class TestEnforceCustomTools:
         ir = {"tools": [dict(FUNCTION_TOOL_IR)]}
         result = enforce_custom_tools(ir, shim=shim)
         assert result["tools"][0]["type"] == "function"
-        assert "provider_type" not in (result["tools"][0].get("metadata") or {})
+        assert "_downgraded_from" not in (result["tools"][0].get("metadata") or {})
 
     def test_downgrades_custom_to_function(self):
         shim = _make_shim(supports=False)
@@ -85,7 +85,7 @@ class TestEnforceCustomTools:
 
         t = result["tools"][0]
         assert t["type"] == "function"
-        assert t["metadata"]["provider_type"] == "custom"
+        assert t["metadata"]["_downgraded_from"] == "custom"
         assert t["parameters"]["properties"]["input"]["type"] == "string"
         assert t["parameters"]["required"] == ["input"]
 
@@ -138,9 +138,9 @@ class TestEnforceCustomTools:
         result = enforce_custom_tools(ir, shim=shim)
 
         assert result["tools"][0]["type"] == "function"
-        assert result["tools"][0]["metadata"]["provider_type"] == "custom"
+        assert result["tools"][0]["metadata"]["_downgraded_from"] == "custom"
         assert result["tools"][1]["type"] == "function"
-        assert "provider_type" not in (result["tools"][1].get("metadata") or {})
+        assert "_downgraded_from" not in (result["tools"][1].get("metadata") or {})
 
 
 # ---------------------------------------------------------------------------
@@ -152,7 +152,7 @@ class TestGetCustomToolNames:
     def test_returns_downgraded_names(self):
         ir = {
             "tools": [
-                {"name": "apply_patch", "metadata": {"provider_type": "custom"}},
+                {"name": "apply_patch", "metadata": {"_downgraded_from": "custom"}},
                 {"name": "get_weather", "metadata": {}},
             ]
         }


### PR DESCRIPTION
## Summary

- Add `supports_custom_tools` field to `ProviderShim` (default `False`) so non-OpenAI Chat upstreams like DeepSeek don't receive `{type: "custom"}` tool definitions they can't parse
- `enforce_custom_tools()` in `capabilities.py` downgrades custom tools to functions with synthesized `{"input": string}` schema on the request path
- Response path restores `tool_type: "custom"` for both non-streaming and streaming, with JSON argument buffering and unwrapping for streaming
- Only OpenAI official and Argo OpenAI shims set `supports_custom_tools: true`

Fixes the scenario where Codex sends `apply_patch` (custom tool) through a DeepSeek upstream and gets `unknown variant 'custom', expected 'function'`.

Refs #460, supersedes #453

## Test plan

- [x] `make lint` — clean (ruff + ty)
- [x] `make test` — 2417 passed, 0 failed
- [x] Unit tests for `enforce_custom_tools`, `get_custom_tool_names`, `restore_custom_tool_calls`, `unwrap_custom_tool_input`
- [x] Pipeline integration test: non-streaming custom tool roundtrip through a non-supporting shim
- [x] Pipeline integration test: streaming custom tool roundtrip with JSON argument buffering/unwrapping
- [ ] Live test: `POST /v1/responses` with `model=deepseek-v4-flash` and custom tool on rosetta-dev after deploy