### PR TITLE
refactor(gateway): unify outbound transport — merge send_request and send_passthrough

### DIFF
--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -623,11 +623,11 @@ class GatewayConfig:
                 continue
             if cfg.get("enabled") is False:
                 continue
+            rerank_path = cfg.get("rerank_path", "/v1/rerank")
             providers[name] = {
                 "format": cfg.get("format", "jina"),
-                "rerank_path": cfg.get("rerank_path", "/v1/rerank"),
+                "rerank_path": rerank_path,
             }
-            rerank_path = cfg.get("rerank_path", "/v1/rerank")
             provider_infos[name] = ProviderInfo(
                 name=f"rerank:{name}",
                 api_key=cfg.get("api_key", ""),

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -107,7 +107,7 @@ async def handle_embeddings(
     error_detail: str | None = None
 
     try:
-        resp = await transport.send_passthrough(
+        resp = await transport.send(
             provider_info,
             upstream_url,
             body,

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -103,6 +103,26 @@ def error_response_for_source(
 # ---------------------------------------------------------------------------
 
 
+def _inject_stream_flags(
+    target_provider: ProviderType, body: dict[str, Any], *, stream: bool
+) -> dict[str, Any]:
+    """Inject provider-specific stream flags into an outbound request body.
+
+    Returns the body unchanged when *stream* is False. When True, returns
+    a shallow copy with stream flags set for the target provider.
+    """
+    if not stream:
+        return body
+    body = dict(body)
+    if target_provider == "openai_chat":
+        body["stream"] = True
+        body["stream_options"] = {"include_usage": True}
+    elif target_provider in ("openai_responses", "open_responses", "anthropic"):
+        body["stream"] = True
+    # Google streaming is signaled via URL, not body
+    return body
+
+
 def detect_stream_request(source_provider: ProviderType, body: dict[str, Any]) -> bool:
     """Detect if the incoming request asks for streaming."""
     if source_provider in (
@@ -324,13 +344,13 @@ async def handle_non_streaming(
     _strip_internal_metadata(target_body)
 
     # Phase 3: Forward to upstream via transport
+    upstream_url = provider_info.upstream_url(model)
     t_upstream = time.perf_counter()
     try:
-        resp = await transport.send_request(
+        resp = await transport.send(
             provider_info,
-            route.target_provider,
+            upstream_url,
             target_body,
-            model,
             extra_headers=extra_headers,
         )
     except UpstreamConnectionError as exc:
@@ -646,13 +666,14 @@ async def handle_streaming(
 
     # Phase 3: Open upstream connection and check for immediate errors
     # *before* committing to a 200 StreamingResponse.
+    upstream_url = provider_info.upstream_url(model, stream=True)
+    target_body = _inject_stream_flags(route.target_provider, target_body, stream=True)
     t_connect = time.perf_counter()
     try:
         stream = await transport.send_streaming(
             provider_info,
-            route.target_provider,
+            upstream_url,
             target_body,
-            model,
             extra_headers=extra_headers,
         )
     except UpstreamConnectionError as exc:

--- a/src/llm_rosetta/gateway/rerank.py
+++ b/src/llm_rosetta/gateway/rerank.py
@@ -124,7 +124,7 @@ async def handle_rerank(
     status_code = 500
 
     try:
-        resp = await transport.send_passthrough(
+        resp = await transport.send(
             route.provider_info,
             upstream_url,
             target_body,

--- a/src/llm_rosetta/gateway/transport/_base.py
+++ b/src/llm_rosetta/gateway/transport/_base.py
@@ -13,8 +13,6 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, Protocol
 
-from llm_rosetta.auto_detect import ProviderType
-
 from .provider_info import ProviderInfo
 
 
@@ -128,31 +126,7 @@ class UpstreamTransport(Protocol):
     implementations live in sub-packages (``transport.http``, etc.).
     """
 
-    async def send_request(
-        self,
-        provider_info: ProviderInfo,
-        target_provider: ProviderType,
-        body: dict[str, Any],
-        model: str,
-        *,
-        extra_headers: dict[str, str] | None = None,
-    ) -> UpstreamResponse:
-        """Send a non-streaming request and return the full response."""
-        ...
-
-    async def send_streaming(
-        self,
-        provider_info: ProviderInfo,
-        target_provider: ProviderType,
-        body: dict[str, Any],
-        model: str,
-        *,
-        extra_headers: dict[str, str] | None = None,
-    ) -> UpstreamStream:
-        """Send a streaming request and return an async chunk iterator."""
-        ...
-
-    async def send_passthrough(
+    async def send(
         self,
         provider_info: ProviderInfo,
         url: str,
@@ -160,13 +134,23 @@ class UpstreamTransport(Protocol):
         *,
         extra_headers: dict[str, str] | None = None,
     ) -> UpstreamResponse:
-        """Send a raw passthrough request (no format-specific URL or flags).
+        """Send a non-streaming request and return the full response.
 
-        Used for endpoints that don't go through IR conversion (e.g.
-        embeddings, reranking) — the URL is caller-provided, auth
-        headers come from *provider_info*, and the body is forwarded
-        as-is.
+        The caller is responsible for constructing the upstream URL and
+        injecting any provider-specific body modifications (e.g. stream
+        flags) before calling this method.
         """
+        ...
+
+    async def send_streaming(
+        self,
+        provider_info: ProviderInfo,
+        url: str,
+        body: dict[str, Any],
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> UpstreamStream:
+        """Send a streaming request and return an async chunk iterator."""
         ...
 
     async def close(self) -> None:

--- a/src/llm_rosetta/gateway/transport/http/transport.py
+++ b/src/llm_rosetta/gateway/transport/http/transport.py
@@ -3,6 +3,10 @@
 Implements the :class:`~transport._base.UpstreamTransport` protocol for
 HTTP REST + SSE streaming, backed by the vendored ``httpclient`` and ``sse``
 modules.
+
+The transport layer is URL-agnostic — callers construct the upstream URL
+and inject any provider-specific body modifications (e.g. stream flags)
+before calling :meth:`send` or :meth:`send_streaming`.
 """
 
 from __future__ import annotations
@@ -19,7 +23,6 @@ from llm_rosetta._vendor.httpclient import (
     StreamingResponse as HttpStreamingResponse,
 )
 from llm_rosetta._vendor.sse import AsyncEventSource
-from llm_rosetta.auto_detect import ProviderType
 
 from .._base import (
     UpstreamConnectionError,
@@ -31,43 +34,6 @@ from ..provider_info import ProviderInfo
 from .client_pool import HttpClientPool
 
 logger = logging.getLogger("llm-rosetta-gateway")
-
-
-# ---------------------------------------------------------------------------
-# Upstream request assembly
-# ---------------------------------------------------------------------------
-
-
-def _prepare_upstream(
-    target_provider: ProviderType,
-    provider_info: ProviderInfo,
-    provider_request: dict[str, Any],
-    model: str,
-    *,
-    stream: bool,
-    extra_headers: dict[str, str] | None = None,
-) -> tuple[str, dict[str, str], dict[str, Any]]:
-    """Return ``(url, headers, body)`` ready for the upstream HTTP call."""
-    url = provider_info.upstream_url(model, stream=stream)
-    headers = {
-        "Content-Type": "application/json",
-        **provider_info.auth_headers(),
-    }
-    if extra_headers:
-        headers.update(extra_headers)
-
-    body = dict(provider_request)
-
-    # Inject stream flag into the body for providers that use it
-    if stream:
-        if target_provider in ("openai_chat",):
-            body["stream"] = True
-            body["stream_options"] = {"include_usage": True}
-        elif target_provider in ("openai_responses", "open_responses", "anthropic"):
-            body["stream"] = True
-        # Google streaming is signaled via URL, not body
-
-    return url, headers, body
 
 
 # ---------------------------------------------------------------------------
@@ -124,30 +90,35 @@ class HttpTransport:
     def __init__(self, *, timeout: float = 300.0) -> None:
         self._pool = HttpClientPool(timeout=timeout)
 
-    async def send_request(
+    def _build_headers(
         self,
         provider_info: ProviderInfo,
-        target_provider: ProviderType,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        headers = {
+            "Content-Type": "application/json",
+            **provider_info.auth_headers(),
+        }
+        if extra_headers:
+            headers.update(extra_headers)
+        return headers
+
+    async def send(
+        self,
+        provider_info: ProviderInfo,
+        url: str,
         body: dict[str, Any],
-        model: str,
         *,
         extra_headers: dict[str, str] | None = None,
     ) -> UpstreamResponse:
         """Send a non-streaming request and return the full response."""
-        url, headers, req_body = _prepare_upstream(
-            target_provider,
-            provider_info,
-            body,
-            model,
-            stream=False,
-            extra_headers=extra_headers,
-        )
+        headers = self._build_headers(provider_info, extra_headers)
         client = self._pool.get(provider_info.proxy_url)
         try:
             kwargs: dict[str, Any] = {}
             if provider_info.timeout is not None:
                 kwargs["timeout"] = provider_info.timeout
-            resp = await client.post(url, json=req_body, headers=headers, **kwargs)
+            resp = await client.post(url, json=body, headers=headers, **kwargs)
         except HttpTimeoutError as exc:
             raise UpstreamTimeoutError(str(exc)) from exc
         except HttpClientError as exc:
@@ -163,28 +134,20 @@ class HttpTransport:
     async def send_streaming(
         self,
         provider_info: ProviderInfo,
-        target_provider: ProviderType,
+        url: str,
         body: dict[str, Any],
-        model: str,
         *,
         extra_headers: dict[str, str] | None = None,
     ) -> HttpUpstreamStream:
         """Send a streaming request and return an async chunk iterator."""
-        url, headers, req_body = _prepare_upstream(
-            target_provider,
-            provider_info,
-            body,
-            model,
-            stream=True,
-            extra_headers=extra_headers,
-        )
+        headers = self._build_headers(provider_info, extra_headers)
         client = self._pool.get(provider_info.proxy_url)
         try:
             kwargs: dict[str, Any] = {}
             if provider_info.timeout is not None:
                 kwargs["timeout"] = provider_info.timeout
             resp = await client.post(
-                url, json=req_body, headers=headers, stream=True, **kwargs
+                url, json=body, headers=headers, stream=True, **kwargs
             )
         except HttpTimeoutError as exc:
             raise UpstreamTimeoutError(str(exc)) from exc
@@ -193,40 +156,6 @@ class HttpTransport:
 
         assert isinstance(resp, HttpStreamingResponse)
         return HttpUpstreamStream(resp)
-
-    async def send_passthrough(
-        self,
-        provider_info: ProviderInfo,
-        url: str,
-        body: dict[str, Any],
-        *,
-        extra_headers: dict[str, str] | None = None,
-    ) -> UpstreamResponse:
-        """Send a raw passthrough request — no URL template or stream flags.
-
-        Used for non-conversion endpoints (embeddings, reranking, etc.).
-        """
-        headers = {
-            "Content-Type": "application/json",
-            **provider_info.auth_headers(),
-        }
-        if extra_headers:
-            headers.update(extra_headers)
-
-        client = self._pool.get(provider_info.proxy_url)
-        try:
-            resp = await client.post(url, json=body, headers=headers)
-        except HttpTimeoutError as exc:
-            raise UpstreamTimeoutError(str(exc)) from exc
-        except HttpClientError as exc:
-            raise UpstreamConnectionError(str(exc)) from exc
-
-        assert isinstance(resp, HttpResponse)
-        return UpstreamResponse(
-            status_code=resp.status_code,
-            body=resp.json() if resp.status_code < 400 else None,
-            raw_content=resp.content,
-        )
 
     async def close(self) -> None:
         """Close all pooled HTTP clients."""

--- a/tests/gateway/test_embeddings.py
+++ b/tests/gateway/test_embeddings.py
@@ -169,7 +169,7 @@ class TestEmbeddingUpstreamModel:
             headers=headers,
         )
         request.app.transport = MagicMock()
-        request.app.transport.send_passthrough = AsyncMock(
+        request.app.transport.send = AsyncMock(
             return_value=UpstreamResponse(
                 status_code=200,
                 body={"object": "list", "data": [], "model": "my-embed"},
@@ -180,7 +180,7 @@ class TestEmbeddingUpstreamModel:
         response = asyncio.run(handle_embeddings(request, config))
 
         assert response.status_code == 200
-        _, kwargs = request.app.transport.send_passthrough.call_args
+        _, kwargs = request.app.transport.send.call_args
         upstream_headers = kwargs["extra_headers"]
         assert upstream_headers["User-Agent"] == "codex-cli/1.2.3"
         assert upstream_headers["x-request-id"]

--- a/tests/gateway/test_proxy_transforms.py
+++ b/tests/gateway/test_proxy_transforms.py
@@ -102,9 +102,7 @@ def _make_mock_transport(
 ) -> MagicMock:
     """Create a mock transport that returns an UpstreamResponse."""
 
-    async def mock_send_request(
-        provider_info, target_provider, body, model, *, extra_headers=None
-    ):
+    async def mock_send(provider_info, url, body, *, extra_headers=None):
         if captured_body is not None:
             captured_body.update(body)
         return UpstreamResponse(
@@ -114,7 +112,7 @@ def _make_mock_transport(
         )
 
     transport = MagicMock()
-    transport.send_request = AsyncMock(side_effect=mock_send_request)
+    transport.send = AsyncMock(side_effect=mock_send)
     return transport
 
 


### PR DESCRIPTION
## Summary

Move URL construction and stream-flag injection from the transport layer up to the proxy/handler layer. Merge `send_request` + `send_passthrough` into a single `send(provider_info, url, body)`. Net -68 lines.

## What changed

**Transport layer** (`transport/http/transport.py`):
- Delete `_prepare_upstream` (bundled URL building, auth headers, stream flags)
- Replace `send_request` + `send_passthrough` → unified `send()`
- Simplify `send_streaming` to take explicit URL

**Proxy layer** (`proxy.py`):
- Add `_inject_stream_flags()` for provider-specific stream body mods
- Build upstream URL via `provider_info.upstream_url()` before calling `transport.send`

**Callers**: `embeddings.py`, `rerank.py` — trivial `send_passthrough` → `send` rename

**Protocol** (`_base.py`): `UpstreamTransport` updated to match

## Why

`_prepare_upstream` bundled three concerns (URL construction, auth headers, stream-flag injection) in the transport layer. Non-chat modalities couldn't use it, creating two parallel code paths. Now every handler constructs its own URL and the transport just sends.

## Behavior change

The unified `send()` applies `provider_info.timeout`, which the old `send_passthrough` did **not**. This means embeddings and rerank now honor per-provider timeout config (previously they only used the global default). This is an improvement, but worth noting: if a provider has a very short per-provider timeout configured, it will now affect embedding/rerank workloads too.

## Test plan

- [x] 2587 tests pass, lint clean
- [x] `grep -rn "send_request\|send_passthrough" src/` returns zero hits
- [x] Test mocks updated (`test_proxy_transforms.py`, `test_embeddings.py`)

Closes #514