### PR TITLE
fix: distinguish upstream timeout (504) from connection error (502)

### DIFF
--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -627,12 +627,13 @@ class GatewayConfig:
                 "format": cfg.get("format", "jina"),
                 "rerank_path": cfg.get("rerank_path", "/v1/rerank"),
             }
+            rerank_path = cfg.get("rerank_path", "/v1/rerank")
             provider_infos[name] = ProviderInfo(
                 name=f"rerank:{name}",
                 api_key=cfg.get("api_key", ""),
                 base_url=cfg.get("base_url", "").rstrip("/"),
                 auth_header_fn=openai_auth,
-                url_template="{base_url}" + cfg.get("rerank_path", "/v1/rerank"),
+                url_template="{base_url}" + rerank_path,
                 proxy_url=global_proxy,
             )
 

--- a/src/llm_rosetta/gateway/rerank.py
+++ b/src/llm_rosetta/gateway/rerank.py
@@ -17,7 +17,7 @@ from .config import GatewayConfig
 from .headers import build_upstream_extra_headers, get_request_id
 from .logging import get_logger
 from .rerank_pipeline import RerankConversionPipeline
-from .transport import UpstreamConnectionError, UpstreamTransport
+from .transport import UpstreamConnectionError, UpstreamTimeoutError, UpstreamTransport
 
 logger = get_logger()
 
@@ -173,6 +173,19 @@ async def handle_rerank(
 
         return with_request_id(JSONResponse(source_body, status_code=200))
 
+    except UpstreamTimeoutError as exc:
+        status_code = 504
+        return with_request_id(
+            JSONResponse(
+                {
+                    "error": {
+                        "message": f"Upstream timeout: {exc}",
+                        "type": "upstream_error",
+                    }
+                },
+                status_code=504,
+            )
+        )
     except UpstreamConnectionError as exc:
         status_code = 502
         return with_request_id(

--- a/src/llm_rosetta/gateway/transport/__init__.py
+++ b/src/llm_rosetta/gateway/transport/__init__.py
@@ -12,6 +12,7 @@ sub-packages:
 
 from ._base import (
     UpstreamConnectionError,
+    UpstreamTimeoutError,
     UpstreamResponse,
     UpstreamStream,
     UpstreamTransport,
@@ -30,6 +31,7 @@ from .sse_format import SSE_FORMATTERS, format_sse_done
 __all__ = [
     # Protocol + response types
     "UpstreamConnectionError",
+    "UpstreamTimeoutError",
     "UpstreamResponse",
     "UpstreamStream",
     "UpstreamTransport",

--- a/src/llm_rosetta/gateway/transport/_base.py
+++ b/src/llm_rosetta/gateway/transport/_base.py
@@ -112,6 +112,10 @@ class UpstreamConnectionError(Exception):
     """Raised when the transport cannot reach the upstream provider."""
 
 
+class UpstreamTimeoutError(UpstreamConnectionError):
+    """Raised when the upstream provider does not respond in time."""
+
+
 # ---------------------------------------------------------------------------
 # Transport protocol
 # ---------------------------------------------------------------------------

--- a/src/llm_rosetta/gateway/transport/http/transport.py
+++ b/src/llm_rosetta/gateway/transport/http/transport.py
@@ -14,13 +14,19 @@ from typing import Any
 
 from llm_rosetta._vendor.httpclient import (
     HttpClientError,
+    HttpTimeoutError,
     Response as HttpResponse,
     StreamingResponse as HttpStreamingResponse,
 )
 from llm_rosetta._vendor.sse import AsyncEventSource
 from llm_rosetta.auto_detect import ProviderType
 
-from .._base import UpstreamConnectionError, UpstreamResponse, UpstreamStream
+from .._base import (
+    UpstreamConnectionError,
+    UpstreamResponse,
+    UpstreamStream,
+    UpstreamTimeoutError,
+)
 from ..provider_info import ProviderInfo
 from .client_pool import HttpClientPool
 
@@ -142,6 +148,8 @@ class HttpTransport:
             if provider_info.timeout is not None:
                 kwargs["timeout"] = provider_info.timeout
             resp = await client.post(url, json=req_body, headers=headers, **kwargs)
+        except HttpTimeoutError as exc:
+            raise UpstreamTimeoutError(str(exc)) from exc
         except HttpClientError as exc:
             raise UpstreamConnectionError(str(exc)) from exc
 
@@ -178,6 +186,8 @@ class HttpTransport:
             resp = await client.post(
                 url, json=req_body, headers=headers, stream=True, **kwargs
             )
+        except HttpTimeoutError as exc:
+            raise UpstreamTimeoutError(str(exc)) from exc
         except HttpClientError as exc:
             raise UpstreamConnectionError(str(exc)) from exc
 
@@ -206,6 +216,8 @@ class HttpTransport:
         client = self._pool.get(provider_info.proxy_url)
         try:
             resp = await client.post(url, json=body, headers=headers)
+        except HttpTimeoutError as exc:
+            raise UpstreamTimeoutError(str(exc)) from exc
         except HttpClientError as exc:
             raise UpstreamConnectionError(str(exc)) from exc
 


### PR DESCRIPTION
## Summary

Add `UpstreamTimeoutError` to the transport layer so handlers can distinguish timeout (504) from connection failure (502).

## Changes

- **transport/_base.py**: Add `UpstreamTimeoutError(UpstreamConnectionError)` — subclass preserves backward compat
- **transport/http/transport.py**: All three `send_*` methods catch `HttpTimeoutError` → `UpstreamTimeoutError` before `HttpClientError` → `UpstreamConnectionError`
- **gateway/rerank.py**: Catch `UpstreamTimeoutError` → 504, `UpstreamConnectionError` → 502

Existing chat/embeddings handlers catch the parent `UpstreamConnectionError` and are unaffected.

## Test plan

- [x] 2587 tests pass, lint clean