### PR TITLE
feat(shims): add multimodal_tool_result capability to ProviderShim

### DIFF
--- a/src/llm_rosetta/auto_detect.py
+++ b/src/llm_rosetta/auto_detect.py
@@ -270,6 +270,8 @@ def convert(
             cap = target_shim.model_reasoning[req_model]
         if cap is not None:
             ctx.options["reasoning_cap"] = cap
+        if target_shim.multimodal_tool_result is not None:
+            ctx.options["multimodal_tool_result"] = target_shim.multimodal_tool_result
 
     ir_request = source_converter.request_from_provider(body, context=ctx)
     target_body, _warnings = target_converter.request_to_provider(

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -260,6 +260,9 @@ class ConversionPipeline:
         # from the source provider name.
         target_shim = resolved or resolve_shim(target_provider)
         self._target_id_prefix = target_shim.response_id_prefix if target_shim else ""
+        self._multimodal_tool_result = (
+            target_shim.multimodal_tool_result if target_shim else None
+        )
         source_shim = resolve_shim(source_provider)
         self._source_id_prefix = source_shim.response_id_prefix if source_shim else ""
 
@@ -414,10 +417,8 @@ class ConversionPipeline:
         if self._target_provider == "google":
             ctx.options["output_format"] = "rest"
 
-        # Shim-driven multimodal tool result override
-        target_shim = resolve_shim(self._shim) or resolve_shim(self._target_provider)
-        if target_shim is not None and target_shim.multimodal_tool_result is not None:
-            ctx.options["multimodal_tool_result"] = target_shim.multimodal_tool_result
+        if self._multimodal_tool_result is not None:
+            ctx.options["multimodal_tool_result"] = self._multimodal_tool_result
 
         # Capability enforcement: reasoning (pre-IR)
         enforce_reasoning(

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -414,6 +414,11 @@ class ConversionPipeline:
         if self._target_provider == "google":
             ctx.options["output_format"] = "rest"
 
+        # Shim-driven multimodal tool result override
+        target_shim = resolve_shim(self._shim) or resolve_shim(self._target_provider)
+        if target_shim is not None and target_shim.multimodal_tool_result is not None:
+            ctx.options["multimodal_tool_result"] = target_shim.multimodal_tool_result
+
         # Capability enforcement: reasoning (pre-IR)
         enforce_reasoning(
             ctx,

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -131,6 +131,11 @@ class ProviderShim:
             Default ``False`` — only OpenAI's official API supports
             this.  When ``False``, custom tools are downgraded to
             function wrappers.
+        multimodal_tool_result: Whether the provider supports multimodal
+            content (images, files) in tool results natively.  ``None``
+            (default) defers to the converter's class-level flag.
+            ``True`` forces native multimodal pass-through; ``False``
+            forces dual-encoding (text fallback + synthetic user message).
     """
 
     name: str
@@ -147,6 +152,7 @@ class ProviderShim:
     response_id_prefix: str = ""
     supports_custom_tools: bool = False
     hoist_system_messages: bool = True
+    multimodal_tool_result: bool | None = None
 
     def __init__(self, **kwargs: Any) -> None:  # type: ignore[override]
         """Accept both new and legacy kwarg names.
@@ -194,6 +200,7 @@ class ProviderShim:
             "response_id_prefix": "",
             "supports_custom_tools": False,
             "hoist_system_messages": True,
+            "multimodal_tool_result": None,
         }
         _VALID_FIELDS = {"name", "base"} | _FIELD_DEFAULTS.keys()
         for k, v in _FIELD_DEFAULTS.items():

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -202,6 +202,7 @@ def _load_single_provider(
         model_reasoning=model_reasoning,
         response_id_prefix=cfg.get("response_id_prefix", ""),
         supports_custom_tools=cfg.get("supports_custom_tools", False),
+        multimodal_tool_result=cfg.get("multimodal_tool_result"),
     )
     register_shim(shim)
     logger.debug("Registered provider shim: %s (base=%s)", shim.name, shim.base)

--- a/tests/test_shim_loader.py
+++ b/tests/test_shim_loader.py
@@ -328,6 +328,37 @@ class TestLoadProviders:
         assert len(shims) == 1
         assert shims[0].name == "good"
 
+    def test_multimodal_tool_result_from_yaml(self, tmp_path: Path):
+        """multimodal_tool_result is parsed from provider YAML."""
+        d = tmp_path / "multimodal_provider"
+        d.mkdir()
+        (d / "provider.yaml").write_text(
+            "name: multimodal_provider\nbase: openai_chat\nmultimodal_tool_result: true\n"
+        )
+        shims = load_providers_from_dir(tmp_path)
+        assert len(shims) == 1
+        assert shims[0].multimodal_tool_result is True
+
+    def test_multimodal_tool_result_false_from_yaml(self, tmp_path: Path):
+        """multimodal_tool_result: false is parsed correctly."""
+        d = tmp_path / "nomm"
+        d.mkdir()
+        (d / "provider.yaml").write_text(
+            "name: nomm\nbase: anthropic\nmultimodal_tool_result: false\n"
+        )
+        shims = load_providers_from_dir(tmp_path)
+        assert len(shims) == 1
+        assert shims[0].multimodal_tool_result is False
+
+    def test_multimodal_tool_result_absent_from_yaml(self, tmp_path: Path):
+        """Missing multimodal_tool_result defaults to None."""
+        d = tmp_path / "plain"
+        d.mkdir()
+        (d / "provider.yaml").write_text("name: plain\nbase: openai_chat\n")
+        shims = load_providers_from_dir(tmp_path)
+        assert len(shims) == 1
+        assert shims[0].multimodal_tool_result is None
+
 
 class TestLoadProvidersFromDir:
     """Tests for the public load_providers_from_dir API."""

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -303,3 +303,121 @@ class TestGroupedProviders:
         grouped_names = ("argo--anthropic", "argo--openai_chat")
         for name in (*flat_names, *grouped_names):
             assert get_shim(name) is not None, f"Shim '{name}' not found"
+
+
+# ---------------------------------------------------------------------------
+# multimodal_tool_result capability plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestMultimodalToolResultCapability:
+    def test_shim_default_is_none(self):
+        s = ProviderShim(name="test", base="openai_chat")
+        assert s.multimodal_tool_result is None
+
+    def test_shim_explicit_true(self):
+        s = ProviderShim(name="test", base="openai_chat", multimodal_tool_result=True)
+        assert s.multimodal_tool_result is True
+
+    def test_shim_explicit_false(self):
+        s = ProviderShim(name="test", base="anthropic", multimodal_tool_result=False)
+        assert s.multimodal_tool_result is False
+
+    def test_convert_wires_shim_override_into_context(self):
+        """convert() sets ctx.options['multimodal_tool_result'] from target shim."""
+        from unittest.mock import patch
+        from typing import Any
+
+        from llm_rosetta.auto_detect import convert
+        from llm_rosetta.converters.base.context import ConversionContext
+
+        register_shim(
+            ProviderShim(
+                name="mm-target", base="openai_chat", multimodal_tool_result=True
+            )
+        )
+        register_shim(ProviderShim(name="mm-source", base="anthropic"))
+
+        captured_ctx: list[Any] = []
+
+        from llm_rosetta.converters.openai_chat.converter import OpenAIChatConverter
+
+        orig_req_to = OpenAIChatConverter.request_to_provider
+
+        def capture_ctx(
+            self: Any, ir_request: Any, *, context: Any = None, **kwargs: Any
+        ) -> Any:
+            captured_ctx.append(context)
+            return orig_req_to(self, ir_request, context=context, **kwargs)
+
+        with patch.object(OpenAIChatConverter, "request_to_provider", capture_ctx):
+            body = {
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+                ],
+                "model": "test",
+                "max_tokens": 100,
+            }
+            convert(body, "mm-target", source_provider="mm-source")
+
+        assert len(captured_ctx) == 1
+        ctx: ConversionContext = captured_ctx[0]
+        assert ctx.options.get("multimodal_tool_result") is True
+
+    def test_convert_no_override_when_shim_is_none(self):
+        """convert() does not set multimodal_tool_result when shim field is None."""
+        from unittest.mock import patch
+        from typing import Any
+
+        from llm_rosetta.auto_detect import convert
+
+        register_shim(ProviderShim(name="plain-target", base="openai_chat"))
+        register_shim(ProviderShim(name="plain-source", base="anthropic"))
+
+        captured_ctx: list[Any] = []
+
+        from llm_rosetta.converters.openai_chat.converter import OpenAIChatConverter
+
+        orig_req_to = OpenAIChatConverter.request_to_provider
+
+        def capture_ctx(
+            self: Any, ir_request: Any, *, context: Any = None, **kwargs: Any
+        ) -> Any:
+            captured_ctx.append(context)
+            return orig_req_to(self, ir_request, context=context, **kwargs)
+
+        with patch.object(OpenAIChatConverter, "request_to_provider", capture_ctx):
+            body = {
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+                ],
+                "model": "test",
+                "max_tokens": 100,
+            }
+            convert(body, "plain-target", source_provider="plain-source")
+
+        assert len(captured_ctx) == 1
+        assert "multimodal_tool_result" not in captured_ctx[0].options
+
+    def test_pipeline_wires_shim_override_into_context(self):
+        """ConversionPipeline sets ctx.options from target shim."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        register_shim(
+            ProviderShim(
+                name="pipe-target", base="openai_chat", multimodal_tool_result=True
+            )
+        )
+
+        pipeline = ConversionPipeline(
+            source_provider="anthropic",
+            target_provider="openai_chat",
+            shim="pipe-target",
+        )
+        body = {
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            "model": "test",
+            "max_tokens": 100,
+        }
+        pipeline.convert_request(body)
+        assert pipeline.context.options.get("multimodal_tool_result") is True

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -22,10 +22,19 @@ from llm_rosetta.shims.provider_shim import (
 
 @pytest.fixture(autouse=True)
 def _clean_registry():
-    """Reset the shim registry before and after each test."""
+    """Isolate each test from the global shim registry.
+
+    Saves the current registry state, clears it for the test, and
+    restores the original entries afterward so other test modules
+    that depend on built-in shims are not affected by test ordering.
+    """
+    from llm_rosetta.shims.provider_shim import _SHIM_REGISTRY
+
+    saved = dict(_SHIM_REGISTRY)
     _reset_registry()
     yield
     _reset_registry()
+    _SHIM_REGISTRY.update(saved)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `multimodal_tool_result: bool | None` field to `ProviderShim` dataclass
- Parse from `provider.yaml` in the shim loader
- Wire into `ConversionContext.options` in both `auto_detect.convert()` and `ConversionPipeline.convert_request()`
- `BaseConverter._supports_multimodal_tool_result()` already reads `context.options["multimodal_tool_result"]` — this PR connects the pipe that was previously disconnected

A shim can now override the converter's class-level multimodal tool result support flag via YAML:

```yaml
# provider.yaml
name: my-chat-provider
base: openai_chat
multimodal_tool_result: true  # override Chat's default False
```

Part of #470

## Test plan

- [x] `ProviderShim` accepts `multimodal_tool_result` kwarg (True/False/None)
- [x] YAML loader parses `multimodal_tool_result` from provider.yaml
- [x] Missing field defaults to `None` (defer to converter)
- [x] `convert()` wires shim override into `ConversionContext.options`
- [x] `convert()` does NOT set the option when shim field is `None`
- [x] `ConversionPipeline.convert_request()` wires shim override into context
- [x] All 2673 existing tests still pass