### PR TITLE
fix(gateway): auto-detect embedding source format from request body

### DIFF
--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -55,6 +55,7 @@ class _ResolvedEmbedding:
     upstream_url: str
     provider_name: str
     target_format: str = "openai_chat"
+    source_format: str = "openai_chat"
     pipeline: EmbeddingConversionPipeline | None = field(default=None)
 
 
@@ -66,6 +67,7 @@ def _resolve_embedding_provider(
     try:
         route = config.resolve_embedding(model)
         source_format = _detect_embedding_source(body, config)
+        logger.debug("embedding: detected source format: %s", source_format)
         pipeline = (
             EmbeddingConversionPipeline(source_format, route.format)
             if source_format != route.format
@@ -76,6 +78,7 @@ def _resolve_embedding_provider(
             upstream_url=f"{route.provider_info.base_url}{route.embedding_path}",
             provider_name=route.provider_name,
             target_format=route.format,
+            source_format=source_format,
             pipeline=pipeline,
         )
     except KeyError:
@@ -267,7 +270,7 @@ async def handle_embeddings(
         _record_telemetry(
             request,
             model=model,
-            source_provider=cast(ProviderType, config.default_embedding_format),
+            source_provider=cast(ProviderType, resolved.source_format),
             target_provider=cast(ProviderType, resolved.target_format),
             provider_name=resolved.provider_name,
             is_stream=False,

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -31,6 +31,24 @@ from .transport import (
 logger = get_logger()
 
 
+def _detect_embedding_source(body: dict[str, Any], config: GatewayConfig) -> str:
+    """Infer the source embedding format from the request body.
+
+    Detection order:
+    1. ``texts`` field (without ``input``) → Cohere
+    2. ``task`` field → Jina
+    3. ``output_dtype`` field → Voyage
+    4. Fall back to ``config.default_embedding_format``
+    """
+    if "texts" in body and "input" not in body:
+        return "cohere"
+    if "task" in body:
+        return "jina"
+    if "output_dtype" in body:
+        return "voyage"
+    return config.default_embedding_format
+
+
 @dataclass
 class _ResolvedEmbedding:
     provider_info: ProviderInfo
@@ -47,7 +65,7 @@ def _resolve_embedding_provider(
     # Try embedding-specific routing first
     try:
         route = config.resolve_embedding(model)
-        source_format = config.default_embedding_format
+        source_format = _detect_embedding_source(body, config)
         pipeline = (
             EmbeddingConversionPipeline(source_format, route.format)
             if source_format != route.format

--- a/tests/gateway/test_embeddings.py
+++ b/tests/gateway/test_embeddings.py
@@ -187,3 +187,82 @@ class TestEmbeddingUpstreamModel:
         assert response.headers["x-request-id"] == upstream_headers["x-request-id"]
         if client_request_id:
             assert upstream_headers["x-request-id"] == client_request_id
+
+
+# ============================================================================
+# Auto-detection tests
+# ============================================================================
+
+
+class TestDetectEmbeddingSource:
+    """Tests for _detect_embedding_source auto-detection logic."""
+
+    @pytest.fixture()
+    def config(self) -> GatewayConfig:
+        return GatewayConfig(
+            {
+                "providers": {
+                    "openai_chat": {
+                        "api_key": "sk-test",
+                        "base_url": "https://api.openai.com/v1",
+                    }
+                },
+                "models": {"gpt-4o": "openai_chat"},
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "body, expected",
+        [
+            ({"texts": ["hello"]}, "cohere"),
+            ({"input": "hello", "task": "retrieval.query"}, "jina"),
+            ({"input": "hello", "output_dtype": "float"}, "voyage"),
+            ({"input": "hello"}, "openai"),  # fallback
+            ({"input": "hello", "model": "x"}, "openai"),  # fallback
+            # edge: texts + input → not Cohere, falls to default
+            ({"texts": ["hello"], "input": "hello"}, "openai"),
+        ],
+    )
+    def test_parametrized(
+        self, body: dict, expected: str, config: GatewayConfig
+    ) -> None:
+        from llm_rosetta.gateway.embeddings import _detect_embedding_source
+
+        assert _detect_embedding_source(body, config) == expected
+
+    def test_cohere_texts_field(self, config: GatewayConfig) -> None:
+        from llm_rosetta.gateway.embeddings import _detect_embedding_source
+
+        assert _detect_embedding_source({"texts": ["hi"]}, config) == "cohere"
+
+    def test_cohere_skipped_when_input_present(self, config: GatewayConfig) -> None:
+        from llm_rosetta.gateway.embeddings import _detect_embedding_source
+
+        assert (
+            _detect_embedding_source({"texts": ["hi"], "input": "hi"}, config)
+            != "cohere"
+        )
+
+    def test_jina_task_field(self, config: GatewayConfig) -> None:
+        from llm_rosetta.gateway.embeddings import _detect_embedding_source
+
+        assert (
+            _detect_embedding_source({"input": "hi", "task": "retrieval.query"}, config)
+            == "jina"
+        )
+
+    def test_voyage_output_dtype(self, config: GatewayConfig) -> None:
+        from llm_rosetta.gateway.embeddings import _detect_embedding_source
+
+        assert (
+            _detect_embedding_source({"input": "hi", "output_dtype": "float"}, config)
+            == "voyage"
+        )
+
+    def test_fallback_to_default(self, config: GatewayConfig) -> None:
+        from llm_rosetta.gateway.embeddings import _detect_embedding_source
+
+        assert (
+            _detect_embedding_source({"input": "hi"}, config)
+            == config.default_embedding_format
+        )


### PR DESCRIPTION
## Summary

Auto-detect incoming embedding request format from body fields instead of always using `default_embedding_format`.

Detection signals:
- `texts` field (without `input`) → **Cohere** (uses `texts` instead of `input`)
- `task` field → **Jina** (task mapping like `retrieval.query`)
- `output_dtype` field → **Voyage** (output data type selection)
- No distinguishing field → fall back to `default_embedding_format` (default: `openai`)

Mirrors the rerank auto-detection pattern added earlier for `top_k` → Voyage.

## Test plan

- [x] 2644 tests pass, lint clean