### PR TITLE
feat(admin): add disabled_tabs parameter to setup_admin()

### DIFF
--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -62,11 +62,15 @@ def _resolve_log_caps(config: GatewayConfig) -> tuple[int, int]:
     )
 
 
+_VALID_TABS = frozenset({"providers", "models", "keys", "dashboard", "logs"})
+
+
 def setup_admin(
     app: Any,
     config: GatewayConfig,
     config_path: str | None,
     config_io: ConfigIO | None = None,
+    disabled_tabs: list[str] | None = None,
     custom_head: str | None = None,
     branding: dict[str, Any] | None = None,
 ) -> None:
@@ -81,6 +85,11 @@ def setup_admin(
             file.  Defaults to :class:`JsoncConfigIO` when ``None``.
             Supply a custom implementation for non-JSONC formats
             (e.g. YAML in argo-proxy).
+        disabled_tabs: Optional list of tab identifiers to hide from the
+            admin panel.  Valid values: ``"providers"``, ``"models"``,
+            ``"keys"``, ``"dashboard"``, ``"logs"``.  Disabled tabs are
+            hidden via CSS, their data-fetching JS functions are
+            suppressed, and their API routes return 404.
         custom_head: Optional HTML fragment (``<style>``, ``<script>``,
             etc.) injected before ``</head>`` when serving the admin
             panel.  Allows downstream projects to override UI behavior
@@ -98,6 +107,16 @@ def setup_admin(
     Routes are registered separately via ``register_admin_routes`` before
     calling this function.
     """
+    disabled = frozenset(disabled_tabs or ())
+    unknown = disabled - _VALID_TABS
+    if unknown:
+        logger.warning(
+            "Ignoring unknown disabled_tabs: %s (valid: %s)",
+            ", ".join(sorted(unknown)),
+            ", ".join(sorted(_VALID_TABS)),
+        )
+        disabled = disabled & _VALID_TABS
+    app.disabled_tabs = disabled
     if config_io is None:
         from ..config import JsoncConfigIO
 
@@ -153,13 +172,21 @@ def setup_admin(
     app.config_io = config_io
     app.profiler_state = profiler_state
     app.capture_state = capture_state
-    # Build custom_head: user-supplied fragment + branding injection
+    # Build custom_head: disabled-tab CSS + user fragment + branding injection
     parts: list[str] = []
+    if disabled:
+        selectors = ", ".join(
+            f'.tab[data-tab="{t}"], #tab-{t}' for t in sorted(disabled)
+        )
+        parts.append(f"<style>{selectors} {{ display: none !important; }}</style>")
     if custom_head:
         parts.append(custom_head)
-    if branding:
+    merged_branding = dict(branding) if branding else {}
+    if disabled:
+        merged_branding["disabled_tabs"] = sorted(disabled)
+    if merged_branding:
         import json as _json
 
-        serialized = _json.dumps(branding).replace("</", r"<\/")
+        serialized = _json.dumps(merged_branding).replace("</", r"<\/")
         parts.append(f"<script>window.__branding={serialized};</script>")
     app.admin_custom_head = "\n".join(parts)

--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -184,6 +184,7 @@ def setup_admin(
     merged_branding = dict(branding) if branding else {}
     if disabled:
         merged_branding["disabled_tabs"] = sorted(disabled)
+        merged_branding["all_tabs"] = sorted(_VALID_TABS)
     if merged_branding:
         import json as _json
 

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -4038,7 +4038,7 @@ checkAuthAndInit();
     if (_dt.indexOf('logs') !== -1) { loadLogs = _noop; }
     // Fall back to first non-disabled tab if persisted tab is disabled
     if (_dt.indexOf(currentTab) !== -1) {
-      var _allTabs = ['providers','models','keys','dashboard','logs'];
+      var _allTabs = b.all_tabs || ['providers','models','keys','dashboard','logs'];
       for (var i = 0; i < _allTabs.length; i++) {
         if (_dt.indexOf(_allTabs[i]) === -1) { currentTab = _allTabs[i]; break; }
       }

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -4029,6 +4029,22 @@ checkAuthAndInit();
       fn2.parentNode.insertBefore(attr, fn2.nextSibling);
     }
   }
+  // Suppress data fetching for disabled tabs
+  if (b.disabled_tabs) {
+    var _noop = function(){};
+    var _dt = b.disabled_tabs;
+    if (_dt.indexOf('keys') !== -1) { loadKeys = _noop; }
+    if (_dt.indexOf('dashboard') !== -1) { loadMetrics = _noop; loadProfilingStatus = _noop; loadProfilingResults = _noop; loadCaptureStatus = _noop; loadCaptureResults = _noop; }
+    if (_dt.indexOf('logs') !== -1) { loadLogs = _noop; }
+    // Fall back to first non-disabled tab if persisted tab is disabled
+    if (_dt.indexOf(currentTab) !== -1) {
+      var _allTabs = ['providers','models','keys','dashboard','logs'];
+      for (var i = 0; i < _allTabs.length; i++) {
+        if (_dt.indexOf(_allTabs[i]) === -1) { currentTab = _allTabs[i]; break; }
+      }
+      localStorage.setItem('llm-rosetta-tab', currentTab);
+    }
+  }
 })();
 
 document.addEventListener('click', function(e) {

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -12,7 +12,10 @@ This package splits the admin route handlers into focused modules:
 
 from __future__ import annotations
 
+import functools
 from typing import Any
+
+from llm_rosetta._vendor.httpserver import JSONResponse
 
 from ._shared import (  # noqa: F401  (re-exported for backward compat)
     _ENV_VAR_RE,
@@ -91,6 +94,25 @@ from .testing import (
 )
 
 
+def _tab_guard(tab_id: str, handler: Any) -> Any:
+    """Wrap a route handler to return 404 when its tab is disabled."""
+
+    @functools.wraps(handler)
+    async def _guarded(request: Any, **kw: Any) -> Any:
+        if tab_id in getattr(request.app, "disabled_tabs", ()):
+            return JSONResponse(
+                {"error": "Tab disabled", "disabled": True}, status_code=404
+            )
+        return await handler(request, **kw)
+
+    return _guarded
+
+
+def _guard(tab_id: str, handler: Any) -> Any:
+    """Shorthand: wrap *handler* with a disabled-tab guard for *tab_id*."""
+    return _tab_guard(tab_id, handler)
+
+
 def register_admin_routes(app: Any) -> None:
     """Register all admin panel routes on the httpserver App."""
     # HTML
@@ -101,35 +123,49 @@ def register_admin_routes(app: Any) -> None:
     app.route("/admin/api/auth-check", methods=["GET"])(admin_check)
     app.route("/admin/api/config/password", methods=["PUT"])(change_password)
     app.route("/admin/api/token/rotate", methods=["POST"])(rotate_token)
-    # Config CRUD
+    # Config CRUD (providers + models tabs)
     app.route("/admin/api/config", methods=["GET"])(get_config)
-    app.route("/admin/api/config/providers/<name>", methods=["PUT"])(put_provider)
-    app.route("/admin/api/config/providers/<name>", methods=["DELETE"])(delete_provider)
+    app.route("/admin/api/config/providers/<name>", methods=["PUT"])(
+        _guard("providers", put_provider)
+    )
+    app.route("/admin/api/config/providers/<name>", methods=["DELETE"])(
+        _guard("providers", delete_provider)
+    )
     app.route("/admin/api/config/providers/<name>/toggle", methods=["POST"])(
-        toggle_provider
+        _guard("providers", toggle_provider)
     )
     app.route("/admin/api/config/providers/<name>/key", methods=["GET"])(
         get_provider_key
     )
-    app.route("/admin/api/config/models/<path:name>", methods=["PUT"])(put_model)
-    app.route("/admin/api/config/models/<path:name>", methods=["DELETE"])(delete_model)
-    app.route("/admin/api/config/models/<path:name>/toggle", methods=["POST"])(
-        toggle_model
+    app.route("/admin/api/config/models/<path:name>", methods=["PUT"])(
+        _guard("models", put_model)
     )
-    app.route("/admin/api/config/models/bulk", methods=["POST"])(bulk_update_models)
+    app.route("/admin/api/config/models/<path:name>", methods=["DELETE"])(
+        _guard("models", delete_model)
+    )
+    app.route("/admin/api/config/models/<path:name>/toggle", methods=["POST"])(
+        _guard("models", toggle_model)
+    )
+    app.route("/admin/api/config/models/bulk", methods=["POST"])(
+        _guard("models", bulk_update_models)
+    )
     app.route("/admin/api/config/providers/<name>/models", methods=["GET"])(
         fetch_upstream_models
     )
-    app.route("/admin/api/config/models", methods=["POST"])(bulk_add_models)
+    app.route("/admin/api/config/models", methods=["POST"])(
+        _guard("models", bulk_add_models)
+    )
     app.route("/admin/api/config/server", methods=["PUT"])(put_server_settings)
     app.route("/admin/api/config/reload", methods=["POST"])(reload_config)
-    # Metrics
+    # Metrics (dashboard tab)
     app.route("/admin/api/metrics", methods=["GET"])(get_metrics)
-    app.route("/admin/api/metrics/rebuild", methods=["POST"])(rebuild_metrics)
-    # Request log
-    app.route("/admin/api/requests", methods=["GET"])(get_requests)
+    app.route("/admin/api/metrics/rebuild", methods=["POST"])(
+        _guard("dashboard", rebuild_metrics)
+    )
+    # Request log (logs tab)
+    app.route("/admin/api/requests", methods=["GET"])(_guard("logs", get_requests))
     app.route("/admin/api/requests/key-labels", methods=["GET"])(get_request_key_labels)
-    app.route("/admin/api/requests", methods=["DELETE"])(clear_requests)
+    app.route("/admin/api/requests", methods=["DELETE"])(_guard("logs", clear_requests))
     # Network diagnostics
     app.route("/admin/api/diagnostics/network", methods=["GET"])(network_diagnostics)
     app.route("/admin/api/diagnostics/host-ip", methods=["GET"])(get_host_ip)
@@ -142,36 +178,62 @@ def register_admin_routes(app: Any) -> None:
         get_error_dump_body
     )
     app.route("/admin/api/error-dumps", methods=["DELETE"])(clear_error_dumps)
-    # API key management
-    app.route("/admin/api/keys", methods=["GET"])(get_api_keys)
-    app.route("/admin/api/keys", methods=["POST"])(create_api_key)
-    app.route("/admin/api/keys/<key_id>", methods=["PUT"])(update_api_key)
-    app.route("/admin/api/keys/<key_id>", methods=["DELETE"])(delete_api_key)
-    app.route("/admin/api/keys/<key_id>/rotate", methods=["POST"])(rotate_api_key)
+    # API key management (keys tab)
+    app.route("/admin/api/keys", methods=["GET"])(_guard("keys", get_api_keys))
+    app.route("/admin/api/keys", methods=["POST"])(_guard("keys", create_api_key))
+    app.route("/admin/api/keys/<key_id>", methods=["PUT"])(
+        _guard("keys", update_api_key)
+    )
+    app.route("/admin/api/keys/<key_id>", methods=["DELETE"])(
+        _guard("keys", delete_api_key)
+    )
+    app.route("/admin/api/keys/<key_id>/rotate", methods=["POST"])(
+        _guard("keys", rotate_api_key)
+    )
     app.route("/admin/api/internal-token", methods=["GET"])(get_internal_token)
     # Async model test
     app.route("/admin/api/test", methods=["POST"])(start_test)
     app.route("/admin/api/test/<task_id>", methods=["GET"])(get_test_result)
     app.route("/admin/api/test/<task_id>/poll", methods=["POST"])(get_test_result)
     app.route("/admin/api/test/<task_id>", methods=["DELETE"])(cancel_test)
-    # Content capture
-    app.route("/admin/api/capture/status", methods=["GET"])(get_capture_status)
-    app.route("/admin/api/capture/enable", methods=["POST"])(enable_capture)
-    app.route("/admin/api/capture/disable", methods=["POST"])(disable_capture)
-    app.route("/admin/api/capture/results", methods=["GET"])(get_capture_results)
-    app.route("/admin/api/capture/results/<index>", methods=["GET"])(get_capture_result)
-    app.route("/admin/api/capture/results", methods=["DELETE"])(clear_capture_results)
-    # Profiling
-    app.route("/admin/api/profiling/status", methods=["GET"])(get_profiling_status)
-    app.route("/admin/api/profiling/enable", methods=["POST"])(enable_profiling)
-    app.route("/admin/api/profiling/disable", methods=["POST"])(disable_profiling)
-    app.route("/admin/api/profiling/results", methods=["GET"])(get_profiling_results)
+    # Content capture (dashboard tab)
+    app.route("/admin/api/capture/status", methods=["GET"])(
+        _guard("dashboard", get_capture_status)
+    )
+    app.route("/admin/api/capture/enable", methods=["POST"])(
+        _guard("dashboard", enable_capture)
+    )
+    app.route("/admin/api/capture/disable", methods=["POST"])(
+        _guard("dashboard", disable_capture)
+    )
+    app.route("/admin/api/capture/results", methods=["GET"])(
+        _guard("dashboard", get_capture_results)
+    )
+    app.route("/admin/api/capture/results/<index>", methods=["GET"])(
+        _guard("dashboard", get_capture_result)
+    )
+    app.route("/admin/api/capture/results", methods=["DELETE"])(
+        _guard("dashboard", clear_capture_results)
+    )
+    # Profiling (dashboard tab)
+    app.route("/admin/api/profiling/status", methods=["GET"])(
+        _guard("dashboard", get_profiling_status)
+    )
+    app.route("/admin/api/profiling/enable", methods=["POST"])(
+        _guard("dashboard", enable_profiling)
+    )
+    app.route("/admin/api/profiling/disable", methods=["POST"])(
+        _guard("dashboard", disable_profiling)
+    )
+    app.route("/admin/api/profiling/results", methods=["GET"])(
+        _guard("dashboard", get_profiling_results)
+    )
     app.route("/admin/api/profiling/results/<index>", methods=["GET"])(
-        get_profiling_result
+        _guard("dashboard", get_profiling_result)
     )
     app.route("/admin/api/profiling/results/download", methods=["GET"])(
-        download_profiling_results
+        _guard("dashboard", download_profiling_results)
     )
     app.route("/admin/api/profiling/results", methods=["DELETE"])(
-        clear_profiling_results
+        _guard("dashboard", clear_profiling_results)
     )

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -94,8 +94,15 @@ from .testing import (
 )
 
 
-def _tab_guard(tab_id: str, handler: Any) -> Any:
-    """Wrap a route handler to return 404 when its tab is disabled."""
+def _guard(tab_id: str, handler: Any) -> Any:
+    """Wrap a route handler to return 404 when its tab is disabled.
+
+    Read-only endpoints (``get_config``, ``get_metrics``,
+    ``get_request_key_labels``) are intentionally left unguarded —
+    disabled tabs are a UI convenience, not security isolation, and
+    other components (e.g. argo-proxy's ``ArgoConfigIO``) may depend
+    on them regardless of tab visibility.
+    """
 
     @functools.wraps(handler)
     async def _guarded(request: Any, **kw: Any) -> Any:
@@ -106,11 +113,6 @@ def _tab_guard(tab_id: str, handler: Any) -> Any:
         return await handler(request, **kw)
 
     return _guarded
-
-
-def _guard(tab_id: str, handler: Any) -> Any:
-    """Shorthand: wrap *handler* with a disabled-tab guard for *tab_id*."""
-    return _tab_guard(tab_id, handler)
 
 
 def register_admin_routes(app: Any) -> None:


### PR DESCRIPTION
## Summary

- Add `disabled_tabs: list[str] | None` parameter to `setup_admin()` for downstream projects to hide irrelevant admin tabs
- **CSS layer**: auto-generates `<style>` to hide `.tab[data-tab="X"]` and `#tab-X` for each disabled tab
- **JS layer**: branding IIFE overrides `loadKeys`, `loadMetrics`, `loadLogs`, etc. to no-ops for disabled tabs; falls back to first enabled tab if persisted `currentTab` is disabled
- **Route layer**: `_tab_guard` wrapper returns `404 {"error": "Tab disabled"}` instead of crashing with 500 when `keystore=None`

Valid tab IDs: `providers`, `models`, `keys`, `dashboard`, `logs`.

## Usage

```python
setup_admin(
    app, gateway_config, config_path,
    disabled_tabs=["keys"],  # hide API Keys tab
    custom_head=_ADMIN_CUSTOM_HEAD,
    branding={...},
)
```

## Motivation

argo-proxy passes `keystore=None` to `AuthState` since it delegates auth to upstream ARGO. The admin panel's API Keys tab calls `/admin/api/keys` which crashes with `RuntimeError("KeyStore not configured")` → 500. Currently argo-proxy works around this via fragile `custom_head` CSS/JS hacks.

Closes #503

## Test plan

- [x] 319 existing gateway tests pass
- [ ] Verify CSS injection in served HTML
- [ ] Verify `/admin/api/keys` returns 404 (not 500) when `disabled_tabs=["keys"]`
- [ ] Verify JS suppresses `loadKeys()` calls — no console errors
- [ ] Verify tab restore fallback when persisted tab is disabled