### PR TITLE
fix(openai_chat): custom tool grammar shape and streaming tool-call deltas

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -681,8 +681,8 @@ class OpenAIChatConverter(BaseConverter):
             tc_id = tc.get("id")
             tc_index = tc.get("index")
 
-            # Resolve the effective call ID for delta-only chunks
-            # (they carry index but no id).
+            # Resolve effective call ID before dispatch — the helper
+            # uses it for context-based type recovery on null-type deltas.
             effective_tc_id = tc_id
             if not effective_tc_id and tc_index is not None and context is not None:
                 effective_tc_id = context.resolve_tool_call_id_by_index(tc_index)
@@ -710,7 +710,6 @@ class OpenAIChatConverter(BaseConverter):
                         tc_name,
                         "custom" if tc_type == "custom" else "function",
                     )
-
 
             if tc_input:
                 delta_event = ToolCallDeltaEvent(

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -45,6 +45,52 @@ from .tool_ops import OpenAIChatToolOps
 logger = logging.getLogger(__name__)
 
 
+def _resolve_tool_call_delta(
+    tc: dict[str, Any],
+    effective_tc_id: str | None,
+    context: StreamContext | None,
+) -> tuple[str, str, str]:
+    """Resolve the type, name and input payload of one tool-call delta.
+
+    Providers serialise every member of the streaming tool-call union on
+    each delta and set the inactive ones to null; continuation deltas null
+    out ``type`` as well::
+
+        {"index": 0, "id": null, "type": null, "function": null,
+         "custom": {"input": "***"}}
+
+    ``dict.get(key, default)`` does not help here — the keys exist, so the
+    default never applies — hence the ``or`` coercion. The type is then
+    recovered from whichever payload is populated, falling back to the type
+    registered when the call started, so continuation deltas of a custom
+    tool call are not misread as function calls and silently dropped.
+
+    Args:
+        tc: A single tool-call delta from a provider chunk.
+        effective_tc_id: Resolved tool call ID, if one is known yet.
+        context: Stream context holding previously registered call types.
+
+    Returns:
+        Tuple of ``(tool_type, tool_name, tool_input)``. ``tool_type`` is
+        either ``"custom"`` or ``"function"``.
+    """
+    tc_custom = tc.get("custom") or {}
+    tc_func = tc.get("function") or {}
+    tc_type = tc.get("type")
+
+    if not tc_type:
+        if tc_custom:
+            tc_type = "custom"
+        elif tc_func:
+            tc_type = "function"
+        elif context is not None and effective_tc_id:
+            tc_type = context.get_tool_type(effective_tc_id)
+
+    if tc_type == "custom":
+        return tc_type, tc_custom.get("name", ""), tc_custom.get("input", "")
+    return "function", tc_func.get("name", ""), tc_func.get("arguments", "")
+
+
 class OpenAIChatConverter(BaseConverter):
     """OpenAI Chat Completions API converter.
 
@@ -632,18 +678,18 @@ class OpenAIChatConverter(BaseConverter):
     ) -> None:
         """Process tool call deltas from a choice."""
         for tc in tool_calls:
-            tc_type = tc.get("type", "function")
             tc_id = tc.get("id")
             tc_index = tc.get("index")
 
-            if tc_type == "custom":
-                tc_custom = tc.get("custom", {})
-                tc_name = tc_custom.get("name", "")
-                tc_input = tc_custom.get("input", "")
-            else:
-                tc_func = tc.get("function", {})
-                tc_name = tc_func.get("name", "")
-                tc_input = tc_func.get("arguments", "")
+            # Resolve the effective call ID for delta-only chunks
+            # (they carry index but no id).
+            effective_tc_id = tc_id
+            if not effective_tc_id and tc_index is not None and context is not None:
+                effective_tc_id = context.resolve_tool_call_id_by_index(tc_index)
+
+            tc_type, tc_name, tc_input = _resolve_tool_call_delta(
+                tc, effective_tc_id, context
+            )
 
             if tc_id:
                 start_event_tc = ToolCallStartEvent(
@@ -665,11 +711,6 @@ class OpenAIChatConverter(BaseConverter):
                         "custom" if tc_type == "custom" else "function",
                     )
 
-            # Resolve the effective call ID for delta-only chunks
-            # (they carry index but no id).
-            effective_tc_id = tc_id
-            if not effective_tc_id and tc_index is not None and context is not None:
-                effective_tc_id = context.resolve_tool_call_id_by_index(tc_index)
 
             if tc_input:
                 delta_event = ToolCallDeltaEvent(

--- a/src/llm_rosetta/converters/openai_chat/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/tool_ops.py
@@ -29,6 +29,43 @@ from ..base.helpers import log_orphan_warnings, sanitize_schema
 logger = logging.getLogger(__name__)
 
 
+# ==================== Custom Tool Format Shape ====================
+#
+# The Responses API flattens grammar fields into ``format``:
+#     {"type": "grammar", "syntax": "lark", "definition": "..."}
+# Chat Completions nests them under ``format.grammar``:
+#     {"type": "grammar", "grammar": {"syntax": "lark", "definition": "..."}}
+# IR canonically stores the flat (Responses) shape in ``metadata["format"]``,
+# so the Chat boundary has to nest on the way out and flatten on the way in.
+# Both helpers are idempotent.
+
+
+def _custom_format_to_chat(fmt: Any) -> Any:
+    """Flat IR/Responses custom-tool ``format`` → nested Chat Completions shape."""
+    if not isinstance(fmt, dict) or fmt.get("type") != "grammar":
+        return fmt
+    if isinstance(fmt.get("grammar"), dict):
+        return fmt  # already Chat-shaped
+    grammar = {k: fmt[k] for k in ("syntax", "definition") if fmt.get(k) is not None}
+    if not grammar:
+        return fmt
+    return {"type": "grammar", "grammar": grammar}
+
+
+def _custom_format_to_ir(fmt: Any) -> Any:
+    """Nested Chat Completions custom-tool ``format`` → flat IR/Responses shape."""
+    if not isinstance(fmt, dict) or fmt.get("type") != "grammar":
+        return fmt
+    grammar = fmt.get("grammar")
+    if not isinstance(grammar, dict):
+        return fmt  # already flat
+    flat = {"type": "grammar"}
+    for k in ("syntax", "definition"):
+        if grammar.get(k) is not None:
+            flat[k] = grammar[k]
+    return flat
+
+
 # ==================== Orphaned Tool Call Fix ====================
 
 
@@ -157,7 +194,7 @@ class OpenAIChatToolOps(BaseToolOps):
                 custom["description"] = desc
             fmt = metadata.get("format")
             if fmt:
-                custom["format"] = fmt
+                custom["format"] = _custom_format_to_chat(fmt)
             return {"type": "custom", "custom": custom}
 
         if tool_type == "function":
@@ -203,7 +240,7 @@ class OpenAIChatToolOps(BaseToolOps):
             metadata: dict[str, Any] = {}
             fmt = custom.get("format")
             if fmt:
-                metadata["format"] = fmt
+                metadata["format"] = _custom_format_to_ir(fmt)
             return cast(
                 ToolDefinition,
                 {

--- a/tests/converters/openai_chat/test_custom_tool_grammar.py
+++ b/tests/converters/openai_chat/test_custom_tool_grammar.py
@@ -1,0 +1,103 @@
+"""Tests for the OpenAI Chat custom-tool grammar format shape.
+
+The Responses API flattens grammar fields into ``format``
+(``{"type", "syntax", "definition"}``) while Chat Completions nests them
+under ``format.grammar``. Emitting the flat shape to a Chat Completions
+upstream is rejected with
+``Missing required parameter: 'tools[N].custom.format.grammar'``.
+"""
+
+from llm_rosetta.converters.openai_chat.tool_ops import OpenAIChatToolOps
+from llm_rosetta.converters.openai_responses.tool_ops import OpenAIResponsesToolOps
+
+LARK_DEFINITION = 'start: "*** Begin Patch" /(.|\\n)+/ "*** End Patch"'
+
+RESPONSES_CUSTOM_TOOL = {
+    "type": "custom",
+    "name": "apply_patch",
+    "description": "Apply a V4A patch. FREEFORM — do not wrap in JSON.",
+    "format": {
+        "type": "grammar",
+        "syntax": "lark",
+        "definition": LARK_DEFINITION,
+    },
+}
+
+CHAT_CUSTOM_TOOL = {
+    "type": "custom",
+    "custom": {
+        "name": "apply_patch",
+        "description": "Apply a V4A patch. FREEFORM — do not wrap in JSON.",
+        "format": {
+            "type": "grammar",
+            "grammar": {"syntax": "lark", "definition": LARK_DEFINITION},
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Request path — grammar format shape
+# ---------------------------------------------------------------------------
+
+
+class TestCustomToolGrammarShape:
+    """Grammar fields must nest under ``format.grammar`` for Chat Completions."""
+
+    def test_responses_flat_format_becomes_nested_for_chat(self):
+        """Responses → IR → Chat nests syntax/definition under ``grammar``."""
+        ir_tool = OpenAIResponsesToolOps.p_tool_definition_to_ir(RESPONSES_CUSTOM_TOOL)
+        chat_tool = OpenAIChatToolOps.ir_tool_definition_to_p(ir_tool)
+
+        fmt = chat_tool["custom"]["format"]
+        assert fmt["type"] == "grammar"
+        assert fmt["grammar"] == {
+            "syntax": "lark",
+            "definition": LARK_DEFINITION,
+        }
+        # The flat spelling must not leak through alongside the nested one.
+        assert "syntax" not in fmt
+        assert "definition" not in fmt
+
+    def test_chat_nested_format_becomes_flat_for_responses(self):
+        """Chat → IR → Responses flattens ``grammar`` back into ``format``."""
+        ir_tool = OpenAIChatToolOps.p_tool_definition_to_ir(CHAT_CUSTOM_TOOL)
+        responses_tool = OpenAIResponsesToolOps.ir_tool_definition_to_p(ir_tool)
+
+        assert responses_tool["format"] == {
+            "type": "grammar",
+            "syntax": "lark",
+            "definition": LARK_DEFINITION,
+        }
+
+    def test_chat_round_trip_does_not_double_nest(self):
+        """Chat → IR → Chat is stable (no ``grammar.grammar``)."""
+        ir_tool = OpenAIChatToolOps.p_tool_definition_to_ir(CHAT_CUSTOM_TOOL)
+        chat_tool = OpenAIChatToolOps.ir_tool_definition_to_p(ir_tool)
+
+        assert chat_tool["custom"]["format"] == CHAT_CUSTOM_TOOL["custom"]["format"]
+
+    def test_responses_round_trip_is_stable(self):
+        """Responses → IR → Chat → IR → Responses preserves the flat shape."""
+        ir_a = OpenAIResponsesToolOps.p_tool_definition_to_ir(RESPONSES_CUSTOM_TOOL)
+        chat_tool = OpenAIChatToolOps.ir_tool_definition_to_p(ir_a)
+        ir_b = OpenAIChatToolOps.p_tool_definition_to_ir(chat_tool)
+        responses_tool = OpenAIResponsesToolOps.ir_tool_definition_to_p(ir_b)
+
+        assert responses_tool["format"] == RESPONSES_CUSTOM_TOOL["format"]
+
+    def test_text_format_is_untouched(self):
+        """Non-grammar formats pass through both directions unchanged."""
+        tool = dict(RESPONSES_CUSTOM_TOOL, format={"type": "text"})
+        ir_tool = OpenAIResponsesToolOps.p_tool_definition_to_ir(tool)
+        chat_tool = OpenAIChatToolOps.ir_tool_definition_to_p(ir_tool)
+
+        assert chat_tool["custom"]["format"] == {"type": "text"}
+
+    def test_custom_tool_without_format_is_untouched(self):
+        """A custom tool with no ``format`` gains none."""
+        tool = {k: v for k, v in RESPONSES_CUSTOM_TOOL.items() if k != "format"}
+        ir_tool = OpenAIResponsesToolOps.p_tool_definition_to_ir(tool)
+        chat_tool = OpenAIChatToolOps.ir_tool_definition_to_p(ir_tool)
+
+        assert "format" not in chat_tool["custom"]

--- a/tests/converters/openai_chat/test_custom_tool_grammar.py
+++ b/tests/converters/openai_chat/test_custom_tool_grammar.py
@@ -75,7 +75,9 @@ class TestCustomToolGrammarShape:
         ir_tool = OpenAIChatToolOps.p_tool_definition_to_ir(CHAT_CUSTOM_TOOL)
         chat_tool = OpenAIChatToolOps.ir_tool_definition_to_p(ir_tool)
 
-        assert chat_tool["custom"]["format"] == CHAT_CUSTOM_TOOL["custom"]["format"]
+        expected_fmt = CHAT_CUSTOM_TOOL["custom"]
+        assert isinstance(expected_fmt, dict)
+        assert chat_tool["custom"]["format"] == expected_fmt["format"]
 
     def test_responses_round_trip_is_stable(self):
         """Responses → IR → Chat → IR → Responses preserves the flat shape."""

--- a/tests/converters/openai_chat/test_stream_custom_tool_calls.py
+++ b/tests/converters/openai_chat/test_stream_custom_tool_calls.py
@@ -1,0 +1,187 @@
+"""Streaming tool-call deltas with present-but-null union members.
+
+Providers serialise every member of the Chat Completions tool-call union on
+each streaming delta and set the inactive ones to ``null`` — including
+``type`` on every delta after the first. ``dict.get(key, default)`` returns
+``None`` rather than the default for a present-but-null key, which made the
+converter dereference ``None`` and abort the stream.
+
+The deltas below are shaped exactly as captured from a live upstream
+returning a custom (``apply_patch``) tool call.
+"""
+
+from typing import Any, cast
+
+from llm_rosetta.converters.base.context import StreamContext
+from llm_rosetta.converters.openai_chat import OpenAIChatConverter
+
+PATCH_PIECES = ("*** Begin Patch\n", "*** Add File: a.txt\n", "+hi\n", "*** End Patch")
+PATCH_TEXT = "".join(PATCH_PIECES)
+
+FIRST_CUSTOM_DELTA = {
+    "index": 0,
+    "id": "call_abc123",
+    "function": None,
+    "type": "custom",
+    "custom": {"input": "", "name": "apply_patch"},
+}
+CONTINUATION_CUSTOM_DELTAS = [
+    {"index": 0, "id": None, "function": None, "type": None, "custom": {"input": p}}
+    for p in PATCH_PIECES
+]
+
+
+def _chunk(tool_call: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a single tool-call delta in a Chat Completions stream chunk."""
+    return {
+        "choices": [
+            {"index": 0, "delta": {"tool_calls": [tool_call]}, "finish_reason": None}
+        ]
+    }
+
+
+class TestStreamingCustomToolDeltas:
+    """Continuation deltas must survive null union members."""
+
+    def setup_method(self):
+        self.converter = OpenAIChatConverter()
+
+    def test_continuation_delta_with_null_function_does_not_raise(self):
+        """A null ``function`` key must not be dereferenced."""
+        context = StreamContext()
+        self.converter.stream_response_from_provider(
+            _chunk(FIRST_CUSTOM_DELTA), context
+        )
+
+        events = cast(
+            list[Any],
+            self.converter.stream_response_from_provider(
+                _chunk(CONTINUATION_CUSTOM_DELTAS[0]), context
+            ),
+        )
+        assert len(events) == 1
+        assert events[0]["type"] == "tool_call_delta"
+
+    def test_custom_tool_input_is_fully_reassembled(self):
+        """Every continuation delta contributes to the accumulated input.
+
+        A bare null-guard would leave ``type`` unresolved, classify the
+        continuation deltas as function calls, read an empty ``arguments``
+        and silently drop the payload — so assert on the reassembled text,
+        not merely on the absence of an exception.
+        """
+        context = StreamContext()
+        events: list[Any] = []
+        for delta in [FIRST_CUSTOM_DELTA, *CONTINUATION_CUSTOM_DELTAS]:
+            events.extend(
+                self.converter.stream_response_from_provider(_chunk(delta), context)
+            )
+
+        starts = [e for e in events if e["type"] == "tool_call_start"]
+        assert len(starts) == 1
+        assert starts[0]["tool_name"] == "apply_patch"
+        assert starts[0]["tool_type"] == "custom"
+
+        deltas = [e for e in events if e["type"] == "tool_call_delta"]
+        assert len(deltas) == len(CONTINUATION_CUSTOM_DELTAS)
+        assert "".join(e["arguments_delta"] for e in deltas) == PATCH_TEXT
+        assert context.get_tool_call_args("call_abc123") == PATCH_TEXT
+
+    def test_tool_type_recovered_from_context_when_payload_is_empty(self):
+        """A delta carrying neither payload falls back to the registered type."""
+        context = StreamContext()
+        self.converter.stream_response_from_provider(
+            _chunk(FIRST_CUSTOM_DELTA), context
+        )
+
+        empty = {"index": 0, "id": None, "function": None, "type": None, "custom": {}}
+        events = cast(
+            list[Any],
+            self.converter.stream_response_from_provider(_chunk(empty), context),
+        )
+        assert events == []
+        assert context.get_tool_type("call_abc123") == "custom"
+
+    def test_function_call_deltas_still_work(self):
+        """The ordinary function-call path is unaffected."""
+        context = StreamContext()
+        deltas = [
+            {
+                "index": 0,
+                "id": "call_fn1",
+                "type": "function",
+                "custom": None,
+                "function": {"name": "get_weather", "arguments": ""},
+            },
+            {
+                "index": 0,
+                "id": None,
+                "type": None,
+                "custom": None,
+                "function": {"arguments": '{"city":"Chicago"}'},
+            },
+        ]
+        events: list[Any] = []
+        for delta in deltas:
+            events.extend(
+                self.converter.stream_response_from_provider(_chunk(delta), context)
+            )
+
+        starts = [e for e in events if e["type"] == "tool_call_start"]
+        assert starts[0]["tool_name"] == "get_weather"
+        assert starts[0].get("tool_type", "function") == "function"
+        assert context.get_tool_call_args("call_fn1") == '{"city":"Chicago"}'
+
+    def test_type_omitted_entirely_still_defaults_to_function(self):
+        """Absent ``type``/``custom`` keys keep the legacy function default."""
+        context = StreamContext()
+        chunk = _chunk(
+            {
+                "index": 0,
+                "id": "call_fn2",
+                "function": {"name": "ping", "arguments": "{}"},
+            }
+        )
+        events = cast(
+            list[Any], self.converter.stream_response_from_provider(chunk, context)
+        )
+        starts = [e for e in events if e["type"] == "tool_call_start"]
+        assert starts[0]["tool_name"] == "ping"
+        assert context.get_tool_type("call_fn2") == "function"
+
+    def test_parallel_custom_and_function_calls_do_not_cross_contaminate(self):
+        """Two concurrent calls of different types stay correctly typed."""
+        context = StreamContext()
+        opening = [
+            FIRST_CUSTOM_DELTA,
+            {
+                "index": 1,
+                "id": "call_fn3",
+                "type": "function",
+                "custom": None,
+                "function": {"name": "get_weather", "arguments": ""},
+            },
+        ]
+        continuing = [
+            {
+                "index": 1,
+                "id": None,
+                "type": None,
+                "custom": None,
+                "function": {"arguments": '{"city":"Oak"}'},
+            },
+            {
+                "index": 0,
+                "id": None,
+                "type": None,
+                "function": None,
+                "custom": {"input": PATCH_TEXT},
+            },
+        ]
+        for delta in [*opening, *continuing]:
+            self.converter.stream_response_from_provider(_chunk(delta), context)
+
+        assert context.get_tool_type("call_abc123") == "custom"
+        assert context.get_tool_type("call_fn3") == "function"
+        assert context.get_tool_call_args("call_abc123") == PATCH_TEXT
+        assert context.get_tool_call_args("call_fn3") == '{"city":"Oak"}'


### PR DESCRIPTION
Fixes #488.

Two sequential defects that make grammar-constrained custom tools unusable on
`openai_chat`. Found running Codex CLI → argo-proxy 3.2.3 → Argo → gpt-5.5;
full analysis, captured wire data and a network-free reproduction are in the
issue.

Only shims with `supports_custom_tools: true` reach this code
(`argo--openai_chat`, `openai`, `openai_responses`) — everything else
downgrades custom tools to functions first, which is why neither bug has
surfaced before.

## Commit 1 — request path: nest the grammar

Responses flattens grammar fields into `format`; Chat Completions nests them
under `format.grammar`. `ir_tool_definition_to_p` copied the IR format through
verbatim, so upstream rejected every such request with:

```
Missing required parameter: 'tools[N].custom.format.grammar'
```

Adds two idempotent shape converters applied at the Chat boundary in both
directions, keeping the flat Responses spelling as the IR canonical form so
round trips stay stable.

## Commit 2 — response path: null union members in streaming deltas

Only reachable once commit 1 lands, because before that the upstream never
returns a custom tool call.

Continuation deltas arrive as:

```json
{"index": 0, "id": null, "type": null, "function": null,
 "custom": {"input": "***"}}
```

`dict.get(key, default)` returns the default only for an *absent* key, so
`tc.get("type", "function")` gave `None`, execution fell to the function
branch, and `tc.get("function", {})` gave `None` — `AttributeError` on the
second chunk of every custom tool call, killing the stream.

Worth flagging for review: **a pure null-guard is not sufficient.** With only
`or {}`, `tc_type` stays `None`, continuation deltas are read as function
calls with empty `arguments`, and the `if tc_input:` guard drops them — a
crash becomes silent loss of the tool payload. So the type is recovered from
whichever payload is populated, falling back to `context.get_tool_type()` for
the type registered when the call started.
`test_custom_tool_input_is_fully_reassembled` asserts on the reassembled text
rather than just the absence of a raise, to pin that down.

Extracted `_resolve_tool_call_delta` as a module-level helper — inlining it
pushed `_handle_p_tool_calls_to_ir` to C901 17, over the ceiling of 15.

## Tests

12 new tests in `tests/converters/openai_chat/`:

- `test_custom_tool_grammar.py` — shape conversion both directions, Chat→IR→Chat
  and Responses→IR→Chat→IR→Responses round trips, `{"type": "text"}` and
  no-format tools untouched
- `test_stream_custom_tool_calls.py` — deltas shaped exactly as captured from
  the live upstream, full input reassembly, type recovery from context,
  unaffected function-call path, and parallel custom + function calls not
  cross-contaminating

5 of the 12 fail on `main`. Suite goes 2484 → 2496 passed, 4 skipped;
`make lint` and `make test` both clean.

## Verification beyond unit tests

- The original failing Codex request (11 tools, streaming) replays end-to-end
  through argo-proxy and reaches `response.completed`
- A forced `apply_patch` round-trips as 18 `response.custom_tool_call_input.delta`
  events reassembling to a valid V4A patch
- Confirmed pristine `1b71414` reproduces the reported traceback byte-for-byte
  on the captured chunks

## Notes for you

- I could not verify whether OpenAI direct serialises the tool-call union the
  same way as Argo; the handling is defensive either way, since `null` is a
  legal value for an inactive union member.
- The Chat Completions `custom.format.grammar.{syntax,definition}` nesting is
  documented in the Chat API reference but *not* in the function-calling guide,
  which shows only the Responses shape — worth a second look if you want to
  confirm independently.
