### PR TITLE
feat(ir): add Embedding IR types and converter family

### DIFF
--- a/src/llm_rosetta/converters/__init__.py
+++ b/src/llm_rosetta/converters/__init__.py
@@ -6,7 +6,13 @@ Provides converter implementations between various providers
 """
 
 from .anthropic import AnthropicConverter
-from .base import BaseConverter, BaseRerankConverter
+from .base import BaseConverter, BaseEmbeddingConverter, BaseRerankConverter
+from .embedding import (
+    CohereEmbeddingConverter,
+    JinaEmbeddingConverter,
+    OpenAIEmbeddingConverter,
+    VoyageEmbeddingConverter,
+)
 from .google_genai import GoogleConverter, GoogleGenAIConverter
 from .openai_chat import OpenAIChatConverter
 from .openai_responses import OpenAIResponsesConverter
@@ -15,6 +21,11 @@ from .rerank import CohereRerankConverter, JinaRerankConverter, VoyageRerankConv
 __all__ = [
     "BaseConverter",
     "BaseRerankConverter",
+    "BaseEmbeddingConverter",
+    "OpenAIEmbeddingConverter",
+    "JinaEmbeddingConverter",
+    "VoyageEmbeddingConverter",
+    "CohereEmbeddingConverter",
     "OpenAIChatConverter",
     "AnthropicConverter",
     "GoogleGenAIConverter",

--- a/src/llm_rosetta/converters/base/__init__.py
+++ b/src/llm_rosetta/converters/base/__init__.py
@@ -22,6 +22,7 @@ from .configs import BaseConfigOps  # noqa: F401
 from .content import BaseContentOps  # noqa: F401
 from .context import ConversionContext, MetadataMode, StreamContext
 from .converter import BaseConverter
+from .embedding_converter import BaseEmbeddingConverter
 from .rerank_converter import BaseRerankConverter
 from .messages import BaseMessageOps  # noqa: F401
 from .helpers.tool_content import convert_content_blocks_to_ir  # noqa: F401
@@ -33,6 +34,7 @@ __all__ = [
     # 主转换器 Main converter
     "BaseConverter",
     "BaseRerankConverter",
+    "BaseEmbeddingConverter",
     # 转换上下文 Conversion context
     "ConversionContext",
     "MetadataMode",

--- a/src/llm_rosetta/converters/base/embedding_converter.py
+++ b/src/llm_rosetta/converters/base/embedding_converter.py
@@ -1,0 +1,150 @@
+"""
+LLM-Rosetta - Base Embedding Converter
+
+Embedding 转换器抽象基类
+Abstract base class for embedding converters
+
+Parallel hierarchy to BaseConverter and BaseRerankConverter — embedding
+APIs have a different shape from chat completions and rerank (no messages,
+no streaming, list-of-vectors output).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+from llm_rosetta.types.ir.embedding import (
+    EmbeddingUsageInfo,
+    IREmbeddingRequest,
+    IREmbeddingResponse,
+)
+
+from .context import ConversionContext
+
+
+class BaseEmbeddingConverter(ABC):
+    """Abstract base class for embedding format converters.
+
+    Subclasses MUST:
+    - Set ``_CONVERTER_TAG`` to a unique string identifier
+    - Implement all ``_do_*`` hooks and usage conversion methods
+    """
+
+    _CONVERTER_TAG: ClassVar[str]
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if not getattr(cls, "__abstractmethods__", None) and not hasattr(
+            cls, "_CONVERTER_TAG"
+        ):
+            raise TypeError(
+                f"{cls.__name__} must define a _CONVERTER_TAG class attribute"
+            )
+
+    # ==================== Public template methods ====================
+
+    def request_to_provider(
+        self,
+        ir_request: IREmbeddingRequest,
+        *,
+        context: ConversionContext | None = None,
+    ) -> tuple[dict[str, Any], list[str]]:
+        """Convert IR embedding request to provider request format."""
+        ctx = context if context is not None else ConversionContext()
+        result = self._do_request_to_provider(ir_request, context=ctx)
+        return result, ctx.warnings
+
+    def request_from_provider(
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
+    ) -> IREmbeddingRequest:
+        """Convert provider embedding request to IR format."""
+        provider_request = self._normalize(provider_request)
+        ctx = context if context is not None else ConversionContext()
+        return self._do_request_from_provider(provider_request, context=ctx)
+
+    def response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext | None = None,
+    ) -> IREmbeddingResponse:
+        """Convert provider embedding response to IR format."""
+        provider_response = self._normalize(provider_response)
+        ctx = context if context is not None else ConversionContext()
+        return self._do_response_from_provider(provider_response, context=ctx)
+
+    def response_to_provider(
+        self,
+        ir_response: IREmbeddingResponse,
+        *,
+        context: ConversionContext | None = None,
+    ) -> dict[str, Any]:
+        """Convert IR embedding response to provider format."""
+        ctx = context if context is not None else ConversionContext()
+        return self._do_response_to_provider(ir_response, context=ctx)
+
+    # ==================== Abstract hooks ====================
+
+    @abstractmethod
+    def _do_request_to_provider(
+        self,
+        ir_request: IREmbeddingRequest,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]: ...
+
+    @abstractmethod
+    def _do_request_from_provider(
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IREmbeddingRequest: ...
+
+    @abstractmethod
+    def _do_response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IREmbeddingResponse: ...
+
+    @abstractmethod
+    def _do_response_to_provider(
+        self,
+        ir_response: IREmbeddingResponse,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]: ...
+
+    @staticmethod
+    @abstractmethod
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> EmbeddingUsageInfo: ...
+
+    @staticmethod
+    @abstractmethod
+    def _build_ir_usage_to_p(ir_usage: EmbeddingUsageInfo) -> dict[str, Any]: ...
+
+    # ==================== Utilities ====================
+
+    @staticmethod
+    def _normalize(data: Any) -> dict[str, Any]:
+        """Normalize SDK objects to plain dicts."""
+        if isinstance(data, dict):
+            return data
+        if hasattr(data, "model_dump"):
+            return data.model_dump()
+        if hasattr(data, "to_dict"):
+            return data.to_dict()
+        if hasattr(data, "__dict__"):
+            return dict(data.__dict__)
+        raise TypeError(f"Cannot normalize {type(data).__name__} to dict")
+
+    @classmethod
+    def create_conversion_context(cls, **options: Any) -> ConversionContext:
+        """Create a conversion context for embedding conversions."""
+        return ConversionContext(options=dict(options) if options else {})

--- a/src/llm_rosetta/converters/embedding/__init__.py
+++ b/src/llm_rosetta/converters/embedding/__init__.py
@@ -1,0 +1,24 @@
+"""
+LLM-Rosetta - Embedding Converters
+
+Embedding 格式转换器
+Embedding format converters
+
+Provides converters for:
+- OpenAI: the baseline format (IR follows OpenAI convention)
+- Jina: OpenAI-compatible with task mapping
+- Voyage: OpenAI-compatible with input_type mapping
+- Cohere: different structure (texts, embeddings.{type}, meta)
+"""
+
+from .cohere import CohereEmbeddingConverter
+from .jina import JinaEmbeddingConverter
+from .openai import OpenAIEmbeddingConverter
+from .voyage import VoyageEmbeddingConverter
+
+__all__ = [
+    "OpenAIEmbeddingConverter",
+    "JinaEmbeddingConverter",
+    "VoyageEmbeddingConverter",
+    "CohereEmbeddingConverter",
+]

--- a/src/llm_rosetta/converters/embedding/cohere.py
+++ b/src/llm_rosetta/converters/embedding/cohere.py
@@ -1,0 +1,168 @@
+"""
+LLM-Rosetta - Cohere Embedding Converter
+
+Cohere v2 embed API has a fundamentally different structure:
+
+Request:
+  { model, texts: [...], input_type, embedding_types: ["float"], truncate }
+  (uses "texts" instead of "input", and "input_type" instead of task)
+
+Response:
+  { id, texts, embeddings: { float: [[...], [...]] }, meta: { billed_units }, response_type }
+  (embeddings keyed by type, each is a list of vectors)
+
+Cohere input_type values:
+  search_query → retrieval_query, search_document → retrieval_document,
+  classification, clustering, image
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.converters.base.embedding_converter import BaseEmbeddingConverter
+from llm_rosetta.types.ir.embedding import (
+    EmbeddingItem,
+    EmbeddingTaskType,
+    EmbeddingUsageInfo,
+    IREmbeddingRequest,
+    IREmbeddingResponse,
+)
+
+_COHERE_INPUT_TYPE_TO_IR: dict[str, EmbeddingTaskType] = {
+    "search_query": "retrieval_query",
+    "search_document": "retrieval_document",
+    "classification": "classification",
+    "clustering": "clustering",
+}
+
+_IR_TASK_TO_COHERE: dict[EmbeddingTaskType, str] = {
+    "retrieval_query": "search_query",
+    "retrieval_document": "search_document",
+    "classification": "classification",
+    "clustering": "clustering",
+}
+
+
+class CohereEmbeddingConverter(BaseEmbeddingConverter):
+    _CONVERTER_TAG = "cohere_embedding"
+
+    def _do_request_to_provider(
+        self,
+        ir_request: IREmbeddingRequest,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "model": ir_request["model"],
+            "texts": ir_request["input"],
+        }
+        if "task_type" in ir_request:
+            cohere_type = _IR_TASK_TO_COHERE.get(ir_request["task_type"])
+            if cohere_type:
+                result["input_type"] = cohere_type
+        enc = ir_request.get("encoding_format", "float")
+        result["embedding_types"] = [enc]
+        if "truncation" in ir_request:
+            result["truncate"] = "START" if ir_request["truncation"] else "NONE"
+        return result
+
+    def _do_request_from_provider(
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IREmbeddingRequest:
+        texts = provider_request.get("texts", [])
+        if isinstance(texts, str):
+            texts = [texts]
+
+        ir = IREmbeddingRequest(
+            model=provider_request["model"],
+            input=texts,
+        )
+        if "input_type" in provider_request:
+            ir_task = _COHERE_INPUT_TYPE_TO_IR.get(provider_request["input_type"])
+            if ir_task:
+                ir["task_type"] = ir_task
+        embed_types = provider_request.get("embedding_types", ["float"])
+        if embed_types:
+            ir["encoding_format"] = embed_types[0]
+        if "truncate" in provider_request:
+            ir["truncation"] = provider_request["truncate"] != "NONE"
+        return ir
+
+    def _do_response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IREmbeddingResponse:
+        embeddings = provider_response.get("embeddings", {})
+
+        # Cohere returns embeddings keyed by type: {float: [[...], [...]]}
+        # Pick the first available type
+        embed_type = next(iter(embeddings), "float")
+        vectors = embeddings.get(embed_type, [])
+
+        data = [EmbeddingItem(index=i, embedding=vec) for i, vec in enumerate(vectors)]
+
+        ir = IREmbeddingResponse(
+            object="list",
+            model=provider_response.get("model", ""),
+            data=data,
+        )
+        if embed_type != "float":
+            ir["encoding_format"] = embed_type
+
+        if "id" in provider_response:
+            ir["id"] = provider_response["id"]
+
+        meta = provider_response.get("meta", {})
+        billed = meta.get("billed_units")
+        if billed:
+            usage = self._build_p_usage_to_ir(billed)
+            if usage:
+                ir["usage"] = usage
+
+        return ir
+
+    def _do_response_to_provider(
+        self,
+        ir_response: IREmbeddingResponse,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        embed_type = ir_response.get("encoding_format", "float")
+        vectors = [item["embedding"] for item in ir_response["data"]]
+
+        result: dict[str, Any] = {
+            "embeddings": {embed_type: vectors},
+            "response_type": "embeddings_by_type",
+        }
+        if "id" in ir_response:
+            result["id"] = ir_response["id"]
+        if "usage" in ir_response:
+            result["meta"] = {
+                "billed_units": self._build_ir_usage_to_p(ir_response["usage"]),
+            }
+        return result
+
+    @staticmethod
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> EmbeddingUsageInfo:
+        usage = EmbeddingUsageInfo()
+        input_tokens = p_usage.get("input_tokens")
+        if input_tokens is not None:
+            usage["total_tokens"] = input_tokens
+            usage["prompt_tokens"] = input_tokens
+        return usage
+
+    @staticmethod
+    def _build_ir_usage_to_p(ir_usage: EmbeddingUsageInfo) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if "prompt_tokens" in ir_usage:
+            result["input_tokens"] = ir_usage["prompt_tokens"]
+        elif "total_tokens" in ir_usage:
+            result["input_tokens"] = ir_usage["total_tokens"]
+        return result

--- a/src/llm_rosetta/converters/embedding/cohere.py
+++ b/src/llm_rosetta/converters/embedding/cohere.py
@@ -65,7 +65,7 @@ class CohereEmbeddingConverter(BaseEmbeddingConverter):
         enc = ir_request.get("encoding_format", "float")
         result["embedding_types"] = [enc]
         if "truncation" in ir_request:
-            result["truncate"] = "START" if ir_request["truncation"] else "NONE"
+            result["truncate"] = "END" if ir_request["truncation"] else "NONE"
         return result
 
     def _do_request_from_provider(

--- a/src/llm_rosetta/converters/embedding/jina.py
+++ b/src/llm_rosetta/converters/embedding/jina.py
@@ -1,0 +1,156 @@
+"""
+LLM-Rosetta - Jina Embedding Converter
+
+Jina follows OpenAI format with additional fields:
+- Request: task (maps to EmbeddingTaskType), late_chunking, normalized
+- Response: identical to OpenAI (object:"list", data:[...], usage)
+
+Jina task values:
+  retrieval.query → retrieval_query, retrieval.passage → retrieval_document,
+  text-matching → semantic_similarity, classification, separation, clustering
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.converters.base.embedding_converter import BaseEmbeddingConverter
+from llm_rosetta.types.ir.embedding import (
+    EmbeddingItem,
+    EmbeddingTaskType,
+    EmbeddingUsageInfo,
+    IREmbeddingRequest,
+    IREmbeddingResponse,
+)
+
+_JINA_TASK_TO_IR: dict[str, EmbeddingTaskType] = {
+    "retrieval.query": "retrieval_query",
+    "retrieval.passage": "retrieval_document",
+    "text-matching": "semantic_similarity",
+    "classification": "classification",
+    "separation": "clustering",
+    "clustering": "clustering",
+}
+
+_IR_TASK_TO_JINA: dict[EmbeddingTaskType, str] = {
+    "retrieval_query": "retrieval.query",
+    "retrieval_document": "retrieval.passage",
+    "semantic_similarity": "text-matching",
+    "classification": "classification",
+    "clustering": "clustering",
+}
+
+
+class JinaEmbeddingConverter(BaseEmbeddingConverter):
+    _CONVERTER_TAG = "jina_embedding"
+
+    def _do_request_to_provider(
+        self,
+        ir_request: IREmbeddingRequest,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "model": ir_request["model"],
+            "input": ir_request["input"],
+        }
+        if "task_type" in ir_request:
+            jina_task = _IR_TASK_TO_JINA.get(ir_request["task_type"])
+            if jina_task:
+                result["task"] = jina_task
+        if "dimensions" in ir_request:
+            result["dimensions"] = ir_request["dimensions"]
+        if "encoding_format" in ir_request:
+            result["embedding_type"] = ir_request["encoding_format"]
+        if "truncation" in ir_request:
+            result["truncate"] = ir_request["truncation"]
+        return result
+
+    def _do_request_from_provider(
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IREmbeddingRequest:
+        inp = provider_request["input"]
+        if isinstance(inp, str):
+            inp = [inp]
+
+        ir = IREmbeddingRequest(
+            model=provider_request["model"],
+            input=inp,
+        )
+        if "task" in provider_request:
+            ir_task = _JINA_TASK_TO_IR.get(provider_request["task"])
+            if ir_task:
+                ir["task_type"] = ir_task
+        if "dimensions" in provider_request:
+            ir["dimensions"] = provider_request["dimensions"]
+        if "embedding_type" in provider_request:
+            ir["encoding_format"] = provider_request["embedding_type"]
+        if "truncate" in provider_request:
+            ir["truncation"] = provider_request["truncate"]
+        return ir
+
+    def _do_response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IREmbeddingResponse:
+        data = [
+            EmbeddingItem(index=item["index"], embedding=item["embedding"])
+            for item in provider_response.get("data", [])
+        ]
+
+        ir = IREmbeddingResponse(
+            object="list",
+            model=provider_response.get("model", ""),
+            data=data,
+        )
+        if "usage" in provider_response and provider_response["usage"]:
+            usage = self._build_p_usage_to_ir(provider_response["usage"])
+            if usage:
+                ir["usage"] = usage
+        return ir
+
+    def _do_response_to_provider(
+        self,
+        ir_response: IREmbeddingResponse,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        data = [
+            {
+                "object": "embedding",
+                "index": item["index"],
+                "embedding": item["embedding"],
+            }
+            for item in ir_response["data"]
+        ]
+
+        result: dict[str, Any] = {
+            "model": ir_response["model"],
+            "object": "list",
+            "data": data,
+        }
+        if "usage" in ir_response:
+            result["usage"] = self._build_ir_usage_to_p(ir_response["usage"])
+        return result
+
+    @staticmethod
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> EmbeddingUsageInfo:
+        usage = EmbeddingUsageInfo()
+        if "total_tokens" in p_usage:
+            usage["total_tokens"] = p_usage["total_tokens"]
+        if "prompt_tokens" in p_usage:
+            usage["prompt_tokens"] = p_usage["prompt_tokens"]
+        return usage
+
+    @staticmethod
+    def _build_ir_usage_to_p(ir_usage: EmbeddingUsageInfo) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if "total_tokens" in ir_usage:
+            result["total_tokens"] = ir_usage["total_tokens"]
+        return result

--- a/src/llm_rosetta/converters/embedding/openai.py
+++ b/src/llm_rosetta/converters/embedding/openai.py
@@ -1,0 +1,129 @@
+"""
+LLM-Rosetta - OpenAI Embedding Converter
+
+Near-identity converter — the IR embedding types follow OpenAI conventions.
+
+OpenAI request:  { model, input: [...], encoding_format?, dimensions?, user? }
+OpenAI response: { object:"list", data:[{object:"embedding", embedding:[...], index}], model, usage }
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.converters.base.embedding_converter import BaseEmbeddingConverter
+from llm_rosetta.types.ir.embedding import (
+    EmbeddingItem,
+    EmbeddingUsageInfo,
+    IREmbeddingRequest,
+    IREmbeddingResponse,
+)
+
+
+class OpenAIEmbeddingConverter(BaseEmbeddingConverter):
+    _CONVERTER_TAG = "openai_embedding"
+
+    def _do_request_to_provider(
+        self,
+        ir_request: IREmbeddingRequest,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "model": ir_request["model"],
+            "input": ir_request["input"],
+        }
+        if "encoding_format" in ir_request:
+            result["encoding_format"] = ir_request["encoding_format"]
+        if "dimensions" in ir_request:
+            result["dimensions"] = ir_request["dimensions"]
+        if "user" in ir_request:
+            result["user"] = ir_request["user"]
+        return result
+
+    def _do_request_from_provider(
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IREmbeddingRequest:
+        inp = provider_request["input"]
+        if isinstance(inp, str):
+            inp = [inp]
+
+        ir = IREmbeddingRequest(
+            model=provider_request["model"],
+            input=inp,
+        )
+        if "encoding_format" in provider_request:
+            ir["encoding_format"] = provider_request["encoding_format"]
+        if "dimensions" in provider_request:
+            ir["dimensions"] = provider_request["dimensions"]
+        if "user" in provider_request:
+            ir["user"] = provider_request["user"]
+        return ir
+
+    def _do_response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IREmbeddingResponse:
+        data = [
+            EmbeddingItem(index=item["index"], embedding=item["embedding"])
+            for item in provider_response.get("data", [])
+        ]
+
+        ir = IREmbeddingResponse(
+            object="list",
+            model=provider_response.get("model", ""),
+            data=data,
+        )
+        if "usage" in provider_response and provider_response["usage"]:
+            usage = self._build_p_usage_to_ir(provider_response["usage"])
+            if usage:
+                ir["usage"] = usage
+        return ir
+
+    def _do_response_to_provider(
+        self,
+        ir_response: IREmbeddingResponse,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        data = [
+            {
+                "object": "embedding",
+                "index": item["index"],
+                "embedding": item["embedding"],
+            }
+            for item in ir_response["data"]
+        ]
+
+        result: dict[str, Any] = {
+            "object": "list",
+            "data": data,
+            "model": ir_response["model"],
+        }
+        if "usage" in ir_response:
+            result["usage"] = self._build_ir_usage_to_p(ir_response["usage"])
+        return result
+
+    @staticmethod
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> EmbeddingUsageInfo:
+        usage = EmbeddingUsageInfo()
+        if "total_tokens" in p_usage:
+            usage["total_tokens"] = p_usage["total_tokens"]
+        if "prompt_tokens" in p_usage:
+            usage["prompt_tokens"] = p_usage["prompt_tokens"]
+        return usage
+
+    @staticmethod
+    def _build_ir_usage_to_p(ir_usage: EmbeddingUsageInfo) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if "total_tokens" in ir_usage:
+            result["total_tokens"] = ir_usage["total_tokens"]
+        if "prompt_tokens" in ir_usage:
+            result["prompt_tokens"] = ir_usage["prompt_tokens"]
+        return result

--- a/src/llm_rosetta/converters/embedding/voyage.py
+++ b/src/llm_rosetta/converters/embedding/voyage.py
@@ -1,0 +1,142 @@
+"""
+LLM-Rosetta - Voyage Embedding Converter
+
+Voyage follows OpenAI format with:
+- Request: input_type (maps to EmbeddingTaskType), output_dtype, truncation
+- Response: identical to OpenAI (data:[{object:"embedding", embedding, index}])
+
+Voyage input_type values:
+  query → retrieval_query, document → retrieval_document
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.converters.base.embedding_converter import BaseEmbeddingConverter
+from llm_rosetta.types.ir.embedding import (
+    EmbeddingItem,
+    EmbeddingTaskType,
+    EmbeddingUsageInfo,
+    IREmbeddingRequest,
+    IREmbeddingResponse,
+)
+
+_VOYAGE_INPUT_TYPE_TO_IR: dict[str, EmbeddingTaskType] = {
+    "query": "retrieval_query",
+    "document": "retrieval_document",
+}
+
+_IR_TASK_TO_VOYAGE: dict[EmbeddingTaskType, str] = {
+    "retrieval_query": "query",
+    "retrieval_document": "document",
+}
+
+
+class VoyageEmbeddingConverter(BaseEmbeddingConverter):
+    _CONVERTER_TAG = "voyage_embedding"
+
+    def _do_request_to_provider(
+        self,
+        ir_request: IREmbeddingRequest,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "model": ir_request["model"],
+            "input": ir_request["input"],
+        }
+        if "task_type" in ir_request:
+            voyage_type = _IR_TASK_TO_VOYAGE.get(ir_request["task_type"])
+            if voyage_type:
+                result["input_type"] = voyage_type
+        if "encoding_format" in ir_request:
+            result["output_dtype"] = ir_request["encoding_format"]
+        if "truncation" in ir_request:
+            result["truncation"] = ir_request["truncation"]
+        return result
+
+    def _do_request_from_provider(
+        self,
+        provider_request: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IREmbeddingRequest:
+        inp = provider_request["input"]
+        if isinstance(inp, str):
+            inp = [inp]
+
+        ir = IREmbeddingRequest(
+            model=provider_request["model"],
+            input=inp,
+        )
+        if "input_type" in provider_request:
+            ir_task = _VOYAGE_INPUT_TYPE_TO_IR.get(provider_request["input_type"])
+            if ir_task:
+                ir["task_type"] = ir_task
+        if "output_dtype" in provider_request:
+            ir["encoding_format"] = provider_request["output_dtype"]
+        if "truncation" in provider_request:
+            ir["truncation"] = provider_request["truncation"]
+        return ir
+
+    def _do_response_from_provider(
+        self,
+        provider_response: dict[str, Any],
+        *,
+        context: ConversionContext,
+    ) -> IREmbeddingResponse:
+        data = [
+            EmbeddingItem(index=item["index"], embedding=item["embedding"])
+            for item in provider_response.get("data", [])
+        ]
+
+        ir = IREmbeddingResponse(
+            object="list",
+            model=provider_response.get("model", ""),
+            data=data,
+        )
+        if "usage" in provider_response and provider_response["usage"]:
+            usage = self._build_p_usage_to_ir(provider_response["usage"])
+            if usage:
+                ir["usage"] = usage
+        return ir
+
+    def _do_response_to_provider(
+        self,
+        ir_response: IREmbeddingResponse,
+        *,
+        context: ConversionContext,
+    ) -> dict[str, Any]:
+        data = [
+            {
+                "object": "embedding",
+                "index": item["index"],
+                "embedding": item["embedding"],
+            }
+            for item in ir_response["data"]
+        ]
+
+        result: dict[str, Any] = {
+            "object": "list",
+            "data": data,
+            "model": ir_response["model"],
+        }
+        if "usage" in ir_response:
+            result["usage"] = self._build_ir_usage_to_p(ir_response["usage"])
+        return result
+
+    @staticmethod
+    def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> EmbeddingUsageInfo:
+        usage = EmbeddingUsageInfo()
+        if "total_tokens" in p_usage:
+            usage["total_tokens"] = p_usage["total_tokens"]
+        return usage
+
+    @staticmethod
+    def _build_ir_usage_to_p(ir_usage: EmbeddingUsageInfo) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if "total_tokens" in ir_usage:
+            result["total_tokens"] = ir_usage["total_tokens"]
+        return result

--- a/src/llm_rosetta/types/__init__.py
+++ b/src/llm_rosetta/types/__init__.py
@@ -46,6 +46,13 @@ from .ir import (
     StreamConfig,
     ReasoningConfig,
     CacheConfig,
+    # Embedding types
+    EmbeddingTaskType,
+    EmbeddingEncodingFormat,
+    EmbeddingUsageInfo,
+    EmbeddingItem,
+    IREmbeddingRequest,
+    IREmbeddingResponse,
     # Rerank types
     RerankDocument,
     RerankUsageInfo,
@@ -120,6 +127,13 @@ __all__ = [
     "StreamConfig",
     "ReasoningConfig",
     "CacheConfig",
+    # Embedding types
+    "EmbeddingTaskType",
+    "EmbeddingEncodingFormat",
+    "EmbeddingUsageInfo",
+    "EmbeddingItem",
+    "IREmbeddingRequest",
+    "IREmbeddingResponse",
     # Rerank types
     "RerankDocument",
     "RerankUsageInfo",

--- a/src/llm_rosetta/types/ir/__init__.py
+++ b/src/llm_rosetta/types/ir/__init__.py
@@ -107,6 +107,16 @@ from .parts import (
     UserContentPart,
 )
 
+# Embedding 类型 Embedding types
+from .embedding import (
+    EmbeddingEncodingFormat,
+    EmbeddingItem,
+    EmbeddingTaskType,
+    EmbeddingUsageInfo,
+    IREmbeddingRequest,
+    IREmbeddingResponse,
+)
+
 # Rerank 类型 Rerank types
 from .rerank import (
     IRRerankRequest,
@@ -255,6 +265,13 @@ __all__ = [
     "ToolCallDeltaEvent",
     "FinishEvent",
     "UsageEvent",
+    # ========== Embedding 类型 Embedding types ==========
+    "EmbeddingTaskType",
+    "EmbeddingEncodingFormat",
+    "EmbeddingUsageInfo",
+    "EmbeddingItem",
+    "IREmbeddingRequest",
+    "IREmbeddingResponse",
     # ========== Rerank 类型 Rerank types ==========
     "RerankDocument",
     "RerankUsageInfo",

--- a/src/llm_rosetta/types/ir/embedding.py
+++ b/src/llm_rosetta/types/ir/embedding.py
@@ -201,6 +201,9 @@ class IREmbeddingResponse(TypedDict):
     usage: NotRequired[EmbeddingUsageInfo]
     encoding_format: NotRequired[EmbeddingEncodingFormat]
 
+    # ========== Provider 特定扩展 Provider-specific Extensions ==========
+    provider_extensions: NotRequired[dict[str, Any]]
+
 
 # ============================================================================
 # 导出的主要类型 Main Exported Types

--- a/src/llm_rosetta/types/ir/embedding.py
+++ b/src/llm_rosetta/types/ir/embedding.py
@@ -1,0 +1,216 @@
+"""
+LLM-Rosetta - IR Embedding Types
+
+Embedding 中间表示类型定义
+Embedding intermediate representation type definitions
+
+Covers 5 major embedding API format families:
+- OpenAI: input + encoding_format + dimensions → data[].embedding
+- Google GenAI: embedContent / batchEmbedContents with Content/Parts + taskType
+- Cohere: texts + input_type + embedding_types (multi-format) → embeddings.{type}[][]
+- Voyage: input + input_type + output_dtype + encoding_format → data[].embedding
+- Jina: input + task + embedding_type + dimensions → data[].embedding
+"""
+
+import sys
+from typing import Any, Literal
+
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, Required, TypedDict
+else:
+    from typing_extensions import NotRequired, Required, TypedDict
+
+
+# ============================================================================
+# 任务类型 Task type
+# ============================================================================
+
+EmbeddingTaskType = Literal[
+    "retrieval_query",
+    "retrieval_document",
+    "semantic_similarity",
+    "classification",
+    "clustering",
+    "question_answering",
+    "fact_verification",
+    "code_retrieval_query",
+    "code_retrieval_document",
+]
+"""
+归一化的 embedding 任务类型（所有 provider 枚举值的超集）。
+Canonical embedding task type (superset of all provider enum values).
+
+Provider 映射 Provider mapping:
+- retrieval_query:        Google RETRIEVAL_QUERY, Cohere search_query, Voyage query, Jina retrieval.query
+- retrieval_document:     Google RETRIEVAL_DOCUMENT, Cohere search_document, Voyage document, Jina retrieval.passage
+- semantic_similarity:    Google SEMANTIC_SIMILARITY, Jina text-matching
+- classification:         Google CLASSIFICATION, Cohere classification, Jina classification
+- clustering:             Google CLUSTERING, Cohere clustering, Jina clustering (v5)
+- question_answering:     Google QUESTION_ANSWERING
+- fact_verification:      Google FACT_VERIFICATION
+- code_retrieval_query:   Google CODE_RETRIEVAL_QUERY, Jina code.query (v4)
+- code_retrieval_document: Jina code.passage (v4)
+"""
+
+
+# ============================================================================
+# 编码格式 Encoding format
+# ============================================================================
+
+EmbeddingEncodingFormat = Literal[
+    "float",
+    "base64",
+    "int8",
+    "uint8",
+    "binary",
+    "ubinary",
+]
+"""
+输出数据类型与序列化格式的统一表示。
+Unified representation of output data type and serialization format.
+
+合并了 Voyage 的 output_dtype（数据类型）和 encoding_format（序列化）两个维度。
+Cohere 支持单次请求返回多种格式，这属于 provider 特有行为，不进入 IR。
+Merges Voyage's output_dtype (data type) and encoding_format (serialization) axes.
+Cohere's simultaneous multi-type request is provider-specific, not modeled in IR.
+
+- float:   float32 数组 float32 array (default, all providers)
+- base64:  base64 编码的浮点字节 base64-encoded float bytes (OpenAI, Cohere, Voyage, Jina)
+- int8:    有符号 8 位整数数组 signed 8-bit int array (Cohere, Voyage)
+- uint8:   无符号 8 位整数数组 unsigned 8-bit int array (Cohere, Voyage)
+- binary:  打包有符号二进制 packed signed binary (Cohere, Voyage, Jina)
+- ubinary: 打包无符号二进制 packed unsigned binary (Cohere, Voyage, Jina)
+"""
+
+
+# ============================================================================
+# 用量统计 Usage statistics
+# ============================================================================
+
+
+class EmbeddingUsageInfo(TypedDict, total=False):
+    """
+    Embedding 专用的 token 用量统计。
+    Embedding-specific token usage statistics.
+
+    与 chat 的 UsageInfo 分离，因为 embedding 没有 completion_tokens。
+    Cohere 的 billed_units、Jina 的多模态 token 细分不进入 IR，
+    converter 可将其存入 response 级别的 provider_extensions。
+
+    Separate from chat UsageInfo because embedding has no completion_tokens.
+    Cohere's billed_units and Jina's per-modality token breakdown are not
+    included in the IR — converters can stash them in provider_extensions.
+    """
+
+    total_tokens: int
+    prompt_tokens: int
+
+
+# ============================================================================
+# 嵌入结果 Embedding result
+# ============================================================================
+
+
+class EmbeddingItem(TypedDict):
+    """
+    单个嵌入向量结果。
+    Single embedding vector result.
+
+    embedding 字段的实际类型取决于 encoding_format:
+    - float/int8/uint8: list[float] 或 list[int]
+    - binary/ubinary:   list[int]（打包后长度为原始维度的 1/8）
+    - base64:           str（base64 编码的字节）
+
+    The actual type of the embedding field depends on encoding_format:
+    - float/int8/uint8: list[float] or list[int]
+    - binary/ubinary:   list[int] (packed, 1/8 of original dimensions)
+    - base64:           str (base64-encoded bytes)
+    """
+
+    index: Required[int]
+    embedding: Required[list[float] | list[int] | str]
+
+
+# ============================================================================
+# 请求类型 Request type
+# ============================================================================
+
+
+class IREmbeddingRequest(TypedDict):
+    """
+    统一的 IR Embedding 请求类型。
+    Unified IR embedding request type.
+
+    必需字段 Required fields:
+    - model: 模型 ID
+    - input: 归一化的文本列表（所有 provider 格式在 IR 边界上统一为 list[str]）
+
+    可选字段 Optional fields:
+    - task_type: 归一化的任务类型（Google taskType, Cohere input_type, Jina task 等）
+    - dimensions: 输出向量维度（Google outputDimensionality, Voyage/Cohere output_dimension）
+    - encoding_format: 输出编码格式
+    - truncation: 是否截断过长输入（简化自 Cohere 的 NONE/START/END 枚举）
+    - user: 最终用户标识符（OpenAI 透传）
+    - provider_extensions: provider 特有参数的兜底字段
+    """
+
+    # ========== 必需字段 Required Fields ==========
+    model: Required[str]
+    input: Required[list[str]]
+
+    # ========== 可选字段 Optional Fields ==========
+    task_type: NotRequired[EmbeddingTaskType]
+    dimensions: NotRequired[int]
+    encoding_format: NotRequired[EmbeddingEncodingFormat]
+    truncation: NotRequired[bool]
+    user: NotRequired[str]
+
+    # ========== Provider 特定扩展 Provider-specific Extensions ==========
+    provider_extensions: NotRequired[dict[str, Any]]
+
+
+# ============================================================================
+# 响应类型 Response type
+# ============================================================================
+
+
+class IREmbeddingResponse(TypedDict):
+    """
+    统一的 IR Embedding 响应类型。
+    Unified IR embedding response type.
+
+    遵循 OpenAI 约定使用 "list" 作为 object 字段值。
+    Google 的 embedding.values 和 Cohere 的 embeddings.{type}[][] 由
+    converter 归一化为 data 列表。
+    encoding_format 回显请求中指定的格式，帮助消费者解读 embedding 字段。
+
+    Follows the OpenAI convention of using "list" as the object field value.
+    Google's embedding.values and Cohere's embeddings.{type}[][] are
+    normalized to the data list by converters.
+    encoding_format echoes the requested format to help consumers
+    interpret the embedding field.
+    """
+
+    # ========== 必需字段 Required Fields ==========
+    object: Required[Literal["list"]]
+    model: Required[str]
+    data: Required[list[EmbeddingItem]]
+
+    # ========== 可选字段 Optional Fields ==========
+    id: NotRequired[str]
+    usage: NotRequired[EmbeddingUsageInfo]
+    encoding_format: NotRequired[EmbeddingEncodingFormat]
+
+
+# ============================================================================
+# 导出的主要类型 Main Exported Types
+# ============================================================================
+
+__all__ = [
+    "EmbeddingTaskType",
+    "EmbeddingEncodingFormat",
+    "EmbeddingUsageInfo",
+    "EmbeddingItem",
+    "IREmbeddingRequest",
+    "IREmbeddingResponse",
+]

--- a/tests/converters/embedding/test_embedding_converters.py
+++ b/tests/converters/embedding/test_embedding_converters.py
@@ -1,0 +1,313 @@
+"""Unit tests for embedding converters using real API response fixtures."""
+
+from __future__ import annotations
+
+
+from llm_rosetta.converters.embedding import (
+    CohereEmbeddingConverter,
+    JinaEmbeddingConverter,
+    OpenAIEmbeddingConverter,
+    VoyageEmbeddingConverter,
+)
+from llm_rosetta.types.ir.embedding import (
+    IREmbeddingRequest,
+)
+
+# ============================================================================
+# Fixtures — captured from real API calls
+# ============================================================================
+
+OPENAI_RESPONSE = {
+    "object": "list",
+    "data": [
+        {
+            "object": "embedding",
+            "embedding": [-0.07, -0.41, 0.35, 0.30],
+            "index": 0,
+        }
+    ],
+    "model": "text-embedding-3-small",
+    "usage": {"prompt_tokens": 2, "total_tokens": 2},
+}
+
+JINA_RESPONSE = {
+    "model": "jina-embeddings-v3",
+    "object": "list",
+    "usage": {"total_tokens": 17},
+    "data": [
+        {
+            "object": "embedding",
+            "index": 0,
+            "embedding": [0.31, -0.16, 0.67, -0.11],
+        }
+    ],
+}
+
+COHERE_RESPONSE = {
+    "id": "c91871ab-919f-47fc-b3c7-598e33333164",
+    "texts": ["hello world"],
+    "embeddings": {"float": [[-0.007, -0.012, 0.034]]},
+    "meta": {
+        "api_version": {"version": "2"},
+        "billed_units": {"input_tokens": 1, "image_tokens": 0},
+    },
+    "response_type": "embeddings_by_type",
+}
+
+VOYAGE_RESPONSE = {
+    "object": "list",
+    "data": [
+        {
+            "object": "embedding",
+            "embedding": [-0.035, -0.028, 0.060],
+            "index": 0,
+        }
+    ],
+    "model": "voyage-3-lite",
+    "usage": {"total_tokens": 1},
+}
+
+SAMPLE_REQUEST = {
+    "model": "test-model",
+    "input": ["hello world"],
+}
+
+
+# ============================================================================
+# OpenAI converter tests
+# ============================================================================
+
+
+class TestOpenAIEmbeddingConverter:
+    def setup_method(self) -> None:
+        self.converter = OpenAIEmbeddingConverter()
+
+    def test_response_from_provider(self) -> None:
+        ir = self.converter.response_from_provider(OPENAI_RESPONSE)
+        assert ir["object"] == "list"
+        assert ir["model"] == "text-embedding-3-small"
+        assert len(ir["data"]) == 1
+        assert ir["data"][0]["index"] == 0
+        assert len(ir["data"][0]["embedding"]) == 4
+        assert ir["usage"]["total_tokens"] == 2
+        assert ir["usage"]["prompt_tokens"] == 2
+
+    def test_request_to_provider(self) -> None:
+        ir = IREmbeddingRequest(model="test", input=["hello"], dimensions=8)
+        result, warnings = self.converter.request_to_provider(ir)
+        assert result["model"] == "test"
+        assert result["input"] == ["hello"]
+        assert result["dimensions"] == 8
+        assert warnings == []
+
+    def test_request_from_provider_string_input(self) -> None:
+        ir = self.converter.request_from_provider(
+            {"model": "test", "input": "single string"}
+        )
+        assert ir["input"] == ["single string"]
+
+    def test_response_roundtrip(self) -> None:
+        ir = self.converter.response_from_provider(OPENAI_RESPONSE)
+        provider = self.converter.response_to_provider(ir)
+        ir_back = self.converter.response_from_provider(provider)
+        assert ir_back["data"][0]["embedding"] == ir["data"][0]["embedding"]
+        assert ir_back["usage"]["total_tokens"] == ir["usage"]["total_tokens"]
+
+
+# ============================================================================
+# Jina converter tests
+# ============================================================================
+
+
+class TestJinaEmbeddingConverter:
+    def setup_method(self) -> None:
+        self.converter = JinaEmbeddingConverter()
+
+    def test_response_from_provider(self) -> None:
+        ir = self.converter.response_from_provider(JINA_RESPONSE)
+        assert ir["object"] == "list"
+        assert ir["model"] == "jina-embeddings-v3"
+        assert len(ir["data"]) == 1
+        assert ir["usage"]["total_tokens"] == 17
+
+    def test_task_mapping_to_provider(self) -> None:
+        ir = IREmbeddingRequest(
+            model="jina-embeddings-v3",
+            input=["hello"],
+            task_type="retrieval_query",
+        )
+        result, _ = self.converter.request_to_provider(ir)
+        assert result["task"] == "retrieval.query"
+
+    def test_task_mapping_from_provider(self) -> None:
+        ir = self.converter.request_from_provider(
+            {"model": "test", "input": ["hello"], "task": "retrieval.passage"}
+        )
+        assert ir["task_type"] == "retrieval_document"
+
+    def test_encoding_format_mapping(self) -> None:
+        ir = IREmbeddingRequest(model="test", input=["hello"], encoding_format="base64")
+        result, _ = self.converter.request_to_provider(ir)
+        assert result["embedding_type"] == "base64"
+
+
+# ============================================================================
+# Voyage converter tests
+# ============================================================================
+
+
+class TestVoyageEmbeddingConverter:
+    def setup_method(self) -> None:
+        self.converter = VoyageEmbeddingConverter()
+
+    def test_response_from_provider(self) -> None:
+        ir = self.converter.response_from_provider(VOYAGE_RESPONSE)
+        assert ir["object"] == "list"
+        assert ir["model"] == "voyage-3-lite"
+        assert len(ir["data"]) == 1
+        assert ir["usage"]["total_tokens"] == 1
+
+    def test_input_type_to_provider(self) -> None:
+        ir = IREmbeddingRequest(
+            model="voyage-3-lite",
+            input=["hello"],
+            task_type="retrieval_query",
+        )
+        result, _ = self.converter.request_to_provider(ir)
+        assert result["input_type"] == "query"
+
+    def test_input_type_from_provider(self) -> None:
+        ir = self.converter.request_from_provider(
+            {"model": "test", "input": ["hello"], "input_type": "document"}
+        )
+        assert ir["task_type"] == "retrieval_document"
+
+    def test_output_dtype_mapping(self) -> None:
+        ir = IREmbeddingRequest(model="test", input=["hello"], encoding_format="int8")
+        result, _ = self.converter.request_to_provider(ir)
+        assert result["output_dtype"] == "int8"
+
+
+# ============================================================================
+# Cohere converter tests
+# ============================================================================
+
+
+class TestCohereEmbeddingConverter:
+    def setup_method(self) -> None:
+        self.converter = CohereEmbeddingConverter()
+
+    def test_response_from_provider(self) -> None:
+        ir = self.converter.response_from_provider(COHERE_RESPONSE)
+        assert ir["object"] == "list"
+        assert len(ir["data"]) == 1
+        assert ir["data"][0]["index"] == 0
+        assert ir["data"][0]["embedding"] == [-0.007, -0.012, 0.034]
+        assert ir["id"] == "c91871ab-919f-47fc-b3c7-598e33333164"
+        assert ir["usage"]["total_tokens"] == 1
+
+    def test_request_to_provider(self) -> None:
+        ir = IREmbeddingRequest(
+            model="embed-v4.0",
+            input=["hello world"],
+            task_type="retrieval_query",
+        )
+        result, _ = self.converter.request_to_provider(ir)
+        assert result["texts"] == ["hello world"]
+        assert "input" not in result
+        assert result["input_type"] == "search_query"
+        assert result["embedding_types"] == ["float"]
+
+    def test_request_from_provider(self) -> None:
+        ir = self.converter.request_from_provider(
+            {
+                "model": "embed-v4.0",
+                "texts": ["hello"],
+                "input_type": "search_document",
+                "embedding_types": ["float"],
+            }
+        )
+        assert ir["input"] == ["hello"]
+        assert ir["task_type"] == "retrieval_document"
+        assert ir["encoding_format"] == "float"
+
+    def test_response_to_provider(self) -> None:
+        ir = self.converter.response_from_provider(COHERE_RESPONSE)
+        provider = self.converter.response_to_provider(ir)
+        assert "embeddings" in provider
+        assert "float" in provider["embeddings"]
+        assert provider["response_type"] == "embeddings_by_type"
+
+    def test_truncation_mapping(self) -> None:
+        ir = IREmbeddingRequest(model="test", input=["hello"], truncation=True)
+        result, _ = self.converter.request_to_provider(ir)
+        assert result["truncate"] == "START"
+
+        ir2 = IREmbeddingRequest(model="test", input=["hello"], truncation=False)
+        result2, _ = self.converter.request_to_provider(ir2)
+        assert result2["truncate"] == "NONE"
+
+
+# ============================================================================
+# Cross-provider round-trip tests
+# ============================================================================
+
+
+class TestCrossProviderRoundtrip:
+    def test_openai_to_cohere_response(self) -> None:
+        openai = OpenAIEmbeddingConverter()
+        cohere = CohereEmbeddingConverter()
+        ir = openai.response_from_provider(OPENAI_RESPONSE)
+        cohere_resp = cohere.response_to_provider(ir)
+        assert "embeddings" in cohere_resp
+        assert "float" in cohere_resp["embeddings"]
+        assert len(cohere_resp["embeddings"]["float"]) == 1
+
+    def test_cohere_to_openai_response(self) -> None:
+        cohere = CohereEmbeddingConverter()
+        openai = OpenAIEmbeddingConverter()
+        ir = cohere.response_from_provider(COHERE_RESPONSE)
+        openai_resp = openai.response_to_provider(ir)
+        assert openai_resp["object"] == "list"
+        assert len(openai_resp["data"]) == 1
+        assert openai_resp["data"][0]["object"] == "embedding"
+
+    def test_jina_to_voyage_response(self) -> None:
+        jina = JinaEmbeddingConverter()
+        voyage = VoyageEmbeddingConverter()
+        ir = jina.response_from_provider(JINA_RESPONSE)
+        voyage_resp = voyage.response_to_provider(ir)
+        assert voyage_resp["object"] == "list"
+        assert len(voyage_resp["data"]) == 1
+
+    def test_request_openai_to_jina(self) -> None:
+        openai = OpenAIEmbeddingConverter()
+        jina = JinaEmbeddingConverter()
+        ir = openai.request_from_provider(SAMPLE_REQUEST)
+        jina_req, _ = jina.request_to_provider(ir)
+        assert jina_req["input"] == ["hello world"]
+
+    def test_request_cohere_to_voyage(self) -> None:
+        cohere = CohereEmbeddingConverter()
+        voyage = VoyageEmbeddingConverter()
+        cohere_req = {
+            "model": "embed-v4.0",
+            "texts": ["hello"],
+            "input_type": "search_query",
+            "embedding_types": ["float"],
+        }
+        ir = cohere.request_from_provider(cohere_req)
+        voyage_req, _ = voyage.request_to_provider(ir)
+        assert voyage_req["input"] == ["hello"]
+        assert voyage_req["input_type"] == "query"
+
+    def test_empty_usage_not_set(self) -> None:
+        openai = OpenAIEmbeddingConverter()
+        response_with_empty_usage = {
+            "object": "list",
+            "data": [{"object": "embedding", "index": 0, "embedding": [0.1]}],
+            "model": "test",
+            "usage": {},
+        }
+        ir = openai.response_from_provider(response_with_empty_usage)
+        assert "usage" not in ir

--- a/tests/converters/embedding/test_embedding_converters.py
+++ b/tests/converters/embedding/test_embedding_converters.py
@@ -241,7 +241,7 @@ class TestCohereEmbeddingConverter:
     def test_truncation_mapping(self) -> None:
         ir = IREmbeddingRequest(model="test", input=["hello"], truncation=True)
         result, _ = self.converter.request_to_provider(ir)
-        assert result["truncate"] == "START"
+        assert result["truncate"] == "END"
 
         ir2 = IREmbeddingRequest(model="test", input=["hello"], truncation=False)
         result2, _ = self.converter.request_to_provider(ir2)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -58,11 +58,11 @@ EXPECTED_EXPORTS: dict[str, _ModuleSpec] = {
     },
     "llm_rosetta.types.ir": {
         "items": None,  # too many to enumerate; just check count
-        "max_count": 70,
+        "max_count": 80,
     },
     "llm_rosetta.types": {
         "items": None,
-        "max_count": 70,
+        "max_count": 80,
     },
     "llm_rosetta.converters.base": {
         "items": [

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -68,11 +68,12 @@ EXPECTED_EXPORTS: dict[str, _ModuleSpec] = {
         "items": [
             "BaseConverter",
             "BaseRerankConverter",
+            "BaseEmbeddingConverter",
             "ConversionContext",
             "MetadataMode",
             "StreamContext",
         ],
-        "max_count": 6,
+        "max_count": 7,
     },
 }
 


### PR DESCRIPTION
## Summary

- Add embedding IR types (TypedDict) for cross-provider embedding conversion
- Add `BaseEmbeddingConverter` ABC and 4 concrete converters (OpenAI, Jina, Voyage, Cohere)
- All verified with real API response fixtures and cross-provider roundtrips

## IR Types (`types/ir/embedding.py`)

- `EmbeddingTaskType` — canonical task type literal (superset of all provider enum values)
- `EmbeddingEncodingFormat` — unified output format (float, base64, int8, uint8, binary, ubinary)
- `EmbeddingUsageInfo` — token usage (total_tokens, prompt_tokens)
- `EmbeddingItem` — single embedding vector result
- `IREmbeddingRequest` — unified request (model, input, task_type, dimensions, encoding_format, etc.)
- `IREmbeddingResponse` — unified response (object="list", data, model, usage)

## Converters (`converters/embedding/`)

| Converter | Format | Key mappings |
|-----------|--------|-------------|
| `OpenAIEmbeddingConverter` | Near-identity | IR follows OpenAI convention |
| `JinaEmbeddingConverter` | OpenAI-compatible | `task` ↔ `task_type`, `embedding_type` ↔ `encoding_format` |
| `VoyageEmbeddingConverter` | OpenAI-compatible | `input_type` ↔ `task_type`, `output_dtype` ↔ `encoding_format` |
| `CohereEmbeddingConverter` | Different structure | `texts` ↔ `input`, `embeddings.{type}` ↔ `data`, `meta.billed_units` ↔ `usage` |

## Test plan

- [x] 23 unit tests: per-converter request/response, task/format mappings, roundtrips
- [x] Cross-provider tests: OpenAI↔Cohere, Jina↔Voyage, Cohere→Voyage request chain
- [x] Empty usage guard test
- [x] `make lint` clean, 2610 tests pass

## Next step

Gateway integration (#515): `EmbeddingConversionPipeline` + convert `embeddings.py` from passthrough to IR conversion mode.