### PR TITLE
refactor: enforce complexipy v6 checks (threshold 30)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,10 @@ repos:
         require_serial: true
         types: [python]
 
-  # - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-  #   rev: v5.1.0
-  #   hooks:
-  #     - id: complexipy
-  #       files: ^src/llm_rosetta/
-  #       exclude: ^src/llm_rosetta/_vendor/
-  #       args: [-mx, "25"]
+  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+    rev: v6.2.0
+    hooks:
+      - id: complexipy
+        files: ^(src/llm_rosetta/|tests/)
+        exclude: ^src/llm_rosetta/_vendor/
+        args: [-mx, "30"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "llm-comply>=0.2.0",
     "pytest-cov",
     "pre-commit>=4.0.0",
-    "complexipy>=5.2.0",
+    "complexipy>=6.2.0,<7",
     "ruff==0.15.20",
     "ty==0.0.54",
     "build>=1.2.2.post1",
@@ -99,6 +99,6 @@ max-complexity = 15
 "src/llm_rosetta/_vendor/*" = ["C901", "UP"]
 
 [tool.complexipy]
-paths = ["src"]
-max-complexity-allowed = 25
+paths = ["src", "tests"]
+max-complexity-allowed = 30
 exclude = ["src/llm_rosetta/_vendor"]

--- a/src/llm_rosetta/converters/base/helpers/multimodal_tool_patch.py
+++ b/src/llm_rosetta/converters/base/helpers/multimodal_tool_patch.py
@@ -159,6 +159,49 @@ def is_synthetic_tool_content_msg(msg: dict[str, Any]) -> bool:
     return False
 
 
+def _parse_synthetic_tags(
+    content: list[Any],
+) -> dict[str, list[dict[str, Any]]]:
+    """Parse ``<tool-content>`` XML tags from a synthetic message's parts.
+
+    Returns:
+        Mapping of call-id to the content blocks enclosed by each tag pair.
+    """
+    entries: dict[str, list[dict[str, Any]]] = {}
+    current_call_id: str | None = None
+    current_blocks: list[dict[str, Any]] = []
+
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+
+        if part.get("type") == "text":
+            text = part.get("text", "")
+
+            open_match = TOOL_CONTENT_OPEN_TAG_RE.match(text)
+            if open_match:
+                if current_call_id and current_blocks:
+                    entries[current_call_id] = current_blocks
+                current_call_id = open_match.group(1)
+                current_blocks = []
+                continue
+
+            if text == TOOL_CONTENT_CLOSE_TAG:
+                if current_call_id and current_blocks:
+                    entries[current_call_id] = current_blocks
+                current_call_id = None
+                current_blocks = []
+                continue
+
+        if current_call_id is not None:
+            current_blocks.append(part)
+
+    if current_call_id and current_blocks:
+        entries[current_call_id] = current_blocks
+
+    return entries
+
+
 def unpack_tool_content(
     messages: list[dict[str, Any]],
 ) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]]]:
@@ -174,38 +217,7 @@ def unpack_tool_content(
         if not is_synthetic_tool_content_msg(msg):
             clean.append(msg)
             continue
-
-        content = msg.get("content", [])
-        current_call_id: str | None = None
-        current_blocks: list[dict[str, Any]] = []
-
-        for part in content:
-            if not isinstance(part, dict):
-                continue
-
-            if part.get("type") == "text":
-                text = part.get("text", "")
-
-                open_match = TOOL_CONTENT_OPEN_TAG_RE.match(text)
-                if open_match:
-                    if current_call_id and current_blocks:
-                        unpacked[current_call_id] = current_blocks
-                    current_call_id = open_match.group(1)
-                    current_blocks = []
-                    continue
-
-                if text == TOOL_CONTENT_CLOSE_TAG:
-                    if current_call_id and current_blocks:
-                        unpacked[current_call_id] = current_blocks
-                    current_call_id = None
-                    current_blocks = []
-                    continue
-
-            if current_call_id is not None:
-                current_blocks.append(part)
-
-        if current_call_id and current_blocks:
-            unpacked[current_call_id] = current_blocks
+        unpacked.update(_parse_synthetic_tags(msg.get("content", [])))
 
     return unpacked, clean
 
@@ -213,6 +225,7 @@ def unpack_tool_content(
 __all__ = [
     "TOOL_CONTENT_CLOSE_TAG",
     "TOOL_CONTENT_OPEN_TAG_RE",
+    "_parse_synthetic_tags",
     "has_multimodal_content",
     "inject_packed_tool_content",
     "is_synthetic_tool_content_msg",

--- a/src/llm_rosetta/converters/base/helpers/multimodal_tool_patch.py
+++ b/src/llm_rosetta/converters/base/helpers/multimodal_tool_patch.py
@@ -225,7 +225,6 @@ def unpack_tool_content(
 __all__ = [
     "TOOL_CONTENT_CLOSE_TAG",
     "TOOL_CONTENT_OPEN_TAG_RE",
-    "_parse_synthetic_tags",
     "has_multimodal_content",
     "inject_packed_tool_content",
     "is_synthetic_tool_content_msg",

--- a/src/llm_rosetta/converters/base/helpers/reasoning.py
+++ b/src/llm_rosetta/converters/base/helpers/reasoning.py
@@ -281,6 +281,34 @@ def _derive_budget_tokens(
     return min(budget, max_tokens - 1)
 
 
+def _apply_thinking_type_override(
+    result: dict[str, Any],
+    cap: ReasoningCapability | None,
+    max_tokens: int | None,
+) -> None:
+    """Apply shim ``thinking_type`` override to the ``thinking`` dict.
+
+    When the shim declares a preferred thinking type, reconcile it with
+    what is already set — deriving ``budget_tokens`` from the ratio when
+    switching to ``"enabled"``, or stripping it when falling back to
+    ``"adaptive"``.
+    """
+    if cap is None or cap.thinking_type is None or "thinking" not in result:
+        return
+    current_type = result["thinking"].get("type")
+    target_type = cap.thinking_type
+    if target_type == "enabled" and "budget_tokens" not in result["thinking"]:
+        derived = _derive_budget_tokens(cap, max_tokens)
+        if derived is not None:
+            result["thinking"]["budget_tokens"] = derived
+        else:
+            target_type = "adaptive"
+    if current_type != target_type:
+        result["thinking"]["type"] = target_type
+        if target_type == "adaptive" and "budget_tokens" in result["thinking"]:
+            del result["thinking"]["budget_tokens"]
+
+
 # ── Converter-specific pass-through extras ─────────────────────────────────
 
 
@@ -303,20 +331,7 @@ def _apply_openai_chat_extras(
     if thinking:
         result["thinking"] = thinking
 
-    # Apply shim thinking_type override if set.
-    if cap is not None and cap.thinking_type is not None and "thinking" in result:
-        current_type = result["thinking"].get("type")
-        target_type = cap.thinking_type
-        if target_type == "enabled" and "budget_tokens" not in result["thinking"]:
-            derived = _derive_budget_tokens(cap, max_tokens)
-            if derived is not None:
-                result["thinking"]["budget_tokens"] = derived
-            else:
-                target_type = "adaptive"
-        if current_type != target_type:
-            result["thinking"]["type"] = target_type
-            if target_type == "adaptive" and "budget_tokens" in result["thinking"]:
-                del result["thinking"]["budget_tokens"]
+    _apply_thinking_type_override(result, cap, max_tokens)
 
 
 def _apply_openai_responses_extras(
@@ -373,22 +388,7 @@ def _apply_anthropic_extras(
     elif budget_tokens is not None:
         result["thinking"] = {"type": "enabled", "budget_tokens": budget_tokens}
 
-    # Apply shim thinking_type override if set.
-    if cap is not None and cap.thinking_type is not None and "thinking" in result:
-        current_type = result["thinking"].get("type")
-        target_type = cap.thinking_type
-        # Anthropic requires budget_tokens when type=enabled; if missing,
-        # try to derive from ratio, otherwise fall back to adaptive.
-        if target_type == "enabled" and "budget_tokens" not in result["thinking"]:
-            derived = _derive_budget_tokens(cap, max_tokens)
-            if derived is not None:
-                result["thinking"]["budget_tokens"] = derived
-            else:
-                target_type = "adaptive"
-        if current_type != target_type:
-            result["thinking"]["type"] = target_type
-            if target_type == "adaptive" and "budget_tokens" in result["thinking"]:
-                del result["thinking"]["budget_tokens"]
+    _apply_thinking_type_override(result, cap, max_tokens)
 
 
 def _apply_google_extras(

--- a/src/llm_rosetta/converters/base/helpers/schema.py
+++ b/src/llm_rosetta/converters/base/helpers/schema.py
@@ -262,6 +262,23 @@ def sanitize_schema(
 # ---- nullable → type-array conversion ----
 
 
+def _inject_null_type(result: dict[str, Any]) -> None:
+    """Inject ``"null"`` into an already-copied schema node's type declaration."""
+    if "type" in result:
+        current_type = result["type"]
+        if isinstance(current_type, str):
+            result["type"] = [current_type, "null"]
+        elif isinstance(current_type, list) and "null" not in current_type:
+            result["type"] = [*current_type, "null"]
+    else:
+        for kw in ("anyOf", "oneOf"):
+            if kw in result and isinstance(result[kw], list):
+                null_variant = {"type": "null"}
+                if null_variant not in result[kw]:
+                    result[kw] = [*result[kw], null_variant]
+                break
+
+
 def _nullable_to_type_array(schema: dict[str, Any]) -> dict[str, Any]:
     """Recursively convert ``"nullable": true`` to standard JSON Schema type arrays.
 
@@ -285,20 +302,7 @@ def _nullable_to_type_array(schema: dict[str, Any]) -> dict[str, Any]:
             result[key] = value
 
     if schema.get("nullable") is True:
-        if "type" in result:
-            current_type = result["type"]
-            if isinstance(current_type, str):
-                result["type"] = [current_type, "null"]
-            elif isinstance(current_type, list) and "null" not in current_type:
-                result["type"] = [*current_type, "null"]
-        else:
-            # No type field — inject null variant into anyOf/oneOf if present
-            for kw in ("anyOf", "oneOf"):
-                if kw in result and isinstance(result[kw], list):
-                    null_variant = {"type": "null"}
-                    if null_variant not in result[kw]:
-                        result[kw] = [*result[kw], null_variant]
-                    break
+        _inject_null_type(result)
 
     return result
 

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -740,47 +740,10 @@ class GoogleGenAIConverter(BaseConverter):
         deferred_finish: FinishEvent | None = None
 
         for candidate in chunk.get("candidates", []):
-            choice_index = candidate.get("index", 0)
-            content = candidate.get("content", {})
-
-            finish_reason = candidate.get("finish_reason") or candidate.get(
-                "finishReason"
-            )
-
-            # Track how many events existed before processing this
-            # candidate's parts, so we can identify which text_delta
-            # events belong to this compound chunk.
-            pre_parts_len = len(events)
-
-            for part in content.get("parts", []):
-                self._handle_p_part_to_ir(part, choice_index, context, events)
-
-            # When a compound chunk has both text and finishReason,
-            # defer the text into context so _handle_ir_finish_to_p can
-            # merge it into the finish candidate's parts, avoiding
-            # an extra output event.
-            if finish_reason and context is not None:
-                new_events = events[pre_parts_len:]
-                deferred_texts: list[str] = []
-                kept_new: list[IRStreamEvent] = []
-                for ev in new_events:
-                    if ev["type"] == "text_delta":
-                        deferred_texts.append(ev["text"])
-                    else:
-                        kept_new.append(ev)
-                if deferred_texts:
-                    context.pending_text = "".join(deferred_texts)
-                    events[pre_parts_len:] = kept_new
-
-            if finish_reason:
+            finish = self._process_stream_candidate(candidate, context, events)
+            if finish is not None:
                 has_finish_reason = True
-                deferred_finish = FinishEvent(
-                    type="finish",
-                    finish_reason={
-                        "reason": GOOGLE_REASON_FROM_PROVIDER.get(finish_reason, "stop")  # ty: ignore[invalid-argument-type]
-                    },
-                    choice_index=choice_index,
-                )
+                deferred_finish = finish
 
         # Handle prompt-level blocks in streaming (no candidates)
         if not has_finish_reason and not chunk.get("candidates"):
@@ -811,6 +774,49 @@ class GoogleGenAIConverter(BaseConverter):
             events.append(StreamEndEvent(type="stream_end"))
 
         return events
+
+    def _process_stream_candidate(
+        self,
+        candidate: dict[str, Any],
+        context: StreamContext | None,
+        events: list[IRStreamEvent],
+    ) -> FinishEvent | None:
+        """Process a single candidate from a stream chunk.
+
+        Handles part dispatch, text deferral for compound chunks, and
+        finish reason detection.  Returns a ``FinishEvent`` if the
+        candidate signals completion, otherwise ``None``.
+        """
+        choice_index = candidate.get("index", 0)
+        cand_content = candidate.get("content", {})
+        finish_reason = candidate.get("finish_reason") or candidate.get("finishReason")
+
+        pre_parts_len = len(events)
+        for part in cand_content.get("parts", []):
+            self._handle_p_part_to_ir(part, choice_index, context, events)
+
+        if finish_reason and context is not None:
+            new_events = events[pre_parts_len:]
+            deferred_texts: list[str] = []
+            kept_new: list[IRStreamEvent] = []
+            for ev in new_events:
+                if ev["type"] == "text_delta":
+                    deferred_texts.append(ev["text"])
+                else:
+                    kept_new.append(ev)
+            if deferred_texts:
+                context.pending_text = "".join(deferred_texts)
+                events[pre_parts_len:] = kept_new
+
+        if finish_reason:
+            return FinishEvent(
+                type="finish",
+                finish_reason={
+                    "reason": GOOGLE_REASON_FROM_PROVIDER.get(finish_reason, "stop")  # ty: ignore[invalid-argument-type]
+                },
+                choice_index=choice_index,
+            )
+        return None
 
     def _handle_p_stream_start_to_ir(
         self,

--- a/src/llm_rosetta/converters/google_genai/message_ops.py
+++ b/src/llm_rosetta/converters/google_genai/message_ops.py
@@ -51,6 +51,18 @@ _GOOGLE_TO_IR_ROLE = {
 }
 
 
+def _match_tool_name(result_id: str, known_names: dict[str, list[str]]) -> str:
+    """Find the tool_name that best matches a result ID.
+
+    Checks for exact match first, then Gemini CLI prefix format
+    (``<name>_<timestamp>_<index>``).  Falls back to *result_id* itself.
+    """
+    for name in known_names:
+        if result_id == name or result_id.startswith(name + "_"):
+            return name
+    return result_id
+
+
 class GoogleGenAIMessageOps(BaseMessageOps):
     """Google GenAI message conversion operations.
 
@@ -283,16 +295,7 @@ class GoogleGenAIMessageOps(BaseMessageOps):
                 # function name (Google convention) or a client-generated
                 # ID.  We need to find the matching tool_call by name.
                 result_id = part.get("tool_call_id", "")
-                # Try to identify the function name: check if result_id
-                # matches any known tool_name directly.
-                tool_name = result_id  # default guess
-                for name in call_queue:
-                    # Match if the result_id starts with the tool name
-                    # (Gemini CLI format: "<name>_<timestamp>_<index>")
-                    # or equals the tool name exactly.
-                    if result_id == name or result_id.startswith(name + "_"):
-                        tool_name = name
-                        break
+                tool_name = _match_tool_name(result_id, call_queue)
 
                 ids = call_queue.get(tool_name)
                 if not ids:

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -58,6 +58,30 @@ from .tool_ops import OpenAIResponsesToolOps
 from .utils import build_message_preamble_events, resolve_call_id
 
 
+def _capture_item_metadata(item: dict[str, Any]) -> dict[str, Any]:
+    """Extract per-output-item metadata for lossless round-trip."""
+    meta: dict[str, Any] = {}
+    if "id" in item:
+        meta["id"] = item["id"]
+    if "status" in item:
+        meta["status"] = item["status"]
+    item_content = item.get("content", [])
+    if isinstance(item_content, list):
+        parts_meta: list[dict[str, Any]] = []
+        for cp in item_content:
+            if not isinstance(cp, dict):
+                continue
+            pm: dict[str, Any] = {}
+            if "annotations" in cp:
+                pm["annotations"] = cp["annotations"]
+            if "logprobs" in cp:
+                pm["logprobs"] = cp["logprobs"]
+            parts_meta.append(pm)
+        if parts_meta:
+            meta["content_meta"] = parts_meta
+    return meta
+
+
 class OpenAIResponsesConverter(BaseConverter):
     """OpenAI Responses API converter.
 
@@ -583,30 +607,11 @@ class OpenAIResponsesConverter(BaseConverter):
         if extras:
             ctx.store_response_extras(extras)
 
-        items_meta: list[dict[str, Any]] = []
-        for item in output_items:
-            if not OpenAIResponsesMessageOps.is_portable_response_output_item(item):
-                continue
-            meta: dict[str, Any] = {}
-            if "id" in item:
-                meta["id"] = item["id"]
-            if "status" in item:
-                meta["status"] = item["status"]
-            content = item.get("content", [])
-            if isinstance(content, list):
-                parts_meta: list[dict[str, Any]] = []
-                for cp in content:
-                    if not isinstance(cp, dict):
-                        continue
-                    pm: dict[str, Any] = {}
-                    if "annotations" in cp:
-                        pm["annotations"] = cp["annotations"]
-                    if "logprobs" in cp:
-                        pm["logprobs"] = cp["logprobs"]
-                    parts_meta.append(pm)
-                if parts_meta:
-                    meta["content_meta"] = parts_meta
-            items_meta.append(meta)
+        items_meta = [
+            _capture_item_metadata(item)
+            for item in output_items
+            if OpenAIResponsesMessageOps.is_portable_response_output_item(item)
+        ]
         if items_meta:
             ctx.store_output_items_meta(items_meta)
 

--- a/src/llm_rosetta/converters/openai_responses/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/tool_ops.py
@@ -116,6 +116,82 @@ def fix_orphaned_tool_calls(
     return patched
 
 
+def _synthesize_passthrough_tool(
+    provider_tool: dict[str, Any], tool_type: str
+) -> ToolDefinition:
+    """Build a passthrough IR tool for non-standard provider tool types.
+
+    Synthesizes a minimal JSON Schema so cross-provider degradation
+    produces "a function that accepts one text input" instead of an
+    empty schema.  Appends format-constraint hints to the description.
+    """
+    synth_params: dict[str, Any] = {}
+    if provider_tool.get("name"):
+        synth_params = {
+            "type": "object",
+            "properties": {
+                "input": {
+                    "type": "string",
+                    "description": "Free-form text input",
+                }
+            },
+            "required": ["input"],
+        }
+    desc = provider_tool.get("description", "")
+    fmt = provider_tool.get("format")
+    if fmt:
+        fmt_type = fmt.get("type", "unknown")
+        fmt_syntax = fmt.get("syntax", "")
+        hint = f"[Output format: {fmt_type}"
+        if fmt_syntax:
+            hint += f", syntax: {fmt_syntax}"
+        hint += "]"
+        desc = f"{desc}\n\n{hint}" if desc else hint
+    return cast(
+        ToolDefinition,
+        {
+            "type": "function",
+            "name": provider_tool.get("name", tool_type),
+            "description": desc,
+            "parameters": synth_params,
+            "_passthrough": dict(provider_tool),
+            "metadata": {"provider_type": tool_type},
+            "required_parameters": synth_params.get("required", []),
+        },
+    )
+
+
+def _build_function_call_item(
+    ir_tool_call: ToolCallPart,
+    tool_call_id: str,
+    tool_name: str,
+    arguments: str,
+) -> dict:
+    """Build a ``function_call`` item with correct ``fc_`` prefixed ID.
+
+    Recovers the Responses API item ID from provider_metadata when
+    available, otherwise converts ``call_`` prefix to ``fc_`` or adds
+    the prefix for other ID schemes (e.g. Anthropic ``toolu_``).
+    """
+    metadata = ir_tool_call.get("provider_metadata") or {}
+    item_id = metadata.get("responses_item_id")
+    if not item_id:
+        if tool_call_id and tool_call_id.startswith("fc_"):
+            item_id = tool_call_id
+        elif tool_call_id and tool_call_id.startswith("call_"):
+            item_id = "fc_" + tool_call_id[5:]
+        else:
+            item_id = "fc_" + tool_call_id
+    return {
+        "type": "function_call",
+        "id": item_id,
+        "call_id": tool_call_id,
+        "name": tool_name,
+        "arguments": arguments,
+        "status": "completed",
+    }
+
+
 class OpenAIResponsesToolOps(BaseToolOps):
     """OpenAI Responses API tool conversion operations.
 
@@ -213,46 +289,7 @@ class OpenAIResponsesToolOps(BaseToolOps):
             # satisfy validation; ``ir_tool_definition_to_p`` restores the
             # original payload on the outbound leg.
             if tool_type != "function" and tool_type not in _IR_ALLOWED_TYPES:
-                # Synthesize a minimal JSON Schema for cross-provider
-                # degradation so other providers see "a function that
-                # accepts one text input" instead of an empty schema.
-                synth_params: dict[str, Any] = {}
-                if provider_tool.get("name"):
-                    synth_params = {
-                        "type": "object",
-                        "properties": {
-                            "input": {
-                                "type": "string",
-                                "description": "Free-form text input",
-                            }
-                        },
-                        "required": ["input"],
-                    }
-                # Append format constraint info to description so
-                # cross-provider models get a hint about the expected
-                # output shape (best-effort, not enforced).
-                desc = provider_tool.get("description", "")
-                fmt = provider_tool.get("format")
-                if fmt:
-                    fmt_type = fmt.get("type", "unknown")
-                    fmt_syntax = fmt.get("syntax", "")
-                    hint = f"[Output format: {fmt_type}"
-                    if fmt_syntax:
-                        hint += f", syntax: {fmt_syntax}"
-                    hint += "]"
-                    desc = f"{desc}\n\n{hint}" if desc else hint
-                result = {
-                    "type": "function",
-                    "name": provider_tool.get("name", tool_type),
-                    "description": desc,
-                    "parameters": synth_params,
-                    "_passthrough": dict(provider_tool),
-                }
-                result["metadata"] = {"provider_type": tool_type}
-                result["required_parameters"] = (
-                    synth_params.get("required", []) if synth_params else []
-                )
-                return cast(ToolDefinition, result)
+                return _synthesize_passthrough_tool(provider_tool, tool_type)
 
             # Flat format (Responses API native).
             # Custom tools use "schema" instead of "parameters".
@@ -398,17 +435,8 @@ class OpenAIResponsesToolOps(BaseToolOps):
             json.dumps(tool_input) if isinstance(tool_input, dict) else str(tool_input)
         )
 
-        # Detect MCP call
-        if tool_name and tool_name.startswith("mcp://"):
-            return {
-                "type": "mcp_call",
-                "id": tool_call_id,
-                "name": tool_name,
-                "arguments": arguments,
-                "server_label": ir_tool_call.get("server_name", "default"),
-                "status": "calling",
-            }
-        elif tool_type == "mcp":
+        is_mcp = tool_type == "mcp" or (tool_name and tool_name.startswith("mcp://"))
+        if is_mcp:
             return {
                 "type": "mcp_call",
                 "id": tool_call_id,
@@ -418,27 +446,9 @@ class OpenAIResponsesToolOps(BaseToolOps):
                 "status": "calling",
             }
         elif tool_type == "function":
-            # Recover Responses API item ID from provider_metadata if available;
-            # the API requires 'id' to start with 'fc_' prefix.
-            metadata = ir_tool_call.get("provider_metadata") or {}
-            item_id = metadata.get("responses_item_id")
-            if not item_id:
-                # Cross-format: ensure fc_ prefix required by Responses API
-                if tool_call_id and tool_call_id.startswith("fc_"):
-                    item_id = tool_call_id
-                elif tool_call_id and tool_call_id.startswith("call_"):
-                    item_id = "fc_" + tool_call_id[5:]
-                else:
-                    # Other prefixes (e.g. toolu_ from Anthropic)
-                    item_id = "fc_" + tool_call_id
-            return {
-                "type": "function_call",
-                "id": item_id,
-                "call_id": tool_call_id,
-                "name": tool_name,
-                "arguments": arguments,
-                "status": "completed",
-            }
+            return _build_function_call_item(
+                ir_tool_call, tool_call_id, tool_name, arguments
+            )
         elif tool_type == "custom":
             # Custom tool calls use plain text 'input' instead of JSON
             # 'arguments'.  If tool_input has a single "input" key, unwrap

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -224,138 +224,27 @@ class GatewayConfig:
             self._raw_providers
         )
 
-        # Per-provider supports_custom_tools override from config.
-        self.provider_supports_custom_tools: dict[str, bool] = {}
-        for pname, pcfg in self._raw_providers.items():
-            if isinstance(pcfg, dict) and "supports_custom_tools" in pcfg:
-                self.provider_supports_custom_tools[pname] = bool(
-                    pcfg["supports_custom_tools"]
-                )
+        self.provider_supports_custom_tools = self._parse_custom_tools_overrides(
+            self._raw_providers
+        )
 
         self.models, self.model_capabilities, self.model_upstream_names = (
             self._parse_models(raw.get("models", {}), self._raw_providers)
         )
 
-        # Per-model URL template overrides.
-        self.model_url_templates: dict[str, str] = {}
-        self.model_stream_url_templates: dict[str, str] = {}
-        for model_name, value in raw.get("models", {}).items():
-            if isinstance(value, dict):
-                if "url_template" in value:
-                    self.model_url_templates[model_name] = value["url_template"]
-                if "stream_url_template" in value:
-                    self.model_stream_url_templates[model_name] = value[
-                        "stream_url_template"
-                    ]
-
-        # Per-model reasoning overrides from config.jsonc (admin UI edits).
-        # Keyed by gateway model name (same as self.models keys).
-        self.model_reasoning_overrides: dict[str, dict[str, Any]] = {}
-        for model_name, value in raw.get("models", {}).items():
-            if isinstance(value, dict) and value.get("reasoning_override"):
-                self.model_reasoning_overrides[model_name] = value["reasoning_override"]
-
-        # Per-model flatten_system flag (explicit config or auto-detected).
-        # When True, system message content arrays are flattened to plain
-        # strings before sending upstream.
-        self.model_flatten_system: dict[str, bool] = {}
-        for model_name, value in raw.get("models", {}).items():
-            if isinstance(value, dict) and "flatten_system" in value:
-                self.model_flatten_system[model_name] = bool(value["flatten_system"])
-            elif re.search(r"gemini", model_name, re.IGNORECASE):
-                # Auto-detect: gemini models default to flatten_system=True
-                self.model_flatten_system[model_name] = True
+        raw_models = raw.get("models", {})
+        (
+            self.model_url_templates,
+            self.model_stream_url_templates,
+            self.model_reasoning_overrides,
+            self.model_flatten_system,
+        ) = self._parse_model_overrides(raw_models)
 
         _server = raw.get("server", {})
-        self.host: str = _server.get("host", "0.0.0.0")
-        self.port: int = _server.get("port", 8765)
-        self.proxy: str | None = _server.get("proxy")
-        self.socket: str | None = _server.get("socket")
-        self.credential_visible: bool = _server.get("credential_visible", True)
+        self._apply_server_settings(_server)
+        self._apply_auth_settings(_server)
 
-        # When no API keys are configured, ``open_on_no_keys`` decides whether
-        # the standalone gateway serves /v1/* anonymously (True) or rejects
-        # every request with 403 (False). Defaults to False (secure by
-        # default). Set to True to restore the pre-0.7 behaviour for a
-        # trusted, localhost-only deployment, e.g.:
-        #   "server": { "open_on_no_keys": true }
-        self.open_on_no_keys: bool = bool(_server.get("open_on_no_keys", False))
-
-        self.admin_password: str | None = _server.get("admin_password")
-        if self.admin_password and _ENV_VAR_RE.search(self.admin_password):
-            raise ValueError(
-                "config: admin_password contains an unresolved ${...} placeholder. "
-                "Set the environment variable or use a literal password."
-            )
-
-        # CORS allow-list for /admin/* endpoints.
-        # Default [] means same-origin only (no Access-Control-Allow-Origin header).
-        # To permit a specific trusted origin set e.g. in your config (JSONC):
-        #   "server": {
-        #     "admin_cors_origins": ["https://my-admin.example.com"]
-        #   }
-        self.admin_cors_origins: list[str] = _server.get("admin_cors_origins", []) or []
-
-        # Optional root redirect: when set, GET / returns a 307 to the given
-        # path (e.g. "/admin").  Disabled by default (no redirect).
-        self.root_redirect: str | None = _server.get("root_redirect")
-
-        # Timeout settings (seconds).  upstream_timeout governs the entire
-        # upstream HTTP lifecycle: connect, header-read, and per-chunk
-        # streaming reads.  read_timeout governs how long the inbound
-        # httpserver waits for the client to send a complete request.
-        self.upstream_timeout: float = max(
-            1.0, float(_server.get("upstream_timeout", 300.0))
-        )
-        self.read_timeout: float = max(1.0, float(_server.get("read_timeout", 300.0)))
-
-        # Request-log retention knobs (consumed by setup_admin).  Kept as
-        # a raw dict here so admin layer owns the resolution policy.
-        self.request_log: dict[str, Any] = _server.get("request_log", {}) or {}
-
-        # Multi-key auth: server.api_keys takes precedence over server.api_key
-        self.api_keys: list[dict[str, str]] = _server.get("api_keys", [])
-        if not self.api_keys and _server.get("api_key"):
-            # Backward compat: single api_key → synthetic entry
-            self.api_keys = [
-                {
-                    "id": "default",
-                    "key": _server["api_key"],
-                    "label": "default",
-                    "created": "",
-                }
-            ]
-        # O(1) lookup set and key→label map for auth middleware
-        self.api_key_set: frozenset[str] = frozenset(
-            entry["key"] for entry in self.api_keys
-        )
-        self.api_key_labels: dict[str, str] = {
-            entry["key"]: entry.get("label", "") for entry in self.api_keys
-        }
-
-        # Debug / logging options (config + env-var overrides)
-        _debug = raw.get("debug", {})
-        self.verbose: bool = _debug.get("verbose", False) or os.environ.get(
-            "LLM_ROSETTA_VERBOSE", ""
-        ).lower() in ("1", "true", "yes")
-        self.log_bodies: bool = _debug.get("log_bodies", False) or os.environ.get(
-            "LLM_ROSETTA_LOG_BODIES", ""
-        ).lower() in ("1", "true", "yes")
-        self.error_dumps_enabled: bool = _debug.get("error_dumps", True)
-
-        # Log format: "text" (colourised, default for TTY), "json" (structured
-        # one-line JSON, default for non-TTY), or "auto" (detect from stderr
-        # TTY status).  Env var LLM_ROSETTA_LOG_FORMAT overrides config.
-        _env_log_format = os.environ.get("LLM_ROSETTA_LOG_FORMAT", "").strip().lower()
-        _cfg_log_format = _debug.get("log_format", "auto")
-        raw_log_format = _env_log_format or _cfg_log_format
-        if raw_log_format not in ("json", "text", "auto"):
-            logger.warning(
-                "config: invalid log_format %r, falling back to 'auto'",
-                raw_log_format,
-            )
-            raw_log_format = "auto"
-        self.log_format: str = raw_log_format  # resolved later by setup_logging
+        self._apply_debug_settings(raw.get("debug", {}))
 
         self._validate()
 
@@ -366,6 +255,104 @@ class GatewayConfig:
             )
             for name, cfg in self._raw_providers.items()
         }
+
+    @staticmethod
+    def _parse_custom_tools_overrides(
+        raw_providers: dict[str, dict[str, str]],
+    ) -> dict[str, bool]:
+        """Extract per-provider supports_custom_tools overrides."""
+        result: dict[str, bool] = {}
+        for pname, pcfg in raw_providers.items():
+            if isinstance(pcfg, dict) and "supports_custom_tools" in pcfg:
+                result[pname] = bool(pcfg["supports_custom_tools"])
+        return result
+
+    @staticmethod
+    def _parse_model_overrides(
+        raw_models: dict[str, Any],
+    ) -> tuple[
+        dict[str, str], dict[str, str], dict[str, dict[str, Any]], dict[str, bool]
+    ]:
+        """Extract per-model URL templates, reasoning overrides, and flatten_system flags."""
+        url_templates: dict[str, str] = {}
+        stream_url_templates: dict[str, str] = {}
+        reasoning_overrides: dict[str, dict[str, Any]] = {}
+        flatten_system: dict[str, bool] = {}
+        for model_name, value in raw_models.items():
+            if isinstance(value, dict):
+                if "url_template" in value:
+                    url_templates[model_name] = value["url_template"]
+                if "stream_url_template" in value:
+                    stream_url_templates[model_name] = value["stream_url_template"]
+                if value.get("reasoning_override"):
+                    reasoning_overrides[model_name] = value["reasoning_override"]
+                if "flatten_system" in value:
+                    flatten_system[model_name] = bool(value["flatten_system"])
+                    continue
+            if re.search(r"gemini", model_name, re.IGNORECASE):
+                flatten_system[model_name] = True
+        return url_templates, stream_url_templates, reasoning_overrides, flatten_system
+
+    def _apply_server_settings(self, _server: dict[str, Any]) -> None:
+        """Parse server section: host, port, proxy, timeouts, CORS, etc."""
+        self.host: str = _server.get("host", "0.0.0.0")
+        self.port: int = _server.get("port", 8765)
+        self.proxy: str | None = _server.get("proxy")
+        self.socket: str | None = _server.get("socket")
+        self.credential_visible: bool = _server.get("credential_visible", True)
+        self.open_on_no_keys: bool = bool(_server.get("open_on_no_keys", False))
+        self.admin_password: str | None = _server.get("admin_password")
+        if self.admin_password and _ENV_VAR_RE.search(self.admin_password):
+            raise ValueError(
+                "config: admin_password contains an unresolved ${...} placeholder. "
+                "Set the environment variable or use a literal password."
+            )
+        self.admin_cors_origins: list[str] = _server.get("admin_cors_origins", []) or []
+        self.root_redirect: str | None = _server.get("root_redirect")
+        self.upstream_timeout: float = max(
+            1.0, float(_server.get("upstream_timeout", 300.0))
+        )
+        self.read_timeout: float = max(1.0, float(_server.get("read_timeout", 300.0)))
+        self.request_log: dict[str, Any] = _server.get("request_log", {}) or {}
+
+    def _apply_auth_settings(self, _server: dict[str, Any]) -> None:
+        """Parse API key auth settings from the server section."""
+        self.api_keys: list[dict[str, str]] = _server.get("api_keys", [])
+        if not self.api_keys and _server.get("api_key"):
+            self.api_keys = [
+                {
+                    "id": "default",
+                    "key": _server["api_key"],
+                    "label": "default",
+                    "created": "",
+                }
+            ]
+        self.api_key_set: frozenset[str] = frozenset(
+            entry["key"] for entry in self.api_keys
+        )
+        self.api_key_labels: dict[str, str] = {
+            entry["key"]: entry.get("label", "") for entry in self.api_keys
+        }
+
+    def _apply_debug_settings(self, _debug: dict[str, Any]) -> None:
+        """Parse debug/logging settings with env-var overrides."""
+        self.verbose: bool = _debug.get("verbose", False) or os.environ.get(
+            "LLM_ROSETTA_VERBOSE", ""
+        ).lower() in ("1", "true", "yes")
+        self.log_bodies: bool = _debug.get("log_bodies", False) or os.environ.get(
+            "LLM_ROSETTA_LOG_BODIES", ""
+        ).lower() in ("1", "true", "yes")
+        self.error_dumps_enabled: bool = _debug.get("error_dumps", True)
+        _env_log_format = os.environ.get("LLM_ROSETTA_LOG_FORMAT", "").strip().lower()
+        _cfg_log_format = _debug.get("log_format", "auto")
+        raw_log_format = _env_log_format or _cfg_log_format
+        if raw_log_format not in ("json", "text", "auto"):
+            logger.warning(
+                "config: invalid log_format %r, falling back to 'auto'",
+                raw_log_format,
+            )
+            raw_log_format = "auto"
+        self.log_format: str = raw_log_format
 
     def _validate(self) -> None:
         if not self._raw_providers:

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -300,23 +300,45 @@ class GatewayConfig:
         self.proxy: str | None = _server.get("proxy")
         self.socket: str | None = _server.get("socket")
         self.credential_visible: bool = _server.get("credential_visible", True)
+
+        # When no API keys are configured, ``open_on_no_keys`` decides whether
+        # the standalone gateway serves /v1/* anonymously (True) or rejects
+        # every request with 403 (False).  Defaults to False (secure by
+        # default).  Set to True for trusted, localhost-only deployments.
         self.open_on_no_keys: bool = bool(_server.get("open_on_no_keys", False))
+
         self.admin_password: str | None = _server.get("admin_password")
         if self.admin_password and _ENV_VAR_RE.search(self.admin_password):
             raise ValueError(
                 "config: admin_password contains an unresolved ${...} placeholder. "
                 "Set the environment variable or use a literal password."
             )
+
+        # CORS allow-list for /admin/* endpoints.
+        # Default [] means same-origin only (no Access-Control-Allow-Origin).
         self.admin_cors_origins: list[str] = _server.get("admin_cors_origins", []) or []
+
+        # Optional root redirect: GET / returns 307 to the given path.
         self.root_redirect: str | None = _server.get("root_redirect")
+
+        # upstream_timeout: entire upstream HTTP lifecycle (connect + headers
+        # + per-chunk streaming reads).  read_timeout: how long the inbound
+        # httpserver waits for the client to send a complete request.
         self.upstream_timeout: float = max(
             1.0, float(_server.get("upstream_timeout", 300.0))
         )
         self.read_timeout: float = max(1.0, float(_server.get("read_timeout", 300.0)))
+
+        # Request-log retention knobs (consumed by setup_admin).
         self.request_log: dict[str, Any] = _server.get("request_log", {}) or {}
 
     def _apply_auth_settings(self, _server: dict[str, Any]) -> None:
-        """Parse API key auth settings from the server section."""
+        """Parse API key auth settings from the server section.
+
+        ``server.api_keys`` (list) takes precedence over the legacy
+        ``server.api_key`` (single string).  A lone ``api_key`` is promoted
+        to a synthetic ``api_keys`` entry for backward compatibility.
+        """
         self.api_keys: list[dict[str, str]] = _server.get("api_keys", [])
         if not self.api_keys and _server.get("api_key"):
             self.api_keys = [
@@ -327,6 +349,7 @@ class GatewayConfig:
                     "created": "",
                 }
             ]
+        # O(1) lookup set and key→label map for auth middleware
         self.api_key_set: frozenset[str] = frozenset(
             entry["key"] for entry in self.api_keys
         )
@@ -335,7 +358,11 @@ class GatewayConfig:
         }
 
     def _apply_debug_settings(self, _debug: dict[str, Any]) -> None:
-        """Parse debug/logging settings with env-var overrides."""
+        """Parse debug/logging settings with env-var overrides.
+
+        Env vars ``LLM_ROSETTA_VERBOSE``, ``LLM_ROSETTA_LOG_BODIES``,
+        and ``LLM_ROSETTA_LOG_FORMAT`` override their config counterparts.
+        """
         self.verbose: bool = _debug.get("verbose", False) or os.environ.get(
             "LLM_ROSETTA_VERBOSE", ""
         ).lower() in ("1", "true", "yes")
@@ -343,6 +370,10 @@ class GatewayConfig:
             "LLM_ROSETTA_LOG_BODIES", ""
         ).lower() in ("1", "true", "yes")
         self.error_dumps_enabled: bool = _debug.get("error_dumps", True)
+
+        # Log format: "text" (colourised, default for TTY), "json" (structured
+        # one-line JSON, default for non-TTY), or "auto" (detect from stderr
+        # TTY status).  Env var LLM_ROSETTA_LOG_FORMAT overrides config.
         _env_log_format = os.environ.get("LLM_ROSETTA_LOG_FORMAT", "").strip().lower()
         _cfg_log_format = _debug.get("log_format", "auto")
         raw_log_format = _env_log_format or _cfg_log_format
@@ -352,7 +383,7 @@ class GatewayConfig:
                 raw_log_format,
             )
             raw_log_format = "auto"
-        self.log_format: str = raw_log_format
+        self.log_format: str = raw_log_format  # resolved later by setup_logging
 
     def _validate(self) -> None:
         if not self._raw_providers:

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -121,81 +121,96 @@ class _Socks5Handler(socketserver.StreamRequestHandler):
         except Exception:
             return
 
-    def _do_handshake(self):  # noqa: C901
-        # Phase 1: method negotiation
+    def _do_handshake(self):
+        if not self._negotiate_method():
+            return
+
+        target_addr = self._read_connect_request()
+        if target_addr is None:
+            return
+        target_host, target_port = target_addr
+
+        try:
+            target = socket.create_connection((target_host, target_port), timeout=10)
+        except Exception:
+            self._send_reply(0x05)
+            return
+
+        self._send_reply(0x00)
+        self._relay(target)
+
+    def _negotiate_method(self) -> bool:
+        """SOCKS5 method negotiation (RFC 1928) + optional auth (RFC 1929)."""
         header = self.rfile.read(2)
         if len(header) < 2:
-            return
+            return False
         ver, nmethods = struct.unpack("BB", header)
         if ver != 0x05:
-            return
+            return False
         methods = self.rfile.read(nmethods)
         if len(methods) < nmethods:
-            return
+            return False
 
         require_auth = self.server.socks5_auth is not None  # type: ignore
 
         if require_auth:
             if 0x02 not in methods:
                 self.wfile.write(struct.pack("BB", 0x05, 0xFF))
-                return
+                return False
             self.wfile.write(struct.pack("BB", 0x05, 0x02))
-            # Phase 2: username/password auth (RFC 1929)
-            auth_header = self.rfile.read(2)
-            if len(auth_header) < 2:
-                return
-            _auth_ver, ulen = struct.unpack("BB", auth_header)
-            uname = self.rfile.read(ulen)
-            plen_byte = self.rfile.read(1)
-            if not plen_byte:
-                return
-            plen = struct.unpack("B", plen_byte)[0]
-            passwd = self.rfile.read(plen)
+            return self._authenticate()
 
-            expected_user, expected_pass = self.server.socks5_auth  # type: ignore
-            if uname.decode() != expected_user or passwd.decode() != expected_pass:
-                self.wfile.write(struct.pack("BB", 0x01, 0x01))  # auth failure
-                return
-            self.wfile.write(struct.pack("BB", 0x01, 0x00))  # auth success
-        else:
-            self.wfile.write(struct.pack("BB", 0x05, 0x00))  # no auth
+        self.wfile.write(struct.pack("BB", 0x05, 0x00))
+        return True
 
-        # Phase 3: connect request
+    def _authenticate(self) -> bool:
+        """RFC 1929 username/password sub-negotiation."""
+        auth_header = self.rfile.read(2)
+        if len(auth_header) < 2:
+            return False
+        _auth_ver, ulen = struct.unpack("BB", auth_header)
+        uname = self.rfile.read(ulen)
+        plen_byte = self.rfile.read(1)
+        if not plen_byte:
+            return False
+        plen = struct.unpack("B", plen_byte)[0]
+        passwd = self.rfile.read(plen)
+
+        expected_user, expected_pass = self.server.socks5_auth  # type: ignore
+        if uname.decode() != expected_user or passwd.decode() != expected_pass:
+            self.wfile.write(struct.pack("BB", 0x01, 0x01))
+            return False
+        self.wfile.write(struct.pack("BB", 0x01, 0x00))
+        return True
+
+    def _read_connect_request(self) -> tuple[str, int] | None:
+        """Parse SOCKS5 CONNECT request and return (host, port)."""
         req_header = self.rfile.read(4)
         if len(req_header) < 4:
-            return
-        ver, cmd, _rsv, atype = struct.unpack("BBBB", req_header)
-        if cmd != 0x01:  # only CONNECT supported
+            return None
+        _ver, cmd, _rsv, atype = struct.unpack("BBBB", req_header)
+        if cmd != 0x01:
             self._send_reply(0x07)
-            return
+            return None
 
-        # Parse target address
-        if atype == 0x01:  # IPv4
+        if atype == 0x01:
             addr_bytes = self.rfile.read(4)
             target_host = socket.inet_ntoa(addr_bytes)
-        elif atype == 0x03:  # domain
+        elif atype == 0x03:
             addr_len = struct.unpack("B", self.rfile.read(1))[0]
             target_host = self.rfile.read(addr_len).decode()
-        elif atype == 0x04:  # IPv6
+        elif atype == 0x04:
             addr_bytes = self.rfile.read(16)
             target_host = socket.inet_ntop(socket.AF_INET6, addr_bytes)
         else:
             self._send_reply(0x08)
-            return
+            return None
 
         target_port = struct.unpack("!H", self.rfile.read(2))[0]
+        return target_host, target_port
 
-        # Connect to target
-        try:
-            target = socket.create_connection((target_host, target_port), timeout=10)
-        except Exception:
-            self._send_reply(0x05)  # connection refused
-            return
-
-        # Success reply
-        self._send_reply(0x00)
-
-        # Bidirectional relay
+    def _relay(self, target: socket.socket) -> None:
+        """Bidirectional relay between client and target sockets."""
         client_sock = self.connection
         client_sock.setblocking(False)
         target.setblocking(False)


### PR DESCRIPTION
## Summary

- Bump complexipy to v6.2.0 (aligned with SonarSource v1.7 cognitive complexity paper) and raise the enforcement threshold from 25 → **30**
- Refactor the 10 functions that exceeded threshold 30, each with genuine readability wins — no mechanical score-lowering
- Enable the complexipy pre-commit hook so future regressions are caught at commit time

### Threshold rationale

Functions scoring 26–29 are inherently complex protocol mapping (N-way tool type dispatch, stateful SSE parsing, multi-stage reordering algorithms). Forcing extraction on these would fragment cohesive logic without readability benefit. Threshold 30 keeps enforcement meaningful while accepting inherent complexity.

### Refactored functions (10 total)

| Function | Before | After | Approach |
|----------|--------|-------|----------|
| `unpack_tool_content` | 37 | ~7 | Extract `_parse_synthetic_tags` |
| `_nullable_to_type_array` | 37 | ~24 | Extract `_inject_null_type` |
| `GatewayConfig.__init__` | 37 | ~10 | Extract 5 config-section parsers |
| `_Socks5Handler._do_handshake` | 37 | ~6 | Split along RFC 1928 protocol phases |
| `p_tool_definition_to_ir` | 35 | ~18 | Extract `_synthesize_passthrough_tool` |
| `ir_tool_call_to_p` | 33 | ~25 | Merge duplicate MCP branches, extract `_build_function_call_item` |
| `_reconcile_tool_call_ids` | 33 | ~22 | Extract `_match_tool_name` heuristic |
| `_capture_preserve_metadata` | 32 | ~12 | Extract `_capture_item_metadata` |
| `_apply_anthropic_extras` | 31 | ~19 | Extract shared `_apply_thinking_type_override` (DRY win with `_apply_openai_chat_extras`) |
| `stream_response_from_provider` | 31 | ~16 | Extract `_process_stream_candidate` |

Supersedes #395. Closes #201.

## Test plan

- [x] `complexipy src tests -e src/llm_rosetta/_vendor -mx 30 -f` → 0 violations
- [x] `pre-commit run --all-files` → all passed (ruff, ruff-format, ty, complexipy)
- [x] `make test` → 2493 passed, 0 failed
- [x] `make lint` → clean

AI was used to assist with implementation; the changes were reviewed and tested.