### PR TITLE
fix(gateway): auto-detect Voyage rerank format from request body

### DIFF
--- a/src/llm_rosetta/gateway/rerank.py
+++ b/src/llm_rosetta/gateway/rerank.py
@@ -22,15 +22,21 @@ from .transport import UpstreamConnectionError, UpstreamTimeoutError, UpstreamTr
 logger = get_logger()
 
 
-def _detect_source_format(request: Any, config: GatewayConfig) -> str:
-    """Infer the source rerank format from the request path.
+def _detect_source_format(
+    request: Any, body: dict[str, Any], config: GatewayConfig
+) -> str:
+    """Infer the source rerank format from the request path and body.
 
-    ``/v2/rerank`` implies Cohere format (only Cohere uses v2).
-    ``/v1/rerank`` falls back to ``config.default_rerank_format``.
+    Detection order:
+    1. ``/v2/rerank`` path → Cohere (only Cohere uses v2)
+    2. ``top_k`` in body (without ``top_n``) → Voyage
+    3. Fall back to ``config.default_rerank_format``
     """
     path: str = getattr(request, "path", "")
     if path.startswith("/v2/"):
         return "cohere"
+    if "top_k" in body and "top_n" not in body:
+        return "voyage"
     return config.default_rerank_format
 
 
@@ -95,7 +101,7 @@ async def handle_rerank(
             )
         )
 
-    source_format = _detect_source_format(request, config)
+    source_format = _detect_source_format(request, body, config)
 
     # --- Convert request ---
     pipeline = RerankConversionPipeline(source_format, route.format)

--- a/src/llm_rosetta/gateway/rerank.py
+++ b/src/llm_rosetta/gateway/rerank.py
@@ -103,6 +103,7 @@ async def handle_rerank(
 
     source_format = _detect_source_format(request, body, config)
 
+    logger.debug("rerank: detected source format: %s", source_format)
     # --- Convert request ---
     pipeline = RerankConversionPipeline(source_format, route.format)
     try:

--- a/tests/gateway/test_rerank_proxy.py
+++ b/tests/gateway/test_rerank_proxy.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import pytest
+from llm_rosetta.gateway.config import GatewayConfig
+from llm_rosetta.gateway.rerank import _detect_source_format
 
 from llm_rosetta.gateway.rerank_pipeline import (
     RerankConversionPipeline,
@@ -272,3 +274,78 @@ class TestRerankConfig:
         config = GatewayConfig(raw)
         assert "jina" not in config.rerank_providers
         assert len(config.rerank_models) == 0
+
+
+# ============================================================================
+# Auto-detection tests
+# ============================================================================
+
+
+class _FakeRequest:
+    """Minimal request stub with a .path attribute."""
+
+    def __init__(self, path: str = "/v1/rerank") -> None:
+        self.path = path
+
+
+class TestDetectSourceFormat:
+    """Tests for _detect_source_format auto-detection logic."""
+
+    @pytest.fixture()
+    def config(self) -> GatewayConfig:
+        return GatewayConfig(
+            {
+                "providers": {
+                    "openai_chat": {
+                        "api_key": "sk-test",
+                        "base_url": "https://api.openai.com/v1",
+                    }
+                },
+                "models": {"gpt-4o": "openai_chat"},
+            }
+        )
+
+    def test_v2_path_detects_cohere(self, config: GatewayConfig) -> None:
+
+        assert _detect_source_format(_FakeRequest("/v2/rerank"), {}, config) == "cohere"
+
+    def test_top_k_without_top_n_detects_voyage(self, config: GatewayConfig) -> None:
+
+        assert (
+            _detect_source_format(
+                _FakeRequest(), {"top_k": 5, "query": "q", "documents": ["d"]}, config
+            )
+            == "voyage"
+        )
+
+    def test_top_k_with_top_n_falls_to_default(self, config: GatewayConfig) -> None:
+
+        assert (
+            _detect_source_format(_FakeRequest(), {"top_k": 5, "top_n": 3}, config)
+            == config.default_rerank_format
+        )
+
+    def test_plain_body_falls_to_default(self, config: GatewayConfig) -> None:
+
+        assert (
+            _detect_source_format(
+                _FakeRequest(), {"query": "q", "documents": ["d"]}, config
+            )
+            == config.default_rerank_format
+        )
+
+    @pytest.mark.parametrize(
+        "path, body, expected",
+        [
+            ("/v2/rerank", {}, "cohere"),
+            ("/v2/rerank", {"top_k": 5}, "cohere"),  # path takes precedence
+            ("/v1/rerank", {"top_k": 5}, "voyage"),
+            ("/v1/rerank", {"top_k": 5, "top_n": 3}, "jina"),  # fallback
+            ("/v1/rerank", {}, "jina"),  # fallback
+        ],
+    )
+    def test_parametrized(
+        self, path: str, body: dict, expected: str, config: GatewayConfig
+    ) -> None:
+
+        assert _detect_source_format(_FakeRequest(path), body, config) == expected


### PR DESCRIPTION
## Summary

Detect `top_k` (without `top_n`) in the rerank request body as a signal for Voyage format. Previously only `/v2/` path triggered Cohere detection; all `/v1/` requests used the config default regardless of body content.

Detection order:
1. `/v2/rerank` path → Cohere
2. `top_k` in body (without `top_n`) → Voyage
3. Fall back to `default_rerank_format`

## Test plan

- [x] 2644 tests pass, lint clean
- [x] Tested on cloud.usa2 devtest — Voyage-style `top_k` request correctly auto-detected and routed