### PR TITLE
feat(shims): hoist late system messages to preserve prompt cache prefix

### DIFF
--- a/src/llm_rosetta/converters/base/helpers/__init__.py
+++ b/src/llm_rosetta/converters/base/helpers/__init__.py
@@ -47,3 +47,8 @@ __all__ = [
     "convert_content_blocks_to_ir",
     "convert_ir_content_blocks_to_p",
 ]
+
+# system_message_hoist
+from .system_message_hoist import hoist_late_system_messages_ir
+
+__all__ += ["hoist_late_system_messages_ir"]

--- a/src/llm_rosetta/converters/base/helpers/system_message_hoist.py
+++ b/src/llm_rosetta/converters/base/helpers/system_message_hoist.py
@@ -1,0 +1,119 @@
+"""Hoist late system messages to preserve prompt cache prefix stability.
+
+When a system/developer message appears mid-conversation (after user or
+assistant turns), it breaks the prompt cache prefix for upstreams that
+support caching (Anthropic, OpenAI).  The Anthropic converter also drops
+non-leading system messages entirely, causing silent data loss.
+
+This helper rewrites the IR request so that:
+
+1. **Leading** system messages (before any non-system message) are moved
+   into ``system_instruction``.
+2. **Late** system messages (after the first non-system message) are
+   rewritten as ``UserMessage`` with a ``[System: ...]`` envelope.
+
+The result is a stable prefix that caching can rely on, and no data loss
+regardless of target format.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_system_text(msg: dict[str, Any]) -> str:
+    """Join all text parts of a system message into a single string."""
+    content = msg.get("content", [])
+    if isinstance(content, str):
+        return content
+    parts = []
+    for part in content:
+        if isinstance(part, dict) and part.get("type") == "text":
+            parts.append(part.get("text", ""))
+    return "\n".join(parts)
+
+
+def _rewrite_as_user(msg: dict[str, Any]) -> dict[str, Any]:
+    """Convert a SystemMessage to a UserMessage with envelope."""
+    text = _extract_system_text(msg)
+    envelope = f"[System: {text}]" if text.strip() else "[System instruction]"
+    result: dict[str, Any] = {
+        "role": "user",
+        "content": [{"type": "text", "text": envelope}],
+    }
+    if "metadata" in msg:
+        result["metadata"] = msg["metadata"]
+    return result
+
+
+def hoist_late_system_messages_ir(
+    ir_request: dict[str, Any],
+    *,
+    request_id: str = "-",
+) -> dict[str, Any]:
+    """Hoist late system messages to preserve prompt cache prefix.
+
+    Args:
+        ir_request: The IR request dict (not mutated).
+        request_id: For logging.
+
+    Returns:
+        A new IR request with system messages hoisted, or the original
+        if no changes were needed.
+    """
+    messages = ir_request.get("messages", [])
+    if not messages:
+        return ir_request
+
+    first_non_system = 0
+    for i, msg in enumerate(messages):
+        if not isinstance(msg, dict) or msg.get("role") != "system":
+            first_non_system = i
+            break
+    else:
+        first_non_system = len(messages)
+
+    leading_indices: set[int] = set()
+    late_indices: set[int] = set()
+    for i, msg in enumerate(messages):
+        if not isinstance(msg, dict) or msg.get("role") != "system":
+            continue
+        if i < first_non_system:
+            leading_indices.add(i)
+        else:
+            late_indices.add(i)
+
+    if not leading_indices and not late_indices:
+        return ir_request
+
+    existing_si = list(ir_request.get("system_instruction") or [])
+    for idx in sorted(leading_indices):
+        text = _extract_system_text(messages[idx])
+        if text.strip():
+            existing_si.append({"type": "text", "text": text})
+
+    new_messages = []
+    for i, msg in enumerate(messages):
+        if i in leading_indices:
+            continue
+        if i in late_indices:
+            new_messages.append(_rewrite_as_user(msg))
+        else:
+            new_messages.append(msg)
+
+    changed = len(leading_indices) + len(late_indices)
+    logger.debug(
+        "[%s] hoisted %d system message(s): %d leading, %d late",
+        request_id,
+        changed,
+        len(leading_indices),
+        len(late_indices),
+    )
+
+    result = {**ir_request, "messages": new_messages}
+    if existing_si:
+        result["system_instruction"] = existing_si
+    return result

--- a/src/llm_rosetta/converters/base/helpers/system_message_hoist.py
+++ b/src/llm_rosetta/converters/base/helpers/system_message_hoist.py
@@ -49,6 +49,46 @@ def _rewrite_as_user(msg: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _build_new_messages(
+    messages: list[dict[str, Any]],
+    leading_indices: set[int],
+    late_indices: set[int],
+) -> list[dict[str, Any]]:
+    """Build new message list with late system messages rewritten.
+
+    When a late system message is immediately followed by a user message,
+    the envelope is merged into that user message to avoid consecutive
+    user roles (which Anthropic rejects).
+    """
+    skip: set[int] = set(leading_indices)
+    new_messages: list[dict[str, Any]] = []
+    for i, msg in enumerate(messages):
+        if i in skip:
+            continue
+        if i in late_indices:
+            rewritten = _rewrite_as_user(msg)
+            next_idx = i + 1
+            while next_idx in skip:
+                next_idx += 1
+            if (
+                next_idx < len(messages)
+                and isinstance(messages[next_idx], dict)
+                and messages[next_idx].get("role") == "user"
+            ):
+                next_msg = messages[next_idx]
+                merged = {
+                    **next_msg,
+                    "content": rewritten["content"] + list(next_msg.get("content", [])),
+                }
+                new_messages.append(merged)
+                skip.add(next_idx)
+            else:
+                new_messages.append(rewritten)
+        else:
+            new_messages.append(msg)
+    return new_messages
+
+
 def hoist_late_system_messages_ir(
     ir_request: dict[str, Any],
     *,
@@ -68,13 +108,11 @@ def hoist_late_system_messages_ir(
     if not messages:
         return ir_request
 
-    first_non_system = 0
+    first_non_system = len(messages)
     for i, msg in enumerate(messages):
         if not isinstance(msg, dict) or msg.get("role") != "system":
             first_non_system = i
             break
-    else:
-        first_non_system = len(messages)
 
     leading_indices: set[int] = set()
     late_indices: set[int] = set()
@@ -95,14 +133,7 @@ def hoist_late_system_messages_ir(
         if text.strip():
             existing_si.append({"type": "text", "text": text})
 
-    new_messages = []
-    for i, msg in enumerate(messages):
-        if i in leading_indices:
-            continue
-        if i in late_indices:
-            new_messages.append(_rewrite_as_user(msg))
-        else:
-            new_messages.append(msg)
+    new_messages = _build_new_messages(messages, leading_indices, late_indices)
 
     changed = len(leading_indices) + len(late_indices)
     logger.debug(

--- a/src/llm_rosetta/shims/providers/argo/anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/anthropic/transforms.py
@@ -18,7 +18,11 @@ import copy
 import json
 from typing import Any
 
-from llm_rosetta.shims.transforms import _NamedTransform, auto_cache_breakpoints
+from llm_rosetta.shims.transforms import (
+    _NamedTransform,
+    auto_cache_breakpoints,
+    hoist_late_system_messages,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -127,4 +131,4 @@ post_ir_transforms = ()
 pre_ir_transforms = (
     _NamedTransform(_normalize_openai_response, "normalize_openai_response()"),
 )
-ir_transforms = (auto_cache_breakpoints(),)
+ir_transforms = (hoist_late_system_messages(), auto_cache_breakpoints())

--- a/src/llm_rosetta/shims/providers/openrouter/anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/openrouter/anthropic/transforms.py
@@ -2,12 +2,16 @@
 
 OpenRouter's Anthropic-compatible endpoint (`/api`) is a faithful proxy
 of the Anthropic Messages API — no request- or response-side transforms
-are needed.  The IR-level ``auto_cache_breakpoints`` transform injects
-cache breakpoints for cross-format requests.
+are needed.  The IR-level transforms hoist late system messages (to
+preserve prompt cache prefix) and inject cache breakpoints for
+cross-format requests.
 """
 
-from llm_rosetta.shims.transforms import auto_cache_breakpoints
+from llm_rosetta.shims.transforms import (
+    auto_cache_breakpoints,
+    hoist_late_system_messages,
+)
 
 post_ir_transforms = ()
 pre_ir_transforms = ()
-ir_transforms = (auto_cache_breakpoints(),)
+ir_transforms = (hoist_late_system_messages(), auto_cache_breakpoints())

--- a/src/llm_rosetta/shims/transforms.py
+++ b/src/llm_rosetta/shims/transforms.py
@@ -430,3 +430,32 @@ def flatten_system_content(pattern: str | None = None) -> Transform:
         label += f"pattern={pattern!r}"
     label += ")"
     return _NamedTransform(_flatten, label)
+
+
+# ---------------------------------------------------------------------------
+# IR-level: late system message hoisting
+# ---------------------------------------------------------------------------
+
+
+def hoist_late_system_messages() -> IRTransform:
+    """Return an IR transform that hoists late system messages.
+
+    Leading system messages (before any non-system message) are moved to
+    ``system_instruction``.  Mid-conversation system messages are rewritten
+    as ``UserMessage`` with a ``[System: ...]`` envelope so they don't
+    break the prompt cache prefix or get silently dropped by target
+    converters.
+
+    Idempotent: once rewritten to ``role: "user"``, a second pass is a
+    no-op.  Should run **before** ``auto_cache_breakpoints()`` so cache
+    hints target the post-hoist message structure.
+    """
+
+    def _hoist(body: dict[str, Any], context: TransformContext) -> dict[str, Any]:
+        from llm_rosetta.converters.base.helpers.system_message_hoist import (
+            hoist_late_system_messages_ir,
+        )
+
+        return hoist_late_system_messages_ir(body, request_id=context.request_id)
+
+    return _NamedIRTransform(_hoist, "hoist_late_system_messages()")

--- a/tests/converters/test_system_message_hoist.py
+++ b/tests/converters/test_system_message_hoist.py
@@ -79,10 +79,11 @@ class TestLateSystem:
             "messages": [_user("hi"), _asst("hey"), _sys("Be formal"), _user("ok")],
         }
         result = hoist_late_system_messages_ir(req)
-        assert len(result["messages"]) == 4
-        rewritten = result["messages"][2]
-        assert rewritten["role"] == "user"
-        assert rewritten["content"][0]["text"] == "[System: Be formal]"
+        assert len(result["messages"]) == 3
+        merged = result["messages"][2]
+        assert merged["role"] == "user"
+        assert merged["content"][0]["text"] == "[System: Be formal]"
+        assert merged["content"][1]["text"] == "ok"
 
     def test_multiple_late(self):
         req = {
@@ -123,10 +124,11 @@ class TestMixed:
         assert result["system_instruction"] == [
             {"type": "text", "text": "System prompt"}
         ]
-        assert len(result["messages"]) == 4
+        assert len(result["messages"]) == 3
         assert result["messages"][0]["role"] == "user"  # "hi"
-        assert result["messages"][2]["role"] == "user"  # rewritten
+        assert result["messages"][2]["role"] == "user"  # merged
         assert result["messages"][2]["content"][0]["text"] == "[System: Now be formal]"
+        assert result["messages"][2]["content"][1]["text"] == "ok"
 
     def test_multi_part_system(self):
         msg = {
@@ -235,3 +237,34 @@ class TestTransformIntegration:
         assert len(enveloped) == 1
         # system_instruction preserved
         assert result["system_instruction"][0]["text"] == "You are helpful."
+
+    def test_no_consecutive_user_after_anthropic_conversion(self):
+        """Hoisted late system → user must not create consecutive user roles.
+
+        The Anthropic converter merges consecutive same-role messages, so
+        the final output should always alternate roles.
+        """
+        from llm_rosetta.converters.anthropic import AnthropicConverter
+        from llm_rosetta.pipeline import apply_ir_transforms
+
+        ir_request = {
+            "model": "claude-haiku-4-5",
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+                {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+                {"role": "system", "content": [{"type": "text", "text": "Be formal"}]},
+                {"role": "user", "content": [{"type": "text", "text": "ok"}]},
+            ],
+        }
+        hoisted = apply_ir_transforms(ir_request, "argo--anthropic")
+        converter = AnthropicConverter()
+        from typing import cast
+        from llm_rosetta.types.ir.request import IRRequest
+
+        result, _ = converter.request_to_provider(cast(IRRequest, hoisted))
+
+        roles = [m["role"] for m in result["messages"]]
+        for i in range(1, len(roles)):
+            assert roles[i] != roles[i - 1], (
+                f"consecutive {roles[i]} at index {i}: {roles}"
+            )

--- a/tests/converters/test_system_message_hoist.py
+++ b/tests/converters/test_system_message_hoist.py
@@ -1,0 +1,237 @@
+"""Tests for late system message hoisting.
+
+Verifies that system messages appearing mid-conversation are either moved
+to system_instruction (leading) or rewritten as user messages with a
+[System: ...] envelope (late), preserving prompt cache prefix stability.
+"""
+
+from __future__ import annotations
+
+from llm_rosetta.converters.base.helpers.system_message_hoist import (
+    hoist_late_system_messages_ir,
+)
+
+
+def _sys(text: str, **kw) -> dict:
+    return {"role": "system", "content": [{"type": "text", "text": text}], **kw}
+
+
+def _user(text: str) -> dict:
+    return {"role": "user", "content": [{"type": "text", "text": text}]}
+
+
+def _asst(text: str) -> dict:
+    return {"role": "assistant", "content": [{"type": "text", "text": text}]}
+
+
+class TestNoOp:
+    def test_no_messages(self):
+        req = {"model": "m", "messages": []}
+        assert hoist_late_system_messages_ir(req) is req
+
+    def test_no_system_messages(self):
+        req = {"model": "m", "messages": [_user("hi"), _asst("hello")]}
+        assert hoist_late_system_messages_ir(req) is req
+
+    def test_empty_messages_key(self):
+        req = {"model": "m"}
+        assert hoist_late_system_messages_ir(req) is req
+
+
+class TestLeadingSystem:
+    def test_single_leading_moved_to_empty_si(self):
+        req = {"model": "m", "messages": [_sys("Be helpful"), _user("hi")]}
+        result = hoist_late_system_messages_ir(req)
+        assert result["system_instruction"] == [{"type": "text", "text": "Be helpful"}]
+        assert len(result["messages"]) == 1
+        assert result["messages"][0]["role"] == "user"
+
+    def test_leading_appended_to_existing_si(self):
+        req = {
+            "model": "m",
+            "system_instruction": [{"type": "text", "text": "Existing"}],
+            "messages": [_sys("Extra"), _user("hi")],
+        }
+        result = hoist_late_system_messages_ir(req)
+        assert len(result["system_instruction"]) == 2
+        assert result["system_instruction"][0]["text"] == "Existing"
+        assert result["system_instruction"][1]["text"] == "Extra"
+
+    def test_multiple_leading(self):
+        req = {"model": "m", "messages": [_sys("A"), _sys("B"), _user("hi")]}
+        result = hoist_late_system_messages_ir(req)
+        assert len(result["system_instruction"]) == 2
+        assert result["system_instruction"][0]["text"] == "A"
+        assert result["system_instruction"][1]["text"] == "B"
+        assert len(result["messages"]) == 1
+
+    def test_all_system(self):
+        req = {"model": "m", "messages": [_sys("A"), _sys("B")]}
+        result = hoist_late_system_messages_ir(req)
+        assert len(result["system_instruction"]) == 2
+        assert result["messages"] == []
+
+
+class TestLateSystem:
+    def test_single_late_rewritten_as_user(self):
+        req = {
+            "model": "m",
+            "messages": [_user("hi"), _asst("hey"), _sys("Be formal"), _user("ok")],
+        }
+        result = hoist_late_system_messages_ir(req)
+        assert len(result["messages"]) == 4
+        rewritten = result["messages"][2]
+        assert rewritten["role"] == "user"
+        assert rewritten["content"][0]["text"] == "[System: Be formal]"
+
+    def test_multiple_late(self):
+        req = {
+            "model": "m",
+            "messages": [_user("hi"), _sys("A"), _asst("ok"), _sys("B"), _user("bye")],
+        }
+        result = hoist_late_system_messages_ir(req)
+        assert result["messages"][1]["content"][0]["text"] == "[System: A]"
+        assert result["messages"][3]["content"][0]["text"] == "[System: B]"
+
+    def test_empty_system_uses_placeholder(self):
+        req = {"model": "m", "messages": [_user("hi"), _sys("")]}
+        result = hoist_late_system_messages_ir(req)
+        assert result["messages"][1]["content"][0]["text"] == "[System instruction]"
+
+    def test_metadata_preserved(self):
+        req = {
+            "model": "m",
+            "messages": [_user("hi"), _sys("formal", metadata={"source": "dev"})],
+        }
+        result = hoist_late_system_messages_ir(req)
+        assert result["messages"][1]["metadata"] == {"source": "dev"}
+
+
+class TestMixed:
+    def test_leading_and_late(self):
+        req = {
+            "model": "m",
+            "messages": [
+                _sys("System prompt"),
+                _user("hi"),
+                _asst("hello"),
+                _sys("Now be formal"),
+                _user("ok"),
+            ],
+        }
+        result = hoist_late_system_messages_ir(req)
+        assert result["system_instruction"] == [
+            {"type": "text", "text": "System prompt"}
+        ]
+        assert len(result["messages"]) == 4
+        assert result["messages"][0]["role"] == "user"  # "hi"
+        assert result["messages"][2]["role"] == "user"  # rewritten
+        assert result["messages"][2]["content"][0]["text"] == "[System: Now be formal]"
+
+    def test_multi_part_system(self):
+        msg = {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "Part one"},
+                {"type": "text", "text": "Part two"},
+            ],
+        }
+        req = {"model": "m", "messages": [_user("hi"), msg]}
+        result = hoist_late_system_messages_ir(req)
+        assert (
+            result["messages"][1]["content"][0]["text"]
+            == "[System: Part one\nPart two]"
+        )
+
+
+class TestIdempotency:
+    def test_double_apply(self):
+        req = {"model": "m", "messages": [_user("hi"), _sys("Be formal"), _user("ok")]}
+        r1 = hoist_late_system_messages_ir(req)
+        r2 = hoist_late_system_messages_ir(r1)
+        assert r1["messages"] == r2["messages"]
+        assert "system_instruction" not in r1
+        assert "system_instruction" not in r2
+
+    def test_original_not_mutated(self):
+        msgs = [_user("hi"), _sys("Be formal")]
+        req = {"model": "m", "messages": msgs}
+        result = hoist_late_system_messages_ir(req)
+        assert req["messages"] is msgs
+        assert len(msgs) == 2
+        assert msgs[1]["role"] == "system"
+        assert result is not req
+
+
+class TestTransformIntegration:
+    def test_factory_repr(self):
+        from llm_rosetta.shims.transforms import hoist_late_system_messages
+
+        t = hoist_late_system_messages()
+        assert repr(t) == "hoist_late_system_messages()"
+
+    def test_argo_anthropic_includes_hoist(self):
+        from llm_rosetta.shims.provider_shim import get_shim
+
+        shim = get_shim("argo--anthropic")
+        assert shim is not None
+        names = [repr(t) for t in shim.ir_transforms]
+        assert "hoist_late_system_messages()" in names
+
+    def test_openrouter_anthropic_includes_hoist(self):
+        from llm_rosetta.shims.provider_shim import get_shim
+
+        shim = get_shim("openrouter--anthropic")
+        assert shim is not None
+        names = [repr(t) for t in shim.ir_transforms]
+        assert "hoist_late_system_messages()" in names
+
+    def test_hoist_before_cache_breakpoints(self):
+        from llm_rosetta.shims.provider_shim import get_shim
+
+        shim = get_shim("argo--anthropic")
+        assert shim is not None
+        names = [repr(t) for t in shim.ir_transforms]
+        hoist_idx = names.index("hoist_late_system_messages()")
+        cache_idx = names.index("auto_cache_breakpoints()")
+        assert hoist_idx < cache_idx
+
+    def test_pipeline_with_ir_system_messages(self):
+        """Verify hoist works in the pipeline when IR has mid-list system messages.
+
+        Constructs IR directly (bypassing source converter) to simulate
+        a source format that preserves system message positions.
+        """
+        from llm_rosetta.pipeline import apply_ir_transforms
+
+        ir_request = {
+            "model": "claude-haiku-4-5",
+            "system_instruction": [{"type": "text", "text": "You are helpful."}],
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+                {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": "Now be formal."}],
+                },
+                {"role": "user", "content": [{"type": "text", "text": "ok"}]},
+            ],
+        }
+        result = apply_ir_transforms(ir_request, "argo--anthropic")
+        # No system messages in the messages array
+        for msg in result["messages"]:
+            assert msg["role"] != "system", f"system message leaked: {msg}"
+        # Late system rewritten as user envelope
+        user_msgs = [m for m in result["messages"] if m["role"] == "user"]
+        enveloped = [
+            m
+            for m in user_msgs
+            if any(
+                "[System:" in c.get("text", "")
+                for c in m.get("content", [])
+                if isinstance(c, dict)
+            )
+        ]
+        assert len(enveloped) == 1
+        # system_instruction preserved
+        assert result["system_instruction"][0]["text"] == "You are helpful."


### PR DESCRIPTION
## Summary

Mid-conversation system messages break the prompt cache prefix for Anthropic upstreams. The Anthropic converter also silently drops non-leading system messages (data loss). This PR adds a `hoist_late_system_messages()` IR transform that:

- **Leading system messages** (before any user/assistant/tool) → moved to `system_instruction`
- **Late system messages** (mid-conversation) → rewritten as `UserMessage` with `[System: <text>]` envelope

Mounted on `argo--anthropic` and `openrouter--anthropic` shims, ordered **before** `auto_cache_breakpoints` so cache hints target the post-hoist message structure.

Not mounted on OpenAI Chat shims — Chat natively supports system messages at any position and rewriting to user would change model behavior.

Addresses #398 workstream 9.

## Test plan

- [x] `make test` — 2513 passed, 0 failed
- [x] `make lint` — ruff + ty + complexipy clean
- [x] 20 tests covering: no-op, leading hoist, late rewrite, mixed, multi-part, empty, metadata, idempotency, immutability
- [x] Integration: shim mounting verified, ordering verified, `apply_ir_transforms` E2E