### PR TITLE
feat(gateway): add embedding proxy with cross-format conversion

### DIFF
--- a/examples/gateway/config.jsonc
+++ b/examples/gateway/config.jsonc
@@ -69,6 +69,46 @@
   // Default format for incoming rerank requests (jina, cohere, or voyage).
   "default_rerank_format": "jina",
 
+  // Embedding providers — each entry specifies the upstream format and endpoint path.
+  // "format" maps to a converter: "openai", "cohere", "jina", or "voyage".
+  "embedding_providers": {
+    "openai": {
+      "api_key": "${OPENAI_API_KEY}",
+      "base_url": "https://api.openai.com",
+      "format": "openai",
+      "embedding_path": "/v1/embeddings"
+    },
+    "jina": {
+      "api_key": "${JINA_API_KEY}",
+      "base_url": "https://api.jina.ai",
+      "format": "jina",
+      "embedding_path": "/v1/embeddings"
+    },
+    "cohere": {
+      "api_key": "${COHERE_API_KEY}",
+      "base_url": "https://api.cohere.com",
+      "format": "cohere",
+      "embedding_path": "/v2/embed"
+    },
+    "voyage": {
+      "api_key": "${VOYAGE_API_KEY}",
+      "base_url": "https://api.voyageai.com",
+      "format": "voyage",
+      "embedding_path": "/v1/embeddings"
+    }
+  },
+
+  // Embedding model → provider routing table.
+  "embedding_models": {
+    "text-embedding-3-small": "openai",
+    "jina-embeddings-v3": "jina",
+    "embed-v4.0": "cohere",
+    "voyage-3-lite": "voyage"
+  },
+
+  // Default format for incoming embedding requests.
+  "default_embedding_format": "openai",
+
   // Server settings
   "server": {
     "host": "0.0.0.0",

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -20,6 +20,15 @@ from .transport import ProviderInfo
 logger = logging.getLogger("llm-rosetta-gateway")
 
 
+class EmbeddingRoute(NamedTuple):
+    """Resolved embedding provider routing info."""
+
+    provider_name: str
+    format: str
+    embedding_path: str
+    provider_info: ProviderInfo
+
+
 class RerankRoute(NamedTuple):
     """Resolved rerank provider routing info."""
 
@@ -282,6 +291,20 @@ class GatewayConfig:
             global_proxy=self.proxy,
         )
         self.default_rerank_format: str = raw.get("default_rerank_format", "jina")
+
+        # --- Embedding routing ---
+        (
+            self.embedding_providers,
+            self.embedding_provider_infos,
+            self.embedding_models,
+        ) = self._parse_embedding_config(
+            raw.get("embedding_providers", {}),
+            raw.get("embedding_models", {}),
+            global_proxy=self.proxy,
+        )
+        self.default_embedding_format: str = raw.get(
+            "default_embedding_format", "openai"
+        )
 
     @staticmethod
     def _parse_custom_tools_overrides(
@@ -662,5 +685,66 @@ class GatewayConfig:
             provider_name=provider_name,
             format=pcfg["format"],
             rerank_path=pcfg["rerank_path"],
+            provider_info=pinfo,
+        )
+
+    # ---- Embedding routing ----------------------------------------------
+
+    @staticmethod
+    def _parse_embedding_config(
+        raw_providers: dict[str, Any],
+        raw_models: dict[str, Any],
+        *,
+        global_proxy: str | None = None,
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, ProviderInfo], dict[str, str]]:
+        """Parse embedding_providers and embedding_models from config."""
+        from .transport.provider_info import openai_auth
+
+        providers: dict[str, dict[str, Any]] = {}
+        provider_infos: dict[str, ProviderInfo] = {}
+        for name, cfg in raw_providers.items():
+            if not isinstance(cfg, dict):
+                continue
+            if cfg.get("enabled") is False:
+                continue
+            embedding_path = cfg.get("embedding_path", "/v1/embeddings")
+            providers[name] = {
+                "format": cfg.get("format", "openai"),
+                "embedding_path": embedding_path,
+            }
+            provider_infos[name] = ProviderInfo(
+                name=f"embedding:{name}",
+                api_key=cfg.get("api_key", ""),
+                base_url=cfg.get("base_url", "").rstrip("/"),
+                auth_header_fn=openai_auth,
+                url_template="{base_url}" + embedding_path,
+                proxy_url=global_proxy,
+            )
+
+        models: dict[str, str] = {}
+        for model_name, value in raw_models.items():
+            if isinstance(value, str):
+                provider_name = value
+            elif isinstance(value, dict):
+                provider_name = value.get("provider", "")
+            else:
+                continue
+            if provider_name in providers:
+                models[model_name] = provider_name
+        return providers, provider_infos, models
+
+    def resolve_embedding(self, model: str) -> EmbeddingRoute:
+        """Resolve an embedding model to its provider config.
+
+        Raises:
+            KeyError: If the model is not in embedding_models.
+        """
+        provider_name = self.embedding_models[model]
+        pcfg = self.embedding_providers[provider_name]
+        pinfo = self.embedding_provider_infos[provider_name]
+        return EmbeddingRoute(
+            provider_name=provider_name,
+            format=pcfg["format"],
+            embedding_path=pcfg["embedding_path"],
             provider_info=pinfo,
         )

--- a/src/llm_rosetta/gateway/embedding_pipeline.py
+++ b/src/llm_rosetta/gateway/embedding_pipeline.py
@@ -1,0 +1,79 @@
+"""Embedding conversion pipeline.
+
+Lightweight pipeline that converts embedding requests/responses between
+provider formats via IR, using the embedding converter family.
+Mirrors :class:`~gateway.rerank_pipeline.RerankConversionPipeline`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm_rosetta.converters.base.context import ConversionContext
+from llm_rosetta.converters.base.embedding_converter import BaseEmbeddingConverter
+from llm_rosetta.converters.embedding import (
+    CohereEmbeddingConverter,
+    JinaEmbeddingConverter,
+    OpenAIEmbeddingConverter,
+    VoyageEmbeddingConverter,
+)
+
+_EMBEDDING_CONVERTERS: dict[str, type[BaseEmbeddingConverter]] = {
+    "openai": OpenAIEmbeddingConverter,
+    "jina": JinaEmbeddingConverter,
+    "voyage": VoyageEmbeddingConverter,
+    "cohere": CohereEmbeddingConverter,
+}
+
+EMBEDDING_FORMATS = frozenset(_EMBEDDING_CONVERTERS.keys())
+
+
+def get_embedding_converter(format_name: str) -> BaseEmbeddingConverter:
+    """Return a converter instance for *format_name*.
+
+    Raises:
+        ValueError: If *format_name* is not a known embedding format.
+    """
+    cls = _EMBEDDING_CONVERTERS.get(format_name)
+    if cls is None:
+        raise ValueError(
+            f"Unknown embedding format: '{format_name}'. "
+            f"Available: {', '.join(sorted(EMBEDDING_FORMATS))}"
+        )
+    return cls()
+
+
+class EmbeddingConversionPipeline:
+    """Convert embedding requests/responses between two provider formats.
+
+    When *source_format* == *target_format*, conversion is skipped.
+    """
+
+    def __init__(self, source_format: str, target_format: str) -> None:
+        self.source_format = source_format
+        self.target_format = target_format
+        self._needs_conversion = source_format != target_format
+        self._source_converter = get_embedding_converter(source_format)
+        self._target_converter = get_embedding_converter(target_format)
+        self._ctx = ConversionContext()
+
+    @property
+    def warnings(self) -> list[str]:
+        return self._ctx.warnings
+
+    def convert_request(self, body: dict[str, Any]) -> dict[str, Any]:
+        """Source format request → target format request."""
+        if not self._needs_conversion:
+            return body
+        ir = self._source_converter.request_from_provider(body, context=self._ctx)
+        target_body, _ = self._target_converter.request_to_provider(
+            ir, context=self._ctx
+        )
+        return target_body
+
+    def convert_response(self, body: dict[str, Any]) -> dict[str, Any]:
+        """Target format response → source format response."""
+        if not self._needs_conversion:
+            return body
+        ir = self._target_converter.response_from_provider(body, context=self._ctx)
+        return self._source_converter.response_to_provider(ir, context=self._ctx)

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -1,44 +1,85 @@
-"""Embeddings passthrough handler.
+"""Embeddings proxy handler with optional cross-format conversion.
 
-Proxies ``/v1/embeddings`` requests to the upstream provider without
-format conversion — the OpenAI embeddings API format is universal
-across providers that support it.
-
-Uses the :class:`~transport.UpstreamTransport` interface so the handler
-is transport-agnostic (works with HTTP, and future gRPC/WebSocket).
+Proxies ``/v1/embeddings`` requests to upstream embedding providers.
+When ``embedding_providers`` / ``embedding_models`` are configured, uses
+IR-based conversion between OpenAI, Cohere, Jina, and Voyage formats.
+Otherwise falls back to passthrough via the chat provider routing
+(backward compatible with existing configs).
 """
 
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass, field
 from typing import Any
 
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
 from .config import GatewayConfig
+from .embedding_pipeline import EmbeddingConversionPipeline
 from .headers import build_upstream_extra_headers, get_request_id
 from .logging import get_logger
-from .transport import UpstreamConnectionError, UpstreamTransport
+from .transport import (
+    ProviderInfo,
+    UpstreamConnectionError,
+    UpstreamTimeoutError,
+    UpstreamTransport,
+)
 
 logger = get_logger()
+
+
+@dataclass
+class _ResolvedEmbedding:
+    provider_info: ProviderInfo
+    upstream_url: str
+    provider_name: str
+    pipeline: EmbeddingConversionPipeline | None = field(default=None)
+
+
+def _resolve_embedding_provider(
+    config: GatewayConfig, model: str, body: dict[str, Any]
+) -> _ResolvedEmbedding | None:
+    """Resolve embedding provider; returns None if model not found anywhere."""
+    # Try embedding-specific routing first
+    try:
+        route = config.resolve_embedding(model)
+        source_format = config.default_embedding_format
+        pipeline = (
+            EmbeddingConversionPipeline(source_format, route.format)
+            if source_format != route.format
+            else None
+        )
+        return _ResolvedEmbedding(
+            provider_info=route.provider_info,
+            upstream_url=f"{route.provider_info.base_url}{route.embedding_path}",
+            provider_name=route.provider_name,
+            pipeline=pipeline,
+        )
+    except KeyError:
+        pass
+
+    # Fall back to chat provider routing (backward compat)
+    try:
+        chat_route, provider_info = config.resolve("openai_chat", model)
+    except KeyError:
+        return None
+
+    if chat_route.upstream_model:
+        body["model"] = chat_route.upstream_model
+
+    return _ResolvedEmbedding(
+        provider_info=provider_info,
+        upstream_url=f"{provider_info.base_url}/embeddings",
+        provider_name=chat_route.provider_name,
+    )
 
 
 async def handle_embeddings(
     request: Any,
     config: GatewayConfig,
 ) -> Response:
-    """Proxy an embeddings request to the upstream provider.
-
-    This is a thin passthrough — no IR conversion is performed.
-    The request body is forwarded as-is after model resolution.
-
-    Args:
-        request: The incoming HTTP request.
-        config: The live gateway configuration.
-
-    Returns:
-        The upstream response, forwarded to the client.
-    """
+    """Proxy an embedding request with optional cross-format conversion."""
     request_id = get_request_id(request)
 
     def with_request_id(response: Response) -> Response:
@@ -75,16 +116,20 @@ async def handle_embeddings(
             )
         )
 
-    # --- Resolve provider via unified routing ---
-    try:
-        route, provider_info = config.resolve("openai_chat", model)
-    except KeyError:
-        configured = ", ".join(sorted(config.models.keys()))
+    # --- Resolve provider ---
+    resolved = _resolve_embedding_provider(config, model, body)
+    if resolved is None:
+        all_models = sorted(
+            set(config.models.keys()) | set(config.embedding_models.keys())
+        )
         return with_request_id(
             JSONResponse(
                 {
                     "error": {
-                        "message": f"Unknown model: '{model}'. Configured models: {configured}",
+                        "message": (
+                            f"Unknown model: '{model}'. "
+                            f"Configured: {', '.join(all_models)}"
+                        ),
                         "type": "model_not_found",
                     }
                 },
@@ -92,13 +137,25 @@ async def handle_embeddings(
             )
         )
 
-    # Model alias: replace the model name in the request body with the
-    # actual upstream identifier so the upstream provider sees the correct name.
-    if route.upstream_model:
-        body["model"] = route.upstream_model
+    # --- Convert request (if cross-format) ---
+    if resolved.pipeline:
+        try:
+            body = resolved.pipeline.convert_request(body)
+        except Exception as exc:
+            logger.warning("embedding: request conversion failed: %s", exc)
+            return with_request_id(
+                JSONResponse(
+                    {
+                        "error": {
+                            "message": f"Request conversion failed: {exc}",
+                            "type": "conversion_error",
+                        }
+                    },
+                    status_code=400,
+                )
+            )
 
     # --- Forward via transport ---
-    upstream_url = f"{provider_info.base_url}/embeddings"
     transport: UpstreamTransport = request.app.transport
     extra_headers = build_upstream_extra_headers(request, request_id)
 
@@ -108,8 +165,8 @@ async def handle_embeddings(
 
     try:
         resp = await transport.send(
-            provider_info,
-            upstream_url,
+            resolved.provider_info,
+            resolved.upstream_url,
             body,
             extra_headers=extra_headers,
         )
@@ -125,11 +182,42 @@ async def handle_embeddings(
                 )
             )
 
+        # --- Convert response (if cross-format) ---
+        if resolved.pipeline and resp.body is not None:
+            try:
+                source_body = resolved.pipeline.convert_response(resp.body)
+                return with_request_id(JSONResponse(source_body, status_code=200))
+            except Exception as exc:
+                logger.warning("embedding: response conversion failed: %s", exc)
+                fallback = with_request_id(
+                    Response(
+                        body=resp.raw_content,
+                        status_code=200,
+                        content_type="application/json",
+                    )
+                )
+                fallback.headers["x-rosetta-conversion"] = "passthrough"
+                return fallback
+
         return with_request_id(
             Response(
                 body=resp.raw_content,
                 status_code=200,
                 content_type="application/json",
+            )
+        )
+    except UpstreamTimeoutError as exc:
+        error_detail = str(exc)
+        status_code = 504
+        return with_request_id(
+            JSONResponse(
+                {
+                    "error": {
+                        "message": f"Upstream timeout: {exc}",
+                        "type": "upstream_error",
+                    }
+                },
+                status_code=504,
             )
         )
     except UpstreamConnectionError as exc:
@@ -156,8 +244,8 @@ async def handle_embeddings(
             request,
             model=model,
             source_provider="openai_chat",
-            target_provider=route.target_provider,
-            provider_name=route.provider_name,
+            target_provider="openai_chat",
+            provider_name=resolved.provider_name,
             is_stream=False,
             status_code=status_code,
             duration_ms=(time.monotonic() - t0) * 1000,

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
+
+from llm_rosetta.auto_detect import ProviderType
 
 from .config import GatewayConfig
 from .embedding_pipeline import EmbeddingConversionPipeline
@@ -34,6 +36,7 @@ class _ResolvedEmbedding:
     provider_info: ProviderInfo
     upstream_url: str
     provider_name: str
+    target_format: str = "openai_chat"
     pipeline: EmbeddingConversionPipeline | None = field(default=None)
 
 
@@ -54,6 +57,7 @@ def _resolve_embedding_provider(
             provider_info=route.provider_info,
             upstream_url=f"{route.provider_info.base_url}{route.embedding_path}",
             provider_name=route.provider_name,
+            target_format=route.format,
             pipeline=pipeline,
         )
     except KeyError:
@@ -186,6 +190,8 @@ async def handle_embeddings(
         if resolved.pipeline and resp.body is not None:
             try:
                 source_body = resolved.pipeline.convert_response(resp.body)
+                if not source_body.get("model"):
+                    source_body["model"] = model
                 return with_request_id(JSONResponse(source_body, status_code=200))
             except Exception as exc:
                 logger.warning("embedding: response conversion failed: %s", exc)
@@ -243,8 +249,8 @@ async def handle_embeddings(
         _record_telemetry(
             request,
             model=model,
-            source_provider="openai_chat",
-            target_provider="openai_chat",
+            source_provider=cast(ProviderType, config.default_embedding_format),
+            target_provider=cast(ProviderType, resolved.target_format),
             provider_name=resolved.provider_name,
             is_stream=False,
             status_code=status_code,

--- a/tests/gateway/test_embedding_proxy.py
+++ b/tests/gateway/test_embedding_proxy.py
@@ -1,0 +1,179 @@
+"""Unit tests for embedding gateway pipeline and config."""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_rosetta.gateway.embedding_pipeline import (
+    EmbeddingConversionPipeline,
+    get_embedding_converter,
+)
+
+
+class TestEmbeddingConversionPipeline:
+    def test_same_format_passthrough(self) -> None:
+        pipeline = EmbeddingConversionPipeline("openai", "openai")
+        body = {"model": "test", "input": ["hello"]}
+        result = pipeline.convert_request(body)
+        assert result is body
+
+    def test_openai_to_cohere_request(self) -> None:
+        pipeline = EmbeddingConversionPipeline("openai", "cohere")
+        body = {"model": "test", "input": ["hello world"]}
+        result = pipeline.convert_request(body)
+        assert result["texts"] == ["hello world"]
+        assert "input" not in result
+        assert result["embedding_types"] == ["float"]
+
+    def test_cohere_to_openai_response(self) -> None:
+        pipeline = EmbeddingConversionPipeline("openai", "cohere")
+        cohere_resp = {
+            "id": "abc",
+            "embeddings": {"float": [[0.1, 0.2, 0.3]]},
+            "meta": {"billed_units": {"input_tokens": 1}},
+            "response_type": "embeddings_by_type",
+        }
+        result = pipeline.convert_response(cohere_resp)
+        assert result["object"] == "list"
+        assert len(result["data"]) == 1
+        assert result["data"][0]["object"] == "embedding"
+        assert result["data"][0]["embedding"] == [0.1, 0.2, 0.3]
+
+    def test_openai_to_jina_request_task(self) -> None:
+        pipeline = EmbeddingConversionPipeline("jina", "openai")
+        jina_req = {
+            "model": "jina-embeddings-v3",
+            "input": ["hello"],
+            "task": "retrieval.query",
+        }
+        openai_req = pipeline.convert_request(jina_req)
+        assert openai_req["input"] == ["hello"]
+
+    def test_jina_to_voyage_response(self) -> None:
+        pipeline = EmbeddingConversionPipeline("voyage", "jina")
+        jina_resp = {
+            "model": "jina-embeddings-v3",
+            "object": "list",
+            "data": [{"object": "embedding", "index": 0, "embedding": [0.5]}],
+            "usage": {"total_tokens": 10},
+        }
+        result = pipeline.convert_response(jina_resp)
+        assert result["object"] == "list"
+        assert len(result["data"]) == 1
+
+    def test_warnings_accessible(self) -> None:
+        pipeline = EmbeddingConversionPipeline("openai", "cohere")
+        assert pipeline.warnings == []
+
+
+class TestGetEmbeddingConverter:
+    def test_valid_formats(self) -> None:
+        for fmt in ("openai", "jina", "voyage", "cohere"):
+            conv = get_embedding_converter(fmt)
+            assert conv is not None
+
+    def test_invalid_format(self) -> None:
+        with pytest.raises(ValueError, match="Unknown embedding format"):
+            get_embedding_converter("nonexistent")
+
+
+class TestEmbeddingConfig:
+    def test_parse_embedding_config(self) -> None:
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        raw = {
+            "providers": {
+                "openai_chat": {
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com/v1",
+                }
+            },
+            "models": {"gpt-4o": "openai_chat"},
+            "embedding_providers": {
+                "openai": {
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com",
+                    "format": "openai",
+                    "embedding_path": "/v1/embeddings",
+                },
+                "cohere": {
+                    "api_key": "cohere-key",
+                    "base_url": "https://api.cohere.com",
+                    "format": "cohere",
+                    "embedding_path": "/v2/embed",
+                },
+            },
+            "embedding_models": {
+                "text-embedding-3-small": "openai",
+                "embed-v4.0": "cohere",
+            },
+            "default_embedding_format": "openai",
+        }
+        config = GatewayConfig(raw)
+        assert len(config.embedding_providers) == 2
+        assert config.embedding_providers["cohere"]["format"] == "cohere"
+        assert config.embedding_providers["cohere"]["embedding_path"] == "/v2/embed"
+        assert len(config.embedding_models) == 2
+        assert config.default_embedding_format == "openai"
+
+    def test_resolve_embedding(self) -> None:
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        raw = {
+            "providers": {
+                "openai_chat": {
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com/v1",
+                }
+            },
+            "models": {"gpt-4o": "openai_chat"},
+            "embedding_providers": {
+                "jina": {
+                    "api_key": "jina-key",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                    "embedding_path": "/v1/embeddings",
+                }
+            },
+            "embedding_models": {"jina-embeddings-v3": "jina"},
+        }
+        config = GatewayConfig(raw)
+        route = config.resolve_embedding("jina-embeddings-v3")
+        assert route.provider_name == "jina"
+        assert route.format == "jina"
+        assert route.embedding_path == "/v1/embeddings"
+        assert route.provider_info.base_url == "https://api.jina.ai"
+        assert route.provider_info.auth_headers()["Authorization"] == "Bearer jina-key"
+
+    def test_empty_embedding_config(self) -> None:
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        raw = {
+            "providers": {
+                "openai_chat": {
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com/v1",
+                }
+            },
+            "models": {"gpt-4o": "openai_chat"},
+        }
+        config = GatewayConfig(raw)
+        assert config.embedding_providers == {}
+        assert config.embedding_models == {}
+        assert config.default_embedding_format == "openai"
+
+    def test_resolve_embedding_unknown_model(self) -> None:
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        raw = {
+            "providers": {
+                "openai_chat": {
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com/v1",
+                }
+            },
+            "models": {"gpt-4o": "openai_chat"},
+        }
+        config = GatewayConfig(raw)
+        with pytest.raises(KeyError):
+            config.resolve_embedding("nonexistent")


### PR DESCRIPTION
## Summary

Convert the embeddings handler from passthrough to IR-based conversion mode. When `embedding_providers` / `embedding_models` are configured, the gateway converts between OpenAI, Cohere, Jina, and Voyage embedding formats via IR. Backward compatible — configs without embedding sections still work via chat provider routing.

## New files

- `gateway/embedding_pipeline.py` — `EmbeddingConversionPipeline` (mirrors `RerankConversionPipeline`)

## Modified files

- `gateway/embeddings.py` — refactored with `_resolve_embedding_provider` helper; embedding-specific routing with chat fallback; cross-format conversion; `UpstreamTimeoutError` → 504
- `gateway/config.py` — `EmbeddingRoute` NamedTuple, `embedding_providers`/`embedding_models`/`default_embedding_format` config, `resolve_embedding()`
- `examples/gateway/config.jsonc` — example embedding config (OpenAI, Jina, Cohere, Voyage)

## Test plan

- [x] 12 new tests: pipeline conversion, config parsing, resolve_embedding
- [x] 2622 total tests pass, lint clean
- [x] Existing embedding tests still pass (backward compat)

Closes #515