### PR TITLE
refactor: unify convert() and ConversionPipeline with dual-shim support

### DIFF
--- a/src/llm_rosetta/__init__.py
+++ b/src/llm_rosetta/__init__.py
@@ -8,9 +8,11 @@ A library for converting message formats between different LLM providers
 from .auto_detect import (
     ProviderType,
     convert,
+    convert_response,
     detect_provider,
     get_converter_for_provider,
 )
+from .pipeline import ConversionError, ConversionPipeline
 from .converters import (
     AnthropicConverter,
     BaseConverter,
@@ -54,7 +56,11 @@ __all__ = [
     "detect_provider",
     "get_converter_for_provider",
     "convert",
+    "convert_response",
     "ProviderType",
+    # Conversion pipeline
+    "ConversionPipeline",
+    "ConversionError",
     # Provider shim layer
     "ProviderShim",
     "register_shim",

--- a/src/llm_rosetta/auto_detect.py
+++ b/src/llm_rosetta/auto_detect.py
@@ -182,6 +182,22 @@ def get_converter_for_provider(provider: str):
     raise ValueError(f"Unsupported provider: {provider}")
 
 
+def _detect_source(
+    source_body: dict[str, Any],
+    source_provider: ProviderType | str | None,
+) -> str:
+    """Detect or validate the source provider, raising on failure."""
+    if source_provider is not None:
+        return str(source_provider)
+    detected = detect_provider(source_body)
+    if detected is None:
+        raise ValueError(
+            "Unable to detect source provider. "
+            "Please specify source_provider explicitly."
+        )
+    return detected
+
+
 def convert(
     source_body: dict[str, Any],
     target_provider: ProviderType | str,
@@ -192,30 +208,26 @@ def convert(
 ) -> dict[str, Any]:
     """Auto-detect source provider and convert to target provider format.
 
-    This is a convenience function that auto-detects the source format and
-    performs conversion through the IR (Intermediate Representation).
-
-    When *source_provider* or *target_provider* is a registered shim name
-    (e.g. ``"deepseek"``), the shim's transforms are applied around the
-    base converter.
+    Delegates to :class:`~llm_rosetta.pipeline.ConversionPipeline`
+    internally, resolving source and target shims from the provider
+    names.  For response or streaming conversion, use
+    :func:`convert_response` or :class:`ConversionPipeline` directly.
 
     Args:
         source_body: Source provider request body.
         target_provider: Target provider type or registered shim name.
         source_provider: Optional source provider type or shim name.
             Auto-detected from *source_body* when not provided.
-        model: Optional model name (currently unused, reserved for future use).
+        model: Optional model name passed as ``upstream_model`` to the
+            pipeline (used for per-model shim overrides).
         force_conversion: When ``True``, always run the full conversion
-            pipeline (source -> IR -> target) even when source and target
-            providers are the same.  This normalises parameter names (e.g.
-            ``max_tokens`` -> ``max_completion_tokens`` for OpenAI Chat) and
-            ensures metadata is round-tripped consistently.
+            pipeline even when source and target providers are the same.
 
     Returns:
         Target provider format request body.
 
     Raises:
-        ValueError: If source provider cannot be detected or conversion fails.
+        ValueError: If source provider cannot be detected.
 
     Examples:
         >>> openai_body = {"messages": [{"role": "user", "content": "Hello"}]}
@@ -231,54 +243,68 @@ def convert(
         >>> body = {"messages": [...], "max_tokens": 256}
         >>> normalised = convert(body, "openai_chat", force_conversion=True)
     """
-    from .converters.base.context import ConversionContext
+    from .pipeline import ConversionPipeline
     from .shims import get_shim
-    from .shims.transforms import apply_transforms
 
-    # Detect source provider
-    if source_provider is None:
-        source_provider = detect_provider(source_body)
-        if source_provider is None:
-            raise ValueError(
-                "Unable to detect source provider. Please specify source_provider explicitly."
-            )
+    src = _detect_source(source_body, source_provider)
 
-    # Skip conversion when source == target (unless forced)
-    if source_provider == target_provider and not force_conversion:
-        return source_body
-
-    # --- Resolve shims and transforms ---
-    source_shim = get_shim(source_provider)
-    target_shim = get_shim(target_provider)
-
-    source_pre_t = source_shim.pre_ir_transforms if source_shim else ()
-    target_post_t = target_shim.post_ir_transforms if target_shim else ()
-
-    # --- Apply source pre_ir_transforms ---
-    body = apply_transforms(source_pre_t, source_body)
-
-    # --- Core conversion: source → IR → target ---
-    source_converter = get_converter_for_provider(source_provider)
-    target_converter = get_converter_for_provider(target_provider)
-
-    ctx = ConversionContext()
-    if target_shim is not None:
-        cap = target_shim.reasoning
-        # Model-level override (keyed by upstream/body model ID)
-        req_model = body.get("model", "")
-        if target_shim.model_reasoning and req_model in target_shim.model_reasoning:
-            cap = target_shim.model_reasoning[req_model]
-        if cap is not None:
-            ctx.options["reasoning_cap"] = cap
-        if target_shim.multimodal_tool_result is not None:
-            ctx.options["multimodal_tool_result"] = target_shim.multimodal_tool_result
-
-    ir_request = source_converter.request_from_provider(body, context=ctx)
-    target_body, _warnings = target_converter.request_to_provider(
-        ir_request, context=ctx
+    pipeline = ConversionPipeline(
+        src,
+        str(target_provider),
+        source_shim=get_shim(src),
+        target_shim=get_shim(str(target_provider)),
+        upstream_model=model,
+        force_conversion=force_conversion,
+        google_output_format="sdk",
     )
+    return pipeline.convert_request(source_body)
 
-    # --- Apply target post_ir_transforms ---
-    target_body = apply_transforms(target_post_t, target_body)
 
-    return target_body
+def convert_response(
+    response_body: dict[str, Any],
+    request_body: dict[str, Any],
+    source_provider: ProviderType | str,
+    target_provider: ProviderType | str,
+    *,
+    model: str | None = None,
+    force_conversion: bool = False,
+) -> dict[str, Any]:
+    """Convert a response body from target provider format back to source.
+
+    Creates a :class:`~llm_rosetta.pipeline.ConversionPipeline`,
+    replays the request conversion to establish context, then converts
+    the response.
+
+    Args:
+        response_body: Target-format response body from upstream.
+        request_body: The original source-format request body (needed
+            to establish conversion context, e.g. custom-tool state).
+        source_provider: The client/source provider type or shim name.
+        target_provider: The upstream/target provider type or shim name.
+        model: Optional model name for per-model shim overrides.
+        force_conversion: When ``True``, run full conversion even for
+            same-provider passthrough.
+
+    Returns:
+        Source-format response body.
+
+    Raises:
+        ValueError: If conversion fails.
+    """
+    from .pipeline import ConversionPipeline
+    from .shims import get_shim
+
+    src = str(source_provider)
+    tgt = str(target_provider)
+
+    pipeline = ConversionPipeline(
+        src,
+        tgt,
+        source_shim=get_shim(src),
+        target_shim=get_shim(tgt),
+        upstream_model=model,
+        force_conversion=force_conversion,
+        google_output_format="sdk",
+    )
+    pipeline.convert_request(request_body)
+    return pipeline.convert_response(response_body)

--- a/src/llm_rosetta/auto_detect.py
+++ b/src/llm_rosetta/auto_detect.py
@@ -255,6 +255,7 @@ def convert(
         target_shim=get_shim(str(target_provider)),
         upstream_model=model,
         force_conversion=force_conversion,
+        # Library callers expect Google SDK format; gateway uses "rest"
         google_output_format="sdk",
     )
     return pipeline.convert_request(source_body)
@@ -304,7 +305,9 @@ def convert_response(
         target_shim=get_shim(tgt),
         upstream_model=model,
         force_conversion=force_conversion,
+        # Library callers expect Google SDK format; gateway uses "rest"
         google_output_format="sdk",
     )
+    # Replay request to populate pipeline context (tool state, metadata)
     pipeline.convert_request(request_body)
     return pipeline.convert_response(response_body)

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -312,7 +312,7 @@ async def handle_non_streaming(
     pipeline = ConversionPipeline(
         route.source_provider,
         route.target_provider,
-        route.shim_name,
+        target_shim=route.shim_name,
         upstream_model=model,
         model_capabilities=route.model_capabilities,
         reasoning_config_override=route.reasoning_override,
@@ -633,7 +633,7 @@ async def handle_streaming(
     pipeline = ConversionPipeline(
         route.source_provider,
         route.target_provider,
-        route.shim_name,
+        target_shim=route.shim_name,
         upstream_model=model,
         model_capabilities=route.model_capabilities,
         reasoning_config_override=route.reasoning_override,

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -6,7 +6,7 @@ This module provides two layers of API:
 full conversion lifecycle (Phase 1→2→4).  Use this when you need
 request conversion, response conversion, and/or streaming:
 
-    pipeline = ConversionPipeline("openai_chat", "anthropic", shim="argo--anthropic")
+    pipeline = ConversionPipeline("openai_chat", "anthropic", target_shim="argo--anthropic")
     target_body = pipeline.convert_request(body)
     # ... transport sends target_body, receives upstream_response ...
     source_response = pipeline.convert_response(upstream_response)
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 import time
+import warnings
 from collections.abc import Callable
 from typing import Any, Literal, Protocol, runtime_checkable
 
@@ -212,8 +213,10 @@ class ConversionPipeline:
         self,
         source_provider: str,
         target_provider: str,
-        shim: ProviderShim | str | None = None,
+        target_shim: ProviderShim | str | None = None,
         *,
+        source_shim: ProviderShim | str | None = None,
+        shim: ProviderShim | str | None = None,
         upstream_model: str | None = None,
         model_capabilities: list[str] | None = None,
         reasoning_config_override: dict[str, Any] | None = None,
@@ -221,17 +224,35 @@ class ConversionPipeline:
         hoist_system_messages: bool = True,
         force_conversion: bool = True,
         fidelity_mode: Literal["critical", "full"] | None = None,
+        metadata_mode: str = "preserve",
+        google_output_format: str = "rest",
     ) -> None:
         from llm_rosetta import get_converter_for_provider
 
+        # Backward compat: accept legacy ``shim=`` as alias for target_shim
+        if shim is not None:
+            if target_shim is not None:
+                raise ValueError(
+                    "Cannot pass both 'shim' and 'target_shim'. "
+                    "Use 'target_shim' (shim is deprecated)."
+                )
+            warnings.warn(
+                "ConversionPipeline(shim=...) is deprecated, use target_shim instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            target_shim = shim
+
         self._source_provider = source_provider
         self._target_provider = target_provider
-        self._shim = shim
+        self._target_shim = target_shim
         self._upstream_model = upstream_model
         self._model_capabilities = model_capabilities
         self._reasoning_config_override = reasoning_config_override
         self._supports_custom_tools = supports_custom_tools
         self._hoist_system_messages = hoist_system_messages
+        self._metadata_mode = metadata_mode
+        self._google_output_format = google_output_format
 
         self._passthrough = source_provider == target_provider and not force_conversion
         self._fidelity: Any = None
@@ -245,26 +266,42 @@ class ConversionPipeline:
         self._source_converter = get_converter_for_provider(source_provider)
         self._target_converter = get_converter_for_provider(target_provider)
 
-        # Resolve body-level transforms from shim
-        resolved = resolve_shim(shim)
-        if resolved is not None:
-            self._pre_ir_transforms = resolved.pre_ir_transforms
-            self._post_ir_transforms = resolved.post_ir_transforms
+        # Resolve body-level transforms from source shim
+        resolved_source = resolve_shim(source_shim)
+        if resolved_source is not None:
+            self._source_pre_ir_transforms = resolved_source.pre_ir_transforms
+            self._source_post_ir_transforms = resolved_source.post_ir_transforms
         else:
-            self._pre_ir_transforms = _EMPTY_TRANSFORMS
-            self._post_ir_transforms = _EMPTY_TRANSFORMS
+            self._source_pre_ir_transforms = _EMPTY_TRANSFORMS
+            self._source_post_ir_transforms = _EMPTY_TRANSFORMS
+
+        # Resolve body-level transforms from target shim
+        resolved_target = resolve_shim(target_shim)
+        if resolved_target is not None:
+            self._target_pre_ir_transforms = resolved_target.pre_ir_transforms
+            self._target_post_ir_transforms = resolved_target.post_ir_transforms
+        else:
+            self._target_pre_ir_transforms = _EMPTY_TRANSFORMS
+            self._target_post_ir_transforms = _EMPTY_TRANSFORMS
 
         # Resolve response_id_prefix for each converter from its shim.
-        # The target prefix comes from the upstream shim (falling back
-        # to the target provider name); the source prefix is resolved
-        # from the source provider name.
-        target_shim = resolved or resolve_shim(target_provider)
-        self._target_id_prefix = target_shim.response_id_prefix if target_shim else ""
-        self._multimodal_tool_result = (
-            target_shim.multimodal_tool_result if target_shim else None
+        resolved_target_for_prefix = resolved_target or resolve_shim(target_provider)
+        self._target_id_prefix = (
+            resolved_target_for_prefix.response_id_prefix
+            if resolved_target_for_prefix
+            else ""
         )
-        source_shim = resolve_shim(source_provider)
-        self._source_id_prefix = source_shim.response_id_prefix if source_shim else ""
+        self._multimodal_tool_result = (
+            resolved_target_for_prefix.multimodal_tool_result
+            if resolved_target_for_prefix
+            else None
+        )
+        resolved_source_for_prefix = resolved_source or resolve_shim(source_provider)
+        self._source_id_prefix = (
+            resolved_source_for_prefix.response_id_prefix
+            if resolved_source_for_prefix
+            else ""
+        )
 
         # Set after convert_request()
         self._ctx: ConversionContext | None = None
@@ -402,8 +439,13 @@ class ConversionPipeline:
         if self._passthrough:
             t0 = time.perf_counter()
             result = body
-            if self._post_ir_transforms:
-                result = apply_transforms(self._post_ir_transforms, dict(result))
+            if self._source_pre_ir_transforms:
+                result = apply_transforms(self._source_pre_ir_transforms, dict(result))
+            if self._target_post_ir_transforms:
+                result = apply_transforms(
+                    self._target_post_ir_transforms,
+                    dict(result) if result is body else result,
+                )
             # No IR produced in passthrough mode
             self._ir_request = {}
             # Shadow round-trip for fidelity monitoring
@@ -413,9 +455,9 @@ class ConversionPipeline:
                 (time.perf_counter() - t0) * 1000, 2
             )
             return result
-        ctx.options["metadata_mode"] = "preserve"
+        ctx.options["metadata_mode"] = self._metadata_mode
         if self._target_provider == "google":
-            ctx.options["output_format"] = "rest"
+            ctx.options["output_format"] = self._google_output_format
 
         if self._multimodal_tool_result is not None:
             ctx.options["multimodal_tool_result"] = self._multimodal_tool_result
@@ -423,12 +465,16 @@ class ConversionPipeline:
         # Capability enforcement: reasoning (pre-IR)
         enforce_reasoning(
             ctx,
-            self._shim,
+            self._target_shim,
             model=self._upstream_model or body.get("model"),
             config_override=self._reasoning_config_override,
         )
 
         t_total = time.perf_counter()
+
+        # Phase 0: Source shim pre_ir_transforms (normalise source dialect)
+        if self._source_pre_ir_transforms:
+            body = apply_transforms(self._source_pre_ir_transforms, body)
 
         # Phase 1: Source → IR
         t0 = time.perf_counter()
@@ -458,14 +504,14 @@ class ConversionPipeline:
         # Capability enforcement: custom tools (post-IR)
         ir_request = enforce_custom_tools(
             ir_request,
-            shim=self._shim,
+            shim=self._target_shim,
             config_override=self._supports_custom_tools,
         )
 
         # Phase 2a: Shim-driven IR transforms
         ir_request = apply_ir_transforms(
             ir_request,
-            self._shim,
+            self._target_shim,
             upstream_model=self._upstream_model or body.get("model"),
             model_capabilities=self._model_capabilities,
             request_id=request_id,
@@ -486,10 +532,10 @@ class ConversionPipeline:
             ) from exc
         self._profile["ir_to_target_ms"] = round((time.perf_counter() - t0) * 1000, 2)
 
-        # Phase 2c: Body-level shim post_ir_transforms
+        # Phase 2c: Body-level target shim post_ir_transforms
         t0 = time.perf_counter()
-        if self._post_ir_transforms:
-            target_body = apply_transforms(self._post_ir_transforms, target_body)
+        if self._target_post_ir_transforms:
+            target_body = apply_transforms(self._target_post_ir_transforms, target_body)
         self._profile["body_transforms_ms"] = round(
             (time.perf_counter() - t0) * 1000, 2
         )
@@ -531,8 +577,13 @@ class ConversionPipeline:
         if self._passthrough:
             t0 = time.perf_counter()
             result = upstream_response
-            if self._pre_ir_transforms:
-                result = apply_transforms(self._pre_ir_transforms, dict(result))
+            if self._target_pre_ir_transforms:
+                result = apply_transforms(self._target_pre_ir_transforms, dict(result))
+            if self._source_post_ir_transforms:
+                result = apply_transforms(
+                    self._source_post_ir_transforms,
+                    dict(result) if result is upstream_response else result,
+                )
             if self._fidelity is not None:
                 self._run_fidelity_check(upstream_response, direction="response")
             self._profile["response_conversion_ms"] = round(
@@ -542,10 +593,10 @@ class ConversionPipeline:
 
         t_total = time.perf_counter()
 
-        # Phase 4a: Body-level shim pre_ir_transforms
+        # Phase 4a: Body-level target shim pre_ir_transforms
         response = upstream_response
-        if self._pre_ir_transforms:
-            response = apply_transforms(self._pre_ir_transforms, response)
+        if self._target_pre_ir_transforms:
+            response = apply_transforms(self._target_pre_ir_transforms, response)
 
         # Phase 4b: Target response → IR
         t0 = time.perf_counter()
@@ -588,6 +639,12 @@ class ConversionPipeline:
             (time.perf_counter() - t0) * 1000, 2
         )
 
+        # Phase 4d: Source shim post_ir_transforms (denormalise back)
+        if self._source_post_ir_transforms:
+            source_response = apply_transforms(
+                self._source_post_ir_transforms, source_response
+            )
+
         self._profile["response_conversion_ms"] = round(
             (time.perf_counter() - t_total) * 1000, 2
         )
@@ -622,15 +679,16 @@ class ConversionPipeline:
         # Same-format short-circuit: return a passthrough processor
         if self._passthrough:
             return PassthroughStreamProcessor(
-                pre_ir_transforms=self._pre_ir_transforms,
+                pre_ir_transforms=self._target_pre_ir_transforms,
+                post_ir_transforms=self._source_post_ir_transforms,
             )
 
         from_ctx = self._target_converter.create_stream_context()
         to_ctx = self._source_converter.create_stream_context()
 
         # Bridge preserve-mode metadata and shim-driven prefix
-        to_ctx.options["metadata_mode"] = "preserve"
-        from_ctx.options["metadata_mode"] = "preserve"
+        to_ctx.options["metadata_mode"] = self._metadata_mode
+        from_ctx.options["metadata_mode"] = self._metadata_mode
         from_ctx.options["response_id_prefix"] = self._target_id_prefix
         to_ctx.options["response_id_prefix"] = self._source_id_prefix
         if "_request_echo" in ctx.metadata:
@@ -648,7 +706,8 @@ class ConversionPipeline:
             source_converter=self._source_converter,
             from_ctx=from_ctx,
             to_ctx=to_ctx,
-            pre_ir_transforms=self._pre_ir_transforms,
+            pre_ir_transforms=self._target_pre_ir_transforms,
+            post_ir_transforms=self._source_post_ir_transforms,
             custom_tool_names=custom_names,
             on_ir_event=on_ir_event,
         )
@@ -671,8 +730,10 @@ class PassthroughStreamProcessor:
         self,
         *,
         pre_ir_transforms: tuple[Transform, ...] = (),
+        post_ir_transforms: tuple[Transform, ...] = (),
     ) -> None:
         self._pre_ir_transforms = pre_ir_transforms
+        self._post_ir_transforms = post_ir_transforms
         self._ctx = self._PassthroughCtx()
 
     @property
@@ -704,6 +765,8 @@ class PassthroughStreamProcessor:
     def process_chunk(self, chunk: dict[str, Any]) -> list[dict[str, Any]]:
         if self._pre_ir_transforms:
             chunk = apply_transforms(self._pre_ir_transforms, chunk)
+        if self._post_ir_transforms:
+            chunk = apply_transforms(self._post_ir_transforms, chunk)
         # Detect terminal events so source_context.is_ended reflects reality
         ctype = chunk.get("type", "")
         choices = chunk.get("choices", [])
@@ -745,6 +808,7 @@ class StreamProcessor:
         from_ctx: Any,
         to_ctx: Any,
         pre_ir_transforms: tuple[Transform, ...] = (),
+        post_ir_transforms: tuple[Transform, ...] = (),
         custom_tool_names: frozenset[str] = frozenset(),
         on_ir_event: Callable[[dict[str, Any]], None] | None = None,
     ) -> None:
@@ -753,6 +817,7 @@ class StreamProcessor:
         self._from_ctx = from_ctx
         self._to_ctx = to_ctx
         self._pre_ir_transforms = pre_ir_transforms
+        self._post_ir_transforms = post_ir_transforms
         self._custom_tool_names = custom_tool_names
         self._custom_arg_buffers: dict[str, str] = {}
         self._on_ir_event = on_ir_event
@@ -815,6 +880,10 @@ class StreamProcessor:
                 result.extend(sc for sc in source_chunks if sc)
             elif source_chunks:
                 result.append(source_chunks)
+
+        # Apply source shim post_ir_transforms to outbound chunks
+        if self._post_ir_transforms and result:
+            result = [apply_transforms(self._post_ir_transforms, c) for c in result]
 
         return result
 

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -200,10 +200,26 @@ class ConversionPipeline:
     For streaming, call :meth:`create_stream_processor` after
     :meth:`convert_request` to get a stateful chunk converter.
 
+    Transform ordering (diamond flow)::
+
+        Request path:
+          source_shim.pre_ir → Source→IR → [enforce/ir_transforms] →
+          IR→Target → target_shim.post_ir
+
+        Response path (mirror):
+          target_shim.pre_ir → Target→IR → IR→Source →
+          source_shim.post_ir
+
+    In passthrough mode (source == target, force_conversion=False),
+    the IR round-trip is skipped but shim body-level transforms still
+    apply: source pre_ir → target post_ir (request) and target pre_ir
+    → source post_ir (response).
+
     Args:
         source_provider: Client API format (e.g. ``"openai_chat"``).
         target_provider: Upstream API format (e.g. ``"anthropic"``).
-        shim: Provider shim instance, registered name, or ``None``.
+        target_shim: Provider shim for the upstream/target side.
+        source_shim: Provider shim for the client/source side.
         upstream_model: The upstream model ID (for shim pattern matching).
         model_capabilities: Model capability list (e.g. ``["text", "vision"]``).
         reasoning_config_override: External reasoning override (e.g. admin UI).

--- a/tests/gateway/test_proxy_transforms.py
+++ b/tests/gateway/test_proxy_transforms.py
@@ -70,23 +70,23 @@ def shim_with_transforms():
 class TestPipelineTransformResolution:
     def test_none_shim(self):
         p = ConversionPipeline("openai_chat", "openai_chat", None)
-        assert p._pre_ir_transforms == ()
-        assert p._post_ir_transforms == ()
+        assert p._target_pre_ir_transforms == ()
+        assert p._target_post_ir_transforms == ()
 
     def test_unknown_shim(self):
         p = ConversionPipeline("openai_chat", "openai_chat", "nonexistent-provider")
-        assert p._pre_ir_transforms == ()
-        assert p._post_ir_transforms == ()
+        assert p._target_pre_ir_transforms == ()
+        assert p._target_post_ir_transforms == ()
 
     def test_volcengine_shim(self, volcengine_shim):
         p = ConversionPipeline("openai_chat", "openai_chat", "volcengine--openai_chat")
-        assert p._post_ir_transforms == volcengine_shim.post_ir_transforms
-        assert p._pre_ir_transforms == ()
+        assert p._target_post_ir_transforms == volcengine_shim.post_ir_transforms
+        assert p._target_pre_ir_transforms == ()
 
     def test_shim_with_both_transforms(self, shim_with_transforms):
         p = ConversionPipeline("openai_chat", "openai_chat", "custom_provider")
-        assert p._pre_ir_transforms == shim_with_transforms.pre_ir_transforms
-        assert p._post_ir_transforms == shim_with_transforms.post_ir_transforms
+        assert p._target_pre_ir_transforms == shim_with_transforms.pre_ir_transforms
+        assert p._target_post_ir_transforms == shim_with_transforms.post_ir_transforms
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auto_detect.py
+++ b/tests/test_auto_detect.py
@@ -551,3 +551,262 @@ class TestEdgeCases:
             ]
         }
         assert detect_provider(body_with_image) == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# convert_response() tests
+# ---------------------------------------------------------------------------
+
+
+class TestConvertResponse:
+    """Tests for the convert_response() convenience function."""
+
+    def test_basic_roundtrip(self):
+        """Request→Response round-trip through convert_response()."""
+        from llm_rosetta import convert, convert_response
+
+        request_body = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+
+        # Convert request to Anthropic format
+        anthropic_request = convert(
+            request_body, "anthropic", source_provider="openai_chat"
+        )
+        assert "messages" in anthropic_request
+
+        # Simulate an Anthropic response
+        anthropic_response = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hi there!"}],
+            "model": "claude-sonnet-4-20250514",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+
+        # Convert response back to OpenAI format
+        openai_response = convert_response(
+            anthropic_response,
+            request_body,
+            source_provider="openai_chat",
+            target_provider="anthropic",
+        )
+
+        assert "choices" in openai_response
+        assert openai_response["choices"][0]["message"]["content"] == "Hi there!"
+
+    def test_same_provider_passthrough(self):
+        """Same-provider response conversion returns body as-is."""
+        from llm_rosetta import convert_response
+
+        request = {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
+        response = {
+            "id": "chatcmpl-123",
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "hello"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+        result = convert_response(
+            response,
+            request,
+            source_provider="openai_chat",
+            target_provider="openai_chat",
+        )
+        assert result == response
+
+    def test_force_conversion_same_provider(self):
+        """force_conversion=True triggers full pipeline even for same provider."""
+        from llm_rosetta import convert_response
+
+        request = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        response = {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "model": "gpt-4",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "hello"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+        }
+
+        result = convert_response(
+            response,
+            request,
+            source_provider="openai_chat",
+            target_provider="openai_chat",
+            force_conversion=True,
+        )
+        assert "choices" in result
+        assert result["choices"][0]["message"]["content"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# ConversionPipeline dual-shim tests
+# ---------------------------------------------------------------------------
+
+
+class TestDualShimPipeline:
+    """Tests for ConversionPipeline with source_shim and target_shim."""
+
+    def test_source_shim_pre_ir_transforms_applied(self):
+        """Source shim pre_ir_transforms are applied before Source→IR."""
+        from llm_rosetta.pipeline import ConversionPipeline
+        from llm_rosetta.shims import register_shim, unregister_shim
+        from llm_rosetta.shims.provider_shim import ProviderShim
+        from llm_rosetta.shims.transforms import strip_fields
+
+        shim = ProviderShim(
+            name="__test_src__",
+            base="openai_chat",
+            pre_ir_transforms=(strip_fields("custom_field"),),
+        )
+        register_shim(shim)
+        try:
+            pipeline = ConversionPipeline(
+                "openai_chat",
+                "anthropic",
+                source_shim="__test_src__",
+            )
+            body = {
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}],
+                "custom_field": "should-be-stripped",
+            }
+            result = pipeline.convert_request(body)
+            # custom_field should be stripped by source shim, so it won't
+            # appear in the converted Anthropic body
+            assert "custom_field" not in result
+        finally:
+            unregister_shim("__test_src__")
+
+    def test_dual_shim_both_transforms_applied(self):
+        """Both source and target shim transforms are applied."""
+        from llm_rosetta.pipeline import ConversionPipeline
+        from llm_rosetta.shims import register_shim, unregister_shim
+        from llm_rosetta.shims.provider_shim import ProviderShim
+        from llm_rosetta.shims.transforms import set_defaults, strip_fields
+
+        src_shim = ProviderShim(
+            name="__test_dual_src__",
+            base="openai_chat",
+            pre_ir_transforms=(strip_fields("src_marker"),),
+        )
+        tgt_shim = ProviderShim(
+            name="__test_dual_tgt__",
+            base="anthropic",
+            post_ir_transforms=(set_defaults(tgt_marker=True),),
+        )
+        register_shim(src_shim)
+        register_shim(tgt_shim)
+        try:
+            pipeline = ConversionPipeline(
+                "openai_chat",
+                "anthropic",
+                source_shim="__test_dual_src__",
+                target_shim="__test_dual_tgt__",
+            )
+            body = {
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}],
+                "src_marker": "strip-me",
+            }
+            result = pipeline.convert_request(body)
+            assert "src_marker" not in result
+            assert result.get("tgt_marker") is True
+        finally:
+            unregister_shim("__test_dual_src__")
+            unregister_shim("__test_dual_tgt__")
+
+    def test_passthrough_with_dual_shims(self):
+        """Passthrough mode applies both source and target body transforms."""
+        from llm_rosetta.pipeline import ConversionPipeline
+        from llm_rosetta.shims import register_shim, unregister_shim
+        from llm_rosetta.shims.provider_shim import ProviderShim
+        from llm_rosetta.shims.transforms import set_defaults, strip_fields
+
+        src_shim = ProviderShim(
+            name="__test_pass_src__",
+            base="openai_chat",
+            pre_ir_transforms=(strip_fields("src_quirk"),),
+        )
+        tgt_shim = ProviderShim(
+            name="__test_pass_tgt__",
+            base="openai_chat",
+            post_ir_transforms=(set_defaults(tgt_added=True),),
+        )
+        register_shim(src_shim)
+        register_shim(tgt_shim)
+        try:
+            pipeline = ConversionPipeline(
+                "openai_chat",
+                "openai_chat",
+                source_shim="__test_pass_src__",
+                target_shim="__test_pass_tgt__",
+                force_conversion=False,
+            )
+            body = {
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}],
+                "src_quirk": "strip-me",
+            }
+            result = pipeline.convert_request(body)
+            assert "src_quirk" not in result
+            assert result.get("tgt_added") is True
+        finally:
+            unregister_shim("__test_pass_src__")
+            unregister_shim("__test_pass_tgt__")
+
+    def test_shim_backward_compat_keyword(self):
+        """Legacy shim= keyword still works with deprecation warning."""
+        import warnings
+
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            pipeline = ConversionPipeline("openai_chat", "anthropic", shim=None)
+            # shim=None should not trigger deprecation (it's the default)
+            # Actually shim=None IS not None check fails... let me test with a value
+        # Verify the pipeline works
+        body = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        result = pipeline.convert_request(body)
+        assert "messages" in result
+
+    def test_shim_and_target_shim_raises(self):
+        """Passing both shim= and target_shim= raises ValueError."""
+        import pytest
+
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        with pytest.raises(ValueError, match="Cannot pass both"):
+            ConversionPipeline(
+                "openai_chat",
+                "anthropic",
+                target_shim="some-shim",
+                shim="other-shim",
+            )
+
+    def test_source_shim_none_no_transforms(self):
+        """source_shim=None means no source-side transforms."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        pipeline = ConversionPipeline("openai_chat", "anthropic", source_shim=None)
+        assert pipeline._source_pre_ir_transforms == ()
+        assert pipeline._source_post_ir_transforms == ()

--- a/tests/test_auto_detect.py
+++ b/tests/test_auto_detect.py
@@ -770,24 +770,34 @@ class TestDualShimPipeline:
             unregister_shim("__test_pass_src__")
             unregister_shim("__test_pass_tgt__")
 
-    def test_shim_backward_compat_keyword(self):
-        """Legacy shim= keyword still works with deprecation warning."""
+    def test_shim_none_no_deprecation(self):
+        """shim=None should not trigger a deprecation warning."""
         import warnings
 
         from llm_rosetta.pipeline import ConversionPipeline
 
-        with warnings.catch_warnings(record=True):
+        with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             pipeline = ConversionPipeline("openai_chat", "anthropic", shim=None)
-            # shim=None should not trigger deprecation (it's the default)
-            # Actually shim=None IS not None check fails... let me test with a value
-        # Verify the pipeline works
+            assert not any(issubclass(x.category, DeprecationWarning) for x in w)
+
         body = {
             "model": "gpt-4",
             "messages": [{"role": "user", "content": "hi"}],
         }
         result = pipeline.convert_request(body)
         assert "messages" in result
+
+    def test_shim_keyword_emits_deprecation(self):
+        """Legacy shim= with a non-None value emits DeprecationWarning."""
+        import warnings
+
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ConversionPipeline("openai_chat", "anthropic", shim="nonexistent")
+            assert any(issubclass(x.category, DeprecationWarning) for x in w)
 
     def test_shim_and_target_shim_raises(self):
         """Passing both shim= and target_shim= raises ValueError."""

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -39,7 +39,11 @@ EXPECTED_EXPORTS: dict[str, _ModuleSpec] = {
             "detect_provider",
             "get_converter_for_provider",
             "convert",
+            "convert_response",
             "ProviderType",
+            # Conversion pipeline
+            "ConversionPipeline",
+            "ConversionError",
             # Provider shim layer
             "ProviderShim",
             "register_shim",
@@ -54,7 +58,7 @@ EXPECTED_EXPORTS: dict[str, _ModuleSpec] = {
             "rename_field",
             "set_defaults",
         ],
-        "max_count": 30,
+        "max_count": 33,
     },
     "llm_rosetta.types.ir": {
         "items": None,  # too many to enumerate; just check count


### PR DESCRIPTION
## Summary

- **ConversionPipeline** gains dual-shim support (`source_shim` + `target_shim`), enabling proper normalization of both client and upstream provider dialects
- **`convert()`** rewritten as a thin wrapper around `ConversionPipeline`, eliminating ~50 lines of duplicated conversion logic
- **`convert_response()`** added as a new public function for response-direction conversion
- **`ConversionPipeline`**, **`ConversionError`**, and **`convert_response`** exported from the package root

### Breaking changes

- Pipeline's `shim` positional param renamed to `target_shim` — a `shim=` keyword-only alias is preserved with deprecation warning for backward compat
- Internal attributes `_pre_ir_transforms`/`_post_ir_transforms` renamed to `_target_pre_ir_transforms`/`_target_post_ir_transforms`
- **`convert()` passthrough behavior change**: previously, same-provider passthrough (`source == target`, `force_conversion=False`) returned the raw `source_body` unchanged, skipping all shim transforms. Now it delegates to the pipeline's passthrough mode, which applies `source_pre_ir_transforms` + `target_post_ir_transforms`. This is an improvement (registered shim transforms should apply even in passthrough), but callers relying on the old no-op behavior may notice the difference.

### Non-breaking additions

- `source_shim` param on ConversionPipeline for client-side dialect normalization
- `metadata_mode` and `google_output_format` pipeline params to decouple gateway defaults (REST, preserve) from library defaults (SDK, preserve)
- Gateway callers migrated to `target_shim=` keyword arg

## Test plan

- [x] All 2692+ existing tests pass
- [x] 10 new tests added: `convert_response()` round-trip, dual-shim pipeline, passthrough with dual shims, deprecation warning emission, backward compat, error cases
- [x] Lint clean (ruff check + ruff format + ty check + complexipy)
- [x] Pre-commit hooks pass

Closes #518