### PR TITLE
feat(gateway): add rerank proxy with cross-format conversion

### DIFF
--- a/examples/gateway/config.jsonc
+++ b/examples/gateway/config.jsonc
@@ -36,6 +36,39 @@
     "gemini-2.5-flash": "google"
   },
 
+  // Rerank providers — each entry specifies the upstream format and endpoint path.
+  // "format" maps to a converter: "jina", "cohere", or "voyage".
+  "rerank_providers": {
+    "jina": {
+      "api_key": "${JINA_API_KEY}",
+      "base_url": "https://api.jina.ai",
+      "format": "jina",
+      "rerank_path": "/v1/rerank"
+    },
+    "cohere": {
+      "api_key": "${COHERE_API_KEY}",
+      "base_url": "https://api.cohere.com",
+      "format": "cohere",
+      "rerank_path": "/v2/rerank"
+    },
+    "voyage": {
+      "api_key": "${VOYAGE_API_KEY}",
+      "base_url": "https://api.voyageai.com",
+      "format": "voyage",
+      "rerank_path": "/v1/rerank"
+    }
+  },
+
+  // Rerank model → provider routing table.
+  "rerank_models": {
+    "jina-reranker-v2-base-multilingual": "jina",
+    "rerank-v3.5": "cohere",
+    "rerank-2-lite": "voyage"
+  },
+
+  // Default format for incoming rerank requests (jina, cohere, or voyage).
+  "default_rerank_format": "jina",
+
   // Server settings
   "server": {
     "host": "0.0.0.0",

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -24,6 +24,7 @@ from .auth import (
 from .config import GatewayConfig
 from .keystore import KeyStore
 from .embeddings import handle_embeddings as _handle_embeddings
+from .rerank import handle_rerank as _handle_rerank
 from .headers import build_upstream_extra_headers, get_request_id
 from .logging import get_logger
 from llm_rosetta.observability.error_dump import dump_error
@@ -377,6 +378,11 @@ async def handle_embeddings(request: Any) -> Response:
     return await _handle_embeddings(request, _config)
 
 
+async def handle_rerank(request: Any) -> Response:
+    assert _config is not None
+    return await _handle_rerank(request, _config)
+
+
 async def handle_anthropic(request: Any) -> Response | StreamingResponse:
     return await _proxy_handler(request, source_provider="anthropic")
 
@@ -648,6 +654,8 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
     # --- Routes ---
     app.route("/v1/chat/completions", methods=["POST"])(handle_openai_chat)
     app.route("/v1/embeddings", methods=["POST"])(handle_embeddings)
+    app.route("/v1/rerank", methods=["POST"])(handle_rerank)
+    app.route("/v2/rerank", methods=["POST"])(handle_rerank)
     app.route("/v1/messages", methods=["POST"])(handle_anthropic)
     app.route("/v1/responses", methods=["POST"])(handle_openai_responses)
     app.route("/v1/models", methods=["GET"])(handle_list_models)

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -9,7 +9,7 @@ import re
 import sys
 from collections.abc import Generator
 from contextlib import contextmanager, suppress
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, NamedTuple, Protocol, runtime_checkable
 
 from llm_rosetta.auto_detect import ProviderType
 from llm_rosetta.routing import ResolvedRoute
@@ -18,6 +18,17 @@ from .providers import build_provider_info
 from .transport import ProviderInfo
 
 logger = logging.getLogger("llm-rosetta-gateway")
+
+
+class RerankRoute(NamedTuple):
+    """Resolved rerank provider routing info."""
+
+    provider_name: str
+    format: str
+    base_url: str
+    rerank_path: str
+    auth_headers: dict[str, str]
+
 
 # ---------------------------------------------------------------------------
 # Config file search paths (checked in order)
@@ -260,6 +271,13 @@ class GatewayConfig:
             )
             for name, cfg in self._raw_providers.items()
         }
+
+        # --- Rerank routing ---
+        self.rerank_providers, self.rerank_models = self._parse_rerank_config(
+            raw.get("rerank_providers", {}),
+            raw.get("rerank_models", {}),
+        )
+        self.default_rerank_format: str = raw.get("default_rerank_format", "jina")
 
     @staticmethod
     def _parse_custom_tools_overrides(
@@ -581,3 +599,52 @@ class GatewayConfig:
             pinfo = pinfo.with_timeout(model_timeout)
 
         return route, pinfo
+
+    # ---- Rerank routing -------------------------------------------------
+
+    @staticmethod
+    def _parse_rerank_config(
+        raw_providers: dict[str, Any],
+        raw_models: dict[str, Any],
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+        """Parse rerank_providers and rerank_models from config."""
+        providers: dict[str, dict[str, Any]] = {}
+        for name, cfg in raw_providers.items():
+            if not isinstance(cfg, dict):
+                continue
+            if cfg.get("enabled") is False:
+                continue
+            providers[name] = {
+                "api_key": cfg.get("api_key", ""),
+                "base_url": cfg.get("base_url", "").rstrip("/"),
+                "format": cfg.get("format", "jina"),
+                "rerank_path": cfg.get("rerank_path", "/v1/rerank"),
+            }
+
+        models: dict[str, str] = {}
+        for model_name, value in raw_models.items():
+            if isinstance(value, str):
+                provider_name = value
+            elif isinstance(value, dict):
+                provider_name = value.get("provider", "")
+            else:
+                continue
+            if provider_name in providers:
+                models[model_name] = provider_name
+        return providers, models
+
+    def resolve_rerank(self, model: str) -> RerankRoute:
+        """Resolve a rerank model to its provider config.
+
+        Raises:
+            KeyError: If the model is not in rerank_models.
+        """
+        provider_name = self.rerank_models[model]
+        pcfg = self.rerank_providers[provider_name]
+        return RerankRoute(
+            provider_name=provider_name,
+            format=pcfg["format"],
+            base_url=pcfg["base_url"],
+            rerank_path=pcfg["rerank_path"],
+            auth_headers={"Authorization": f"Bearer {pcfg['api_key']}"},
+        )

--- a/src/llm_rosetta/gateway/rerank.py
+++ b/src/llm_rosetta/gateway/rerank.py
@@ -1,0 +1,223 @@
+"""Rerank proxy handler with cross-format conversion.
+
+Proxies ``/v1/rerank`` and ``/v2/rerank`` requests to upstream rerank
+providers, converting between Jina, Cohere, and Voyage formats via IR.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, cast
+
+from llm_rosetta._vendor.httpclient import (
+    AsyncClient,
+    HttpConnectionError,
+    HttpTimeoutError,
+    Response as HttpResponse,
+)
+from llm_rosetta._vendor.httpserver import JSONResponse, Response
+
+from .config import GatewayConfig
+from .headers import build_upstream_extra_headers, get_request_id
+from .logging import get_logger
+from .rerank_pipeline import RerankConversionPipeline
+
+logger = get_logger()
+
+
+def _detect_source_format(request: Any, config: GatewayConfig) -> str:
+    """Infer the source rerank format from the request path.
+
+    ``/v2/rerank`` implies Cohere format (only Cohere uses v2).
+    ``/v1/rerank`` falls back to ``config.default_rerank_format``.
+    """
+    path: str = getattr(request, "path", "")
+    if path.startswith("/v2/"):
+        return "cohere"
+    return config.default_rerank_format
+
+
+async def handle_rerank(
+    request: Any,
+    config: GatewayConfig,
+) -> Response:
+    """Proxy a rerank request with cross-format conversion."""
+    request_id = get_request_id(request)
+
+    def with_request_id(response: Response) -> Response:
+        response.headers["x-request-id"] = request_id
+        return response
+
+    # --- Parse request ---
+    try:
+        body: dict[str, Any] = request.json()
+    except Exception:
+        return with_request_id(
+            JSONResponse(
+                {
+                    "error": {
+                        "message": "Invalid JSON body",
+                        "type": "invalid_request_error",
+                    }
+                },
+                status_code=400,
+            )
+        )
+
+    model = body.get("model")
+    if not model:
+        return with_request_id(
+            JSONResponse(
+                {
+                    "error": {
+                        "message": "Missing 'model' in request body",
+                        "type": "invalid_request_error",
+                    }
+                },
+                status_code=400,
+            )
+        )
+
+    # --- Resolve rerank provider ---
+    try:
+        route = config.resolve_rerank(model)
+    except KeyError:
+        configured = ", ".join(sorted(config.rerank_models.keys()))
+        return with_request_id(
+            JSONResponse(
+                {
+                    "error": {
+                        "message": (
+                            f"Unknown rerank model: '{model}'. "
+                            f"Configured: {configured or '(none)'}"
+                        ),
+                        "type": "model_not_found",
+                    }
+                },
+                status_code=404,
+            )
+        )
+
+    source_format = _detect_source_format(request, config)
+
+    # --- Convert request ---
+    pipeline = RerankConversionPipeline(source_format, route.format)
+    try:
+        target_body = pipeline.convert_request(body)
+    except Exception as exc:
+        logger.warning("rerank: request conversion failed: %s", exc)
+        return with_request_id(
+            JSONResponse(
+                {
+                    "error": {
+                        "message": f"Request conversion failed: {exc}",
+                        "type": "conversion_error",
+                    }
+                },
+                status_code=400,
+            )
+        )
+
+    # --- Forward to upstream ---
+    upstream_url = f"{route.base_url}{route.rerank_path}"
+    extra_headers = build_upstream_extra_headers(request, request_id)
+    headers = {
+        "Content-Type": "application/json",
+        **route.auth_headers,
+        **extra_headers,
+    }
+
+    t0 = time.monotonic()
+    status_code = 500
+
+    try:
+        async with AsyncClient(
+            headers=headers, timeout=config.upstream_timeout
+        ) as client:
+            resp = cast(HttpResponse, await client.post(upstream_url, json=target_body))
+        status_code = resp.status_code
+
+        if resp.status_code >= 400:
+            return with_request_id(
+                Response(
+                    body=resp.content,
+                    status_code=resp.status_code,
+                    content_type="application/json",
+                )
+            )
+
+        # --- Convert response ---
+        try:
+            upstream_body = resp.json()
+        except Exception:
+            fallback = with_request_id(
+                Response(
+                    body=resp.content,
+                    status_code=200,
+                    content_type="application/json",
+                )
+            )
+            fallback.headers["x-rosetta-conversion"] = "passthrough"
+            return fallback
+
+        try:
+            source_body = pipeline.convert_response(upstream_body)
+        except Exception as exc:
+            logger.warning("rerank: response conversion failed: %s", exc)
+            fallback = with_request_id(
+                Response(
+                    body=resp.content,
+                    status_code=200,
+                    content_type="application/json",
+                )
+            )
+            fallback.headers["x-rosetta-conversion"] = "passthrough"
+            return fallback
+
+        return with_request_id(JSONResponse(source_body, status_code=200))
+
+    except HttpTimeoutError as exc:
+        status_code = 504
+        return with_request_id(
+            JSONResponse(
+                {
+                    "error": {
+                        "message": f"Upstream timeout: {exc}",
+                        "type": "upstream_error",
+                    }
+                },
+                status_code=504,
+            )
+        )
+    except HttpConnectionError as exc:
+        status_code = 502
+        return with_request_id(
+            JSONResponse(
+                {
+                    "error": {
+                        "message": f"Upstream connection failed: {exc}",
+                        "type": "upstream_error",
+                    }
+                },
+                status_code=502,
+            )
+        )
+    except Exception:
+        raise
+    finally:
+        duration_ms = (time.monotonic() - t0) * 1000
+        if pipeline.warnings:
+            logger.info(
+                "rerank: conversion warnings for %s: %s",
+                model,
+                "; ".join(pipeline.warnings),
+            )
+        logger.info(
+            "rerank: %s → %s (%s→%s) %dms status=%d",
+            model,
+            route.provider_name,
+            source_format,
+            route.format,
+            duration_ms,
+            status_code,
+        )

--- a/src/llm_rosetta/gateway/rerank_pipeline.py
+++ b/src/llm_rosetta/gateway/rerank_pipeline.py
@@ -1,0 +1,79 @@
+"""Rerank conversion pipeline.
+
+Lightweight pipeline that converts rerank requests/responses between
+provider formats via IR, using the rerank converter family.  No
+streaming, no shims — much simpler than the chat
+:class:`~llm_rosetta.pipeline.ConversionPipeline`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.converters.base.rerank_converter import BaseRerankConverter
+from llm_rosetta.converters.rerank import (
+    CohereRerankConverter,
+    JinaRerankConverter,
+    VoyageRerankConverter,
+)
+
+_RERANK_CONVERTERS: dict[str, type[BaseRerankConverter]] = {
+    "jina": JinaRerankConverter,
+    "cohere": CohereRerankConverter,
+    "voyage": VoyageRerankConverter,
+}
+
+RERANK_FORMATS = frozenset(_RERANK_CONVERTERS.keys())
+
+
+def get_rerank_converter(format_name: str) -> BaseRerankConverter:
+    """Return a converter instance for *format_name*.
+
+    Raises:
+        ValueError: If *format_name* is not a known rerank format.
+    """
+    cls = _RERANK_CONVERTERS.get(format_name)
+    if cls is None:
+        raise ValueError(
+            f"Unknown rerank format: '{format_name}'. "
+            f"Available: {', '.join(sorted(RERANK_FORMATS))}"
+        )
+    return cls()
+
+
+class RerankConversionPipeline:
+    """Convert rerank requests/responses between two provider formats.
+
+    When *source_format* == *target_format*, conversion is skipped
+    (only the model alias is applied).
+    """
+
+    def __init__(self, source_format: str, target_format: str) -> None:
+        self.source_format = source_format
+        self.target_format = target_format
+        self._needs_conversion = source_format != target_format
+        self._source_converter = get_rerank_converter(source_format)
+        self._target_converter = get_rerank_converter(target_format)
+        self._ctx = ConversionContext()
+
+    @property
+    def warnings(self) -> list[str]:
+        return self._ctx.warnings
+
+    def convert_request(self, body: dict[str, Any]) -> dict[str, Any]:
+        """Source format request → target format request."""
+        if not self._needs_conversion:
+            return body
+        ir = self._source_converter.request_from_provider(body, context=self._ctx)
+        target_body, _ = self._target_converter.request_to_provider(
+            ir, context=self._ctx
+        )
+        return target_body
+
+    def convert_response(self, body: dict[str, Any]) -> dict[str, Any]:
+        """Target format response → source format response."""
+        if not self._needs_conversion:
+            return body
+        ir = self._target_converter.response_from_provider(body, context=self._ctx)
+        return self._source_converter.response_to_provider(ir, context=self._ctx)

--- a/tests/gateway/test_rerank_proxy.py
+++ b/tests/gateway/test_rerank_proxy.py
@@ -1,0 +1,274 @@
+"""Unit tests for rerank gateway pipeline and config."""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_rosetta.gateway.rerank_pipeline import (
+    RerankConversionPipeline,
+    get_rerank_converter,
+)
+
+
+# ============================================================================
+# Pipeline tests
+# ============================================================================
+
+
+class TestRerankConversionPipeline:
+    def test_same_format_passthrough(self) -> None:
+        pipeline = RerankConversionPipeline("jina", "jina")
+        body = {
+            "model": "test",
+            "query": "hello",
+            "documents": ["doc1"],
+            "top_n": 1,
+        }
+        result = pipeline.convert_request(body)
+        assert result is body  # same object, no copy
+
+    def test_jina_to_cohere_request(self) -> None:
+        pipeline = RerankConversionPipeline("jina", "cohere")
+        body = {
+            "model": "test",
+            "query": "capital of France",
+            "documents": ["Paris is the capital.", "Berlin is the capital."],
+            "top_n": 1,
+        }
+        result = pipeline.convert_request(body)
+        assert result["model"] == "test"
+        assert result["query"] == "capital of France"
+        assert result["documents"] == [
+            "Paris is the capital.",
+            "Berlin is the capital.",
+        ]
+        assert result["top_n"] == 1
+
+    def test_jina_to_voyage_request_top_k(self) -> None:
+        pipeline = RerankConversionPipeline("jina", "voyage")
+        body = {
+            "model": "test",
+            "query": "hello",
+            "documents": ["doc1"],
+            "top_n": 2,
+        }
+        result = pipeline.convert_request(body)
+        assert result["top_k"] == 2
+        assert "top_n" not in result
+
+    def test_voyage_to_jina_request_top_n(self) -> None:
+        pipeline = RerankConversionPipeline("voyage", "jina")
+        body = {
+            "model": "test",
+            "query": "hello",
+            "documents": ["doc1"],
+            "top_k": 3,
+        }
+        result = pipeline.convert_request(body)
+        assert result["top_n"] == 3
+        assert "top_k" not in result
+
+    def test_cohere_to_jina_response(self) -> None:
+        pipeline = RerankConversionPipeline("jina", "cohere")
+        cohere_resp = {
+            "id": "abc",
+            "results": [
+                {"index": 0, "relevance_score": 0.9},
+                {"index": 1, "relevance_score": 0.3},
+            ],
+            "meta": {"billed_units": {"search_units": 1}},
+        }
+        result = pipeline.convert_response(cohere_resp)
+        assert result["object"] == "list"
+        assert "results" in result
+        assert len(result["results"]) == 2
+        assert result["results"][0]["relevance_score"] == pytest.approx(0.9)
+
+    def test_jina_to_voyage_response(self) -> None:
+        pipeline = RerankConversionPipeline("voyage", "jina")
+        jina_resp = {
+            "model": "jina-reranker-v2",
+            "object": "list",
+            "usage": {"total_tokens": 50},
+            "results": [
+                {"index": 0, "relevance_score": 0.8, "document": "doc text"},
+            ],
+        }
+        result = pipeline.convert_response(jina_resp)
+        assert result["object"] == "list"
+        assert "data" in result
+        assert result["data"][0]["document"] == "doc text"
+
+    def test_full_roundtrip_jina_cohere(self) -> None:
+        pipeline_fwd = RerankConversionPipeline("jina", "cohere")
+        pipeline_bwd = RerankConversionPipeline("cohere", "jina")
+
+        jina_req = {
+            "model": "test",
+            "query": "hello",
+            "documents": ["a", "b"],
+            "top_n": 1,
+        }
+        cohere_req = pipeline_fwd.convert_request(jina_req)
+        jina_req_back = pipeline_bwd.convert_request(cohere_req)
+        assert jina_req_back["query"] == "hello"
+        assert jina_req_back["top_n"] == 1
+
+    def test_warnings_accessible(self) -> None:
+        # source=cohere, target=jina: convert_response goes
+        # jina response (with docs) → IR → cohere response (drops docs → warning)
+        pipeline = RerankConversionPipeline("cohere", "jina")
+        jina_resp = {
+            "model": "test",
+            "object": "list",
+            "results": [
+                {"index": 0, "relevance_score": 0.5, "document": "has doc"},
+            ],
+        }
+        pipeline.convert_response(jina_resp)
+        assert any("document data" in w for w in pipeline.warnings)
+
+
+class TestGetRerankConverter:
+    def test_valid_formats(self) -> None:
+        for fmt in ("jina", "cohere", "voyage"):
+            conv = get_rerank_converter(fmt)
+            assert conv is not None
+
+    def test_invalid_format(self) -> None:
+        with pytest.raises(ValueError, match="Unknown rerank format"):
+            get_rerank_converter("nonexistent")
+
+
+# ============================================================================
+# Config tests
+# ============================================================================
+
+
+class TestRerankConfig:
+    def test_parse_rerank_config(self) -> None:
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        raw = {
+            "providers": {
+                "openai_chat": {
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com/v1",
+                }
+            },
+            "models": {"gpt-4o": "openai_chat"},
+            "rerank_providers": {
+                "jina": {
+                    "api_key": "jina-key",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                    "rerank_path": "/v1/rerank",
+                },
+                "cohere": {
+                    "api_key": "cohere-key",
+                    "base_url": "https://api.cohere.com",
+                    "format": "cohere",
+                    "rerank_path": "/v2/rerank",
+                },
+            },
+            "rerank_models": {
+                "jina-reranker-v2": "jina",
+                "rerank-v3.5": "cohere",
+            },
+            "default_rerank_format": "cohere",
+        }
+        config = GatewayConfig(raw)
+        assert len(config.rerank_providers) == 2
+        assert config.rerank_providers["jina"]["format"] == "jina"
+        assert config.rerank_providers["cohere"]["rerank_path"] == "/v2/rerank"
+        assert len(config.rerank_models) == 2
+        assert config.default_rerank_format == "cohere"
+
+    def test_resolve_rerank(self) -> None:
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        raw = {
+            "providers": {
+                "openai_chat": {
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com/v1",
+                }
+            },
+            "models": {"gpt-4o": "openai_chat"},
+            "rerank_providers": {
+                "jina": {
+                    "api_key": "jina-key",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                    "rerank_path": "/v1/rerank",
+                }
+            },
+            "rerank_models": {"jina-reranker-v2": "jina"},
+        }
+        config = GatewayConfig(raw)
+        route = config.resolve_rerank("jina-reranker-v2")
+        assert route.provider_name == "jina"
+        assert route.format == "jina"
+        assert route.base_url == "https://api.jina.ai"
+        assert route.rerank_path == "/v1/rerank"
+        assert route.auth_headers["Authorization"] == "Bearer jina-key"
+
+    def test_resolve_rerank_unknown_model(self) -> None:
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        raw = {
+            "providers": {
+                "openai_chat": {
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com/v1",
+                }
+            },
+            "models": {"gpt-4o": "openai_chat"},
+            "rerank_providers": {},
+            "rerank_models": {},
+        }
+        config = GatewayConfig(raw)
+        with pytest.raises(KeyError):
+            config.resolve_rerank("nonexistent")
+
+    def test_empty_rerank_config(self) -> None:
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        raw = {
+            "providers": {
+                "openai_chat": {
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com/v1",
+                }
+            },
+            "models": {"gpt-4o": "openai_chat"},
+        }
+        config = GatewayConfig(raw)
+        assert config.rerank_providers == {}
+        assert config.rerank_models == {}
+        assert config.default_rerank_format == "jina"
+
+    def test_disabled_rerank_provider_skipped(self) -> None:
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        raw = {
+            "providers": {
+                "openai_chat": {
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com/v1",
+                }
+            },
+            "models": {"gpt-4o": "openai_chat"},
+            "rerank_providers": {
+                "jina": {
+                    "api_key": "key",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                    "enabled": False,
+                }
+            },
+            "rerank_models": {"jina-reranker-v2": "jina"},
+        }
+        config = GatewayConfig(raw)
+        assert "jina" not in config.rerank_providers
+        assert len(config.rerank_models) == 0


### PR DESCRIPTION
## Summary

- Add `/v1/rerank` and `/v2/rerank` proxy endpoints with IR-based format conversion
- `RerankConversionPipeline` converts between Jina, Cohere, and Voyage formats via IR
- Uses **vendored httpclient** (not httpx) — consistent with rest of gateway
- Config-driven routing: `rerank_providers` + `rerank_models` + `default_rerank_format`
- `RerankRoute` NamedTuple for type-safe route resolution
- `/v2/rerank` auto-infers Cohere source format from route path
- `x-rosetta-conversion: passthrough` header on response conversion failures

## Redo of #509

Closed #509 and redone from scratch to replace `httpx` with the vendored `_vendor.httpclient.AsyncClient`, keeping the gateway's HTTP client usage consistent. All review feedback from #509 (RerankRoute NamedTuple, passthrough header, route-based format detection) is incorporated from the start.

## Test plan

- [x] 15 unit tests: pipeline, config, resolve_rerank, disabled providers
- [x] `make lint` clean (ruff + ty check + complexipy)
- [x] `make test`: 2587 passed

Closes #508