### PR TITLE
refactor(context): expose public API for tool call order

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -693,7 +693,7 @@ class AnthropicConverter(BaseConverter):
                 tool_name=tool_name,
             )
             if context is not None:
-                start_evt["tool_call_index"] = len(context._tool_call_order) - 1
+                start_evt["tool_call_index"] = context.tool_call_count - 1
             events.append(start_evt)
 
     def _handle_p_content_block_delta_to_ir(
@@ -732,11 +732,9 @@ class AnthropicConverter(BaseConverter):
             if (
                 context is not None
                 and tool_call_id
-                and tool_call_id in context._tool_call_order
+                and (tc_idx := context.get_tool_call_index(tool_call_id)) is not None
             ):
-                delta_evt["tool_call_index"] = context._tool_call_order.index(
-                    tool_call_id
-                )
+                delta_evt["tool_call_index"] = tc_idx
             events.append(delta_evt)
 
             if context is not None and tool_call_id:

--- a/src/llm_rosetta/converters/base/context.py
+++ b/src/llm_rosetta/converters/base/context.py
@@ -266,6 +266,43 @@ class StreamContext(ConversionContext):
             result.append((call_id, name, args))
         return result
 
+    @property
+    def tool_call_ids(self) -> list[str]:
+        """Ordered list of registered tool call IDs."""
+        return list(self._tool_call_order)
+
+    @property
+    def tool_call_count(self) -> int:
+        """Number of registered tool calls."""
+        return len(self._tool_call_order)
+
+    def resolve_tool_call_id_by_index(self, index: int) -> str | None:
+        """Look up a tool call ID by its positional index.
+
+        Args:
+            index: Zero-based position in registration order.
+
+        Returns:
+            The tool call ID, or None if the index is out of range.
+        """
+        if 0 <= index < len(self._tool_call_order):
+            return self._tool_call_order[index]
+        return None
+
+    def get_tool_call_index(self, tool_call_id: str) -> int | None:
+        """Look up the positional index of a tool call ID.
+
+        Args:
+            tool_call_id: The tool call ID to look up.
+
+        Returns:
+            Zero-based index, or None if not registered.
+        """
+        try:
+            return self._tool_call_order.index(tool_call_id)
+        except ValueError:
+            return None
+
     def mark_started(self) -> None:
         """Mark the stream as started."""
         self._started = True

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -911,7 +911,7 @@ class GoogleGenAIConverter(BaseConverter):
         if context is not None:
             context.register_tool_call(tool_call_id, tool_name)
 
-        tc_index = len(context._tool_call_order) - 1 if context is not None else 0
+        tc_index = context.tool_call_count - 1 if context is not None else 0
         start_event: dict[str, Any] = {
             "type": "tool_call_start",
             "tool_call_id": tool_call_id,

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -669,9 +669,7 @@ class OpenAIChatConverter(BaseConverter):
             # (they carry index but no id).
             effective_tc_id = tc_id
             if not effective_tc_id and tc_index is not None and context is not None:
-                order = context._tool_call_order
-                if 0 <= tc_index < len(order):
-                    effective_tc_id = order[tc_index]
+                effective_tc_id = context.resolve_tool_call_id_by_index(tc_index)
 
             if tc_input:
                 delta_event = ToolCallDeltaEvent(

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -1437,8 +1437,8 @@ class OpenAIResponsesConverter(BaseConverter):
         # Some upstream providers (e.g. certain Chat Completions
         # implementations) only send tool_call_id on the first chunk.
         if not call_id and context is not None and tc_index is not None:
-            if tc_index < len(context._tool_call_order):
-                call_id = context._tool_call_order[tc_index]
+            if tc_index < context.tool_call_count:
+                call_id = context.resolve_tool_call_id_by_index(tc_index)
 
         # Accumulate arguments in context for done events
         if context is not None and call_id:
@@ -1596,7 +1596,7 @@ class OpenAIResponsesConverter(BaseConverter):
                     part.setdefault("logprobs", [])
             output.append(msg_item)
 
-        for call_id in context._tool_call_order:
+        for call_id in context.tool_call_ids:
             tool_name = context.get_tool_name(call_id)
             arguments = context._tool_call_args.get(call_id, "")
             tc_item_id = context.get_tool_call_item_id(call_id) or call_id
@@ -1776,7 +1776,7 @@ class OpenAIResponsesConverter(BaseConverter):
         results: list[dict[str, Any]],
     ) -> None:
         """Emit done events for each tool call."""
-        for tc_idx, call_id in enumerate(context._tool_call_order):
+        for tc_idx, call_id in enumerate(context.tool_call_ids):
             tool_name = context.get_tool_name(call_id)
             arguments = context._tool_call_args.get(call_id, "")
             item_id = context.get_tool_call_item_id(call_id) or call_id


### PR DESCRIPTION
## Summary

Add public methods on `StreamContext` to replace direct access to the private `_tool_call_order` list from all 4 converters:

- `tool_call_ids` property: ordered list of registered IDs (for iteration)
- `tool_call_count` property: number of registered calls (for `len()`)
- `resolve_tool_call_id_by_index(index)`: index → id lookup
- `get_tool_call_index(tool_call_id)`: id → index lookup

All external accesses in `openai_chat`, `anthropic`, `google_genai`, and `openai_responses` converters now go through the public API.

Motivation: PR #489 needs to add a `_resolve_tool_call_delta` helper that uses index→id resolution. Decoupling this first lets the helper live in `tool_ops.py` without crossing module boundaries.

## Test plan

- [x] `make test` — 2484 passed, 0 failed
- [x] `make lint` — ruff + ty clean
- [x] No external `_tool_call_order` accesses remain outside `context.py`