### PR TITLE
feat(auth): migrate API key storage to SQLite with hash-based validation

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -785,7 +785,6 @@ body { padding-bottom: 26px; }
       </select>
     </div>
     <div class="settings-popup-item">
-    <div class="settings-popup-item">
       <label data-i18n="label.errorDumps">Error Detail Log</label>
       <label class="toggle-label">
         <input type="checkbox" id="settingsErrorDumps" onchange="saveSettingsField('errorDumps',this.checked)">

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -638,7 +638,7 @@ body { padding-bottom: 26px; }
       <div class="table-scroll"><table>
         <thead><tr>
           <th data-i18n="col.label">Label</th>
-          <th data-i18n="col.key">Key</th>
+          <th data-i18n="col.allowedShims">Allowed Shims</th>
           <th data-i18n="col.created">Created</th>
           <th></th>
         </tr></thead>
@@ -785,12 +785,6 @@ body { padding-bottom: 26px; }
       </select>
     </div>
     <div class="settings-popup-item">
-      <label data-i18n="label.credentialReveal">Credential Reveal</label>
-      <label class="toggle-label">
-        <input type="checkbox" id="settingsCredentialVisible" onchange="saveSettingsField('credentialVisible',this.checked)">
-        <span data-i18n="label.enabled">Enabled</span>
-      </label>
-    </div>
     <div class="settings-popup-item">
       <label data-i18n="label.errorDumps">Error Detail Log</label>
       <label class="toggle-label">
@@ -1142,6 +1136,10 @@ Rules:..."</code><br><br>Some upstream providers don't support content arrays in
       <label data-i18n="label.keyManual">Manual key (leave empty to auto-generate)</label>
       <input id="keyManual" placeholder="rsk-... (auto-generated if empty)" style="font-family:var(--mono)">
     </div>
+    <div class="form-group">
+      <label data-i18n="label.keyAllowedShims">Allowed shims (comma-separated, * = all)</label>
+      <input id="keyAllowedShims" placeholder="* (default: all shims)" value="*">
+    </div>
     <div class="modal-actions">
       <button class="btn" onclick="closeModal('keyModal')" data-i18n="btn.cancel">Cancel</button>
       <button class="btn btn-primary" onclick="generateKey()" data-i18n="btn.generate">Generate</button>
@@ -1286,12 +1284,13 @@ const I18N = {
     'empty.searchResults':'No matching results.',
     'section.apiKeys':'API Keys',
     'btn.generateKey':'+ Generate Key', 'btn.generate':'Generate', 'btn.copy':'Copy', 'btn.clone':'Clone',
-    'col.label':'Label', 'col.key':'Key', 'col.created':'Created',
+    'col.label':'Label', 'col.allowedShims':'Allowed Shims', 'col.created':'Created',
     'col.apiKey':'API Key', 'col.clientIp':'Client IP',
     'modal.generateKey':'Generate API Key',
     'modal.keyCreated':'Key Created',
     'label.keyLabel':'Label (optional)',
     'label.keyManual':'Manual key (leave empty to auto-generate)',
+    'label.keyAllowedShims':'Allowed shims (comma-separated, * = all)',
     'keys.description':'Manage gateway API keys used to authenticate requests to /v1/* endpoints.',
     'keys.copyWarning':'Copy this key now. It will not be shown again in full.',
     'keys.noKeys':'No API keys configured. Endpoints are open without authentication.',
@@ -1604,9 +1603,6 @@ function openSettings() {
   // Sync auto-refresh
   const ar = document.getElementById('settingsAutoRefresh');
   if (ar) ar.value = localStorage.getItem('dashboardRefreshMs') || '3000';
-  // Sync credential visibility
-  const cv = document.getElementById('settingsCredentialVisible');
-  if (cv) cv.checked = _credentialVisible;
   const ed = document.getElementById('settingsErrorDumps');
   if (ed) ed.checked = configData?.debug?.error_dumps !== false;
   // Sync log retention
@@ -1637,8 +1633,6 @@ async function saveSettingsField(field, value) {
   if (field === 'logLevel') {
     body.verbose = (value === 'verbose' || value === 'debug');
     body.log_bodies = (value === 'debug');
-  } else if (field === 'credentialVisible') {
-    body.credential_visible = value;
   } else if (field === 'errorDumps') {
     body.error_dumps = value;
   }
@@ -2964,11 +2958,7 @@ function renderKeys() {
     return `<tr>
       <td><span class="key-label-text" id="label-${k.id}">${esc(k.label || '—')}</span>
         <button class="key-btn" style="margin-left:4px" onclick="editKeyLabel('${k.id}','${esc(k.label || '')}')" title="Edit"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg></button></td>
-      <td style="width:40%"><div class="key-cell"><code class="key-masked" data-masked="${esc(k.key)}">${esc(k.key)}</code>
-        ${_credentialVisible ? `<span class="key-actions">
-          <button class="key-btn" onclick="toggleKey('${k.id}',this)" title="Toggle visibility"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
-          <button class="key-btn" onclick="copyKeyById('${k.id}')" title="Copy"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
-        </span>` : ''}</div></td>
+      <td><code>${esc((k.allowed_shims || ['*']).join(', '))}</code></td>
       <td>${created}</td>
       <td style="white-space:nowrap"><button class="btn btn-sm" onclick="rotateKey('${k.id}','${esc(k.label || k.id)}', this)">${t('btn.rotate')}</button> <button class="btn btn-sm btn-danger" onclick="deleteKey('${k.id}','${esc(k.label || k.id)}', this)">${t('btn.delete')}</button></td>
     </tr>`;
@@ -2978,13 +2968,16 @@ function renderKeys() {
 function openKeyModal() {
   document.getElementById('keyLabel').value = '';
   document.getElementById('keyManual').value = '';
+  document.getElementById('keyAllowedShims').value = '*';
   document.getElementById('keyModal').classList.add('open');
 }
 
 async function generateKey() {
   const label = document.getElementById('keyLabel').value.trim();
   const manual = document.getElementById('keyManual').value.trim();
-  const body = {label};
+  const shimsRaw = document.getElementById('keyAllowedShims').value.trim();
+  const allowed_shims = shimsRaw ? shimsRaw.split(',').map(s => s.trim()).filter(Boolean) : ['*'];
+  const body = {label, allowed_shims};
   if (manual) body.key = manual;
   const res = await api.post('/admin/api/keys', body);
   if (res.ok) {
@@ -3013,37 +3006,6 @@ async function _doDeleteKey(id, label) {
   const res = await api.del(`/admin/api/keys/${encodeURIComponent(id)}`);
   if (res.ok) { showToast(t('toast.keyDeleted')); loadKeys(); }
   else { showToast(res.error || 'Failed', 'error'); }
-}
-
-const _eyeOpenSvg = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
-const _eyeClosedSvg = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/><line x1="1" y1="1" x2="23" y2="23"/></svg>';
-
-async function toggleKey(id, btn) {
-  const code = btn.closest('td').querySelector('code');
-  if (code.dataset.revealed === 'true') {
-    code.textContent = code.dataset.masked;
-    code.dataset.revealed = 'false';
-    btn.innerHTML = _eyeOpenSvg;
-  } else {
-    const res = await api.get(`/admin/api/keys/${encodeURIComponent(id)}/reveal`);
-    if (res.key) {
-      code.textContent = res.key;
-      code.dataset.revealed = 'true';
-      btn.innerHTML = _eyeClosedSvg;
-    }
-  }
-}
-
-async function copyKeyById(id) {
-  const res = await api.get(`/admin/api/keys/${encodeURIComponent(id)}/reveal`);
-  if (res.key) {
-    try {
-      await navigator.clipboard.writeText(res.key);
-      showToast(t('toast.keyCopied'));
-    } catch(e) {
-      showToast('Copy failed', 'error');
-    }
-  }
 }
 
 async function editKeyLabel(id, currentLabel) {

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -50,7 +50,6 @@ from .keys import (
     delete_api_key,
     get_api_keys,
     get_internal_token,
-    reveal_api_key,
     rotate_api_key,
     update_api_key,
 )
@@ -148,7 +147,6 @@ def register_admin_routes(app: Any) -> None:
     app.route("/admin/api/keys", methods=["POST"])(create_api_key)
     app.route("/admin/api/keys/<key_id>", methods=["PUT"])(update_api_key)
     app.route("/admin/api/keys/<key_id>", methods=["DELETE"])(delete_api_key)
-    app.route("/admin/api/keys/<key_id>/reveal", methods=["GET"])(reveal_api_key)
     app.route("/admin/api/keys/<key_id>/rotate", methods=["POST"])(rotate_api_key)
     app.route("/admin/api/internal-token", methods=["GET"])(get_internal_token)
     # Async model test

--- a/src/llm_rosetta/gateway/admin/routes/_shared.py
+++ b/src/llm_rosetta/gateway/admin/routes/_shared.py
@@ -90,8 +90,9 @@ def _sync_auth_middleware(app: Any, config: GatewayConfig) -> None:
     """Update the auth hook's state for hot-reload."""
     auth_state = getattr(app, "auth_state", None)
     if auth_state is not None:
-        auth_state.key_set = config.api_key_set
-        auth_state.labels = dict(config.api_key_labels)
+        from ...auth import _build_config_fallback
+
+        auth_state.config_fallback = _build_config_fallback(config.api_keys)
         # Sync admin password (e.g. changed via CLI or config edit)
         if config.admin_password != auth_state.admin_password:
             auth_state.change_password(config.admin_password or "")

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -167,6 +167,7 @@ async def get_config(request: Any) -> Response:
             "server": server,
             "debug": raw.get("debug", {}),
             "credential_visible": config.credential_visible,
+            "api_keys_db": config.api_keys_db,
             "version": _get_version(),
             "known_provider_types": known_provider_types(),
             "registered_shims": [

--- a/src/llm_rosetta/gateway/admin/routes/keys.py
+++ b/src/llm_rosetta/gateway/admin/routes/keys.py
@@ -1,52 +1,30 @@
-"""API key management route handlers."""
+"""API key management route handlers (SQLite keystore)."""
 
 from __future__ import annotations
 
-import secrets
-import uuid
-from datetime import datetime, timezone
 from typing import Any
 
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
-from ...config import GatewayConfig, config_lock
-from ._shared import (
-    _get_config_io,
-    _get_config_path,
-    _mask_api_key,
-    _reload_gateway_config,
-)
+from ...keystore import KeyStore
+
+
+def _get_keystore(request: Any) -> KeyStore:
+    ks = getattr(request.app, "keystore", None)
+    if ks is None:
+        raise RuntimeError("KeyStore not configured on this application")
+    return ks
 
 
 async def get_api_keys(request: Any) -> Response:
-    """List all gateway API keys (values masked)."""
-    config_path = _get_config_path(request)
-
-    try:
-        data = _get_config_io(request).load_raw(config_path)
-    except Exception as exc:
-        return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
-
-    server = data.get("server", {})
-    keys = list(server.get("api_keys", []))
-    # Backward compat: expose legacy single key as a synthetic entry
-    if not keys and server.get("api_key"):
-        keys = [
-            {
-                "id": "default",
-                "key": server["api_key"],
-                "label": "default",
-                "created": "",
-            }
-        ]
-
-    masked = [{**entry, "key": _mask_api_key(entry.get("key", ""))} for entry in keys]
-    return JSONResponse({"keys": masked})
+    """List all gateway API keys (no secrets returned)."""
+    keystore = _get_keystore(request)
+    return JSONResponse({"keys": keystore.list_keys()})
 
 
 async def create_api_key(request: Any) -> Response:
     """Create a new gateway API key."""
-    config_path = _get_config_path(request)
+    keystore = _get_keystore(request)
 
     try:
         body = request.json()
@@ -55,61 +33,26 @@ async def create_api_key(request: Any) -> Response:
 
     label = body.get("label", "")
     manual_key = body.get("key")
-    key_value = manual_key if manual_key else f"rsk-{secrets.token_hex(24)}"
-
-    entry = {
-        "id": uuid.uuid4().hex[:8],
-        "key": key_value,
-        "label": label,
-        "created": datetime.now(timezone.utc).isoformat(),
-    }
-
-    with config_lock(config_path):
-        try:
-            data = _get_config_io(request).load_raw(config_path)
-        except Exception as exc:
-            return JSONResponse(
-                {"error": f"Failed to read config: {exc}"}, status_code=500
-            )
-
-        server = data.setdefault("server", {})
-
-        # Migrate legacy single key → api_keys array
-        if "api_key" in server and "api_keys" not in server:
-            old_key = server.pop("api_key")
-            server["api_keys"] = [
-                {"id": "default", "key": old_key, "label": "default", "created": ""}
-            ]
-
-        server.setdefault("api_keys", []).append(entry)
-
-        try:
-            _get_config_io(request).save(config_path, data)
-        except Exception as exc:
-            return JSONResponse(
-                {"error": f"Failed to write config: {exc}"}, status_code=500
-            )
+    allowed_shims = body.get("allowed_shims")
 
     try:
-        _reload_gateway_config(request, config_path)
-    except Exception as exc:
-        return JSONResponse(
-            {
-                "error": f"Config saved but reload failed: {exc}",
-                "saved": True,
-                "reloaded": False,
-            },
-            status_code=500,
+        key_id, raw_key = keystore.create(
+            label=label,
+            allowed_shims=allowed_shims,
+            manual_key=manual_key,
         )
+    except Exception as exc:
+        return JSONResponse({"error": f"Failed to create key: {exc}"}, status_code=500)
 
-    # Return the full key exactly once so the user can copy it
-    return JSONResponse({"ok": True, "key": entry})
+    entry = keystore.list_keys()
+    created_entry = next((k for k in entry if k["id"] == key_id), {"id": key_id})
+    created_entry["key"] = raw_key
+    return JSONResponse({"ok": True, "key": created_entry})
 
 
 async def update_api_key(request: Any, **kwargs: Any) -> Response:
-    """Update an API key's label."""
-    config_path = _get_config_path(request)
-
+    """Update an API key's label and/or allowed_shims."""
+    keystore = _get_keystore(request)
     key_id = request.path_params["key_id"]
 
     try:
@@ -117,165 +60,41 @@ async def update_api_key(request: Any, **kwargs: Any) -> Response:
     except Exception:
         return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
 
-    with config_lock(config_path):
-        try:
-            data = _get_config_io(request).load_raw(config_path)
-        except Exception as exc:
-            return JSONResponse(
-                {"error": f"Failed to read config: {exc}"}, status_code=500
-            )
+    label = body.get("label")
+    allowed_shims = body.get("allowed_shims")
 
-        keys = data.get("server", {}).get("api_keys", [])
-        target = None
-        for entry in keys:
-            if entry.get("id") == key_id:
-                target = entry
-                break
+    if not keystore.update(key_id, label=label, allowed_shims=allowed_shims):
+        return JSONResponse({"error": f"Key '{key_id}' not found"}, status_code=404)
 
-        if target is None:
-            return JSONResponse({"error": f"Key '{key_id}' not found"}, status_code=404)
-
-        if "label" in body:
-            target["label"] = body["label"]
-
-        try:
-            _get_config_io(request).save(config_path, data)
-        except Exception as exc:
-            return JSONResponse(
-                {"error": f"Failed to write config: {exc}"}, status_code=500
-            )
-
-    try:
-        _reload_gateway_config(request, config_path)
-    except Exception as exc:
-        return JSONResponse(
-            {
-                "error": f"Config saved but reload failed: {exc}",
-                "saved": True,
-                "reloaded": False,
-            },
-            status_code=500,
-        )
-
-    return JSONResponse({"ok": True, "id": key_id, "label": target["label"]})
+    result: dict[str, Any] = {"ok": True, "id": key_id}
+    if label is not None:
+        result["label"] = label
+    if allowed_shims is not None:
+        result["allowed_shims"] = allowed_shims
+    return JSONResponse(result)
 
 
 async def delete_api_key(request: Any, **kwargs: Any) -> Response:
     """Delete a gateway API key."""
-    config_path = _get_config_path(request)
-
+    keystore = _get_keystore(request)
     key_id = request.path_params["key_id"]
 
-    with config_lock(config_path):
-        try:
-            data = _get_config_io(request).load_raw(config_path)
-        except Exception as exc:
-            return JSONResponse(
-                {"error": f"Failed to read config: {exc}"}, status_code=500
-            )
-
-        keys = data.get("server", {}).get("api_keys", [])
-        original_len = len(keys)
-        keys[:] = [e for e in keys if e.get("id") != key_id]
-
-        if len(keys) == original_len:
-            return JSONResponse({"error": f"Key '{key_id}' not found"}, status_code=404)
-
-        try:
-            _get_config_io(request).save(config_path, data)
-        except Exception as exc:
-            return JSONResponse(
-                {"error": f"Failed to write config: {exc}"}, status_code=500
-            )
-
-    try:
-        _reload_gateway_config(request, config_path)
-    except Exception as exc:
-        return JSONResponse(
-            {
-                "error": f"Config saved but reload failed: {exc}",
-                "saved": True,
-                "reloaded": False,
-            },
-            status_code=500,
-        )
+    if not keystore.delete(key_id):
+        return JSONResponse({"error": f"Key '{key_id}' not found"}, status_code=404)
 
     return JSONResponse({"ok": True, "deleted": key_id})
 
 
 async def rotate_api_key(request: Any, **kwargs: Any) -> Response:
     """Rotate an API key: generate a new value, keep the same id and label."""
-    config_path = _get_config_path(request)
-
+    keystore = _get_keystore(request)
     key_id = request.path_params["key_id"]
 
-    with config_lock(config_path):
-        try:
-            data = _get_config_io(request).load_raw(config_path)
-        except Exception as exc:
-            return JSONResponse(
-                {"error": f"Failed to read config: {exc}"}, status_code=500
-            )
+    new_key = keystore.rotate(key_id)
+    if new_key is None:
+        return JSONResponse({"error": f"Key '{key_id}' not found"}, status_code=404)
 
-        keys = data.get("server", {}).get("api_keys", [])
-        target = None
-        for entry in keys:
-            if entry.get("id") == key_id:
-                target = entry
-                break
-
-        if target is None:
-            return JSONResponse({"error": f"Key '{key_id}' not found"}, status_code=404)
-
-        new_key = f"rsk-{secrets.token_hex(24)}"
-        target["key"] = new_key
-        target["rotated"] = datetime.now(timezone.utc).isoformat()
-
-        try:
-            _get_config_io(request).save(config_path, data)
-        except Exception as exc:
-            return JSONResponse(
-                {"error": f"Failed to write config: {exc}"}, status_code=500
-            )
-
-    try:
-        _reload_gateway_config(request, config_path)
-    except Exception as exc:
-        return JSONResponse(
-            {
-                "error": f"Config saved but reload failed: {exc}",
-                "saved": True,
-                "reloaded": False,
-            },
-            status_code=500,
-        )
-
-    # Return the new key exactly once so the user can copy it
     return JSONResponse({"ok": True, "id": key_id, "key": new_key})
-
-
-async def reveal_api_key(request: Any, **kwargs: Any) -> Response:
-    """Return the raw (unmasked) API key value."""
-    config: GatewayConfig = request.app.gateway_config
-    if not config.credential_visible:
-        return JSONResponse(
-            {"error": "Credential visibility is disabled"}, status_code=403
-        )
-    config_path = _get_config_path(request)
-
-    key_id = request.path_params["key_id"]
-
-    try:
-        data = _get_config_io(request).load_raw(config_path)
-    except Exception as exc:
-        return JSONResponse({"error": f"Failed to read config: {exc}"}, status_code=500)
-
-    keys = data.get("server", {}).get("api_keys", [])
-    for entry in keys:
-        if entry.get("id") == key_id:
-            return JSONResponse({"key": entry.get("key", "")})
-
-    return JSONResponse({"error": f"Key '{key_id}' not found"}, status_code=404)
 
 
 async def get_internal_token(request: Any) -> Response:

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -15,8 +15,14 @@ from llm_rosetta._vendor.httpserver import (
 )
 from llm_rosetta.auto_detect import ProviderType
 
-from .auth import AuthState, api_key_label_var, create_auth_hook
+from .auth import (
+    AuthState,
+    _build_config_fallback,
+    api_key_context_var,
+    create_auth_hook,
+)
 from .config import GatewayConfig
+from .keystore import KeyStore
 from .embeddings import handle_embeddings as _handle_embeddings
 from .headers import build_upstream_extra_headers, get_request_id
 from .logging import get_logger
@@ -90,7 +96,9 @@ def _record_telemetry(
             status_code=status_code,
             duration_ms=duration_ms,
             error_detail=error_detail,
-            api_key_label=api_key_label_var.get(),
+            api_key_label=(
+                _kctx.label if (_kctx := api_key_context_var.get()) else None
+            ),
             client_ip=_extract_client_ip(request),
             profile=profile,
         )
@@ -538,12 +546,73 @@ def _flush_now(app: App) -> None:
             logger.warning("Shutdown: failed to flush metrics: %s", exc)
 
     persistence.close()
+
+    keystore = getattr(app, "keystore", None)
+    if keystore is not None:
+        keystore.close()
+
     logger.info("Persistence flushed and closed on shutdown")
 
 
 # ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
+
+
+def _setup_auth(
+    config: GatewayConfig, config_path: str | None
+) -> tuple[str, KeyStore, AuthState]:
+    """Create KeyStore, import config keys, build AuthState."""
+    import os
+    import secrets
+
+    internal_token = f"rsk-internal-{secrets.token_hex(16)}"
+
+    if config.api_keys_db:
+        keys_db_path = config.api_keys_db
+    elif config_path:
+        keys_db_path = os.path.join(
+            os.path.dirname(os.path.abspath(config_path)), "keys.db"
+        )
+    else:
+        keys_db_path = "keys.db"
+
+    keystore = KeyStore(keys_db_path)
+
+    if config.api_keys:
+        imported = keystore.import_from_config(config.api_keys)
+        if imported:
+            logger.info(
+                "Imported %d API key(s) from config into SQLite keystore", imported
+            )
+        logger.warning(
+            "API keys found in config file. Consider removing server.api_keys "
+            "after verifying the SQLite keystore (%s) is working correctly.",
+            keys_db_path,
+        )
+
+    config_fallback = _build_config_fallback(config.api_keys)
+
+    auth_state = AuthState(
+        keystore=keystore,
+        config_fallback=config_fallback,
+        internal_token=internal_token,
+        admin_password=config.admin_password,
+        open_on_no_keys=config.open_on_no_keys,
+    )
+    if not auth_state._has_keys():
+        _no_key_msg = (
+            "No API keys configured — all /v1/* endpoints are OPEN "
+            "(server.open_on_no_keys=true). Set server.api_keys in your "
+            "config or generate keys in the admin panel to restrict access."
+            if config.open_on_no_keys
+            else "No API keys configured — all /v1/* endpoints are BLOCKED. "
+            "Generate keys in the admin panel, set server.api_keys, or "
+            "set server.open_on_no_keys=true to allow anonymous access."
+        )
+        logger.warning(_no_key_msg)
+
+    return internal_token, keystore, auth_state
 
 
 def _install_root_redirect(app: App, target: str | None) -> None:
@@ -590,28 +659,8 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
 
     _install_root_redirect(app, config.root_redirect)
 
-    # --- Auth ---
-    import secrets
-
-    internal_token = f"rsk-internal-{secrets.token_hex(16)}"
-    auth_state = AuthState(
-        config.api_key_set,
-        config.api_key_labels,
-        internal_token,
-        admin_password=config.admin_password,
-        open_on_no_keys=config.open_on_no_keys,
-    )
-    if not config.api_key_set:
-        _no_key_msg = (
-            "No API keys configured — all /v1/* endpoints are OPEN "
-            "(server.open_on_no_keys=true). Set server.api_keys in your "
-            "config or generate keys in the admin panel to restrict access."
-            if config.open_on_no_keys
-            else "No API keys configured — all /v1/* endpoints are BLOCKED. "
-            "Generate keys in the admin panel, set server.api_keys, or "
-            "set server.open_on_no_keys=true to allow anonymous access."
-        )
-        logger.warning(_no_key_msg)
+    # --- Auth (SQLite keystore + config fallback) ---
+    internal_token, keystore, auth_state = _setup_auth(config, config_path)
     app.before_request(create_auth_hook(auth_state))
 
     # --- CORS ---
@@ -692,6 +741,7 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
     app.metadata_store = metadata_store  # type: ignore
     app.internal_token = internal_token  # type: ignore
     app.auth_state = auth_state  # type: ignore
+    app.keystore = keystore  # type: ignore
 
     setup_admin(app, config, config_path)
 

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -585,11 +585,11 @@ def _setup_auth(
             logger.info(
                 "Imported %d API key(s) from config into SQLite keystore", imported
             )
-        logger.warning(
-            "API keys found in config file. Consider removing server.api_keys "
-            "after verifying the SQLite keystore (%s) is working correctly.",
-            keys_db_path,
-        )
+            logger.warning(
+                "API keys found in config file. Consider removing server.api_keys "
+                "after verifying the SQLite keystore (%s) is working correctly.",
+                keys_db_path,
+            )
 
     config_fallback = _build_config_fallback(config.api_keys)
 

--- a/src/llm_rosetta/gateway/auth.py
+++ b/src/llm_rosetta/gateway/auth.py
@@ -1,32 +1,33 @@
 """Gateway API key authentication — before-request hook.
 
-Validates incoming requests against the gateway's configured API keys,
-extracting credentials in the format native to each API standard:
+Validates incoming requests against the gateway's API keys stored in
+SQLite (hash-based) with a config-file fallback for read-only mounts.
+
+Key extraction uses the format native to each API standard:
 
 - OpenAI Chat/Responses: ``Authorization: Bearer <key>``
 - Anthropic: ``x-api-key: <key>``
 - Google GenAI: ``x-goog-api-key: <key>`` or ``?key=<key>`` query param
 
-Supports multiple API keys with labels for tracking.
-
 When no keys are configured, behavior depends on ``open_on_no_keys``:
-- ``True``:  all requests pass through (backward compatible default
-  for the standalone gateway).
-- ``False``: requests are rejected with 403 (secure default for
-  embedded/downstream usage).
+- ``True``:  all requests pass through.
+- ``False``: requests are rejected with 403 (secure default).
 """
 
 from __future__ import annotations
 
 import contextvars
+import hashlib
 import hmac
 from typing import Any
 
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
-# Per-request API key label — set by auth hook, read by proxy handler.
-api_key_label_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "api_key_label", default=None
+from .keystore import KeyContext, KeyStore
+
+# Per-request auth context — set by auth hook, read by telemetry.
+api_key_context_var: contextvars.ContextVar[KeyContext | None] = contextvars.ContextVar(
+    "api_key_context", default=None
 )
 
 # Paths that never require authentication
@@ -159,14 +160,14 @@ class AuthState:
 
     def __init__(
         self,
-        key_set: frozenset[str],
-        labels: dict[str, str],
+        keystore: KeyStore | None,
+        config_fallback: dict[str, KeyContext],
         internal_token: str | None,
         admin_password: str | None = None,
         open_on_no_keys: bool = False,
     ) -> None:
-        self.key_set = key_set
-        self.labels = labels
+        self.keystore = keystore
+        self.config_fallback = config_fallback
         self.internal_token = internal_token
         self.admin_password = admin_password
         self.open_on_no_keys = open_on_no_keys
@@ -174,13 +175,13 @@ class AuthState:
         self.admin_token: str | None = None
         self._recalculate_admin_token()
 
-    def _recalculate_admin_token(self) -> None:
-        """Derive ``admin_token`` from ``admin_password`` + ``internal_token``.
+    def _has_keys(self) -> bool:
+        ks_has = self.keystore.has_keys() if self.keystore else False
+        return ks_has or bool(self.config_fallback)
 
-        Called on init and after password or internal_token changes.
-        """
+    def _recalculate_admin_token(self) -> None:
+        """Derive ``admin_token`` from ``admin_password`` + ``internal_token``."""
         if self.admin_password and self.internal_token:
-            import hashlib
             import hmac as _hmac
 
             self.admin_token = _hmac.new(
@@ -206,15 +207,29 @@ class AuthState:
     def change_password(self, new_password: str) -> str:
         """Update the admin password and recalculate admin_token.
 
-        Args:
-            new_password: The new plaintext password.
-
         Returns:
             The new admin_token.
         """
         self.admin_password = new_password
         self._recalculate_admin_token()
         return self.admin_token or ""
+
+
+def _build_config_fallback(
+    api_keys: list[dict[str, str]],
+) -> dict[str, KeyContext]:
+    """Build a hash → KeyContext dict from config-sourced plaintext keys."""
+    fallback: dict[str, KeyContext] = {}
+    for entry in api_keys:
+        raw_key = entry.get("key", "")
+        if not raw_key:
+            continue
+        key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+        fallback[key_hash] = KeyContext(
+            label=entry.get("label", ""),
+            allowed_shims=frozenset({"*"}),
+        )
+    return fallback
 
 
 def create_auth_hook(auth_state: AuthState) -> Any:
@@ -225,14 +240,13 @@ def create_auth_hook(auth_state: AuthState) -> Any:
     """
 
     async def auth_hook(request: Any) -> Response | None:
-        # Reset per-request label before any early return so downstream
+        # Reset per-request context before any early return so downstream
         # hooks never see a stale value from a previous request.
-        api_key_label_var.set(None)
+        api_key_context_var.set(None)
 
         # CORS preflight must bypass auth — browsers send no credentials
         # on OPTIONS and need CORS headers back to proceed with the
-        # actual request.  Only skip auth for genuine preflights (Origin
-        # + Access-Control-Request-Method present per Fetch spec §3.2.2).
+        # actual request.
         if (
             request.method == "OPTIONS"
             and request.headers.get("origin")
@@ -250,7 +264,7 @@ def create_auth_hook(auth_state: AuthState) -> Any:
         if path.startswith("/admin"):
             return check_admin_auth(request, auth_state)
 
-        if not auth_state.key_set:
+        if not auth_state._has_keys():
             if auth_state.open_on_no_keys:
                 return None
             return _error_for_path(
@@ -262,14 +276,25 @@ def create_auth_hook(auth_state: AuthState) -> Any:
 
         # Check internal token first (admin panel test requests)
         if key and auth_state.internal_token and key == auth_state.internal_token:
-            api_key_label_var.set("internal")
+            api_key_context_var.set(
+                KeyContext(label="internal", allowed_shims=frozenset({"*"}))
+            )
             return None
 
-        if key not in auth_state.key_set:
+        if not key:
             return _error_for_path(path, 401, "Invalid or missing API key")
 
-        # Attach key label for request logging
-        api_key_label_var.set(auth_state.labels.get(key, ""))
+        # Try KeyStore (SQLite) first, then config fallback
+        ctx: KeyContext | None = None
+        if auth_state.keystore:
+            ctx = auth_state.keystore.validate(key)
+        if ctx is None:
+            key_hash = hashlib.sha256(key.encode()).hexdigest()
+            ctx = auth_state.config_fallback.get(key_hash)
+        if ctx is None:
+            return _error_for_path(path, 401, "Invalid or missing API key")
+
+        api_key_context_var.set(ctx)
         return None
 
     return auth_hook

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -349,13 +349,16 @@ class GatewayConfig:
                     "created": "",
                 }
             ]
-        # O(1) lookup set and key→label map for auth middleware
+        # O(1) lookup set and key→label map for config fallback auth
         self.api_key_set: frozenset[str] = frozenset(
             entry["key"] for entry in self.api_keys
         )
         self.api_key_labels: dict[str, str] = {
             entry["key"]: entry.get("label", "") for entry in self.api_keys
         }
+
+        # Custom SQLite DB path for API key storage (default: alongside config)
+        self.api_keys_db: str | None = _server.get("api_keys_db")
 
     def _apply_debug_settings(self, _debug: dict[str, Any]) -> None:
         """Parse debug/logging settings with env-var overrides.

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -349,13 +349,6 @@ class GatewayConfig:
                     "created": "",
                 }
             ]
-        # O(1) lookup set and key→label map for config fallback auth
-        self.api_key_set: frozenset[str] = frozenset(
-            entry["key"] for entry in self.api_keys
-        )
-        self.api_key_labels: dict[str, str] = {
-            entry["key"]: entry.get("label", "") for entry in self.api_keys
-        }
 
         # Custom SQLite DB path for API key storage (default: alongside config)
         self.api_keys_db: str | None = _server.get("api_keys_db")

--- a/src/llm_rosetta/gateway/keystore.py
+++ b/src/llm_rosetta/gateway/keystore.py
@@ -1,0 +1,241 @@
+"""SQLite-backed API key storage with hash-based validation.
+
+Keys are stored as SHA-256 hashes — plaintext is never persisted.
+An in-memory cache (hash → KeyContext) keeps auth lookups at O(1)
+without hitting SQLite on every request.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import secrets
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("llm-rosetta.keystore")
+
+_DB_FILENAME = "keys.db"
+
+
+@dataclass(frozen=True)
+class KeyContext:
+    """Per-request auth context attached via ContextVar after validation."""
+
+    label: str
+    allowed_shims: frozenset[str]
+
+
+def _hash_key(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode()).hexdigest()
+
+
+def _generate_key() -> str:
+    return f"rsk-{secrets.token_hex(24)}"
+
+
+def _generate_id() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+class KeyStore:
+    """SQLite-backed API key store with in-memory validation cache.
+
+    Args:
+        db_path: Path to the SQLite database file.  Created if missing.
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS api_keys (
+                id          TEXT PRIMARY KEY,
+                key_hash    TEXT NOT NULL UNIQUE,
+                label       TEXT NOT NULL DEFAULT '',
+                allowed_shims TEXT NOT NULL DEFAULT '["*"]',
+                created     TEXT NOT NULL,
+                rotated     TEXT
+            )"""
+        )
+        self._conn.commit()
+        self._cache: dict[str, tuple[str, KeyContext]] = {}
+        self._refresh_cache()
+
+    def _refresh_cache(self) -> None:
+        """Rebuild the in-memory hash → (id, KeyContext) lookup."""
+        rows = self._conn.execute(
+            "SELECT id, key_hash, label, allowed_shims FROM api_keys"
+        ).fetchall()
+        cache: dict[str, tuple[str, KeyContext]] = {}
+        for row_id, key_hash, label, shims_json in rows:
+            try:
+                shims = frozenset(json.loads(shims_json))
+            except (json.JSONDecodeError, TypeError):
+                shims = frozenset({"*"})
+            cache[key_hash] = (row_id, KeyContext(label=label, allowed_shims=shims))
+        self._cache = cache
+
+    def validate(self, raw_key: str) -> KeyContext | None:
+        """Validate a raw API key and return its context, or None."""
+        entry = self._cache.get(_hash_key(raw_key))
+        return entry[1] if entry else None
+
+    def has_keys(self) -> bool:
+        return bool(self._cache)
+
+    def create(
+        self,
+        label: str = "",
+        allowed_shims: list[str] | None = None,
+        manual_key: str | None = None,
+    ) -> tuple[str, str]:
+        """Create a new API key.
+
+        Returns:
+            (id, raw_key) — the raw key is shown once and never stored.
+        """
+        key_id = _generate_id()
+        raw_key = manual_key or _generate_key()
+        key_hash = _hash_key(raw_key)
+        shims = json.dumps(allowed_shims or ["*"])
+        from datetime import datetime, timezone
+
+        created = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            "INSERT INTO api_keys (id, key_hash, label, allowed_shims, created) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (key_id, key_hash, label, shims, created),
+        )
+        self._conn.commit()
+        self._refresh_cache()
+        return key_id, raw_key
+
+    def list_keys(self) -> list[dict[str, Any]]:
+        """List all keys without secrets."""
+        rows = self._conn.execute(
+            "SELECT id, label, allowed_shims, created, rotated FROM api_keys"
+        ).fetchall()
+        result = []
+        for row_id, label, shims_json, created, rotated in rows:
+            try:
+                shims = json.loads(shims_json)
+            except (json.JSONDecodeError, TypeError):
+                shims = ["*"]
+            entry: dict[str, Any] = {
+                "id": row_id,
+                "label": label,
+                "allowed_shims": shims,
+                "created": created,
+            }
+            if rotated:
+                entry["rotated"] = rotated
+            result.append(entry)
+        return result
+
+    def update(
+        self,
+        key_id: str,
+        label: str | None = None,
+        allowed_shims: list[str] | None = None,
+    ) -> bool:
+        """Update label and/or allowed_shims for a key.  Returns True if found."""
+        parts: list[str] = []
+        params: list[Any] = []
+        if label is not None:
+            parts.append("label = ?")
+            params.append(label)
+        if allowed_shims is not None:
+            parts.append("allowed_shims = ?")
+            params.append(json.dumps(allowed_shims))
+        if not parts:
+            return self._key_exists(key_id)
+        params.append(key_id)
+        cur = self._conn.execute(
+            f"UPDATE api_keys SET {', '.join(parts)} WHERE id = ?", params
+        )
+        self._conn.commit()
+        if cur.rowcount == 0:
+            return False
+        self._refresh_cache()
+        return True
+
+    def delete(self, key_id: str) -> bool:
+        """Delete a key by id.  Returns True if found."""
+        cur = self._conn.execute("DELETE FROM api_keys WHERE id = ?", (key_id,))
+        self._conn.commit()
+        if cur.rowcount == 0:
+            return False
+        self._refresh_cache()
+        return True
+
+    def rotate(self, key_id: str) -> str | None:
+        """Rotate a key: generate new raw key, update hash.  Returns new raw key or None."""
+        row = self._conn.execute(
+            "SELECT id FROM api_keys WHERE id = ?", (key_id,)
+        ).fetchone()
+        if not row:
+            return None
+        new_key = _generate_key()
+        new_hash = _hash_key(new_key)
+        from datetime import datetime, timezone
+
+        rotated = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            "UPDATE api_keys SET key_hash = ?, rotated = ? WHERE id = ?",
+            (new_hash, rotated, key_id),
+        )
+        self._conn.commit()
+        self._refresh_cache()
+        return new_key
+
+    def import_from_config(self, config_keys: list[dict[str, str]]) -> int:
+        """Import plaintext keys from config into SQLite (idempotent).
+
+        Returns the number of keys newly imported.
+        """
+        imported = 0
+        for entry in config_keys:
+            raw_key = entry.get("key", "")
+            if not raw_key:
+                continue
+            key_hash = _hash_key(raw_key)
+            try:
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO api_keys "
+                    "(id, key_hash, label, allowed_shims, created) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (
+                        entry.get("id", _generate_id()),
+                        key_hash,
+                        entry.get("label", ""),
+                        '["*"]',
+                        entry.get("created", ""),
+                    ),
+                )
+                if self._conn.execute("SELECT changes()").fetchone()[0]:
+                    imported += 1
+            except sqlite3.IntegrityError:
+                pass
+        if imported:
+            self._conn.commit()
+            self._refresh_cache()
+        return imported
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def _key_exists(self, key_id: str) -> bool:
+        return (
+            self._conn.execute(
+                "SELECT 1 FROM api_keys WHERE id = ?", (key_id,)
+            ).fetchone()
+            is not None
+        )

--- a/tests/gateway/test_auth.py
+++ b/tests/gateway/test_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -10,9 +11,11 @@ import pytest
 
 from llm_rosetta.gateway.auth import (
     AuthState,
-    api_key_label_var,
+    _build_config_fallback,
+    api_key_context_var,
     create_auth_hook,
 )
+from llm_rosetta.gateway.keystore import KeyContext, KeyStore
 
 
 # ---------------------------------------------------------------------------
@@ -39,6 +42,23 @@ def _run(coro: Any) -> Any:
     return asyncio.run(coro)
 
 
+def _make_keystore_with_key(
+    tmp_path, raw_key: str, label: str = ""
+) -> tuple[KeyStore, str]:
+    """Create a KeyStore with a single key and return (keystore, key_id)."""
+    ks = KeyStore(tmp_path / "keys.db")
+    key_id, _ = ks.create(label=label, manual_key=raw_key)
+    return ks, key_id
+
+
+def _make_keystore_with_keys(tmp_path, keys: dict[str, str]) -> KeyStore:
+    """Create a KeyStore with multiple keys {raw_key: label}."""
+    ks = KeyStore(tmp_path / "keys.db")
+    for raw_key, label in keys.items():
+        ks.create(label=label, manual_key=raw_key)
+    return ks
+
+
 # ---------------------------------------------------------------------------
 # No API keys configured
 # ---------------------------------------------------------------------------
@@ -48,7 +68,9 @@ class TestNoApiKey:
     """When no api_key is configured, behavior depends on open_on_no_keys."""
 
     def test_open_on_no_keys_allows_all(self):
-        state = AuthState(frozenset(), {}, None, open_on_no_keys=True)
+        state = AuthState(
+            keystore=None, config_fallback={}, internal_token=None, open_on_no_keys=True
+        )
         hook = create_auth_hook(state)
 
         for path in [
@@ -61,7 +83,12 @@ class TestNoApiKey:
             assert resp is None, f"Expected pass-through for {path}"
 
     def test_closed_on_no_keys_blocks_api(self):
-        state = AuthState(frozenset(), {}, None, open_on_no_keys=False)
+        state = AuthState(
+            keystore=None,
+            config_fallback={},
+            internal_token=None,
+            open_on_no_keys=False,
+        )
         hook = create_auth_hook(state)
 
         resp = _run(hook(_make_request("/v1/chat/completions")))
@@ -69,7 +96,12 @@ class TestNoApiKey:
         assert resp.status_code == 403
 
     def test_closed_on_no_keys_allows_health(self):
-        state = AuthState(frozenset(), {}, None, open_on_no_keys=False)
+        state = AuthState(
+            keystore=None,
+            config_fallback={},
+            internal_token=None,
+            open_on_no_keys=False,
+        )
         hook = create_auth_hook(state)
 
         resp = _run(hook(_make_request("/health")))
@@ -77,19 +109,21 @@ class TestNoApiKey:
 
 
 # ---------------------------------------------------------------------------
-# With API keys
+# With API keys (KeyStore)
 # ---------------------------------------------------------------------------
 
 
 class TestWithApiKey:
-    """When api_key is configured, requests must provide valid credentials."""
+    """When api_key is configured via KeyStore, requests must provide valid credentials."""
 
     KEY = "test-gateway-key-123"
 
     @pytest.fixture()
-    def hook(self):
-        state = AuthState(frozenset({self.KEY}), {}, None)
-        return create_auth_hook(state)
+    def hook(self, tmp_path):
+        ks, _ = _make_keystore_with_key(tmp_path, self.KEY)
+        state = AuthState(keystore=ks, config_fallback={}, internal_token=None)
+        yield create_auth_hook(state)
+        ks.close()
 
     # --- Health is always public ---
     def test_health_no_auth(self, hook: Any):
@@ -204,14 +238,16 @@ class TestWithApiKey:
 
 
 class TestMultiKey:
-    """When multiple API keys are configured via api_key_set."""
+    """When multiple API keys are configured via KeyStore."""
 
-    KEYS = {"key-alpha", "key-beta", "key-gamma"}
+    KEYS = {"key-alpha": "alpha", "key-beta": "beta", "key-gamma": "gamma"}
 
     @pytest.fixture()
-    def hook(self):
-        state = AuthState(frozenset(self.KEYS), {}, None)
-        return create_auth_hook(state)
+    def hook(self, tmp_path):
+        ks = _make_keystore_with_keys(tmp_path, self.KEYS)
+        state = AuthState(keystore=ks, config_fallback={}, internal_token=None)
+        yield create_auth_hook(state)
+        ks.close()
 
     def test_first_key_valid(self, hook: Any):
         req = _make_request(
@@ -276,9 +312,11 @@ class TestInternalToken:
     INTERNAL = "rsk-internal-abc123"
 
     @pytest.fixture()
-    def hook(self):
-        state = AuthState(frozenset({self.KEY}), {}, self.INTERNAL)
-        return create_auth_hook(state)
+    def hook(self, tmp_path):
+        ks, _ = _make_keystore_with_key(tmp_path, self.KEY)
+        state = AuthState(keystore=ks, config_fallback={}, internal_token=self.INTERNAL)
+        yield create_auth_hook(state)
+        ks.close()
 
     def test_internal_token_accepted(self, hook: Any):
         req = _make_request(
@@ -305,56 +343,130 @@ class TestInternalToken:
 
 
 # ---------------------------------------------------------------------------
-# Key label tracking
+# Key context tracking (replaces label tracking)
 # ---------------------------------------------------------------------------
 
 
-async def _run_and_get_label(hook: Any, req: Any) -> tuple[Any, str | None]:
-    """Run the auth hook and return (response, label) in the same async context."""
+async def _run_and_get_context(hook: Any, req: Any) -> tuple[Any, KeyContext | None]:
+    """Run the auth hook and return (response, context) in the same async context."""
     resp = await hook(req)
-    return resp, api_key_label_var.get()
+    return resp, api_key_context_var.get()
 
 
-class TestKeyLabelTracking:
-    """API key label is attached to contextvars for logging."""
+class TestKeyContextTracking:
+    """API key context is attached to contextvars for logging."""
 
-    KEYS = {"key-prod", "key-dev"}
-    LABELS = {"key-prod": "Production", "key-dev": "Development"}
+    KEYS = {"key-prod": "Production", "key-dev": "Development"}
     INTERNAL = "rsk-internal-test"
 
     @pytest.fixture()
-    def hook(self):
-        state = AuthState(frozenset(self.KEYS), self.LABELS, self.INTERNAL)
-        return create_auth_hook(state)
+    def hook(self, tmp_path):
+        ks = _make_keystore_with_keys(tmp_path, self.KEYS)
+        state = AuthState(keystore=ks, config_fallback={}, internal_token=self.INTERNAL)
+        yield create_auth_hook(state)
+        ks.close()
 
-    def test_label_attached_for_prod_key(self, hook: Any):
+    def test_context_attached_for_prod_key(self, hook: Any):
         req = _make_request(
             "/v1/chat/completions",
             headers={"authorization": "Bearer key-prod"},
         )
-        _, label = _run(_run_and_get_label(hook, req))
-        assert label == "Production"
+        _, ctx = _run(_run_and_get_context(hook, req))
+        assert ctx is not None
+        assert ctx.label == "Production"
 
-    def test_label_attached_for_dev_key(self, hook: Any):
+    def test_context_attached_for_dev_key(self, hook: Any):
         req = _make_request(
             "/v1/chat/completions",
             headers={"authorization": "Bearer key-dev"},
         )
-        _, label = _run(_run_and_get_label(hook, req))
-        assert label == "Development"
+        _, ctx = _run(_run_and_get_context(hook, req))
+        assert ctx is not None
+        assert ctx.label == "Development"
 
-    def test_internal_token_label(self, hook: Any):
+    def test_internal_token_context(self, hook: Any):
         req = _make_request(
             "/v1/chat/completions",
             headers={"authorization": f"Bearer {self.INTERNAL}"},
         )
-        _, label = _run(_run_and_get_label(hook, req))
-        assert label == "internal"
+        _, ctx = _run(_run_and_get_context(hook, req))
+        assert ctx is not None
+        assert ctx.label == "internal"
+        assert ctx.allowed_shims == frozenset({"*"})
 
-    def test_anthropic_label(self, hook: Any):
+    def test_anthropic_context(self, hook: Any):
         req = _make_request(
             "/v1/messages",
             headers={"x-api-key": "key-prod"},
         )
-        _, label = _run(_run_and_get_label(hook, req))
-        assert label == "Production"
+        _, ctx = _run(_run_and_get_context(hook, req))
+        assert ctx is not None
+        assert ctx.label == "Production"
+
+
+# ---------------------------------------------------------------------------
+# Config fallback
+# ---------------------------------------------------------------------------
+
+
+class TestConfigFallback:
+    """Keys only in config (not KeyStore) still authenticate via fallback."""
+
+    CONFIG_KEY = "config-only-key"
+
+    @pytest.fixture()
+    def hook(self, tmp_path):
+        ks = KeyStore(tmp_path / "empty.db")
+        fallback = _build_config_fallback(
+            [
+                {"key": self.CONFIG_KEY, "label": "from-config"},
+            ]
+        )
+        state = AuthState(keystore=ks, config_fallback=fallback, internal_token=None)
+        yield create_auth_hook(state)
+        ks.close()
+
+    def test_config_fallback_key_accepted(self, hook: Any):
+        req = _make_request(
+            "/v1/chat/completions",
+            headers={"authorization": f"Bearer {self.CONFIG_KEY}"},
+        )
+        assert _run(hook(req)) is None
+
+    def test_config_fallback_sets_context(self, hook: Any):
+        req = _make_request(
+            "/v1/chat/completions",
+            headers={"authorization": f"Bearer {self.CONFIG_KEY}"},
+        )
+        _, ctx = _run(_run_and_get_context(hook, req))
+        assert ctx is not None
+        assert ctx.label == "from-config"
+
+    def test_invalid_key_rejected_with_fallback(self, hook: Any):
+        req = _make_request(
+            "/v1/chat/completions",
+            headers={"authorization": "Bearer wrong"},
+        )
+        resp = _run(hook(req))
+        assert resp is not None
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Build config fallback helper
+# ---------------------------------------------------------------------------
+
+
+class TestBuildConfigFallback:
+    def test_builds_hash_map(self):
+        keys = [{"key": "secret", "label": "test"}]
+        fb = _build_config_fallback(keys)
+        expected_hash = hashlib.sha256(b"secret").hexdigest()
+        assert expected_hash in fb
+        assert fb[expected_hash].label == "test"
+        assert fb[expected_hash].allowed_shims == frozenset({"*"})
+
+    def test_skips_empty_keys(self):
+        keys = [{"key": "", "label": "empty"}]
+        fb = _build_config_fallback(keys)
+        assert len(fb) == 0

--- a/tests/gateway/test_keystore.py
+++ b/tests/gateway/test_keystore.py
@@ -1,0 +1,209 @@
+"""Tests for gateway.keystore — SQLite-backed API key storage."""
+
+from __future__ import annotations
+
+
+import pytest
+
+from llm_rosetta.gateway.keystore import KeyContext, KeyStore
+
+
+@pytest.fixture()
+def keystore(tmp_path):
+    ks = KeyStore(tmp_path / "keys.db")
+    yield ks
+    ks.close()
+
+
+class TestKeyStoreCreate:
+    def test_create_returns_id_and_raw_key(self, keystore):
+        key_id, raw_key = keystore.create(label="test")
+        assert len(key_id) == 8
+        assert raw_key.startswith("rsk-")
+
+    def test_create_with_manual_key(self, keystore):
+        key_id, raw_key = keystore.create(label="manual", manual_key="my-secret-key")
+        assert raw_key == "my-secret-key"
+
+    def test_create_with_allowed_shims(self, keystore):
+        key_id, raw_key = keystore.create(
+            label="limited", allowed_shims=["openai", "anthropic"]
+        )
+        ctx = keystore.validate(raw_key)
+        assert ctx is not None
+        assert ctx.allowed_shims == frozenset({"openai", "anthropic"})
+
+    def test_default_allowed_shims_is_star(self, keystore):
+        _, raw_key = keystore.create(label="default")
+        ctx = keystore.validate(raw_key)
+        assert ctx is not None
+        assert ctx.allowed_shims == frozenset({"*"})
+
+
+class TestKeyStoreValidate:
+    def test_validate_valid_key(self, keystore):
+        _, raw_key = keystore.create(label="valid")
+        ctx = keystore.validate(raw_key)
+        assert ctx is not None
+        assert isinstance(ctx, KeyContext)
+        assert ctx.label == "valid"
+
+    def test_validate_invalid_key(self, keystore):
+        keystore.create(label="exists")
+        assert keystore.validate("wrong-key") is None
+
+    def test_validate_empty_store(self, keystore):
+        assert keystore.validate("any-key") is None
+
+
+class TestKeyStoreList:
+    def test_list_returns_no_secrets(self, keystore):
+        keystore.create(label="a")
+        keystore.create(label="b")
+        keys = keystore.list_keys()
+        assert len(keys) == 2
+        for k in keys:
+            assert "key" not in k
+            assert "key_hash" not in k
+            assert "id" in k
+            assert "label" in k
+            assert "allowed_shims" in k
+            assert "created" in k
+
+    def test_list_empty(self, keystore):
+        assert keystore.list_keys() == []
+
+
+class TestKeyStoreUpdate:
+    def test_update_label(self, keystore):
+        key_id, raw_key = keystore.create(label="old")
+        assert keystore.update(key_id, label="new")
+        ctx = keystore.validate(raw_key)
+        assert ctx is not None
+        assert ctx.label == "new"
+
+    def test_update_allowed_shims(self, keystore):
+        key_id, raw_key = keystore.create(label="x")
+        assert keystore.update(key_id, allowed_shims=["google"])
+        ctx = keystore.validate(raw_key)
+        assert ctx is not None
+        assert ctx.allowed_shims == frozenset({"google"})
+
+    def test_update_nonexistent(self, keystore):
+        assert not keystore.update("nonexistent", label="x")
+
+    def test_update_nothing(self, keystore):
+        key_id, _ = keystore.create(label="y")
+        assert keystore.update(key_id)
+
+
+class TestKeyStoreDelete:
+    def test_delete_existing(self, keystore):
+        key_id, raw_key = keystore.create(label="del")
+        assert keystore.delete(key_id)
+        assert keystore.validate(raw_key) is None
+
+    def test_delete_nonexistent(self, keystore):
+        assert not keystore.delete("nonexistent")
+
+    def test_has_keys_after_delete(self, keystore):
+        key_id, _ = keystore.create(label="only")
+        assert keystore.has_keys()
+        keystore.delete(key_id)
+        assert not keystore.has_keys()
+
+
+class TestKeyStoreRotate:
+    def test_rotate_returns_new_key(self, keystore):
+        key_id, old_key = keystore.create(label="rotate")
+        new_key = keystore.rotate(key_id)
+        assert new_key is not None
+        assert new_key != old_key
+        assert new_key.startswith("rsk-")
+
+    def test_rotate_invalidates_old_key(self, keystore):
+        key_id, old_key = keystore.create(label="rotate")
+        keystore.rotate(key_id)
+        assert keystore.validate(old_key) is None
+
+    def test_rotate_new_key_validates(self, keystore):
+        key_id, _ = keystore.create(label="rotate")
+        new_key = keystore.rotate(key_id)
+        ctx = keystore.validate(new_key)
+        assert ctx is not None
+        assert ctx.label == "rotate"
+
+    def test_rotate_sets_rotated_timestamp(self, keystore):
+        key_id, _ = keystore.create(label="ts")
+        keystore.rotate(key_id)
+        keys = keystore.list_keys()
+        entry = next(k for k in keys if k["id"] == key_id)
+        assert entry.get("rotated") is not None
+
+    def test_rotate_nonexistent(self, keystore):
+        assert keystore.rotate("nonexistent") is None
+
+
+class TestKeyStoreImport:
+    def test_import_from_config(self, keystore):
+        config_keys = [
+            {"id": "k1", "key": "secret-1", "label": "first", "created": "2024-01-01"},
+            {"id": "k2", "key": "secret-2", "label": "second", "created": "2024-01-02"},
+        ]
+        imported = keystore.import_from_config(config_keys)
+        assert imported == 2
+        assert keystore.validate("secret-1") is not None
+        assert keystore.validate("secret-2") is not None
+
+    def test_import_idempotent(self, keystore):
+        config_keys = [
+            {"id": "k1", "key": "secret-1", "label": "first", "created": "2024-01-01"},
+        ]
+        assert keystore.import_from_config(config_keys) == 1
+        assert keystore.import_from_config(config_keys) == 0
+
+    def test_import_preserves_label(self, keystore):
+        config_keys = [
+            {"id": "k1", "key": "secret-1", "label": "mylab", "created": "2024-01-01"},
+        ]
+        keystore.import_from_config(config_keys)
+        ctx = keystore.validate("secret-1")
+        assert ctx is not None
+        assert ctx.label == "mylab"
+
+    def test_import_skips_empty_keys(self, keystore):
+        config_keys = [{"id": "k1", "key": "", "label": "empty", "created": ""}]
+        assert keystore.import_from_config(config_keys) == 0
+
+
+class TestKeyStoreHasKeys:
+    def test_has_keys_empty(self, keystore):
+        assert not keystore.has_keys()
+
+    def test_has_keys_with_key(self, keystore):
+        keystore.create(label="x")
+        assert keystore.has_keys()
+
+
+class TestKeyContext:
+    def test_frozen(self):
+        ctx = KeyContext(label="test", allowed_shims=frozenset({"*"}))
+        with pytest.raises(AttributeError):
+            ctx.label = "changed"  # type: ignore
+
+    def test_equality(self):
+        a = KeyContext(label="a", allowed_shims=frozenset({"*"}))
+        b = KeyContext(label="a", allowed_shims=frozenset({"*"}))
+        assert a == b
+
+
+class TestKeyStoreWAL:
+    def test_wal_mode(self, tmp_path):
+        ks = KeyStore(tmp_path / "test.db")
+        import sqlite3
+
+        conn = sqlite3.connect(str(tmp_path / "test.db"))
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        conn.close()
+        ks.close()
+        assert mode == "wal"


### PR DESCRIPTION
## Summary

Closes #361

- **New `KeyStore` class** (`gateway/keystore.py`): SQLite-backed API key storage with SHA-256 hashing — plaintext keys are never persisted, only shown once at creation/rotation
- **`AuthState` refactored**: uses `KeyStore` + config fallback (hashed dict) instead of plaintext `key_set`/`labels`; new `KeyContext` frozen dataclass carries `label` + `allowed_shims` per request
- **Admin key routes rewritten**: all CRUD goes through `KeyStore` directly — no more config file read-modify-write-reload cycle for key management
- **Reveal endpoint removed**: hash-based storage makes plaintext reveal impossible; `credential_visible` kept only for provider key reveal (separate concern)
- **Frontend updates**: credential reveal UI removed from gateway keys tab, `allowed_shims` column and input added to key management
- **Config fallback**: `server.api_keys` entries auto-imported to SQLite on startup (idempotent); config keys remain as read-only fallback for container/Nix read-only mount scenarios
- **Backward compatible**: no config file modifications, existing `server.api_keys` still work via fallback, new `server.api_keys_db` field for custom DB path

## Test plan

- [x] `make lint` passes (ruff check + format + ty + complexipy)
- [x] `make test` passes — 2528 tests pass, 0 failures
- [x] New `test_keystore.py` — 30 tests covering create/validate/list/update/delete/rotate/import/WAL
- [x] Updated `test_auth.py` — 37 tests covering KeyStore validation, config fallback, KeyContext tracking
- [ ] Manual: start gateway with existing `server.api_keys` → verify auto-import + warning log → admin panel key CRUD → verify auth works → verify reveal button gone