### PR TITLE
fix(gateway): use UpstreamTransport for rerank proxy

### DIFF
--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -25,9 +25,8 @@ class RerankRoute(NamedTuple):
 
     provider_name: str
     format: str
-    base_url: str
     rerank_path: str
-    auth_headers: dict[str, str]
+    provider_info: ProviderInfo
 
 
 # ---------------------------------------------------------------------------
@@ -273,9 +272,14 @@ class GatewayConfig:
         }
 
         # --- Rerank routing ---
-        self.rerank_providers, self.rerank_models = self._parse_rerank_config(
+        (
+            self.rerank_providers,
+            self.rerank_provider_infos,
+            self.rerank_models,
+        ) = self._parse_rerank_config(
             raw.get("rerank_providers", {}),
             raw.get("rerank_models", {}),
+            global_proxy=self.proxy,
         )
         self.default_rerank_format: str = raw.get("default_rerank_format", "jina")
 
@@ -606,20 +610,31 @@ class GatewayConfig:
     def _parse_rerank_config(
         raw_providers: dict[str, Any],
         raw_models: dict[str, Any],
-    ) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+        *,
+        global_proxy: str | None = None,
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, ProviderInfo], dict[str, str]]:
         """Parse rerank_providers and rerank_models from config."""
+        from .transport.provider_info import openai_auth
+
         providers: dict[str, dict[str, Any]] = {}
+        provider_infos: dict[str, ProviderInfo] = {}
         for name, cfg in raw_providers.items():
             if not isinstance(cfg, dict):
                 continue
             if cfg.get("enabled") is False:
                 continue
             providers[name] = {
-                "api_key": cfg.get("api_key", ""),
-                "base_url": cfg.get("base_url", "").rstrip("/"),
                 "format": cfg.get("format", "jina"),
                 "rerank_path": cfg.get("rerank_path", "/v1/rerank"),
             }
+            provider_infos[name] = ProviderInfo(
+                name=f"rerank:{name}",
+                api_key=cfg.get("api_key", ""),
+                base_url=cfg.get("base_url", "").rstrip("/"),
+                auth_header_fn=openai_auth,
+                url_template="{base_url}" + cfg.get("rerank_path", "/v1/rerank"),
+                proxy_url=global_proxy,
+            )
 
         models: dict[str, str] = {}
         for model_name, value in raw_models.items():
@@ -631,7 +646,7 @@ class GatewayConfig:
                 continue
             if provider_name in providers:
                 models[model_name] = provider_name
-        return providers, models
+        return providers, provider_infos, models
 
     def resolve_rerank(self, model: str) -> RerankRoute:
         """Resolve a rerank model to its provider config.
@@ -641,10 +656,10 @@ class GatewayConfig:
         """
         provider_name = self.rerank_models[model]
         pcfg = self.rerank_providers[provider_name]
+        pinfo = self.rerank_provider_infos[provider_name]
         return RerankRoute(
             provider_name=provider_name,
             format=pcfg["format"],
-            base_url=pcfg["base_url"],
             rerank_path=pcfg["rerank_path"],
-            auth_headers={"Authorization": f"Bearer {pcfg['api_key']}"},
+            provider_info=pinfo,
         )

--- a/src/llm_rosetta/gateway/rerank.py
+++ b/src/llm_rosetta/gateway/rerank.py
@@ -2,25 +2,22 @@
 
 Proxies ``/v1/rerank`` and ``/v2/rerank`` requests to upstream rerank
 providers, converting between Jina, Cohere, and Voyage formats via IR.
+Uses the shared :class:`~transport.UpstreamTransport` interface,
+consistent with the embeddings and chat handlers.
 """
 
 from __future__ import annotations
 
 import time
-from typing import Any, cast
+from typing import Any
 
-from llm_rosetta._vendor.httpclient import (
-    AsyncClient,
-    HttpConnectionError,
-    HttpTimeoutError,
-    Response as HttpResponse,
-)
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
 from .config import GatewayConfig
 from .headers import build_upstream_extra_headers, get_request_id
 from .logging import get_logger
 from .rerank_pipeline import RerankConversionPipeline
+from .transport import UpstreamConnectionError, UpstreamTransport
 
 logger = get_logger()
 
@@ -118,29 +115,27 @@ async def handle_rerank(
             )
         )
 
-    # --- Forward to upstream ---
-    upstream_url = f"{route.base_url}{route.rerank_path}"
+    # --- Forward via transport ---
+    upstream_url = f"{route.provider_info.base_url}{route.rerank_path}"
+    transport: UpstreamTransport = request.app.transport
     extra_headers = build_upstream_extra_headers(request, request_id)
-    headers = {
-        "Content-Type": "application/json",
-        **route.auth_headers,
-        **extra_headers,
-    }
 
     t0 = time.monotonic()
     status_code = 500
 
     try:
-        async with AsyncClient(
-            headers=headers, timeout=config.upstream_timeout
-        ) as client:
-            resp = cast(HttpResponse, await client.post(upstream_url, json=target_body))
+        resp = await transport.send_passthrough(
+            route.provider_info,
+            upstream_url,
+            target_body,
+            extra_headers=extra_headers,
+        )
         status_code = resp.status_code
 
-        if resp.status_code >= 400:
+        if resp.is_error:
             return with_request_id(
                 Response(
-                    body=resp.content,
+                    body=resp.raw_content,
                     status_code=resp.status_code,
                     content_type="application/json",
                 )
@@ -148,11 +143,13 @@ async def handle_rerank(
 
         # --- Convert response ---
         try:
-            upstream_body = resp.json()
+            upstream_body = resp.body
+            if upstream_body is None:
+                raise ValueError("Empty response body")
         except Exception:
             fallback = with_request_id(
                 Response(
-                    body=resp.content,
+                    body=resp.raw_content,
                     status_code=200,
                     content_type="application/json",
                 )
@@ -166,7 +163,7 @@ async def handle_rerank(
             logger.warning("rerank: response conversion failed: %s", exc)
             fallback = with_request_id(
                 Response(
-                    body=resp.content,
+                    body=resp.raw_content,
                     status_code=200,
                     content_type="application/json",
                 )
@@ -176,20 +173,7 @@ async def handle_rerank(
 
         return with_request_id(JSONResponse(source_body, status_code=200))
 
-    except HttpTimeoutError as exc:
-        status_code = 504
-        return with_request_id(
-            JSONResponse(
-                {
-                    "error": {
-                        "message": f"Upstream timeout: {exc}",
-                        "type": "upstream_error",
-                    }
-                },
-                status_code=504,
-            )
-        )
-    except HttpConnectionError as exc:
+    except UpstreamConnectionError as exc:
         status_code = 502
         return with_request_id(
             JSONResponse(

--- a/tests/gateway/test_rerank_proxy.py
+++ b/tests/gateway/test_rerank_proxy.py
@@ -209,9 +209,9 @@ class TestRerankConfig:
         route = config.resolve_rerank("jina-reranker-v2")
         assert route.provider_name == "jina"
         assert route.format == "jina"
-        assert route.base_url == "https://api.jina.ai"
         assert route.rerank_path == "/v1/rerank"
-        assert route.auth_headers["Authorization"] == "Bearer jina-key"
+        assert route.provider_info.base_url == "https://api.jina.ai"
+        assert route.provider_info.auth_headers()["Authorization"] == "Bearer jina-key"
 
     def test_resolve_rerank_unknown_model(self) -> None:
         from llm_rosetta.gateway.config import GatewayConfig


### PR DESCRIPTION
## Summary

Unify the rerank handler's HTTP transport with the rest of the gateway. Previously rerank used `_vendor.httpclient.AsyncClient` directly, bypassing the shared `UpstreamTransport` layer that chat and embeddings use.

## Changes

- **config.py**: Build `ProviderInfo` objects for rerank providers (with `openai_auth`, key rotation, proxy support). `RerankRoute` now carries `provider_info: ProviderInfo` instead of `auth_headers: dict`.
- **rerank.py**: Use `transport.send_passthrough(provider_info, ...)` instead of raw `AsyncClient`. Error handling uses `UpstreamConnectionError` (same as embeddings).
- **tests**: Updated `resolve_rerank` assertions to use `route.provider_info.*`.

## Why

Without this, rerank was the only handler creating per-request HTTP clients, bypassing connection pooling, proxy settings, and key rotation. This creates technical debt as more non-chat modalities are added.

## Test plan

- [x] 2587 tests pass, lint clean
- [x] `resolve_rerank` test verifies `ProviderInfo` fields