### PR TITLE
feat: add rerank IR types and converter family

### DIFF
--- a/src/llm_rosetta/converters/__init__.py
+++ b/src/llm_rosetta/converters/__init__.py
@@ -6,13 +6,14 @@ Provides converter implementations between various providers
 """
 
 from .anthropic import AnthropicConverter
-from .base import BaseConverter
+from .base import BaseConverter, BaseRerankConverter
 from .google_genai import GoogleConverter, GoogleGenAIConverter
 from .openai_chat import OpenAIChatConverter
 from .openai_responses import OpenAIResponsesConverter
 
 __all__ = [
     "BaseConverter",
+    "BaseRerankConverter",
     "OpenAIChatConverter",
     "AnthropicConverter",
     "GoogleGenAIConverter",

--- a/src/llm_rosetta/converters/__init__.py
+++ b/src/llm_rosetta/converters/__init__.py
@@ -10,6 +10,7 @@ from .base import BaseConverter, BaseRerankConverter
 from .google_genai import GoogleConverter, GoogleGenAIConverter
 from .openai_chat import OpenAIChatConverter
 from .openai_responses import OpenAIResponsesConverter
+from .rerank import CohereRerankConverter, JinaRerankConverter, VoyageRerankConverter
 
 __all__ = [
     "BaseConverter",
@@ -19,4 +20,7 @@ __all__ = [
     "GoogleGenAIConverter",
     "GoogleConverter",
     "OpenAIResponsesConverter",
+    "JinaRerankConverter",
+    "CohereRerankConverter",
+    "VoyageRerankConverter",
 ]

--- a/src/llm_rosetta/converters/base/__init__.py
+++ b/src/llm_rosetta/converters/base/__init__.py
@@ -22,6 +22,7 @@ from .configs import BaseConfigOps  # noqa: F401
 from .content import BaseContentOps  # noqa: F401
 from .context import ConversionContext, MetadataMode, StreamContext
 from .converter import BaseConverter
+from .rerank_converter import BaseRerankConverter
 from .messages import BaseMessageOps  # noqa: F401
 from .helpers.tool_content import convert_content_blocks_to_ir  # noqa: F401
 from .helpers.tool_content import convert_ir_content_blocks_to_p  # noqa: F401
@@ -31,6 +32,7 @@ from .tools import BaseToolOps  # noqa: F401
 __all__ = [
     # 主转换器 Main converter
     "BaseConverter",
+    "BaseRerankConverter",
     # 转换上下文 Conversion context
     "ConversionContext",
     "MetadataMode",

--- a/src/llm_rosetta/converters/base/rerank_converter.py
+++ b/src/llm_rosetta/converters/base/rerank_converter.py
@@ -1,0 +1,162 @@
+"""
+LLM-Rosetta - Base Rerank Converter
+
+Rerank 转换器抽象基类
+Abstract base class for rerank converters
+
+Parallel hierarchy to BaseConverter — rerank and chat completions are
+different API categories with fundamentally different shapes (no messages,
+tools, or streaming).  Shares ConversionContext for warnings/options but
+otherwise stands alone.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+from llm_rosetta.types.ir.rerank import (
+    IRRerankRequest,
+    IRRerankResponse,
+    RerankUsageInfo,
+)
+
+from .context import ConversionContext
+
+
+class BaseRerankConverter(ABC):
+    """Abstract base class for rerank format converters.
+
+    Each concrete converter implements bidirectional conversion between
+    a provider's rerank API format and the IR rerank types.
+
+    Subclasses MUST:
+    - Set ``_CONVERTER_TAG`` to a unique string identifier
+    - Implement all ``_do_*`` hooks and usage conversion methods
+
+    Public methods follow the template-method pattern: they create a
+    fallback ``ConversionContext``, delegate to the abstract ``_do_*``
+    hook, and return the result along with any accumulated warnings.
+    """
+
+    _CONVERTER_TAG: ClassVar[str]
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if not getattr(cls, "__abstractmethods__", None) and not hasattr(
+            cls, "_CONVERTER_TAG"
+        ):
+            raise TypeError(
+                f"{cls.__name__} must define a _CONVERTER_TAG class attribute"
+            )
+
+    # ==================== Public template methods ====================
+
+    def request_to_provider(
+        self,
+        ir_request: IRRerankRequest,
+        *,
+        context: ConversionContext | None = None,
+    ) -> tuple[dict[str, Any], list[str]]:
+        """Convert IR rerank request to provider request format.
+
+        Returns:
+            Tuple of (provider_request_dict, warnings).
+        """
+        ctx = context if context is not None else ConversionContext()
+        result = self._do_request_to_provider(ir_request, context=ctx)
+        return result, ctx.warnings
+
+    def request_from_provider(
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
+    ) -> IRRerankRequest:
+        """Convert provider rerank request to IR format."""
+        provider_request = self._normalize(provider_request)
+        ctx = context if context is not None else ConversionContext()
+        return self._do_request_from_provider(provider_request, context=ctx)
+
+    def response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
+    ) -> IRRerankResponse:
+        """Convert provider rerank response to IR format."""
+        provider_response = self._normalize(provider_response)
+        ctx = context if context is not None else ConversionContext()
+        return self._do_response_from_provider(provider_response, context=ctx)
+
+    def response_to_provider(
+        self,
+        ir_response: IRRerankResponse,
+        *,
+        context: ConversionContext | None = None,
+    ) -> dict[str, Any]:
+        """Convert IR rerank response to provider format."""
+        ctx = context if context is not None else ConversionContext()
+        return self._do_response_to_provider(ir_response, context=ctx)
+
+    # ==================== Abstract hooks ====================
+
+    @abstractmethod
+    def _do_request_to_provider(
+        self,
+        ir_request: IRRerankRequest,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]: ...
+
+    @abstractmethod
+    def _do_request_from_provider(
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IRRerankRequest: ...
+
+    @abstractmethod
+    def _do_response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IRRerankResponse: ...
+
+    @abstractmethod
+    def _do_response_to_provider(
+        self,
+        ir_response: IRRerankResponse,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]: ...
+
+    @staticmethod
+    @abstractmethod
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> RerankUsageInfo: ...
+
+    @staticmethod
+    @abstractmethod
+    def _build_ir_usage_to_p(ir_usage: RerankUsageInfo) -> dict[str, Any]: ...
+
+    # ==================== Utilities ====================
+
+    @staticmethod
+    def _normalize(data: Any) -> dict[str, Any]:
+        """Normalize SDK objects to plain dicts."""
+        if isinstance(data, dict):
+            return data
+        if hasattr(data, "model_dump"):
+            return data.model_dump()
+        if hasattr(data, "to_dict"):
+            return data.to_dict()
+        if hasattr(data, "__dict__"):
+            return dict(data.__dict__)
+        raise TypeError(f"Cannot normalize {type(data).__name__} to dict")
+
+    @classmethod
+    def create_conversion_context(cls, **options: Any) -> ConversionContext:
+        """Create a conversion context for rerank conversions."""
+        return ConversionContext(options=dict(options) if options else {})

--- a/src/llm_rosetta/converters/rerank/__init__.py
+++ b/src/llm_rosetta/converters/rerank/__init__.py
@@ -1,0 +1,21 @@
+"""
+LLM-Rosetta - Rerank Converters
+
+Rerank 格式转换器
+Rerank format converters
+
+Provides converters for:
+- Jina: results + top-level usage (also used by GPUStack, vLLM, Xinference)
+- Cohere: results + meta.billed_units (also used by OpenVINO, Siliconflow variant)
+- Voyage: data + top-level usage (OpenAI Embeddings-style)
+"""
+
+from .cohere import CohereRerankConverter
+from .jina import JinaRerankConverter
+from .voyage import VoyageRerankConverter
+
+__all__ = [
+    "JinaRerankConverter",
+    "CohereRerankConverter",
+    "VoyageRerankConverter",
+]

--- a/src/llm_rosetta/converters/rerank/cohere.py
+++ b/src/llm_rosetta/converters/rerank/cohere.py
@@ -1,0 +1,168 @@
+"""
+LLM-Rosetta - Cohere Rerank Converter
+
+Cohere Rerank API (v2) format converter.
+Also handles the Siliconflow variant (richer meta.tokens + meta.billed_units).
+
+Cohere response format:
+{
+    "id": "...",
+    "results": [{"index": 0, "relevance_score": 0.89}],
+    "meta": {
+        "api_version": {"version": "2"},
+        "billed_units": {"search_units": 1}
+    }
+}
+
+Siliconflow variant:
+{
+    "id": "...",
+    "results": [{"index": 0, "relevance_score": 0.99, "document": null}],
+    "meta": {
+        "tokens": {"input_tokens": 54, "output_tokens": 0},
+        "billed_units": {"input_tokens": 54, "output_tokens": 0, "search_units": 0, ...}
+    }
+}
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.converters.base.rerank_converter import BaseRerankConverter
+from llm_rosetta.types.ir.rerank import (
+    IRRerankRequest,
+    IRRerankResponse,
+    RerankDocument,
+    RerankResultItem,
+    RerankUsageInfo,
+)
+
+
+class CohereRerankConverter(BaseRerankConverter):
+    _CONVERTER_TAG = "cohere_rerank"
+
+    def _do_request_to_provider(
+        self,
+        ir_request: IRRerankRequest,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "model": ir_request["model"],
+            "query": ir_request["query"],
+            "documents": [doc["text"] for doc in ir_request["documents"]],
+        }
+        if "top_n" in ir_request:
+            result["top_n"] = ir_request["top_n"]
+        if "max_tokens_per_doc" in ir_request:
+            result["max_tokens_per_doc"] = ir_request["max_tokens_per_doc"]
+        return result
+
+    def _do_request_from_provider(
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IRRerankRequest:
+        documents = provider_request["documents"]
+        ir_docs = [
+            RerankDocument(text=doc)
+            if isinstance(doc, str)
+            else RerankDocument(text=str(doc))
+            for doc in documents
+        ]
+
+        ir_request = IRRerankRequest(
+            model=provider_request["model"],
+            query=provider_request["query"],
+            documents=ir_docs,
+        )
+        if "top_n" in provider_request:
+            ir_request["top_n"] = provider_request["top_n"]
+        if "max_tokens_per_doc" in provider_request:
+            ir_request["max_tokens_per_doc"] = provider_request["max_tokens_per_doc"]
+        return ir_request
+
+    def _do_response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IRRerankResponse:
+        results: list[RerankResultItem] = []
+        for item in provider_response.get("results", []):
+            result_item = RerankResultItem(
+                index=item["index"],
+                relevance_score=item["relevance_score"],
+            )
+            # Siliconflow sends document: null explicitly
+            doc = item.get("document")
+            if doc is not None:
+                if isinstance(doc, str):
+                    result_item["document"] = RerankDocument(text=doc)
+                elif isinstance(doc, dict) and "text" in doc:
+                    result_item["document"] = RerankDocument(text=doc["text"])
+            results.append(result_item)
+
+        ir_response = IRRerankResponse(
+            object="rerank",
+            model=provider_response.get("model", ""),
+            results=results,
+        )
+        if "id" in provider_response:
+            ir_response["id"] = provider_response["id"]
+
+        # Extract usage from meta.tokens (Cohere v4 / Siliconflow)
+        meta = provider_response.get("meta", {})
+        tokens = meta.get("tokens")
+        if tokens:
+            ir_response["usage"] = self._build_p_usage_to_ir(tokens)
+
+        return ir_response
+
+    def _do_response_to_provider(
+        self,
+        ir_response: IRRerankResponse,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        results = []
+        for item in ir_response["results"]:
+            p_item: dict[str, Any] = {
+                "index": item["index"],
+                "relevance_score": item["relevance_score"],
+            }
+            results.append(p_item)
+
+        result: dict[str, Any] = {"results": results}
+        if "id" in ir_response:
+            result["id"] = ir_response["id"]
+        if "usage" in ir_response:
+            result["meta"] = {
+                "tokens": self._build_ir_usage_to_p(ir_response["usage"]),
+            }
+        return result
+
+    @staticmethod
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> RerankUsageInfo:
+        usage = RerankUsageInfo()
+        # meta.tokens uses input_tokens, map to our canonical names
+        input_tokens = p_usage.get("input_tokens")
+        if input_tokens is not None:
+            usage["total_tokens"] = input_tokens
+            usage["prompt_tokens"] = input_tokens
+        if "cached_tokens" in p_usage:
+            usage["cached_tokens"] = p_usage["cached_tokens"]
+        return usage
+
+    @staticmethod
+    def _build_ir_usage_to_p(ir_usage: RerankUsageInfo) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if "prompt_tokens" in ir_usage:
+            result["input_tokens"] = ir_usage["prompt_tokens"]
+        elif "total_tokens" in ir_usage:
+            result["input_tokens"] = ir_usage["total_tokens"]
+        result["output_tokens"] = 0
+        return result

--- a/src/llm_rosetta/converters/rerank/cohere.py
+++ b/src/llm_rosetta/converters/rerank/cohere.py
@@ -118,7 +118,9 @@ class CohereRerankConverter(BaseRerankConverter):
         meta = provider_response.get("meta", {})
         tokens = meta.get("tokens")
         if tokens:
-            ir_response["usage"] = self._build_p_usage_to_ir(tokens)
+            usage = self._build_p_usage_to_ir(tokens)
+            if usage:
+                ir_response["usage"] = usage
 
         return ir_response
 
@@ -128,6 +130,13 @@ class CohereRerankConverter(BaseRerankConverter):
         *,
         context: ConversionContext,
     ) -> dict[str, Any]:
+        has_docs = any("document" in item for item in ir_response["results"])
+        if has_docs:
+            context.warnings.append(
+                "Cohere rerank format does not include document text in results; "
+                "document data from IR will be dropped"
+            )
+
         results = []
         for item in ir_response["results"]:
             p_item: dict[str, Any] = {
@@ -148,11 +157,13 @@ class CohereRerankConverter(BaseRerankConverter):
     @staticmethod
     def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> RerankUsageInfo:
         usage = RerankUsageInfo()
-        # meta.tokens uses input_tokens, map to our canonical names
-        input_tokens = p_usage.get("input_tokens")
-        if input_tokens is not None:
-            usage["total_tokens"] = input_tokens
-            usage["prompt_tokens"] = input_tokens
+        if "total_tokens" in p_usage:
+            usage["total_tokens"] = p_usage["total_tokens"]
+        if "input_tokens" in p_usage:
+            usage["prompt_tokens"] = p_usage["input_tokens"]
+            # Derive total_tokens from input_tokens only if not explicitly provided
+            if "total_tokens" not in usage:
+                usage["total_tokens"] = p_usage["input_tokens"]
         if "cached_tokens" in p_usage:
             usage["cached_tokens"] = p_usage["cached_tokens"]
         return usage

--- a/src/llm_rosetta/converters/rerank/jina.py
+++ b/src/llm_rosetta/converters/rerank/jina.py
@@ -1,0 +1,152 @@
+"""
+LLM-Rosetta - Jina Rerank Converter
+
+Jina Rerank API format converter.
+Also compatible with GPUStack, vLLM (/v1/rerank), Xinference, llama-box.
+
+Jina response format:
+{
+    "model": "jina-reranker-v2-base-multilingual",
+    "object": "list",
+    "usage": {"total_tokens": 54},
+    "results": [
+        {"index": 0, "relevance_score": 0.84, "document": "..."},
+        ...
+    ]
+}
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.converters.base.rerank_converter import BaseRerankConverter
+from llm_rosetta.types.ir.rerank import (
+    IRRerankRequest,
+    IRRerankResponse,
+    RerankDocument,
+    RerankResultItem,
+    RerankUsageInfo,
+)
+
+
+class JinaRerankConverter(BaseRerankConverter):
+    _CONVERTER_TAG = "jina_rerank"
+
+    def _do_request_to_provider(
+        self,
+        ir_request: IRRerankRequest,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "model": ir_request["model"],
+            "query": ir_request["query"],
+            "documents": [doc["text"] for doc in ir_request["documents"]],
+        }
+        if "top_n" in ir_request:
+            result["top_n"] = ir_request["top_n"]
+        if "return_documents" in ir_request:
+            result["return_documents"] = ir_request["return_documents"]
+        return result
+
+    def _do_request_from_provider(
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IRRerankRequest:
+        documents = provider_request["documents"]
+        ir_docs: list[RerankDocument] = []
+        for doc in documents:
+            if isinstance(doc, str):
+                ir_docs.append(RerankDocument(text=doc))
+            elif isinstance(doc, dict) and "text" in doc:
+                ir_docs.append(RerankDocument(text=doc["text"]))
+            else:
+                ir_docs.append(RerankDocument(text=str(doc)))
+
+        ir_request = IRRerankRequest(
+            model=provider_request["model"],
+            query=provider_request["query"],
+            documents=ir_docs,
+        )
+        if "top_n" in provider_request:
+            ir_request["top_n"] = provider_request["top_n"]
+        if "return_documents" in provider_request:
+            ir_request["return_documents"] = provider_request["return_documents"]
+        return ir_request
+
+    def _do_response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IRRerankResponse:
+        results: list[RerankResultItem] = []
+        for item in provider_response.get("results", []):
+            result_item = RerankResultItem(
+                index=item["index"],
+                relevance_score=item["relevance_score"],
+            )
+            # Jina returns document as plain string, not {text: "..."}
+            if "document" in item:
+                doc = item["document"]
+                if isinstance(doc, str):
+                    result_item["document"] = RerankDocument(text=doc)
+                elif isinstance(doc, dict) and "text" in doc:
+                    result_item["document"] = RerankDocument(text=doc["text"])
+            results.append(result_item)
+
+        ir_response = IRRerankResponse(
+            object="rerank",
+            model=provider_response.get("model", ""),
+            results=results,
+        )
+        if "usage" in provider_response:
+            ir_response["usage"] = self._build_p_usage_to_ir(provider_response["usage"])
+        return ir_response
+
+    def _do_response_to_provider(
+        self,
+        ir_response: IRRerankResponse,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        results = []
+        for item in ir_response["results"]:
+            p_item: dict[str, Any] = {
+                "index": item["index"],
+                "relevance_score": item["relevance_score"],
+            }
+            if "document" in item:
+                p_item["document"] = item["document"]["text"]
+            results.append(p_item)
+
+        result: dict[str, Any] = {
+            "model": ir_response["model"],
+            "object": "list",
+            "results": results,
+        }
+        if "usage" in ir_response:
+            result["usage"] = self._build_ir_usage_to_p(ir_response["usage"])
+        return result
+
+    @staticmethod
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> RerankUsageInfo:
+        usage = RerankUsageInfo()
+        if "total_tokens" in p_usage:
+            usage["total_tokens"] = p_usage["total_tokens"]
+        if "prompt_tokens" in p_usage:
+            usage["prompt_tokens"] = p_usage["prompt_tokens"]
+        return usage
+
+    @staticmethod
+    def _build_ir_usage_to_p(ir_usage: RerankUsageInfo) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if "total_tokens" in ir_usage:
+            result["total_tokens"] = ir_usage["total_tokens"]
+        if "prompt_tokens" in ir_usage:
+            result["prompt_tokens"] = ir_usage["prompt_tokens"]
+        return result

--- a/src/llm_rosetta/converters/rerank/jina.py
+++ b/src/llm_rosetta/converters/rerank/jina.py
@@ -65,6 +65,9 @@ class JinaRerankConverter(BaseRerankConverter):
             elif isinstance(doc, dict) and "text" in doc:
                 ir_docs.append(RerankDocument(text=doc["text"]))
             else:
+                context.warnings.append(
+                    f"Unexpected document type {type(doc).__name__}, coercing to str"
+                )
                 ir_docs.append(RerankDocument(text=str(doc)))
 
         ir_request = IRRerankRequest(
@@ -104,8 +107,10 @@ class JinaRerankConverter(BaseRerankConverter):
             model=provider_response.get("model", ""),
             results=results,
         )
-        if "usage" in provider_response:
-            ir_response["usage"] = self._build_p_usage_to_ir(provider_response["usage"])
+        if "usage" in provider_response and provider_response["usage"]:
+            usage = self._build_p_usage_to_ir(provider_response["usage"])
+            if usage:
+                ir_response["usage"] = usage
         return ir_response
 
     def _do_response_to_provider(

--- a/src/llm_rosetta/converters/rerank/voyage.py
+++ b/src/llm_rosetta/converters/rerank/voyage.py
@@ -109,8 +109,10 @@ class VoyageRerankConverter(BaseRerankConverter):
             model=provider_response.get("model", ""),
             results=results,
         )
-        if "usage" in provider_response:
-            ir_response["usage"] = self._build_p_usage_to_ir(provider_response["usage"])
+        if "usage" in provider_response and provider_response["usage"]:
+            usage = self._build_p_usage_to_ir(provider_response["usage"])
+            if usage:
+                ir_response["usage"] = usage
         return ir_response
 
     def _do_response_to_provider(

--- a/src/llm_rosetta/converters/rerank/voyage.py
+++ b/src/llm_rosetta/converters/rerank/voyage.py
@@ -1,0 +1,154 @@
+"""
+LLM-Rosetta - Voyage Rerank Converter
+
+Voyage AI rerank API format converter.
+Uses OpenAI Embeddings-style response structure (data instead of results).
+
+Voyage response format:
+{
+    "object": "list",
+    "data": [
+        {"relevance_score": 0.72, "index": 0, "document": "..."},
+        ...
+    ],
+    "model": "rerank-2-lite",
+    "usage": {"total_tokens": 32}
+}
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.converters.base.rerank_converter import BaseRerankConverter
+from llm_rosetta.types.ir.rerank import (
+    IRRerankRequest,
+    IRRerankResponse,
+    RerankDocument,
+    RerankResultItem,
+    RerankUsageInfo,
+)
+
+
+class VoyageRerankConverter(BaseRerankConverter):
+    _CONVERTER_TAG = "voyage_rerank"
+
+    def _do_request_to_provider(
+        self,
+        ir_request: IRRerankRequest,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "model": ir_request["model"],
+            "query": ir_request["query"],
+            "documents": [doc["text"] for doc in ir_request["documents"]],
+        }
+        # Voyage uses top_k, not top_n
+        if "top_n" in ir_request:
+            result["top_k"] = ir_request["top_n"]
+        if "return_documents" in ir_request:
+            result["return_documents"] = ir_request["return_documents"]
+        if "truncation" in ir_request:
+            result["truncation"] = ir_request["truncation"]
+        return result
+
+    def _do_request_from_provider(
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IRRerankRequest:
+        documents = provider_request["documents"]
+        ir_docs = [
+            RerankDocument(text=doc)
+            if isinstance(doc, str)
+            else RerankDocument(text=str(doc))
+            for doc in documents
+        ]
+
+        ir_request = IRRerankRequest(
+            model=provider_request["model"],
+            query=provider_request["query"],
+            documents=ir_docs,
+        )
+        # Voyage uses top_k, map to canonical top_n
+        if "top_k" in provider_request:
+            ir_request["top_n"] = provider_request["top_k"]
+        if "return_documents" in provider_request:
+            ir_request["return_documents"] = provider_request["return_documents"]
+        if "truncation" in provider_request:
+            ir_request["truncation"] = provider_request["truncation"]
+        return ir_request
+
+    def _do_response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IRRerankResponse:
+        # Voyage uses "data" instead of "results"
+        results: list[RerankResultItem] = []
+        for item in provider_response.get("data", []):
+            result_item = RerankResultItem(
+                index=item["index"],
+                relevance_score=item["relevance_score"],
+            )
+            # Voyage returns document as plain string
+            if "document" in item and item["document"] is not None:
+                doc = item["document"]
+                if isinstance(doc, str):
+                    result_item["document"] = RerankDocument(text=doc)
+                elif isinstance(doc, dict) and "text" in doc:
+                    result_item["document"] = RerankDocument(text=doc["text"])
+            results.append(result_item)
+
+        ir_response = IRRerankResponse(
+            object="rerank",
+            model=provider_response.get("model", ""),
+            results=results,
+        )
+        if "usage" in provider_response:
+            ir_response["usage"] = self._build_p_usage_to_ir(provider_response["usage"])
+        return ir_response
+
+    def _do_response_to_provider(
+        self,
+        ir_response: IRRerankResponse,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        # Voyage uses "data" instead of "results"
+        data = []
+        for item in ir_response["results"]:
+            p_item: dict[str, Any] = {
+                "index": item["index"],
+                "relevance_score": item["relevance_score"],
+            }
+            if "document" in item:
+                p_item["document"] = item["document"]["text"]
+            data.append(p_item)
+
+        result: dict[str, Any] = {
+            "object": "list",
+            "data": data,
+            "model": ir_response["model"],
+        }
+        if "usage" in ir_response:
+            result["usage"] = self._build_ir_usage_to_p(ir_response["usage"])
+        return result
+
+    @staticmethod
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> RerankUsageInfo:
+        usage = RerankUsageInfo()
+        if "total_tokens" in p_usage:
+            usage["total_tokens"] = p_usage["total_tokens"]
+        return usage
+
+    @staticmethod
+    def _build_ir_usage_to_p(ir_usage: RerankUsageInfo) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if "total_tokens" in ir_usage:
+            result["total_tokens"] = ir_usage["total_tokens"]
+        return result

--- a/src/llm_rosetta/types/__init__.py
+++ b/src/llm_rosetta/types/__init__.py
@@ -46,6 +46,12 @@ from .ir import (
     StreamConfig,
     ReasoningConfig,
     CacheConfig,
+    # Rerank types
+    RerankDocument,
+    RerankUsageInfo,
+    RerankResultItem,
+    IRRerankRequest,
+    IRRerankResponse,
     # Request types
     IRInputItem,
     IRRequest,
@@ -114,6 +120,12 @@ __all__ = [
     "StreamConfig",
     "ReasoningConfig",
     "CacheConfig",
+    # Rerank types
+    "RerankDocument",
+    "RerankUsageInfo",
+    "RerankResultItem",
+    "IRRerankRequest",
+    "IRRerankResponse",
     # Request types
     "IRInputItem",
     "IRRequest",

--- a/src/llm_rosetta/types/ir/__init__.py
+++ b/src/llm_rosetta/types/ir/__init__.py
@@ -107,6 +107,15 @@ from .parts import (
     UserContentPart,
 )
 
+# Rerank 类型 Rerank types
+from .rerank import (
+    IRRerankRequest,
+    IRRerankResponse,
+    RerankDocument,
+    RerankResultItem,
+    RerankUsageInfo,
+)
+
 # 请求类型 Request types
 from .request import IRInputItem, IRRequest
 
@@ -246,6 +255,12 @@ __all__ = [
     "ToolCallDeltaEvent",
     "FinishEvent",
     "UsageEvent",
+    # ========== Rerank 类型 Rerank types ==========
+    "RerankDocument",
+    "RerankUsageInfo",
+    "RerankResultItem",
+    "IRRerankRequest",
+    "IRRerankResponse",
     # ========== 向后兼容类型 Backward compatibility types ==========
     "IRInput",
     "IRInputSimple",

--- a/src/llm_rosetta/types/ir/rerank.py
+++ b/src/llm_rosetta/types/ir/rerank.py
@@ -1,0 +1,159 @@
+"""
+LLM-Rosetta - IR Rerank Types
+
+Rerank 中间表示类型定义
+Rerank intermediate representation type definitions
+
+Covers 4 major rerank API format families:
+- Jina: results + top-level usage
+- Cohere: results + meta.billed_units + meta.tokens
+- Siliconflow: Cohere variant with richer meta
+- Voyage: data + top-level usage (OpenAI Embeddings-style)
+"""
+
+import sys
+from typing import Any, Literal
+
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, Required, TypedDict
+else:
+    from typing_extensions import NotRequired, Required, TypedDict
+
+
+# ============================================================================
+# 文档类型 Document type
+# ============================================================================
+
+
+class RerankDocument(TypedDict):
+    """
+    归一化的文档表示。
+    Normalized document representation.
+
+    所有 provider 接受 list[str]，converter 在 IR 边界上
+    将其归一化为 list[RerankDocument]。
+    All providers accept list[str]; converters normalize
+    to list[RerankDocument] at the IR boundary.
+    """
+
+    text: Required[str]
+
+
+# ============================================================================
+# 用量统计 Usage statistics
+# ============================================================================
+
+
+class RerankUsageInfo(TypedDict, total=False):
+    """
+    Rerank 专用的 token 用量统计。
+    Rerank-specific token usage statistics.
+
+    与 chat 的 UsageInfo 分离，因为 rerank 没有 completion_tokens。
+    Cohere 特有的计费字段（search_units、image_tokens）不进入 IR，
+    converter 可将其存入 response 级别的 provider_extensions。
+
+    Separate from chat UsageInfo because rerank has no completion_tokens.
+    Cohere-specific billing fields (search_units, image_tokens) are not
+    included in the IR — converters can stash them in response-level
+    provider_extensions if needed.
+    """
+
+    total_tokens: int
+    prompt_tokens: int
+    cached_tokens: int
+
+
+# ============================================================================
+# 排序结果 Ranked result
+# ============================================================================
+
+
+class RerankResultItem(TypedDict):
+    """
+    单个排序结果。
+    Single ranked result.
+
+    index 和 relevance_score 在所有 4 种格式族中通用。
+    index and relevance_score are universal across all 4 format families.
+    """
+
+    index: Required[int]
+    relevance_score: Required[float]
+    document: NotRequired[RerankDocument]
+
+
+# ============================================================================
+# 请求类型 Request type
+# ============================================================================
+
+
+class IRRerankRequest(TypedDict):
+    """
+    统一的 IR Rerank 请求类型。
+    Unified IR rerank request type.
+
+    必需字段 Required fields:
+    - model: 模型 ID
+    - query: 搜索查询
+    - documents: 归一化文档列表
+
+    可选字段 Optional fields:
+    - top_n: 返回前 N 个结果（Voyage 使用 top_k）
+    - return_documents: 是否在结果中包含文档文本
+    - max_tokens_per_doc: 每个文档的截断长度（Cohere）
+    - truncation: 是否截断长输入（Voyage）
+    - provider_extensions: provider 特有参数的兜底字段
+    """
+
+    # ========== 必需字段 Required Fields ==========
+    model: Required[str]
+    query: Required[str]
+    documents: Required[list[RerankDocument]]
+
+    # ========== 可选字段 Optional Fields ==========
+    top_n: NotRequired[int]
+    return_documents: NotRequired[bool]
+    max_tokens_per_doc: NotRequired[int]
+    truncation: NotRequired[bool]
+
+    # ========== Provider 特定扩展 Provider-specific Extensions ==========
+    provider_extensions: NotRequired[dict[str, Any]]
+
+
+# ============================================================================
+# 响应类型 Response type
+# ============================================================================
+
+
+class IRRerankResponse(TypedDict):
+    """
+    统一的 IR Rerank 响应类型。
+    Unified IR rerank response type.
+
+    results 为统一字段名——Voyage 的 data 在 converter 中重命名。
+    results is the canonical field name — Voyage's data is renamed
+    by the converter.
+    """
+
+    # ========== 必需字段 Required Fields ==========
+    object: Required[Literal["rerank"]]
+    model: Required[str]
+    results: Required[list[RerankResultItem]]
+
+    # ========== 可选字段 Optional Fields ==========
+    id: NotRequired[str]
+    usage: NotRequired[RerankUsageInfo]
+
+
+# ============================================================================
+# 导出的主要类型 Main Exported Types
+# ============================================================================
+
+__all__ = [
+    "RerankDocument",
+    "RerankUsageInfo",
+    "RerankResultItem",
+    "IRRerankRequest",
+    "IRRerankResponse",
+]

--- a/tests/converters/rerank/test_rerank_converters.py
+++ b/tests/converters/rerank/test_rerank_converters.py
@@ -1,0 +1,378 @@
+"""Unit tests for rerank converters using real API response fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_rosetta.converters.rerank import (
+    CohereRerankConverter,
+    JinaRerankConverter,
+    VoyageRerankConverter,
+)
+from llm_rosetta.types.ir.rerank import (
+    IRRerankRequest,
+    RerankDocument,
+)
+
+# ============================================================================
+# Fixtures — captured from real API calls
+# ============================================================================
+
+JINA_RESPONSE = {
+    "model": "jina-reranker-v2-base-multilingual",
+    "object": "list",
+    "usage": {"total_tokens": 54},
+    "results": [
+        {
+            "index": 0,
+            "relevance_score": 0.83973396,
+            "document": "Paris is the capital of France.",
+        },
+        {
+            "index": 2,
+            "relevance_score": 0.16451646,
+            "document": "The Eiffel Tower is in Paris.",
+        },
+    ],
+}
+
+COHERE_RESPONSE = {
+    "id": "c317b8b2-d572-4725-af60-cfb856aa28c8",
+    "results": [
+        {"index": 0, "relevance_score": 0.8923472},
+        {"index": 2, "relevance_score": 0.25163436},
+    ],
+    "meta": {
+        "api_version": {"version": "2"},
+        "billed_units": {"search_units": 1},
+    },
+}
+
+SILICONFLOW_RESPONSE = {
+    "id": "019fea4450327dbea799b2175a8cc34c",
+    "results": [
+        {
+            "index": 0,
+            "document": None,
+            "relevance_score": 0.9998469352722168,
+        },
+        {
+            "index": 2,
+            "document": None,
+            "relevance_score": 0.19185182452201843,
+        },
+    ],
+    "meta": {
+        "tokens": {"input_tokens": 54, "output_tokens": 0, "image_tokens": 0},
+        "billed_units": {
+            "input_tokens": 54,
+            "output_tokens": 0,
+            "image_tokens": 0,
+            "search_units": 0,
+            "classifications": 0,
+        },
+    },
+}
+
+VOYAGE_RESPONSE = {
+    "object": "list",
+    "data": [
+        {
+            "relevance_score": 0.71875,
+            "index": 0,
+            "document": "Paris is the capital of France.",
+        },
+        {
+            "relevance_score": 0.498046875,
+            "index": 2,
+            "document": "The Eiffel Tower is in Paris.",
+        },
+    ],
+    "model": "rerank-2-lite",
+    "usage": {"total_tokens": 32},
+}
+
+SAMPLE_REQUEST = {
+    "model": "test-model",
+    "query": "What is the capital of France?",
+    "documents": [
+        "Paris is the capital of France.",
+        "Berlin is the capital of Germany.",
+        "The Eiffel Tower is in Paris.",
+    ],
+    "top_n": 2,
+}
+
+SAMPLE_IR_REQUEST = IRRerankRequest(
+    model="test-model",
+    query="What is the capital of France?",
+    documents=[
+        RerankDocument(text="Paris is the capital of France."),
+        RerankDocument(text="Berlin is the capital of Germany."),
+        RerankDocument(text="The Eiffel Tower is in Paris."),
+    ],
+    top_n=2,
+)
+
+
+# ============================================================================
+# Jina converter tests
+# ============================================================================
+
+
+class TestJinaRerankConverter:
+    def setup_method(self) -> None:
+        self.converter = JinaRerankConverter()
+
+    def test_response_from_provider(self) -> None:
+        ir = self.converter.response_from_provider(JINA_RESPONSE)
+        assert ir["object"] == "rerank"
+        assert ir["model"] == "jina-reranker-v2-base-multilingual"
+        assert len(ir["results"]) == 2
+        assert ir["results"][0]["index"] == 0
+        assert ir["results"][0]["relevance_score"] == pytest.approx(0.8397, abs=1e-3)
+        assert ir["results"][0]["document"]["text"] == "Paris is the capital of France."
+        assert ir["usage"]["total_tokens"] == 54
+
+    def test_request_to_provider(self) -> None:
+        result, warnings = self.converter.request_to_provider(SAMPLE_IR_REQUEST)
+        assert result["model"] == "test-model"
+        assert result["query"] == "What is the capital of France?"
+        assert result["documents"] == [
+            "Paris is the capital of France.",
+            "Berlin is the capital of Germany.",
+            "The Eiffel Tower is in Paris.",
+        ]
+        assert result["top_n"] == 2
+        assert warnings == []
+
+    def test_request_from_provider(self) -> None:
+        ir = self.converter.request_from_provider(SAMPLE_REQUEST)
+        assert ir["model"] == "test-model"
+        assert ir["query"] == "What is the capital of France?"
+        assert len(ir["documents"]) == 3
+        assert ir["documents"][0]["text"] == "Paris is the capital of France."
+        assert ir["top_n"] == 2
+
+    def test_response_to_provider(self) -> None:
+        ir = self.converter.response_from_provider(JINA_RESPONSE)
+        provider = self.converter.response_to_provider(ir)
+        assert provider["object"] == "list"
+        assert provider["model"] == "jina-reranker-v2-base-multilingual"
+        assert len(provider["results"]) == 2
+        assert provider["results"][0]["document"] == "Paris is the capital of France."
+        assert provider["usage"]["total_tokens"] == 54
+
+    def test_request_roundtrip(self) -> None:
+        provider, _ = self.converter.request_to_provider(SAMPLE_IR_REQUEST)
+        ir_back = self.converter.request_from_provider(provider)
+        assert ir_back["model"] == SAMPLE_IR_REQUEST["model"]
+        assert ir_back["query"] == SAMPLE_IR_REQUEST["query"]
+        assert len(ir_back["documents"]) == len(SAMPLE_IR_REQUEST["documents"])
+        for orig, back in zip(
+            SAMPLE_IR_REQUEST["documents"], ir_back["documents"], strict=True
+        ):
+            assert orig["text"] == back["text"]
+
+    def test_response_roundtrip(self) -> None:
+        ir = self.converter.response_from_provider(JINA_RESPONSE)
+        provider = self.converter.response_to_provider(ir)
+        ir_back = self.converter.response_from_provider(provider)
+        assert ir_back["results"][0]["index"] == ir["results"][0]["index"]
+        assert ir_back["results"][0]["relevance_score"] == pytest.approx(
+            ir["results"][0]["relevance_score"]
+        )
+
+
+# ============================================================================
+# Cohere converter tests
+# ============================================================================
+
+
+class TestCohereRerankConverter:
+    def setup_method(self) -> None:
+        self.converter = CohereRerankConverter()
+
+    def test_response_from_provider(self) -> None:
+        ir = self.converter.response_from_provider(COHERE_RESPONSE)
+        assert ir["object"] == "rerank"
+        assert ir["id"] == "c317b8b2-d572-4725-af60-cfb856aa28c8"
+        assert len(ir["results"]) == 2
+        assert ir["results"][0]["index"] == 0
+        assert ir["results"][0]["relevance_score"] == pytest.approx(0.8923, abs=1e-3)
+        # Cohere v3 doesn't have meta.tokens, so no usage
+        assert "usage" not in ir
+
+    def test_response_from_provider_siliconflow(self) -> None:
+        ir = self.converter.response_from_provider(SILICONFLOW_RESPONSE)
+        assert ir["object"] == "rerank"
+        assert ir["id"] == "019fea4450327dbea799b2175a8cc34c"
+        assert len(ir["results"]) == 2
+        # Siliconflow sends document: null — should not appear in IR
+        assert "document" not in ir["results"][0]
+        # Siliconflow has meta.tokens
+        assert ir["usage"]["total_tokens"] == 54
+        assert ir["usage"]["prompt_tokens"] == 54
+
+    def test_request_to_provider(self) -> None:
+        result, warnings = self.converter.request_to_provider(SAMPLE_IR_REQUEST)
+        assert result["model"] == "test-model"
+        assert result["documents"] == [
+            "Paris is the capital of France.",
+            "Berlin is the capital of Germany.",
+            "The Eiffel Tower is in Paris.",
+        ]
+        assert result["top_n"] == 2
+        assert "return_documents" not in result
+
+    def test_request_from_provider(self) -> None:
+        ir = self.converter.request_from_provider(SAMPLE_REQUEST)
+        assert ir["model"] == "test-model"
+        assert len(ir["documents"]) == 3
+
+    def test_response_to_provider(self) -> None:
+        ir = self.converter.response_from_provider(COHERE_RESPONSE)
+        provider = self.converter.response_to_provider(ir)
+        assert provider["id"] == "c317b8b2-d572-4725-af60-cfb856aa28c8"
+        assert len(provider["results"]) == 2
+        assert provider["results"][0]["relevance_score"] == pytest.approx(
+            0.8923, abs=1e-3
+        )
+
+    def test_max_tokens_per_doc_roundtrip(self) -> None:
+        ir = IRRerankRequest(
+            model="rerank-v3.5",
+            query="test",
+            documents=[RerankDocument(text="doc")],
+            max_tokens_per_doc=2048,
+        )
+        provider, _ = self.converter.request_to_provider(ir)
+        assert provider["max_tokens_per_doc"] == 2048
+        ir_back = self.converter.request_from_provider(provider)
+        assert ir_back["max_tokens_per_doc"] == 2048
+
+
+# ============================================================================
+# Voyage converter tests
+# ============================================================================
+
+
+class TestVoyageRerankConverter:
+    def setup_method(self) -> None:
+        self.converter = VoyageRerankConverter()
+
+    def test_response_from_provider(self) -> None:
+        ir = self.converter.response_from_provider(VOYAGE_RESPONSE)
+        assert ir["object"] == "rerank"
+        assert ir["model"] == "rerank-2-lite"
+        assert len(ir["results"]) == 2
+        assert ir["results"][0]["index"] == 0
+        assert ir["results"][0]["relevance_score"] == pytest.approx(0.7188, abs=1e-3)
+        assert ir["results"][0]["document"]["text"] == "Paris is the capital of France."
+        assert ir["usage"]["total_tokens"] == 32
+
+    def test_request_to_provider_top_k(self) -> None:
+        result, _ = self.converter.request_to_provider(SAMPLE_IR_REQUEST)
+        # Voyage uses top_k, not top_n
+        assert "top_k" in result
+        assert result["top_k"] == 2
+        assert "top_n" not in result
+
+    def test_request_from_provider_top_k(self) -> None:
+        voyage_request = {
+            "model": "rerank-2-lite",
+            "query": "test",
+            "documents": ["doc1", "doc2"],
+            "top_k": 1,
+            "return_documents": True,
+            "truncation": False,
+        }
+        ir = self.converter.request_from_provider(voyage_request)
+        # top_k mapped to canonical top_n
+        assert ir["top_n"] == 1
+        assert ir["return_documents"] is True
+        assert ir["truncation"] is False
+
+    def test_response_to_provider_uses_data(self) -> None:
+        ir = self.converter.response_from_provider(VOYAGE_RESPONSE)
+        provider = self.converter.response_to_provider(ir)
+        assert provider["object"] == "list"
+        assert "data" in provider
+        assert "results" not in provider
+        assert len(provider["data"]) == 2
+        assert provider["data"][0]["document"] == "Paris is the capital of France."
+        assert provider["usage"]["total_tokens"] == 32
+
+    def test_response_roundtrip(self) -> None:
+        ir = self.converter.response_from_provider(VOYAGE_RESPONSE)
+        provider = self.converter.response_to_provider(ir)
+        ir_back = self.converter.response_from_provider(provider)
+        assert ir_back["model"] == ir["model"]
+        assert len(ir_back["results"]) == len(ir["results"])
+        for orig, back in zip(ir["results"], ir_back["results"], strict=True):
+            assert orig["index"] == back["index"]
+            assert orig["relevance_score"] == pytest.approx(back["relevance_score"])
+
+    def test_truncation_roundtrip(self) -> None:
+        ir = IRRerankRequest(
+            model="rerank-2-lite",
+            query="test",
+            documents=[RerankDocument(text="doc")],
+            truncation=False,
+        )
+        provider, _ = self.converter.request_to_provider(ir)
+        assert provider["truncation"] is False
+        ir_back = self.converter.request_from_provider(provider)
+        assert ir_back["truncation"] is False
+
+
+# ============================================================================
+# Cross-provider round-trip tests
+# ============================================================================
+
+
+class TestCrossProviderRoundtrip:
+    """Test converting responses from one provider format to another via IR."""
+
+    def test_jina_to_cohere(self) -> None:
+        jina = JinaRerankConverter()
+        cohere = CohereRerankConverter()
+        ir = jina.response_from_provider(JINA_RESPONSE)
+        cohere_resp = cohere.response_to_provider(ir)
+        assert "results" in cohere_resp
+        assert len(cohere_resp["results"]) == 2
+        assert cohere_resp["results"][0]["index"] == 0
+
+    def test_cohere_to_voyage(self) -> None:
+        cohere = CohereRerankConverter()
+        voyage = VoyageRerankConverter()
+        ir = cohere.response_from_provider(COHERE_RESPONSE)
+        voyage_resp = voyage.response_to_provider(ir)
+        assert voyage_resp["object"] == "list"
+        assert "data" in voyage_resp
+        assert len(voyage_resp["data"]) == 2
+
+    def test_voyage_to_jina(self) -> None:
+        voyage = VoyageRerankConverter()
+        jina = JinaRerankConverter()
+        ir = voyage.response_from_provider(VOYAGE_RESPONSE)
+        jina_resp = jina.response_to_provider(ir)
+        assert jina_resp["object"] == "list"
+        assert "results" in jina_resp
+        assert jina_resp["results"][0]["document"] == "Paris is the capital of France."
+
+    def test_siliconflow_to_jina(self) -> None:
+        cohere = CohereRerankConverter()
+        jina = JinaRerankConverter()
+        ir = cohere.response_from_provider(SILICONFLOW_RESPONSE)
+        jina_resp = jina.response_to_provider(ir)
+        assert jina_resp["usage"]["total_tokens"] == 54
+
+    def test_request_jina_to_voyage(self) -> None:
+        jina = JinaRerankConverter()
+        voyage = VoyageRerankConverter()
+        ir = jina.request_from_provider(SAMPLE_REQUEST)
+        voyage_req, _ = voyage.request_to_provider(ir)
+        assert voyage_req["top_k"] == 2
+        assert "top_n" not in voyage_req
+        assert voyage_req["documents"] == SAMPLE_REQUEST["documents"]

--- a/tests/converters/rerank/test_rerank_converters.py
+++ b/tests/converters/rerank/test_rerank_converters.py
@@ -376,3 +376,54 @@ class TestCrossProviderRoundtrip:
         assert voyage_req["top_k"] == 2
         assert "top_n" not in voyage_req
         assert voyage_req["documents"] == SAMPLE_REQUEST["documents"]
+
+    def test_request_voyage_to_cohere(self) -> None:
+        voyage = VoyageRerankConverter()
+        cohere = CohereRerankConverter()
+        voyage_req = {
+            "model": "rerank-2-lite",
+            "query": "test",
+            "documents": ["doc1", "doc2"],
+            "top_k": 3,
+        }
+        ir = voyage.request_from_provider(voyage_req)
+        cohere_req, _ = cohere.request_to_provider(ir)
+        assert cohere_req["top_n"] == 3
+        assert "top_k" not in cohere_req
+
+    def test_request_cohere_to_jina(self) -> None:
+        cohere = CohereRerankConverter()
+        jina = JinaRerankConverter()
+        cohere_req = {
+            "model": "rerank-v3.5",
+            "query": "test",
+            "documents": ["doc1"],
+            "top_n": 1,
+            "max_tokens_per_doc": 2048,
+        }
+        ir = cohere.request_from_provider(cohere_req)
+        jina_req, _ = jina.request_to_provider(ir)
+        assert jina_req["top_n"] == 1
+        # max_tokens_per_doc is Cohere-specific, Jina doesn't emit it
+        assert "max_tokens_per_doc" not in jina_req
+
+    def test_jina_to_cohere_warns_on_document_drop(self) -> None:
+        jina = JinaRerankConverter()
+        cohere = CohereRerankConverter()
+        ir = jina.response_from_provider(JINA_RESPONSE)
+        assert "document" in ir["results"][0]
+        from llm_rosetta.converters.base.context import ConversionContext
+
+        ctx = ConversionContext()
+        cohere.response_to_provider(ir, context=ctx)
+        assert any("document data" in w for w in ctx.warnings)
+
+    def test_empty_usage_not_set(self) -> None:
+        jina = JinaRerankConverter()
+        response_with_empty_usage = {
+            "model": "test",
+            "results": [{"index": 0, "relevance_score": 0.5}],
+            "usage": {},
+        }
+        ir = jina.response_from_provider(response_with_empty_usage)
+        assert "usage" not in ir

--- a/tests/integration/test_rerank_e2e.py
+++ b/tests/integration/test_rerank_e2e.py
@@ -1,0 +1,270 @@
+"""
+Rerank Converter End-to-End Integration Test
+
+Tests the full conversion pipeline with real rerank API calls:
+- response_from_provider: real API response → IR
+- Cross-provider: Provider A response → IR → Provider B format
+- Request round-trip: IR → provider request → IR
+
+Requires API keys in .env:
+- JINA_API_KEY
+- COHERE_API_KEY
+- VOYAGE_API_KEY
+- SILICONFLOW_API_KEY + SILICONFLOW_BASE_URL
+
+Usage:
+    conda activate llm-rosetta
+    python tests/integration/test_rerank_e2e.py
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+import dotenv
+import requests
+
+from llm_rosetta.converters.rerank import (
+    CohereRerankConverter,
+    JinaRerankConverter,
+    VoyageRerankConverter,
+)
+from llm_rosetta.types.ir.rerank import IRRerankRequest, RerankDocument
+
+dotenv.load_dotenv()
+
+QUERY = "What is the capital of France?"
+DOCUMENTS = [
+    "Paris is the capital of France.",
+    "Berlin is the capital of Germany.",
+    "The Eiffel Tower is in Paris.",
+]
+TOP_N = 2
+
+
+def _call_jina() -> dict:
+    resp = requests.post(
+        "https://api.jina.ai/v1/rerank",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {os.environ['JINA_API_KEY']}",
+        },
+        json={
+            "model": "jina-reranker-v2-base-multilingual",
+            "query": QUERY,
+            "documents": DOCUMENTS,
+            "top_n": TOP_N,
+            "return_documents": True,
+        },
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _call_cohere() -> dict:
+    resp = requests.post(
+        "https://api.cohere.com/v2/rerank",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {os.environ['COHERE_API_KEY']}",
+        },
+        json={
+            "model": "rerank-v3.5",
+            "query": QUERY,
+            "documents": DOCUMENTS,
+            "top_n": TOP_N,
+        },
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _call_voyage() -> dict:
+    resp = requests.post(
+        "https://api.voyageai.com/v1/rerank",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {os.environ['VOYAGE_API_KEY']}",
+        },
+        json={
+            "model": "rerank-2-lite",
+            "query": QUERY,
+            "documents": DOCUMENTS,
+            "top_k": TOP_N,
+            "return_documents": True,
+        },
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _call_siliconflow() -> dict:
+    base_url = os.environ.get("SILICONFLOW_BASE_URL", "https://api.siliconflow.cn")
+    resp = requests.post(
+        f"{base_url}/v1/rerank",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {os.environ['SILICONFLOW_API_KEY']}",
+        },
+        json={
+            "model": "BAAI/bge-reranker-v2-m3",
+            "query": QUERY,
+            "documents": DOCUMENTS,
+            "top_n": TOP_N,
+        },
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def test_jina_response_to_ir():
+    print("\n=== Jina → IR ===")
+    raw = _call_jina()
+    converter = JinaRerankConverter()
+    ir = converter.response_from_provider(raw)
+    assert ir["object"] == "rerank"
+    assert len(ir["results"]) == TOP_N
+    assert ir["results"][0]["index"] == 0  # Paris doc should rank first
+    assert ir["results"][0]["relevance_score"] > ir["results"][1]["relevance_score"]
+    assert "document" in ir["results"][0]
+    assert "usage" in ir
+    print(f"  model: {ir['model']}")
+    print(f"  top result: index={ir['results'][0]['index']}, score={ir['results'][0]['relevance_score']:.4f}")
+    print(f"  usage: {ir.get('usage')}")
+    print("  ✓ PASS")
+
+
+def test_cohere_response_to_ir():
+    print("\n=== Cohere → IR ===")
+    raw = _call_cohere()
+    converter = CohereRerankConverter()
+    ir = converter.response_from_provider(raw)
+    assert ir["object"] == "rerank"
+    assert len(ir["results"]) == TOP_N
+    assert ir["results"][0]["index"] == 0
+    assert "id" in ir
+    print(f"  id: {ir['id']}")
+    print(f"  top result: index={ir['results'][0]['index']}, score={ir['results'][0]['relevance_score']:.4f}")
+    print("  ✓ PASS")
+
+
+def test_voyage_response_to_ir():
+    print("\n=== Voyage → IR ===")
+    raw = _call_voyage()
+    converter = VoyageRerankConverter()
+    ir = converter.response_from_provider(raw)
+    assert ir["object"] == "rerank"
+    assert ir["model"] == "rerank-2-lite"
+    assert len(ir["results"]) == TOP_N
+    assert ir["results"][0]["index"] == 0
+    assert "document" in ir["results"][0]
+    assert "usage" in ir
+    print(f"  model: {ir['model']}")
+    print(f"  top result: index={ir['results'][0]['index']}, score={ir['results'][0]['relevance_score']:.4f}")
+    print(f"  usage: {ir.get('usage')}")
+    print("  ✓ PASS")
+
+
+def test_siliconflow_response_to_ir():
+    print("\n=== Siliconflow → IR (via Cohere converter) ===")
+    raw = _call_siliconflow()
+    converter = CohereRerankConverter()
+    ir = converter.response_from_provider(raw)
+    assert ir["object"] == "rerank"
+    assert len(ir["results"]) == TOP_N
+    assert ir["results"][0]["index"] == 0
+    assert "document" not in ir["results"][0]  # Siliconflow sends null
+    assert "usage" in ir
+    assert ir["usage"]["total_tokens"] > 0
+    print(f"  id: {ir.get('id')}")
+    print(f"  top result: index={ir['results'][0]['index']}, score={ir['results'][0]['relevance_score']:.4f}")
+    print(f"  usage: {ir.get('usage')}")
+    print("  ✓ PASS")
+
+
+def test_cross_provider_jina_to_voyage():
+    print("\n=== Cross-provider: Jina → IR → Voyage ===")
+    jina_raw = _call_jina()
+    jina = JinaRerankConverter()
+    voyage = VoyageRerankConverter()
+    ir = jina.response_from_provider(jina_raw)
+    voyage_resp = voyage.response_to_provider(ir)
+    assert voyage_resp["object"] == "list"
+    assert "data" in voyage_resp
+    assert len(voyage_resp["data"]) == TOP_N
+    assert voyage_resp["data"][0]["document"] == "Paris is the capital of France."
+    print(f"  Voyage format: {json.dumps(voyage_resp, indent=2)[:200]}...")
+    print("  ✓ PASS")
+
+
+def test_cross_provider_cohere_to_jina():
+    print("\n=== Cross-provider: Cohere → IR → Jina ===")
+    cohere_raw = _call_cohere()
+    cohere = CohereRerankConverter()
+    jina = JinaRerankConverter()
+    ir = cohere.response_from_provider(cohere_raw)
+    jina_resp = jina.response_to_provider(ir)
+    assert jina_resp["object"] == "list"
+    assert "results" in jina_resp
+    assert len(jina_resp["results"]) == TOP_N
+    print(f"  Jina format: {json.dumps(jina_resp, indent=2)[:200]}...")
+    print("  ✓ PASS")
+
+
+def test_request_roundtrip_all_providers():
+    print("\n=== Request round-trip: IR → Provider → IR (all 3) ===")
+    ir_request = IRRerankRequest(
+        model="test-model",
+        query=QUERY,
+        documents=[RerankDocument(text=d) for d in DOCUMENTS],
+        top_n=TOP_N,
+        return_documents=True,
+    )
+
+    for name, converter in [
+        ("Jina", JinaRerankConverter()),
+        ("Cohere", CohereRerankConverter()),
+        ("Voyage", VoyageRerankConverter()),
+    ]:
+        provider_req, warnings = converter.request_to_provider(ir_request)
+        ir_back = converter.request_from_provider(provider_req)
+        assert ir_back["model"] == ir_request["model"]
+        assert ir_back["query"] == ir_request["query"]
+        assert len(ir_back["documents"]) == len(ir_request["documents"])
+        for orig, back in zip(ir_request["documents"], ir_back["documents"], strict=True):
+            assert orig["text"] == back["text"]
+        print(f"  {name}: ✓")
+    print("  ✓ ALL PASS")
+
+
+if __name__ == "__main__":
+    tests = [
+        test_jina_response_to_ir,
+        test_cohere_response_to_ir,
+        test_voyage_response_to_ir,
+        test_siliconflow_response_to_ir,
+        test_cross_provider_jina_to_voyage,
+        test_cross_provider_cohere_to_jina,
+        test_request_roundtrip_all_providers,
+    ]
+
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            passed += 1
+        except Exception as e:
+            print(f"\n  ✗ FAIL: {e}")
+            failed += 1
+
+    print(f"\n{'='*50}")
+    print(f"Results: {passed} passed, {failed} failed")
+    if failed:
+        sys.exit(1)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -58,20 +58,21 @@ EXPECTED_EXPORTS: dict[str, _ModuleSpec] = {
     },
     "llm_rosetta.types.ir": {
         "items": None,  # too many to enumerate; just check count
-        "max_count": 60,
+        "max_count": 70,
     },
     "llm_rosetta.types": {
         "items": None,
-        "max_count": 60,
+        "max_count": 70,
     },
     "llm_rosetta.converters.base": {
         "items": [
             "BaseConverter",
+            "BaseRerankConverter",
             "ConversionContext",
             "MetadataMode",
             "StreamContext",
         ],
-        "max_count": 5,
+        "max_count": 6,
     },
 }
 


### PR DESCRIPTION
## Summary

- Add rerank intermediate representation (IR) types for cross-provider rerank API conversion
- Implement `BaseRerankConverter` ABC and 3 concrete converters (Jina, Cohere, Voyage)
- All verified with real API calls against Jina, Cohere, Voyage, and Siliconflow

## Details

### IR Types (`types/ir/rerank.py`)
5 TypedDict types covering all 4 major rerank API format families:
- `RerankDocument` — normalized document representation
- `RerankUsageInfo` — token-based usage (total_tokens, prompt_tokens, cached_tokens)
- `RerankResultItem` — single ranked result (index + relevance_score + optional document)
- `IRRerankRequest` — unified request (model, query, documents, top_n, etc.)
- `IRRerankResponse` — unified response (object="rerank", results, usage)

### BaseRerankConverter (`converters/base/rerank_converter.py`)
- Parallel ABC hierarchy to `BaseConverter` (no streaming/tools/messages needed)
- Template-method pattern with `ConversionContext` threading
- 6 abstract methods: 4 `_do_*` hooks + 2 usage conversion methods

### Concrete Converters (`converters/rerank/`)
| Converter | Format | Compatible Providers |
|-----------|--------|---------------------|
| `JinaRerankConverter` | `results` + top-level `usage` | Jina, GPUStack, vLLM, Xinference |
| `CohereRerankConverter` | `results` + `meta.tokens` | Cohere, Siliconflow |
| `VoyageRerankConverter` | `data` + top-level `usage` | Voyage AI |

### Key design decisions
- `RerankUsageInfo` is separate from chat `UsageInfo` — rerank has no `completion_tokens`
- Cohere's `search_units` billing field not included in IR (provider-specific billing, not computation metric)
- Voyage's `top_k` ↔ IR canonical `top_n` mapping
- Voyage's `data` ↔ IR canonical `results` mapping

## Test plan

- [x] 23 unit tests with real API response fixtures (converters/rerank/)
- [x] Cross-provider round-trip tests (Jina→IR→Voyage, Cohere→IR→Jina, etc.)
- [x] Request/response round-trip tests per converter
- [x] 7 integration tests with real API calls (Jina, Cohere, Voyage, Siliconflow)
- [x] `make lint` clean, `make test` passes (2568 tests, 0 failures)

Closes #504