### PR TITLE
fix(google): preserve structured content in multimodal tool results

### DIFF
--- a/src/llm_rosetta/converters/google_genai/tool_ops.py
+++ b/src/llm_rosetta/converters/google_genai/tool_ops.py
@@ -58,6 +58,26 @@ def _normalize_schema_types(schema: Any, to_upper: bool = False) -> Any:
     return result
 
 
+def _get_result_content(ir_tool_result: ToolResultPart) -> Any:
+    """Extract and normalize result content from an IR ToolResultPart.
+
+    Structured content (list of content blocks, dicts) is preserved as-is
+    for Google's Struct-based ``functionResponse.response``.  Scalar values
+    are returned unchanged.
+    """
+    result_content = (
+        ir_tool_result.get("result")
+        or ir_tool_result.get("content")
+        or ir_tool_result.get("output")
+        or ""
+    )
+    if isinstance(result_content, dict):
+        import json
+
+        return json.dumps(result_content)
+    return result_content
+
+
 class GoogleGenAIToolOps(BaseToolOps):
     """Google GenAI tool conversion operations.
 
@@ -342,20 +362,7 @@ class GoogleGenAIToolOps(BaseToolOps):
         """
         tool_name = ir_tool_result.get("tool_call_id", "")
 
-        # Get result content from various field names
-        result_content = (
-            ir_tool_result.get("result")
-            or ir_tool_result.get("content")
-            or ir_tool_result.get("output")
-            or ""
-        )
-
-        # Google function_response uses Struct (dict), not content blocks.
-        # Serialize list/dict content to a string for the output field.
-        if isinstance(result_content, (list, dict)):
-            import json
-
-            result_content = json.dumps(result_content)
+        result_content = _get_result_content(ir_tool_result)
 
         response_data: dict[str, Any] = {"output": result_content}
         if ir_tool_result.get("is_error"):
@@ -411,20 +418,7 @@ class GoogleGenAIToolOps(BaseToolOps):
             )
             tool_name = tool_call_id
 
-        # Get result content from various field names
-        result_content = (
-            ir_tool_result.get("result")
-            or ir_tool_result.get("content")
-            or ir_tool_result.get("output")
-            or ""
-        )
-
-        # Google function_response uses Struct (dict), not content blocks.
-        # Serialize list/dict content to a string for the output field.
-        if isinstance(result_content, (list, dict)):
-            import json
-
-            result_content = json.dumps(result_content)
+        result_content = _get_result_content(ir_tool_result)
 
         response_data: dict[str, Any] = {"output": result_content}
         if ir_tool_result.get("is_error"):
@@ -445,7 +439,8 @@ class GoogleGenAIToolOps(BaseToolOps):
         """Google GenAI function_response Part → IR ToolResultPart.
 
         Supports both SDK naming (``function_response``) and REST API naming
-        (``functionResponse``).
+        (``functionResponse``).  Structured content (lists) is preserved
+        as-is for multimodal tool result round-tripping.
 
         Args:
             provider_tool_result: Google Part dict with function_response.
@@ -458,14 +453,18 @@ class GoogleGenAIToolOps(BaseToolOps):
         ) or provider_tool_result.get("functionResponse")
         response_data = func_response.get("response", {})
 
-        # Check if it's an error response
         is_error = "error" in response_data
         content = response_data.get("error" if is_error else "output", "")
+
+        if isinstance(content, list):
+            result: Any = content
+        else:
+            result = str(content)
 
         return ToolResultPart(
             type="tool_result",
             tool_call_id=func_response.get("id", func_response.get("name", "")),
-            result=str(content),
+            result=result,
             is_error=is_error,
         )
 

--- a/src/llm_rosetta/converters/google_genai/tool_ops.py
+++ b/src/llm_rosetta/converters/google_genai/tool_ops.py
@@ -58,12 +58,23 @@ def _normalize_schema_types(schema: Any, to_upper: bool = False) -> Any:
     return result
 
 
+def _is_content_block_list(value: list) -> bool:
+    """Check whether *value* looks like ``list[ContentPart]``.
+
+    IR tool results are typed ``str | list[ContentPart]``.  Content block
+    lists contain typed dicts (``{"type": "text", ...}``,
+    ``{"type": "image", ...}``).  Plain data lists (``[1, 2, 3]``) are
+    not content blocks and should be JSON-serialized instead.
+    """
+    return bool(value) and isinstance(value[0], dict) and "type" in value[0]
+
+
 def _get_result_content(ir_tool_result: ToolResultPart) -> Any:
     """Extract and normalize result content from an IR ToolResultPart.
 
-    Structured content (list of content blocks, dicts) is preserved as-is
-    for Google's Struct-based ``functionResponse.response``.  Scalar values
-    are returned unchanged.
+    Content block lists (``list[ContentPart]``) are preserved as-is for
+    Google's Struct-based ``functionResponse.response``.  Plain data
+    lists and dicts are JSON-serialized.  Scalar values pass through.
     """
     result_content = (
         ir_tool_result.get("result")
@@ -71,6 +82,12 @@ def _get_result_content(ir_tool_result: ToolResultPart) -> Any:
         or ir_tool_result.get("output")
         or ""
     )
+    if isinstance(result_content, list):
+        if _is_content_block_list(result_content):
+            return result_content
+        import json
+
+        return json.dumps(result_content)
     if isinstance(result_content, dict):
         import json
 
@@ -456,9 +473,11 @@ class GoogleGenAIToolOps(BaseToolOps):
         is_error = "error" in response_data
         content = response_data.get("error" if is_error else "output", "")
 
-        if isinstance(content, list):
+        # Preserve content block lists (list[ContentPart]) for multimodal
+        # round-tripping; serialize plain data lists/dicts to JSON string.
+        if isinstance(content, list) and _is_content_block_list(content):
             result: Any = content
-        elif isinstance(content, dict):
+        elif isinstance(content, (list, dict)):
             import json
 
             result = json.dumps(content)

--- a/src/llm_rosetta/converters/google_genai/tool_ops.py
+++ b/src/llm_rosetta/converters/google_genai/tool_ops.py
@@ -458,6 +458,10 @@ class GoogleGenAIToolOps(BaseToolOps):
 
         if isinstance(content, list):
             result: Any = content
+        elif isinstance(content, dict):
+            import json
+
+            result = json.dumps(content)
         else:
             result = str(content)
 

--- a/tests/converters/google_genai/test_tool_ops.py
+++ b/tests/converters/google_genai/test_tool_ops.py
@@ -536,6 +536,21 @@ class TestGoogleGenAIToolOps:
         assert isinstance(output, str)
         assert json.loads(output) == {"key": "value"}
 
+    def test_p_tool_result_to_ir_dict_json_serialized(self):
+        """Test dict content in function_response is json.dumps'd, not str()."""
+        import json
+
+        provider = {
+            "functionResponse": {
+                "name": "get_weather",
+                "id": "call_dict",
+                "response": {"output": {"temp": 72, "unit": "F"}},
+            }
+        }
+        result = GoogleGenAIToolOps.p_tool_result_to_ir(provider)
+        assert isinstance(result["result"], str)
+        assert json.loads(result["result"]) == {"temp": 72, "unit": "F"}
+
     def test_p_tool_result_to_ir_preserves_list(self):
         """Test list content in function_response is preserved as-is in IR."""
         provider = {

--- a/tests/converters/google_genai/test_tool_ops.py
+++ b/tests/converters/google_genai/test_tool_ops.py
@@ -485,22 +485,20 @@ class TestGoogleGenAIToolOps:
         result = GoogleGenAIToolOps.p_tool_result_to_ir(provider)
         assert result["tool_call_id"] == "search"
 
-    def test_ir_tool_result_to_p_list_json_serialized(self):
-        """Test list result is serialized via json.dumps for Google Struct."""
+    def test_ir_tool_result_to_p_list_preserved(self):
+        """Test list result is preserved as-is for Google Struct."""
         ir_tr = ToolResultPart(
             type="tool_result",
             tool_call_id="call_list",
             result=[{"type": "text", "text": "hello"}],
         )
         result = GoogleGenAIToolOps.ir_tool_result_to_p(ir_tr)
-        import json
-
         output = result["functionResponse"]["response"]["output"]
-        assert isinstance(output, str)
-        assert json.loads(output) == [{"type": "text", "text": "hello"}]
+        assert isinstance(output, list)
+        assert output == [{"type": "text", "text": "hello"}]
 
-    def test_ir_tool_result_to_p_with_context_list_json_serialized(self):
-        """Test list result via context method is serialized via json.dumps."""
+    def test_ir_tool_result_to_p_with_context_list_preserved(self):
+        """Test list result via context method is preserved as-is."""
         ir_input = [
             {
                 "role": "assistant",
@@ -520,12 +518,63 @@ class TestGoogleGenAIToolOps:
             result=[{"type": "image", "image_url": "https://example.com/img.png"}],
         )
         result = GoogleGenAIToolOps.ir_tool_result_to_p_with_context(ir_tr, ir_input)
+        output = result["functionResponse"]["response"]["output"]
+        assert isinstance(output, list)
+        assert output[0]["type"] == "image"
+
+    def test_ir_tool_result_to_p_dict_json_serialized(self):
+        """Test dict result is still serialized via json.dumps."""
         import json
 
+        ir_tr = ToolResultPart(
+            type="tool_result",
+            tool_call_id="call_dict",
+            result={"key": "value"},
+        )
+        result = GoogleGenAIToolOps.ir_tool_result_to_p(ir_tr)
         output = result["functionResponse"]["response"]["output"]
         assert isinstance(output, str)
-        parsed = json.loads(output)
-        assert parsed[0]["type"] == "image"
+        assert json.loads(output) == {"key": "value"}
+
+    def test_p_tool_result_to_ir_preserves_list(self):
+        """Test list content in function_response is preserved as-is in IR."""
+        provider = {
+            "functionResponse": {
+                "name": "screenshot",
+                "id": "call_mm",
+                "response": {
+                    "output": [
+                        {"type": "text", "text": "captured"},
+                        {"type": "image", "image_url": "https://example.com/img.png"},
+                    ]
+                },
+            }
+        }
+        result = GoogleGenAIToolOps.p_tool_result_to_ir(provider)
+        assert isinstance(result["result"], list)
+        assert len(result["result"]) == 2
+        assert result["result"][0]["type"] == "text"
+        assert result["result"][1]["type"] == "image"
+
+    def test_multimodal_tool_result_round_trip(self):
+        """Test multimodal tool result round-trip: IR → Google → IR."""
+        ir_tr = ToolResultPart(
+            type="tool_result",
+            tool_call_id="call_rt",
+            result=[
+                {"type": "text", "text": "chart output:"},
+                {"type": "image", "image_url": "https://example.com/chart.png"},
+            ],
+        )
+        google = GoogleGenAIToolOps.ir_tool_result_to_p(ir_tr)
+        restored = GoogleGenAIToolOps.p_tool_result_to_ir(google)
+        assert isinstance(restored["result"], list)
+        assert len(restored["result"]) == 2
+        assert restored["result"][0] == {"type": "text", "text": "chart output:"}
+        assert restored["result"][1] == {
+            "type": "image",
+            "image_url": "https://example.com/chart.png",
+        }
 
     # ==================== Tool Config ====================
 

--- a/tests/converters/google_genai/test_tool_ops.py
+++ b/tests/converters/google_genai/test_tool_ops.py
@@ -571,6 +571,35 @@ class TestGoogleGenAIToolOps:
         assert result["result"][0]["type"] == "text"
         assert result["result"][1]["type"] == "image"
 
+    def test_ir_tool_result_to_p_plain_data_list_serialized(self):
+        """Plain data list (not content blocks) is json.dumps'd, not preserved."""
+        import json
+
+        ir_tr = ToolResultPart(
+            type="tool_result",
+            tool_call_id="call_plain",
+            result=[1, 2, 3],
+        )
+        result = GoogleGenAIToolOps.ir_tool_result_to_p(ir_tr)
+        output = result["functionResponse"]["response"]["output"]
+        assert isinstance(output, str)
+        assert json.loads(output) == [1, 2, 3]
+
+    def test_p_tool_result_to_ir_plain_data_list_serialized(self):
+        """Plain data list from provider is json.dumps'd, not preserved as list."""
+        import json
+
+        provider = {
+            "functionResponse": {
+                "name": "counter",
+                "id": "call_plain",
+                "response": {"output": [1, 2, 3]},
+            }
+        }
+        result = GoogleGenAIToolOps.p_tool_result_to_ir(provider)
+        assert isinstance(result["result"], str)
+        assert json.loads(result["result"]) == [1, 2, 3]
+
     def test_multimodal_tool_result_round_trip(self):
         """Test multimodal tool result round-trip: IR → Google → IR."""
         ir_tr = ToolResultPart(


### PR DESCRIPTION
## Summary

- Extract shared `_get_result_content()` helper that preserves list content as-is (multimodal content blocks) and only `json.dumps` dicts
- Update `p_tool_result_to_ir` to preserve list content instead of flattening with `str()`
- Multimodal tool results now round-trip through Google format without loss

Previously, `ir_tool_result_to_p` would `json.dumps` any list/dict content, and `p_tool_result_to_ir` would `str()` everything — destroying multimodal content blocks (images, text) that should be preserved structurally in Google's Struct-based `functionResponse.response`.

Depends on #524 (multimodal flag threading)

Part of #470

## Test plan

- [x] List content preserved as-is in `ir_tool_result_to_p` (not json.dumps'd)
- [x] List content preserved as-is in `ir_tool_result_to_p_with_context`
- [x] Dict content still json.dumps'd (backward compat for non-content-block dicts)
- [x] `p_tool_result_to_ir` preserves list content (not `str()`)
- [x] Multimodal tool result round-trip: IR → Google → IR
- [x] All 2679 existing + new tests pass