### PR TITLE
feat: ConversionPipeline passthrough mode, converter caching, fidelity checker

### DIFF
--- a/src/llm_rosetta/auto_detect.py
+++ b/src/llm_rosetta/auto_detect.py
@@ -129,22 +129,28 @@ def detect_provider(body: dict[str, Any]) -> ProviderType | None:
     return "openai_chat"
 
 
+_converter_cache: dict[str, Any] = {}
+
+
 def get_converter_for_provider(provider: str):
     """Get the corresponding converter for a provider type or shim name.
 
-    Accepts both base converter types (e.g. ``"openai_chat"``) and
-    registered shim names (e.g. ``"deepseek"``).  Shim names are
-    resolved to their base converter type via the shim registry.
+    Converter instances are cached — the same object is returned for the
+    same resolved base provider.  This is safe because converters are
+    stateless (all per-request state lives in ``ConversionContext``).
 
     Args:
         provider: Provider type string or registered shim name.
 
     Returns:
-        Corresponding converter instance.
+        Corresponding converter instance (cached).
 
     Raises:
         ValueError: If the provider is not a known type or shim name.
     """
+    if provider in _converter_cache:
+        return _converter_cache[provider]
+
     from .converters.anthropic import AnthropicConverter
     from .converters.google_genai import GoogleConverter
     from .converters.openai_chat import OpenAIChatConverter
@@ -161,12 +167,17 @@ def get_converter_for_provider(provider: str):
 
     # Direct match against base converter types
     if provider in converter_map:
-        return converter_map[provider]()
+        instance = converter_map[provider]()
+        _converter_cache[provider] = instance
+        return instance
 
     # Resolve through shim registry
     base = resolve_base(provider)
     if base in converter_map:
-        return converter_map[base]()
+        instance = converter_map[base]()
+        _converter_cache[provider] = instance
+        _converter_cache[base] = instance
+        return instance
 
     raise ValueError(f"Unsupported provider: {provider}")
 

--- a/src/llm_rosetta/fidelity.py
+++ b/src/llm_rosetta/fidelity.py
@@ -1,0 +1,417 @@
+"""Round-trip fidelity checker for same-format conversion.
+
+Compares an original request/response body against its IR round-tripped
+version to detect information loss.  Two modes:
+
+- **critical**: check only fields known to cause breakage (fast, ~0.01ms)
+- **full**: canonical JSON comparison of entire body (~1ms for 50KB)
+
+Usage::
+
+    checker = FidelityChecker(mode="critical")
+    diffs = checker.compare_request(original, roundtripped)
+    if diffs:
+        logger.warning("Round-trip fidelity loss: %s", diffs)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+FidelityMode = Literal["critical", "full"]
+
+
+# ============================================================================
+# Critical field paths — known fragile spots in round-trips
+# ============================================================================
+
+# Request fields that converters may alter
+_COMMON_REQUEST_PATHS: list[str] = [
+    "model",
+    "stream",
+]
+
+_COMMON_RESPONSE_PATHS: list[str] = [
+    "id",
+    "model",
+    "usage",
+]
+
+_CRITICAL_REQUEST_BY_FORMAT: dict[str, list[str]] = {
+    "openai_chat": [
+        "max_tokens",
+        "max_completion_tokens",
+        "tools.*.type",
+        "tools.*.function.name",
+        "tool_choice",
+        "messages.*.role",
+        "messages.*.content.*.type",
+        "messages.*.content.*.tool_call_id",
+        "messages.*.tool_calls.*.type",
+        "messages.*.tool_calls.*.function.name",
+    ],
+    "anthropic": [
+        "max_tokens",
+        "system",
+        "messages.*.role",
+        "messages.*.content.*.type",
+        "messages.*.content.*.tool_use_id",
+        "tools.*.name",
+        "tool_choice.type",
+    ],
+    "openai_responses": [
+        "input.*.type",
+        "input.*.role",
+        "input.*.content.*.type",
+        "input.*.call_id",
+        "input.*.name",
+        "input.*.output",
+        "tools.*.type",
+        "tools.*.name",
+    ],
+    "google": [
+        "contents.*.role",
+        "contents.*.parts.*.text",
+        "contents.*.parts.*.functionCall.name",
+        "contents.*.parts.*.functionResponse.name",
+        "tools.*.functionDeclarations.*.name",
+        "systemInstruction.parts.*.text",
+        "generationConfig.maxOutputTokens",
+        "generationConfig.temperature",
+    ],
+}
+
+_CRITICAL_RESPONSE_BY_FORMAT: dict[str, list[str]] = {
+    "openai_chat": [
+        "object",
+        "choices.*.finish_reason",
+        "choices.*.message.role",
+        "choices.*.message.content.*.type",
+        "choices.*.message.tool_calls.*.type",
+        "choices.*.message.tool_calls.*.id",
+        "choices.*.message.tool_calls.*.function.name",
+    ],
+    "anthropic": [
+        "type",
+        "stop_reason",
+        "content.*.type",
+        "content.*.id",
+        "content.*.name",
+        "content.*.tool_use_id",
+    ],
+    "openai_responses": [
+        "object",
+        "status",
+        "output.*.type",
+        "output.*.id",
+        "output.*.content.*.type",
+        "output.*.call_id",
+        "output.*.name",
+        "output.*.status",
+    ],
+    "google": [
+        "candidates.*.content.role",
+        "candidates.*.content.parts.*.text",
+        "candidates.*.content.parts.*.functionCall.name",
+        "candidates.*.finishReason",
+        "usageMetadata.promptTokenCount",
+        "usageMetadata.candidatesTokenCount",
+        "usageMetadata.totalTokenCount",
+    ],
+}
+
+
+def _get_critical_paths(
+    format_name: str | None,
+    common: list[str],
+    by_format: dict[str, list[str]],
+) -> list[str]:
+    """Return critical paths for a specific format, or all if format is None."""
+    if format_name is not None and format_name in by_format:
+        return common + by_format[format_name]
+    # Unknown format or None: check all paths (union)
+    all_paths = list(common)
+    for paths in by_format.values():
+        all_paths.extend(paths)
+    return all_paths
+
+
+# ============================================================================
+# Diff result
+# ============================================================================
+
+
+@dataclass
+class FidelityDiff:
+    """A single field-level difference found during fidelity comparison."""
+
+    path: str
+    original: Any = field(repr=False, default=None)
+    roundtripped: Any = field(repr=False, default=None)
+    kind: str = ""  # "missing", "added", "changed", "type_changed"
+
+    def __str__(self) -> str:
+        if self.kind == "missing":
+            return f"{self.path}: missing after round-trip"
+        if self.kind == "added":
+            return f"{self.path}: added by round-trip"
+        if self.kind == "type_changed":
+            return (
+                f"{self.path}: type changed "
+                f"{type(self.original).__name__} → {type(self.roundtripped).__name__}"
+            )
+        return f"{self.path}: changed"
+
+
+# ============================================================================
+# Path extraction
+# ============================================================================
+
+
+def _get_at_path(obj: Any, segments: list[str]) -> list[tuple[str, Any]]:
+    """Extract values at a dotted path with ``*`` wildcard for arrays.
+
+    Returns list of (resolved_path, value) pairs.
+    """
+    if not segments:
+        return [("", obj)]
+
+    head, *rest = segments
+
+    if head == "*":
+        if not isinstance(obj, list):
+            return []
+        results = []
+        for i, item in enumerate(obj):
+            for sub_path, val in _get_at_path(item, rest):
+                full = f"[{i}]{('.' + sub_path) if sub_path else ''}"
+                results.append((full, val))
+        return results
+
+    if isinstance(obj, dict) and head in obj:
+        results = []
+        for sub_path, val in _get_at_path(obj[head], rest):
+            full = f"{head}{('.' + sub_path) if sub_path else ''}"
+            results.append((full, val))
+        return results
+
+    return []
+
+
+def _extract_field(obj: Any, path: str) -> list[tuple[str, Any]]:
+    """Extract all values matching a dotted path pattern."""
+    segments = path.split(".")
+    return _get_at_path(obj, segments)
+
+
+# ============================================================================
+# Comparison logic
+# ============================================================================
+
+
+def _compare_critical(
+    original: dict[str, Any],
+    roundtripped: dict[str, Any],
+    paths: list[str],
+) -> list[FidelityDiff]:
+    """Compare only critical field paths between two dicts."""
+    diffs: list[FidelityDiff] = []
+
+    for path_pattern in paths:
+        orig_values = dict(_extract_field(original, path_pattern))
+        rt_values = dict(_extract_field(roundtripped, path_pattern))
+
+        all_paths = set(orig_values.keys()) | set(rt_values.keys())
+        for resolved in sorted(all_paths):
+            full_path = f"{path_pattern}→{resolved}" if resolved else path_pattern
+            if resolved not in orig_values:
+                diffs.append(
+                    FidelityDiff(
+                        path=full_path,
+                        roundtripped=rt_values[resolved],
+                        kind="added",
+                    )
+                )
+            elif resolved not in rt_values:
+                diffs.append(
+                    FidelityDiff(
+                        path=full_path,
+                        original=orig_values[resolved],
+                        kind="missing",
+                    )
+                )
+            else:
+                ov, rv = orig_values[resolved], rt_values[resolved]
+                if type(ov) is not type(rv):
+                    diffs.append(
+                        FidelityDiff(
+                            path=full_path,
+                            original=ov,
+                            roundtripped=rv,
+                            kind="type_changed",
+                        )
+                    )
+                elif ov != rv:
+                    diffs.append(
+                        FidelityDiff(
+                            path=full_path,
+                            original=ov,
+                            roundtripped=rv,
+                            kind="changed",
+                        )
+                    )
+
+    return diffs
+
+
+def _diff_recursive(
+    original: Any,
+    roundtripped: Any,
+    path: str,
+    diffs: list[FidelityDiff],
+) -> None:
+    """Recursively compare two values, reporting leaf-level differences."""
+    if type(original) is not type(roundtripped):
+        diffs.append(
+            FidelityDiff(
+                path=path,
+                original=original,
+                roundtripped=roundtripped,
+                kind="type_changed",
+            )
+        )
+        return
+
+    if isinstance(original, dict):
+        all_keys = set(original.keys()) | set(roundtripped.keys())
+        for key in sorted(all_keys):
+            child_path = f"{path}.{key}" if path else key
+            if key not in original:
+                diffs.append(
+                    FidelityDiff(
+                        path=child_path,
+                        roundtripped=roundtripped[key],
+                        kind="added",
+                    )
+                )
+            elif key not in roundtripped:
+                diffs.append(
+                    FidelityDiff(
+                        path=child_path,
+                        original=original[key],
+                        kind="missing",
+                    )
+                )
+            else:
+                _diff_recursive(original[key], roundtripped[key], child_path, diffs)
+        return
+
+    if isinstance(original, list):
+        for i in range(max(len(original), len(roundtripped))):
+            child_path = f"{path}[{i}]"
+            if i >= len(original):
+                diffs.append(
+                    FidelityDiff(
+                        path=child_path,
+                        roundtripped=roundtripped[i],
+                        kind="added",
+                    )
+                )
+            elif i >= len(roundtripped):
+                diffs.append(
+                    FidelityDiff(
+                        path=child_path,
+                        original=original[i],
+                        kind="missing",
+                    )
+                )
+            else:
+                _diff_recursive(original[i], roundtripped[i], child_path, diffs)
+        return
+
+    # Leaf comparison
+    if original != roundtripped:
+        diffs.append(
+            FidelityDiff(
+                path=path,
+                original=original,
+                roundtripped=roundtripped,
+                kind="changed",
+            )
+        )
+
+
+def _compare_full(
+    original: dict[str, Any],
+    roundtripped: dict[str, Any],
+) -> list[FidelityDiff]:
+    """Full recursive leaf-level diff."""
+    diffs: list[FidelityDiff] = []
+    _diff_recursive(original, roundtripped, "", diffs)
+    return diffs
+
+
+# ============================================================================
+# FidelityChecker
+# ============================================================================
+
+
+class FidelityChecker:
+    """Compare original and round-tripped bodies for fidelity loss.
+
+    Args:
+        mode: ``"critical"`` checks only format-specific fragile fields
+            (~0.01ms). ``"full"`` does recursive leaf-level diff (~1ms
+            for 50KB).
+        format_name: API format to check against (``"openai_chat"``,
+            ``"anthropic"``, ``"openai_responses"``).  When ``None``,
+            checks all formats' paths (slower but safe when format is
+            unknown).
+    """
+
+    def __init__(
+        self,
+        mode: FidelityMode = "critical",
+        format_name: str | None = None,
+    ) -> None:
+        self.mode = mode
+        self.format_name = format_name
+
+    def compare_request(
+        self,
+        original: dict[str, Any],
+        roundtripped: dict[str, Any],
+    ) -> list[FidelityDiff]:
+        """Compare an original request body against its round-tripped version."""
+        if self.mode == "critical":
+            paths = _get_critical_paths(
+                self.format_name, _COMMON_REQUEST_PATHS, _CRITICAL_REQUEST_BY_FORMAT
+            )
+            return _compare_critical(original, roundtripped, paths)
+        return _compare_full(original, roundtripped)
+
+    def compare_response(
+        self,
+        original: dict[str, Any],
+        roundtripped: dict[str, Any],
+    ) -> list[FidelityDiff]:
+        """Compare an original response body against its round-tripped version."""
+        if self.mode == "critical":
+            paths = _get_critical_paths(
+                self.format_name, _COMMON_RESPONSE_PATHS, _CRITICAL_RESPONSE_BY_FORMAT
+            )
+            return _compare_critical(original, roundtripped, paths)
+        return _compare_full(original, roundtripped)
+
+    def compare(
+        self,
+        original: dict[str, Any],
+        roundtripped: dict[str, Any],
+        *,
+        direction: Literal["request", "response"] = "request",
+    ) -> list[FidelityDiff]:
+        """Compare bodies in the specified direction."""
+        if direction == "request":
+            return self.compare_request(original, roundtripped)
+        return self.compare_response(original, roundtripped)

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal, Protocol, runtime_checkable
 
 from llm_rosetta.capabilities import (
     enforce_custom_tools,
@@ -166,6 +166,16 @@ class ConversionError(Exception):
 _EMPTY_TRANSFORMS: tuple[Transform, ...] = ()
 
 
+@runtime_checkable
+class StreamProcessorProtocol(Protocol):
+    """Shared interface for StreamProcessor and PassthroughStreamProcessor."""
+
+    @property
+    def source_context(self) -> Any: ...
+
+    def process_chunk(self, chunk: dict[str, Any]) -> list[dict[str, Any]]: ...
+
+
 class ConversionPipeline:
     """Orchestrates format conversion between LLM API standards.
 
@@ -209,6 +219,8 @@ class ConversionPipeline:
         reasoning_config_override: dict[str, Any] | None = None,
         supports_custom_tools: bool = False,
         hoist_system_messages: bool = True,
+        force_conversion: bool = True,
+        fidelity_mode: Literal["critical", "full"] | None = None,
     ) -> None:
         from llm_rosetta import get_converter_for_provider
 
@@ -220,6 +232,15 @@ class ConversionPipeline:
         self._reasoning_config_override = reasoning_config_override
         self._supports_custom_tools = supports_custom_tools
         self._hoist_system_messages = hoist_system_messages
+
+        self._passthrough = source_provider == target_provider and not force_conversion
+        self._fidelity: Any = None
+        if self._passthrough and fidelity_mode is not None:
+            from llm_rosetta.fidelity import FidelityChecker
+
+            self._fidelity = FidelityChecker(
+                mode=fidelity_mode, format_name=source_provider
+            )
 
         self._source_converter = get_converter_for_provider(source_provider)
         self._target_converter = get_converter_for_provider(target_provider)
@@ -314,6 +335,29 @@ class ConversionPipeline:
         """
         return self._profile
 
+    def _run_fidelity_check(self, body: dict[str, Any], *, direction: str) -> None:
+        """Shadow round-trip and compare for fidelity monitoring."""
+        try:
+            ctx = ConversionContext()
+            ctx.options["metadata_mode"] = "preserve"
+            if direction == "request":
+                ir = self._source_converter.request_from_provider(body, context=ctx)
+                rt, _ = self._target_converter.request_to_provider(ir, context=ctx)
+            else:
+                ir = self._target_converter.response_from_provider(body, context=ctx)
+                rt = self._source_converter.response_to_provider(ir, context=ctx)
+            diffs = self._fidelity.compare(body, rt, direction=direction)
+            if diffs:
+                logger.warning(
+                    "Fidelity loss in %s round-trip (%s→%s): %s",
+                    direction,
+                    self._source_provider,
+                    self._target_provider,
+                    "; ".join(str(d) for d in diffs[:10]),
+                )
+        except Exception:
+            logger.debug("Fidelity check failed", exc_info=True)
+
     def convert_request(
         self,
         body: dict[str, Any],
@@ -347,6 +391,25 @@ class ConversionPipeline:
 
         # Setup context
         ctx = ConversionContext()
+        self._ctx = ctx
+
+        # Same-format short-circuit: skip IR round-trip, apply only shim
+        # body-level transforms.  This avoids lossy round-trips when
+        # source == target (e.g. Anthropic → gateway → Anthropic upstream).
+        if self._passthrough:
+            t0 = time.perf_counter()
+            result = body
+            if self._post_ir_transforms:
+                result = apply_transforms(self._post_ir_transforms, dict(result))
+            # No IR produced in passthrough mode
+            self._ir_request = {}
+            # Shadow round-trip for fidelity monitoring
+            if self._fidelity is not None:
+                self._run_fidelity_check(body, direction="request")
+            self._profile["request_conversion_ms"] = round(
+                (time.perf_counter() - t0) * 1000, 2
+            )
+            return result
         ctx.options["metadata_mode"] = "preserve"
         if self._target_provider == "google":
             ctx.options["output_format"] = "rest"
@@ -358,7 +421,6 @@ class ConversionPipeline:
             model=self._upstream_model or body.get("model"),
             config_override=self._reasoning_config_override,
         )
-        self._ctx = ctx
 
         t_total = time.perf_counter()
 
@@ -458,6 +520,20 @@ class ConversionPipeline:
             RuntimeError: If called before :meth:`convert_request`.
         """
         ctx = self.context  # raises RuntimeError if not ready
+
+        # Same-format short-circuit: skip IR round-trip for response too
+        if self._passthrough:
+            t0 = time.perf_counter()
+            result = upstream_response
+            if self._pre_ir_transforms:
+                result = apply_transforms(self._pre_ir_transforms, dict(result))
+            if self._fidelity is not None:
+                self._run_fidelity_check(upstream_response, direction="response")
+            self._profile["response_conversion_ms"] = round(
+                (time.perf_counter() - t0) * 1000, 2
+            )
+            return result
+
         t_total = time.perf_counter()
 
         # Phase 4a: Body-level shim pre_ir_transforms
@@ -515,7 +591,7 @@ class ConversionPipeline:
         self,
         *,
         on_ir_event: Callable[[dict[str, Any]], None] | None = None,
-    ) -> StreamProcessor:
+    ) -> StreamProcessorProtocol:
         """Create a stateful processor for streaming response chunks.
 
         Must be called after :meth:`convert_request`.  The returned
@@ -536,6 +612,12 @@ class ConversionPipeline:
             RuntimeError: If called before :meth:`convert_request`.
         """
         ctx = self.context  # raises RuntimeError if not ready
+
+        # Same-format short-circuit: return a passthrough processor
+        if self._passthrough:
+            return PassthroughStreamProcessor(
+                pre_ir_transforms=self._pre_ir_transforms,
+            )
 
         from_ctx = self._target_converter.create_stream_context()
         to_ctx = self._source_converter.create_stream_context()
@@ -569,6 +651,61 @@ class ConversionPipeline:
 # ---------------------------------------------------------------------------
 # StreamProcessor
 # ---------------------------------------------------------------------------
+
+
+class PassthroughStreamProcessor:
+    """No-op stream processor for same-format pipelines.
+
+    Forwards upstream chunks directly, applying only shim body-level
+    transforms.  Has a dummy ``source_context`` so the gateway's
+    terminal-event logic doesn't crash.
+    """
+
+    def __init__(
+        self,
+        *,
+        pre_ir_transforms: tuple[Transform, ...] = (),
+    ) -> None:
+        self._pre_ir_transforms = pre_ir_transforms
+        self._ctx = self._PassthroughCtx()
+
+    @property
+    def source_context(self) -> Any:
+        """Minimal context for passthrough — enough for gateway error handling."""
+        return self._ctx
+
+    class _PassthroughCtx:
+        def __init__(self) -> None:
+            self.is_ended = False
+            self.response_id = ""
+            self.options: dict[str, Any] = {}
+
+        def mark_ended(self) -> None:
+            self.is_ended = True
+
+        @property
+        def next_sequence_number(self) -> None:
+            return None
+
+        @property
+        def outbound_response_id(self) -> str:
+            return self.response_id
+
+    _TERMINAL_TYPES = frozenset(
+        {"response.completed", "response.failed", "message_stop"}
+    )
+
+    def process_chunk(self, chunk: dict[str, Any]) -> list[dict[str, Any]]:
+        if self._pre_ir_transforms:
+            chunk = apply_transforms(self._pre_ir_transforms, chunk)
+        # Detect terminal events so source_context.is_ended reflects reality
+        ctype = chunk.get("type", "")
+        choices = chunk.get("choices", [])
+        if ctype in self._TERMINAL_TYPES or (
+            choices and choices[0].get("finish_reason") is not None
+        ):
+            self._ctx.mark_ended()
+        return [chunk]
 
 
 class StreamProcessor:

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -293,3 +293,8 @@ def resolve_base(name: str) -> str:
 def _reset_registry() -> None:
     """Clear the registry.  Intended for testing only."""
     _SHIM_REGISTRY.clear()
+    # Also clear the converter cache since shim resolution may have
+    # cached converters for names that are now unregistered.
+    from llm_rosetta.auto_detect import _converter_cache
+
+    _converter_cache.clear()

--- a/tests/test_passthrough_and_fidelity.py
+++ b/tests/test_passthrough_and_fidelity.py
@@ -1,0 +1,249 @@
+"""Tests for ConversionPipeline passthrough mode and FidelityChecker."""
+
+from __future__ import annotations
+
+from llm_rosetta.fidelity import FidelityChecker
+from llm_rosetta.pipeline import ConversionPipeline
+
+
+# ============================================================================
+# Passthrough mode tests
+# ============================================================================
+
+
+class TestPassthroughMode:
+    def test_same_format_passthrough_returns_body_identity(self) -> None:
+        pipeline = ConversionPipeline(
+            "openai_chat", "openai_chat", force_conversion=False
+        )
+        body = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        result = pipeline.convert_request(body)
+        assert result is body
+
+    def test_same_format_response_passthrough(self) -> None:
+        pipeline = ConversionPipeline("anthropic", "anthropic", force_conversion=False)
+        body = {
+            "model": "claude-sonnet-4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+        }
+        pipeline.convert_request(body)
+
+        response = {
+            "id": "msg_123",
+            "type": "message",
+            "content": [{"type": "text", "text": "hello"}],
+            "stop_reason": "end_turn",
+        }
+        result = pipeline.convert_response(response)
+        assert result is response
+
+    def test_force_conversion_true_does_roundtrip(self) -> None:
+        pipeline = ConversionPipeline(
+            "openai_chat", "openai_chat", force_conversion=True
+        )
+        body = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        result = pipeline.convert_request(body)
+        # Round-trip produces a new dict (not the same object)
+        assert result is not body
+        assert result["model"] == "gpt-4o"
+
+    def test_different_format_always_converts(self) -> None:
+        pipeline = ConversionPipeline(
+            "openai_chat", "anthropic", force_conversion=False
+        )
+        body = {
+            "model": "claude-sonnet-4",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        result = pipeline.convert_request(body)
+        # Cross-format produces Anthropic-format output
+        assert "max_tokens" in result or "messages" in result
+        assert result is not body
+
+    def test_passthrough_stream_processor(self) -> None:
+        pipeline = ConversionPipeline(
+            "openai_chat", "openai_chat", force_conversion=False
+        )
+        pipeline.convert_request(
+            {"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]}
+        )
+        processor = pipeline.create_stream_processor()
+        chunk = {"choices": [{"delta": {"content": "hello"}}]}
+        result = processor.process_chunk(chunk)
+        assert result == [chunk]
+
+    def test_passthrough_profile(self) -> None:
+        pipeline = ConversionPipeline(
+            "openai_chat", "openai_chat", force_conversion=False
+        )
+        pipeline.convert_request(
+            {"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]}
+        )
+        assert "request_conversion_ms" in pipeline.profile
+
+    def test_passthrough_ir_request_empty(self) -> None:
+        pipeline = ConversionPipeline(
+            "openai_chat", "openai_chat", force_conversion=False
+        )
+        pipeline.convert_request(
+            {"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]}
+        )
+        assert pipeline.ir_request == {}
+
+
+# ============================================================================
+# Converter caching tests
+# ============================================================================
+
+
+class TestConverterCaching:
+    def test_same_provider_returns_same_instance(self) -> None:
+        from llm_rosetta.auto_detect import get_converter_for_provider
+
+        c1 = get_converter_for_provider("openai_chat")
+        c2 = get_converter_for_provider("openai_chat")
+        assert c1 is c2
+
+    def test_shim_and_base_share_instance(self) -> None:
+        from llm_rosetta.auto_detect import _converter_cache
+
+        # After getting via a base name, cache should have it
+        from llm_rosetta.auto_detect import get_converter_for_provider
+
+        get_converter_for_provider("anthropic")
+        assert "anthropic" in _converter_cache
+
+
+# ============================================================================
+# FidelityChecker tests
+# ============================================================================
+
+
+class TestFidelityCheckerCritical:
+    def setup_method(self) -> None:
+        self.checker = FidelityChecker(mode="critical")
+
+    def test_identical_bodies_no_diff(self) -> None:
+        body = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        assert self.checker.compare_request(body, body) == []
+
+    def test_missing_field_detected(self) -> None:
+        original = {
+            "model": "gpt-4o",
+            "tools": [{"type": "function", "function": {"name": "get_weather"}}],
+        }
+        roundtripped = {"model": "gpt-4o"}
+        diffs = self.checker.compare_request(original, roundtripped)
+        assert any(d.kind == "missing" for d in diffs)
+
+    def test_changed_field_detected(self) -> None:
+        original = {"model": "gpt-4o", "stream": True}
+        roundtripped = {"model": "gpt-4o", "stream": False}
+        diffs = self.checker.compare_request(original, roundtripped)
+        assert any(d.kind == "changed" and "stream" in d.path for d in diffs)
+
+    def test_response_stop_reason_diff(self) -> None:
+        original = {"stop_reason": "end_turn", "content": [{"type": "text"}]}
+        roundtripped = {"stop_reason": "stop", "content": [{"type": "text"}]}
+        diffs = self.checker.compare_response(original, roundtripped)
+        assert any("stop_reason" in d.path for d in diffs)
+
+
+class TestFidelityCheckerFull:
+    def setup_method(self) -> None:
+        self.checker = FidelityChecker(mode="full")
+
+    def test_identical_bodies(self) -> None:
+        body = {"a": 1, "b": [2, 3]}
+        assert self.checker.compare_request(body, body) == []
+
+    def test_nested_diff_has_full_path(self) -> None:
+        original = {"messages": [{"role": "user", "content": [{"type": "text"}]}]}
+        roundtripped = {"messages": [{"role": "user", "content": [{"type": "image"}]}]}
+        diffs = self.checker.compare_request(original, roundtripped)
+        assert len(diffs) == 1
+        assert "messages[0].content[0].type" in diffs[0].path
+
+    def test_added_field(self) -> None:
+        original = {"a": 1}
+        roundtripped = {"a": 1, "b": 2}
+        diffs = self.checker.compare_request(original, roundtripped)
+        assert any(d.kind == "added" and d.path == "b" for d in diffs)
+
+    def test_type_change(self) -> None:
+        original = {"x": "hello"}
+        roundtripped = {"x": 123}
+        diffs = self.checker.compare_request(original, roundtripped)
+        assert any(d.kind == "type_changed" for d in diffs)
+
+    def test_list_length_diff(self) -> None:
+        original = {"items": [1, 2]}
+        roundtripped = {"items": [1, 2, 3]}
+        diffs = self.checker.compare_request(original, roundtripped)
+        assert any(d.kind == "added" and "[2]" in d.path for d in diffs)
+
+
+# ============================================================================
+# Fidelity integration in pipeline
+# ============================================================================
+
+
+class TestFidelityIntegration:
+    def test_fidelity_check_runs_in_passthrough(self) -> None:
+        pipeline = ConversionPipeline(
+            "openai_chat",
+            "openai_chat",
+            force_conversion=False,
+            fidelity_mode="critical",
+        )
+        body = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        result = pipeline.convert_request(body)
+        # Body is still passthrough (identity)
+        assert result is body
+
+    def test_fidelity_mode_none_skips_check(self) -> None:
+        pipeline = ConversionPipeline(
+            "openai_chat",
+            "openai_chat",
+            force_conversion=False,
+            fidelity_mode=None,
+        )
+        assert pipeline._fidelity is None
+
+    def test_fidelity_mode_only_on_passthrough(self) -> None:
+        pipeline = ConversionPipeline(
+            "openai_chat",
+            "anthropic",
+            force_conversion=False,
+            fidelity_mode="critical",
+        )
+        # Different formats → not passthrough → no fidelity checker
+        assert pipeline._fidelity is None
+
+    def test_fidelity_full_mode_in_passthrough(self) -> None:
+        pipeline = ConversionPipeline(
+            "openai_chat",
+            "openai_chat",
+            force_conversion=False,
+            fidelity_mode="full",
+        )
+        body = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        result = pipeline.convert_request(body)
+        assert result is body
+        assert pipeline._fidelity is not None


### PR DESCRIPTION
## Summary

Three changes to modernize the conversion pipeline:

### 1. Passthrough mode for same-format pipelines

`ConversionPipeline` gains a `force_conversion` parameter (default `True` for backward compat). When `False` and source == target, the pipeline skips the IR round-trip and passes request/response through directly, applying only shim body-level transforms.

This fixes information loss when proxying same-format traffic (e.g. Anthropic → gateway → Anthropic upstream), which caused Claude Code's auto-mode classifier to reject tool calls. Gateway callers can opt in with `force_conversion=False`.

### 2. Converter instance caching

`get_converter_for_provider()` now caches instances in a module-level dict. Converters are stateless (all per-request state lives in `ConversionContext`), so sharing is safe. Eliminates per-request converter allocation (4 ops classes each). Cache cleared alongside shim registry in `_reset_registry()`.

### 3. Fidelity checker (`fidelity.py`)

Compare original and round-tripped bodies to detect IR conversion information loss. Two modes:
- `"critical"`: check only known fragile fields (~0.01ms) — tool_call structure, stop_reason, content block types
- `"full"`: recursive leaf-level diff with exact path reporting (~1ms for 50KB)

```python
checker = FidelityChecker(mode="critical")
diffs = checker.compare_request(original, roundtripped)
# → [FidelityDiff(path="messages[2].content[0].type", kind="type_changed")]
```

## Test plan

- [x] 2622 tests pass, lint clean (ty check, ruff, complexipy)
- [x] Existing same-format pipeline tests pass (default `force_conversion=True`)
- [x] Stream abort tests pass unchanged

Closes #518, #519