### PR TITLE
fix: thread multimodal tool result flag through Chat converter

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -151,7 +151,11 @@ class OpenAIChatConverter(BaseConverter):
         ir_messages = fix_orphaned_tool_calls_ir(ir_request.get("messages", []))
         ctx.warnings.extend(strip_orphaned_tool_config(ir_request))
         converted_msgs, msg_warnings = self.message_ops.ir_messages_to_p(
-            ir_messages, target_provider=self._CONVERTER_TAG
+            ir_messages,
+            target_provider=self._CONVERTER_TAG,
+            supports_multimodal_tool_result=self._supports_multimodal_tool_result(
+                context
+            ),
         )
         messages.extend(converted_msgs)
         ctx.warnings.extend(msg_warnings)

--- a/src/llm_rosetta/converters/openai_chat/message_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/message_ops.py
@@ -81,6 +81,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
         """
         messages: list[dict[str, Any]] = []
         warnings: list[str] = []
+        supports_mm = kwargs.get("supports_multimodal_tool_result", False)
         multimodal_packs: dict[str, list[dict[str, Any]]] = {}
 
         for item in ir_messages:
@@ -94,7 +95,9 @@ class OpenAIChatMessageOps(BaseMessageOps):
                 continue
             if is_message(item):
                 converted, msg_warnings = self._ir_message_to_p(
-                    cast(Message, item), multimodal_packs
+                    cast(Message, item),
+                    multimodal_packs,
+                    supports_multimodal=supports_mm,
                 )
                 warnings.extend(msg_warnings)
                 if isinstance(converted, list):
@@ -108,9 +111,7 @@ class OpenAIChatMessageOps(BaseMessageOps):
                 warnings.extend(ext_warnings)
 
         messages = self._reorder_tool_messages(messages, warnings)
-        if multimodal_packs and not kwargs.get(
-            "supports_multimodal_tool_result", False
-        ):
+        if multimodal_packs and not supports_mm:
             messages = inject_packed_tool_content(messages, multimodal_packs)
         return messages, warnings
 
@@ -189,12 +190,16 @@ class OpenAIChatMessageOps(BaseMessageOps):
         self,
         message: Message,
         multimodal_packs: dict[str, list[dict[str, Any]]],
+        *,
+        supports_multimodal: bool = False,
     ) -> tuple[Any, list[str]]:
         """Convert a single IR message to OpenAI format.
 
         Args:
             message: IR message dict.
             multimodal_packs: Accumulator for multimodal tool result content.
+            supports_multimodal: When True, skip packing and pass multimodal
+                content through natively in tool results.
 
         Returns:
             Tuple of (converted message or list of messages, warnings).
@@ -206,11 +211,21 @@ class OpenAIChatMessageOps(BaseMessageOps):
         if role == "system":
             return self._ir_system_to_p(content), warnings
         elif role == "user":
-            return self._ir_user_to_p(content, warnings, multimodal_packs)
+            return self._ir_user_to_p(
+                content,
+                warnings,
+                multimodal_packs,
+                supports_multimodal=supports_multimodal,
+            )
         elif role == "assistant":
             return self._ir_assistant_to_p(content, warnings)
         elif role == "tool":
-            return self._ir_tool_messages_to_p(content, warnings, multimodal_packs)
+            return self._ir_tool_messages_to_p(
+                content,
+                warnings,
+                multimodal_packs,
+                supports_multimodal=supports_multimodal,
+            )
 
         return None, warnings
 
@@ -230,6 +245,8 @@ class OpenAIChatMessageOps(BaseMessageOps):
         content: list,
         warnings: list[str],
         multimodal_packs: dict[str, list[dict[str, Any]]],
+        *,
+        supports_multimodal: bool = False,
     ) -> tuple[Any, list[str]]:
         """Convert IR user message content to OpenAI user message(s).
 
@@ -248,7 +265,10 @@ class OpenAIChatMessageOps(BaseMessageOps):
                 # ToolResultPart in user message → separate tool role message
                 tool_messages.append(
                     self._convert_tool_result_with_packing(
-                        part, multimodal_packs, warnings
+                        part,
+                        multimodal_packs,
+                        warnings,
+                        supports_multimodal=supports_multimodal,
                     )
                 )
             elif is_file_part(part):
@@ -354,6 +374,8 @@ class OpenAIChatMessageOps(BaseMessageOps):
         content: list,
         warnings: list[str],
         multimodal_packs: dict[str, list[dict[str, Any]]],
+        *,
+        supports_multimodal: bool = False,
     ) -> tuple[Any, list[str]]:
         """Convert IR tool message content to OpenAI tool role message(s).
 
@@ -366,7 +388,10 @@ class OpenAIChatMessageOps(BaseMessageOps):
             if is_tool_result_part(part):
                 tool_messages.append(
                     self._convert_tool_result_with_packing(
-                        part, multimodal_packs, warnings
+                        part,
+                        multimodal_packs,
+                        warnings,
+                        supports_multimodal=supports_multimodal,
                     )
                 )
 
@@ -410,28 +435,29 @@ class OpenAIChatMessageOps(BaseMessageOps):
         part: ToolResultPart,
         multimodal_packs: dict[str, list[dict[str, Any]]],
         warnings: list[str],
+        *,
+        supports_multimodal: bool = False,
     ) -> dict[str, Any]:
-        """Convert an IR ToolResultPart, packing multimodal content for dual encoding.
+        """Convert an IR ToolResultPart, optionally packing multimodal content.
 
-        Delegates to the shared ``pack_multimodal_tool_result`` helper for
-        multimodal extraction; text-only results go straight through
-        ``tool_ops.ir_tool_result_to_p()``.
+        When ``supports_multimodal`` is True, multimodal content passes through
+        directly without packing — the provider handles it natively.
 
-        Blocks that were successfully packed into the synthetic user message
-        are dropped from the tool message body. Re-serializing them here would
-        emit the same bytes twice — and for base64 images that inert copy can
-        be megabytes the model cannot even read.
+        When False (default for Chat Completions), delegates to the shared
+        ``pack_multimodal_tool_result`` helper.  Packed blocks are dropped from
+        the tool message body to avoid emitting large base64 payloads twice.
 
         Args:
             part: IR tool result part.
             multimodal_packs: Accumulator mapping call_id → provider content blocks.
             warnings: Warning list.
+            supports_multimodal: Skip packing when True.
 
         Returns:
             OpenAI tool role message dict.
         """
         result = part.get("result", "")
-        if not has_multimodal_content(result):
+        if supports_multimodal or not has_multimodal_content(result):
             return self.tool_ops.ir_tool_result_to_p(part)
         residual = pack_multimodal_tool_result(
             result, self.content_ops, multimodal_packs, part["tool_call_id"], warnings

--- a/src/llm_rosetta/converters/openai_chat/message_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/message_ops.py
@@ -65,6 +65,8 @@ class OpenAIChatMessageOps(BaseMessageOps):
     def ir_messages_to_p(
         self,
         ir_messages: Sequence[IRInputItem],
+        *,
+        supports_multimodal_tool_result: bool = False,
         **kwargs: Any,
     ) -> tuple[list[Any], list[str]]:
         """IR Messages → OpenAI Chat messages.
@@ -75,13 +77,15 @@ class OpenAIChatMessageOps(BaseMessageOps):
 
         Args:
             ir_messages: IR message list (may contain ExtensionItems).
+            supports_multimodal_tool_result: When True, multimodal content
+                in tool results passes through natively without dual-encoding.
 
         Returns:
             Tuple of (converted messages list, warnings list).
         """
         messages: list[dict[str, Any]] = []
         warnings: list[str] = []
-        supports_mm = kwargs.get("supports_multimodal_tool_result", False)
+        supports_mm = supports_multimodal_tool_result
         multimodal_packs: dict[str, list[dict[str, Any]]] = {}
 
         for item in ir_messages:

--- a/tests/converters/openai_chat/test_message_ops.py
+++ b/tests/converters/openai_chat/test_message_ops.py
@@ -1111,6 +1111,65 @@ class TestMultimodalToolResultPacking:
         assert has_multimodal_content([]) is False
         assert has_multimodal_content(None) is False
 
+    # ==================== supports_multimodal_tool_result flag ====================
+
+    def test_supports_multimodal_skips_packing(self):
+        """When supports_multimodal_tool_result=True, no synthetic user msg."""
+        tr = ToolResultPart(
+            type="tool_result",
+            tool_call_id="call_img",
+            result=[
+                {"type": "image", "image_url": "https://example.com/chart.png"},
+            ],
+        )
+        ir_msgs = self._make_ir_conversation([tr])
+        result, _ = self.message_ops.ir_messages_to_p(
+            ir_msgs, supports_multimodal_tool_result=True
+        )
+
+        roles = [m["role"] for m in result]
+        assert roles == ["user", "assistant", "tool"]
+        assert "user" not in roles[3:]  # no synthetic user msg
+
+    def test_supports_multimodal_preserves_content(self):
+        """When supports_multimodal_tool_result=True, image stays in tool result."""
+        import json
+
+        tr = ToolResultPart(
+            type="tool_result",
+            tool_call_id="call_img",
+            result=[
+                {"type": "text", "text": "chart:"},
+                {"type": "image", "image_url": "https://example.com/chart.png"},
+            ],
+        )
+        ir_msgs = self._make_ir_conversation([tr])
+        result, _ = self.message_ops.ir_messages_to_p(
+            ir_msgs, supports_multimodal_tool_result=True
+        )
+
+        tool_msg = [m for m in result if m["role"] == "tool"][0]
+        content = json.loads(tool_msg["content"])
+        assert len(content) == 2
+        types = [c["type"] for c in content]
+        assert "text" in types
+        assert "image" in types
+
+    def test_default_false_still_packs(self):
+        """Default (False) behavior unchanged — still packs multimodal."""
+        tr = ToolResultPart(
+            type="tool_result",
+            tool_call_id="call_img",
+            result=[
+                {"type": "image", "image_url": "https://example.com/chart.png"},
+            ],
+        )
+        ir_msgs = self._make_ir_conversation([tr])
+        result, _ = self.message_ops.ir_messages_to_p(ir_msgs)
+
+        roles = [m["role"] for m in result]
+        assert roles == ["user", "assistant", "tool", "user"]
+
 
 class TestRefusalFieldAlwaysPresent:
     """Tests for refusal field always present on assistant messages (#427 follow-up)."""

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -430,3 +430,76 @@ class TestMultimodalToolResultCapability:
         }
         pipeline.convert_request(body)
         assert pipeline.context.options.get("multimodal_tool_result") is True
+
+    def test_pipeline_e2e_multimodal_tool_result_preserved(self):
+        """End-to-end: shim + pipeline + multimodal tool result content preserved."""
+        import json
+
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        register_shim(
+            ProviderShim(
+                name="mm-chat", base="openai_chat", multimodal_tool_result=True
+            )
+        )
+
+        pipeline = ConversionPipeline(
+            source_provider="anthropic",
+            target_provider="openai_chat",
+            shim="mm-chat",
+        )
+        body = {
+            "model": "test",
+            "max_tokens": 100,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "take screenshot"}],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_ss",
+                            "name": "screenshot",
+                            "input": {},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_ss",
+                            "content": [
+                                {"type": "text", "text": "captured"},
+                                {
+                                    "type": "image",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": "image/png",
+                                        "data": "iVBOR",
+                                    },
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ],
+        }
+        result = pipeline.convert_request(body)
+
+        tool_msgs = [m for m in result["messages"] if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        content = json.loads(tool_msgs[0]["content"])
+        assert isinstance(content, list)
+        assert len(content) == 2
+        types = [c["type"] for c in content]
+        assert "text" in types
+        assert "image" in types
+
+        # No synthetic user message injected
+        user_msgs = [m for m in result["messages"] if m.get("role") == "user"]
+        assert len(user_msgs) == 1


### PR DESCRIPTION
## Summary

- Fix `_do_request_to_provider` to pass `supports_multimodal_tool_result` from context when calling `ir_messages_to_p` — previously the flag was only used in direct `messages_to_provider()` calls (tests), not the real request pipeline
- Thread the flag through `ir_messages_to_p` → `_ir_message_to_p` → `_ir_user_to_p`/`_ir_tool_messages_to_p` → `_convert_tool_result_with_packing`
- Fix `_convert_tool_result_with_packing` to skip packing entirely when `supports_multimodal=True` — previously images were stripped from tool messages but never injected into synthetic user messages, silently losing content

Depends on #523 (shim capability plumbing)

Part of #470

## Test plan

- [x] `supports_multimodal_tool_result=True` → no synthetic user message, no packing
- [x] `supports_multimodal_tool_result=True` → multimodal content preserved in tool message
- [x] Default `False` behavior unchanged — still packs with dual encoding
- [x] All 2676 existing + new tests pass