### PR TITLE
feat(admin): rerank and embedding provider/model management

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -196,6 +196,40 @@ tr:hover td { background: var(--bg-hover); }
 .seg-control > *:hover { background:var(--bg); }
 .seg-control input { position:absolute;opacity:0;width:0;height:0;pointer-events:auto; }
 .seg-control > *.active { background:var(--accent);color:#fff; }
+/* Capability badges for provider cards */
+.cap-badge { display:inline-flex;align-items:center;gap:3px;padding:1px 6px;border-radius:10px;font-size:10px;font-weight:600;margin-left:4px;vertical-align:middle; }
+.cap-badge svg { width:10px;height:10px;flex-shrink:0; }
+.cap-badge-llm { background:rgba(99,102,241,0.15);color:var(--accent); }
+.cap-badge-embedding { background:rgba(16,185,129,0.12);color:var(--green); }
+.cap-badge-rerank { background:rgba(245,158,11,0.12);color:var(--orange); }
+/* Provider-model cross-navigation */
+.provider-card .model-link { margin-left:auto;font-size:12px;color:var(--accent);cursor:pointer;display:inline-flex;align-items:center;gap:4px;opacity:0.8;transition:opacity 0.15s; }
+.provider-card .model-link:hover { opacity:1;text-decoration:underline; }
+.provider-link { color:inherit;cursor:pointer;text-decoration:none; }
+.provider-link:hover { text-decoration:underline;color:var(--accent); }
+.provider-card.highlight { border-color:var(--accent);box-shadow:0 0 0 2px rgba(99,102,241,0.3);transition:box-shadow 0.3s,border-color 0.3s; }
+/* Reset filter button */
+.btn-reset { padding:4px 8px;font-size:11px;color:var(--text-dim);border:1px solid var(--border);border-radius:6px;background:none;cursor:pointer;display:none;align-items:center;gap:3px;transition:all 0.15s; }
+.btn-reset:hover { color:var(--red);border-color:var(--red); }
+.btn-reset.visible { display:inline-flex; }
+/* Endpoint config sections in provider modal */
+.endpoint-section { margin-top:12px;padding:12px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);display:none; }
+.endpoint-section.visible { display:block; }
+.endpoint-section .section-label { font-size:12px;font-weight:600;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:10px;display:flex;align-items:center;gap:6px; }
+.endpoint-section .section-label .dot { width:8px;height:8px;border-radius:50%;display:inline-block; }
+.dot-llm { background:var(--accent); }
+.dot-embedding { background:var(--green); }
+.dot-rerank { background:var(--orange); }
+.endpoint-section .form-group { margin-bottom:10px; }
+.endpoint-section .form-group label { font-size:11px; }
+.endpoint-section .form-row { display:flex;gap:10px; }
+.endpoint-section .form-row .form-group { flex:1; }
+/* Capability checkboxes in provider modal */
+.cap-section { margin-top:18px;border-top:1px solid var(--border);padding-top:14px; }
+.cap-section-title { font-size:13px;font-weight:600;margin-bottom:10px;color:var(--text); }
+.cap-checks { display:flex;gap:16px;margin-bottom:14px; }
+.cap-checks label { display:flex;align-items:center;gap:6px;font-size:13px;cursor:pointer;color:var(--text);user-select:none; }
+.cap-checks input[type="checkbox"] { accent-color:var(--accent);width:16px;height:16px; }
 .chip-group { display:flex;gap:6px;flex-wrap:wrap; }
 .chip { display:inline-flex;align-items:center;gap:5px;padding:5px 12px;border:1px solid var(--border);border-radius:20px;font-size:13px;cursor:pointer;user-select:none;transition:all 0.15s;background:var(--bg-card);color:var(--text-dim); }
 .chip:hover { border-color:var(--accent);color:var(--accent); }
@@ -577,6 +611,12 @@ body { padding-bottom: 26px; }
     <div class="section">
       <div class="section-header">
         <h2 data-i18n="section.providers">Providers</h2>
+        <div class="seg-control" id="providerSeg">
+          <div class="active" onclick="switchProviderFilter(this,'all')"><span data-i18n="filter.all">All</span></div>
+          <div onclick="switchProviderFilter(this,'llm')"><span data-i18n="label.llm">LLM</span></div>
+          <div onclick="switchProviderFilter(this,'embedding')"><span data-i18n="label.embedding">Embedding</span></div>
+          <div onclick="switchProviderFilter(this,'rerank')"><span data-i18n="label.rerank">Rerank</span></div>
+        </div>
       </div>
       <div class="provider-toolbar" id="providerToolbar">
         <input id="providerSearch" placeholder="Search providers..." oninput="renderProviders()" data-i18n-placeholder="label.searchProviders" style="display:none">
@@ -605,7 +645,14 @@ body { padding-bottom: 26px; }
         <select id="modelProviderFilter" onchange="renderModels()">
           <option value="" data-i18n="filter.allProviders">All Providers</option>
         </select>
+        <div class="seg-control" id="modelTypeSeg">
+          <div class="active" onclick="switchModelDomain(this,'all')"><span data-i18n="filter.all">All</span></div>
+          <div onclick="switchModelDomain(this,'llm')"><span data-i18n="label.llm">LLM</span></div>
+          <div onclick="switchModelDomain(this,'embedding')"><span data-i18n="label.embedding">Embedding</span></div>
+          <div onclick="switchModelDomain(this,'rerank')"><span data-i18n="label.rerank">Rerank</span></div>
+        </div>
         <input id="modelSearch" placeholder="Search models..." oninput="renderModels()" data-i18n-placeholder="label.searchModels">
+        <button class="btn-reset" id="modelResetBtn" onclick="resetModelFilters()" data-i18n="btn.resetFilters">✕ Reset</button>
         <span class="model-count" id="modelCount"></span>
       </div>
       <div class="bulk-bar" id="modelBulkBar">
@@ -912,6 +959,43 @@ body { padding-bottom: 26px; }
         <label><input type="checkbox" id="provHoistSystem" checked> <span data-i18n="label.hoistSystemMessages">Hoist late system messages</span></label><span class="hint-icon">i<span class="hint-popup" style="width:340px;text-align:left" data-i18n-html="hint.hoistSystem">Rewrite mid-conversation system/developer messages as user-role envelopes (<code>[System: ...]</code>) to preserve the prompt cache prefix.<br><br><b>When enabled:</b> late system messages are hoisted — leading ones move to the system instruction, mid-conversation ones become user messages. This keeps the cacheable prefix stable and avoids silent message loss on some providers.<br><br><b>When disabled:</b> system messages are left in their original positions. This may break prompt caching or cause message loss on providers that reject non-leading system messages.</span></span>
       </div>
     </div>
+    <!-- Capability checkboxes -->
+    <div class="cap-section">
+      <div class="cap-section-title" data-i18n="label.capabilities">Capabilities</div>
+      <div class="cap-checks">
+        <label><input type="checkbox" id="provCapLlm" checked onchange="toggleProvCapSection()"> <span data-i18n="label.llm">LLM</span></label>
+        <label><input type="checkbox" id="provCapEmbedding" onchange="toggleProvCapSection()"> <span data-i18n="label.embedding">Embedding</span></label>
+        <label><input type="checkbox" id="provCapRerank" onchange="toggleProvCapSection()"> <span data-i18n="label.rerank">Rerank</span></label>
+      </div>
+      <!-- Embedding endpoint config -->
+      <div class="endpoint-section" id="provEmbeddingSection">
+        <div class="section-label"><span class="dot dot-embedding"></span> <span data-i18n="label.embeddingEndpoint">Embedding Endpoint</span></div>
+        <div class="form-row">
+          <div class="form-group">
+            <label data-i18n="label.format">Format</label>
+            <select id="provEmbeddingFormat"></select>
+          </div>
+          <div class="form-group">
+            <label data-i18n="label.embeddingPath">Embedding Path</label>
+            <input type="text" id="provEmbeddingPath" placeholder="/v1/embeddings">
+          </div>
+        </div>
+      </div>
+      <!-- Rerank endpoint config -->
+      <div class="endpoint-section" id="provRerankSection">
+        <div class="section-label"><span class="dot dot-rerank"></span> <span data-i18n="label.rerankEndpoint">Rerank Endpoint</span></div>
+        <div class="form-row">
+          <div class="form-group">
+            <label data-i18n="label.format">Format</label>
+            <select id="provRerankFormat"></select>
+          </div>
+          <div class="form-group">
+            <label data-i18n="label.rerankPath">Rerank Path</label>
+            <input type="text" id="provRerankPath" placeholder="/v1/rerank">
+          </div>
+        </div>
+      </div>
+    </div>
     <div class="modal-actions">
       <button class="btn" onclick="closeModal('providerModal')" data-i18n="btn.cancel">Cancel</button>
       <button class="btn btn-primary" onclick="saveProvider()" data-i18n="btn.save">Save</button>
@@ -949,9 +1033,10 @@ body { padding-bottom: 26px; }
       </div>
       <div class="form-group">
         <label data-i18n="label.modelType">Type</label>
-        <div class="seg-control">
+        <div class="seg-control" id="modelModalTypeSeg">
           <div class="active" onclick="segModelType(this,'llm')"><input type="radio" name="modelType" value="llm" checked><span data-i18n="label.llm">LLM</span></div>
           <div onclick="segModelType(this,'embedding')"><input type="radio" name="modelType" value="embedding"><span data-i18n="label.embedding">Embedding</span></div>
+          <div onclick="segModelType(this,'rerank')"><input type="radio" name="modelType" value="rerank"><span data-i18n="label.rerank">Rerank</span></div>
         </div>
       </div>
       <div class="form-group" id="modelCapsGroup">
@@ -1326,6 +1411,15 @@ const I18N = {
     'label.modelType':'Model Type',
     'label.llm':'LLM',
     'label.embedding':'Embedding',
+    'label.rerank':'Rerank',
+    'label.capabilities':'Capabilities',
+    'label.format':'Format',
+    'label.embeddingEndpoint':'Embedding Endpoint',
+    'label.rerankEndpoint':'Rerank Endpoint',
+    'label.embeddingPath':'Embedding Path',
+    'label.rerankPath':'Rerank Path',
+    'filter.all':'All',
+    'btn.resetFilters':'✕ Reset',
     'fetch.loading':'Fetching models...',
     'fetch.count':'{checked} / {total} selected',
     'fetch.noModels':'No models found from this provider.',
@@ -1456,6 +1550,15 @@ const I18N = {
     'label.modelType':'\u6a21\u578b\u7c7b\u578b',
     'label.llm':'LLM',
     'label.embedding':'Embedding',
+    'label.rerank':'Rerank',
+    'label.capabilities':'能力',
+    'label.format':'格式',
+    'label.embeddingEndpoint':'Embedding 端点',
+    'label.rerankEndpoint':'Rerank 端点',
+    'label.embeddingPath':'Embedding 路径',
+    'label.rerankPath':'Rerank 路径',
+    'filter.all':'全部',
+    'btn.resetFilters':'✕ 重置',
     'fetch.loading':'\u6b63\u5728\u83b7\u53d6\u6a21\u578b...',
     'fetch.count':'{checked} / {total} \u5df2\u9009',
     'fetch.noModels':'\u672a\u4ece\u8be5\u670d\u52a1\u65b9\u627e\u5230\u6a21\u578b\u3002',
@@ -1521,6 +1624,14 @@ function applyI18n() {
 let currentTab = localStorage.getItem('llm-rosetta-tab') || 'providers';
 let configData = null;
 let _credentialVisible = true;
+let _providerFilter = 'all';
+let _modelDomain = 'all';
+
+const _CAP_ICONS = {
+  llm: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4c0-1.1.9-2 2-2h8a2 2 0 012 2v5a2 2 0 01-2 2H5l-3 3V4z"/></svg>',
+  embedding: '<svg viewBox="0 0 16 16" fill="currentColor"><circle cx="4" cy="5" r="1.3"/><circle cx="10" cy="3" r="1.3"/><circle cx="12" cy="9" r="1.3"/><circle cx="6" cy="11" r="1.3"/><circle cx="3" cy="9" r="1"/><circle cx="9" cy="7" r="1"/><circle cx="13" cy="13" r="1"/></svg>',
+  rerank: '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M4 3h8M4 7h6M4 11h10"/><path d="M13 1.5l1.5 1.5-1.5 1.5" stroke-linejoin="round"/><path d="M3 9.5L1.5 11 3 12.5" stroke-linejoin="round"/></svg>',
+};
 let keysData = null;
 let logKeyLabels = [];
 let internalToken = null;
@@ -1978,6 +2089,28 @@ function openProviderModal(name, baseUrl, apiKey, proxy, provType) {
   document.getElementById('provTimeout').value = (provCfg && provCfg.timeout != null) ? provCfg.timeout : '';
   document.getElementById('provTimeout').placeholder = (configData.server && configData.server.upstream_timeout) || 300;
   if (window._detectedHostIp) document.getElementById('provProxy').placeholder = `e.g. http://${window._detectedHostIp}:7890`;
+  // Populate embedding/rerank capability checkboxes
+  const provCaps = provCfg ? _getProviderCaps(provCfg) : ['llm'];
+  document.getElementById('provCapLlm').checked = provCaps.includes('llm');
+  document.getElementById('provCapEmbedding').checked = provCaps.includes('embedding');
+  document.getElementById('provCapRerank').checked = provCaps.includes('rerank');
+  // Populate format dropdowns
+  const embFmts = configData?.embedding_formats || ['openai','cohere','jina','voyage'];
+  const rrFmts = configData?.rerank_formats || ['jina','cohere','voyage'];
+  const embFmtSel = document.getElementById('provEmbeddingFormat');
+  embFmtSel.innerHTML = embFmts.map(f => `<option value="${f}">${f}</option>`).join('');
+  const rrFmtSel = document.getElementById('provRerankFormat');
+  rrFmtSel.innerHTML = rrFmts.map(f => `<option value="${f}">${f}</option>`).join('');
+  if (provCfg) {
+    if (provCfg.embedding_format) embFmtSel.value = provCfg.embedding_format;
+    document.getElementById('provEmbeddingPath').value = provCfg.embedding_path || '/v1/embeddings';
+    if (provCfg.rerank_format) rrFmtSel.value = provCfg.rerank_format;
+    document.getElementById('provRerankPath').value = provCfg.rerank_path || '/v1/rerank';
+  } else {
+    document.getElementById('provEmbeddingPath').value = '';
+    document.getElementById('provRerankPath').value = '';
+  }
+  toggleProvCapSection();
   document.getElementById('providerModal').classList.add('open');
   // When editing, fetch the real (unmasked) key
   if (name && _credentialVisible) {
@@ -2057,10 +2190,13 @@ function openModelModal(model, provider, capabilities, upstreamModel, sourceMode
   // Set model type via seg-control
   const caps = capabilities || ['text', 'tools'];
   const isEmbedding = caps.includes('embedding') && !caps.includes('text');
-  const segLabels = modal.querySelectorAll('.seg-control > div');
+  const isRerank = caps.includes('rerank') && !caps.includes('text');
+  const detectedType = isRerank ? 'rerank' : isEmbedding ? 'embedding' : 'llm';
+  const segLabels = document.getElementById('modelModalTypeSeg').querySelectorAll(':scope > div');
   segLabels.forEach(l => l.classList.remove('active'));
-  segLabels[isEmbedding ? 1 : 0].classList.add('active');
-  document.querySelector('input[name="modelType"][value="' + (isEmbedding ? 'embedding' : 'llm') + '"]').checked = true;
+  const typeIdx = detectedType === 'rerank' ? 2 : detectedType === 'embedding' ? 1 : 0;
+  segLabels[typeIdx].classList.add('active');
+  document.querySelector('input[name="modelType"][value="' + detectedType + '"]').checked = true;
   // Set capability chips
   const chipMap = {capText: 'text', capVision: 'vision', capTools: 'tools', capReasoning: 'reasoning'};
   for (const [id, cap] of Object.entries(chipMap)) {
@@ -2178,6 +2314,116 @@ async function runNetDiag() {
   }
 }
 
+// ── Provider/Model domain switching and cross-navigation ──
+
+function _activateSegChild(el) {
+  el.parentElement.querySelectorAll(':scope > div').forEach(s => s.classList.remove('active'));
+  el.classList.add('active');
+}
+
+function switchProviderFilter(el, filter) {
+  _activateSegChild(el);
+  _providerFilter = filter;
+  renderProviders();
+}
+
+function switchModelDomain(el, domain) {
+  _activateSegChild(el);
+  _modelDomain = domain;
+  renderModels();
+}
+
+function resetModelFilters() {
+  _modelDomain = 'all';
+  const allSeg = document.querySelector('#modelTypeSeg > div:first-child');
+  if (allSeg) _activateSegChild(allSeg);
+  document.getElementById('modelProviderFilter').value = '';
+  document.getElementById('modelSearch').value = '';
+  renderModels();
+}
+
+function _getProviderCaps(cfg) {
+  const caps = [];
+  if (cfg.type || cfg.url_template || cfg.stream_url_template) caps.push('llm');
+  if (cfg.embedding_format) caps.push('embedding');
+  if (cfg.rerank_format) caps.push('rerank');
+  if (caps.length === 0) caps.push('llm');
+  return caps;
+}
+
+function _capBadgesHtml(caps) {
+  return caps.map(c => {
+    const cls = c === 'llm' ? 'cap-badge-llm' : c === 'embedding' ? 'cap-badge-embedding' : 'cap-badge-rerank';
+    return `<span class="cap-badge ${cls}">${_CAP_ICONS[c] || ''}${esc(c.toUpperCase())}</span>`;
+  }).join('');
+}
+
+function _countModelsForProvider(provName) {
+  if (!configData) return 0;
+  let count = 0;
+  for (const [, info] of Object.entries(configData.models || {})) {
+    const prov = typeof info === 'string' ? info : info.provider;
+    if (prov === provName) count++;
+  }
+  return count;
+}
+
+function goToModelsForProvider(provName) {
+  const modelsTab = document.querySelector('[data-tab="models"]');
+  if (modelsTab) { modelsTab.click(); }
+  _modelDomain = 'all';
+  const allSeg = document.querySelector('#modelTypeSeg > div:first-child');
+  if (allSeg) _activateSegChild(allSeg);
+  const filterSelect = document.getElementById('modelProviderFilter');
+  // Need to wait for renderModels to populate dropdown, then set value
+  setTimeout(() => {
+    filterSelect.value = provName;
+    renderModels();
+  }, 50);
+}
+
+function goToProviderFromModel(provName) {
+  const provTab = document.querySelector('[data-tab="providers"]');
+  if (provTab) { provTab.click(); }
+  _providerFilter = 'all';
+  const allSeg = document.querySelector('#providerSeg > div:first-child');
+  if (allSeg) _activateSegChild(allSeg);
+  renderProviders();
+  setTimeout(() => {
+    const card = document.querySelector(`[data-provider="${provName}"]`);
+    if (card) {
+      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      card.classList.add('highlight');
+      setTimeout(() => card.classList.remove('highlight'), 2000);
+    }
+  }, 50);
+}
+
+function toggleProvCapSection() {
+  const llm = document.getElementById('provCapLlm').checked;
+  const embed = document.getElementById('provCapEmbedding').checked;
+  const rerank = document.getElementById('provCapRerank').checked;
+  document.getElementById('provEmbeddingSection').classList.toggle('visible', embed);
+  document.getElementById('provRerankSection').classList.toggle('visible', rerank);
+  // Populate format dropdowns if shown
+  if (embed) _populateFormatDropdown('provEmbeddingFormat', configData?.embedding_formats || ['openai','cohere','jina','voyage']);
+  if (rerank) _populateFormatDropdown('provRerankFormat', configData?.rerank_formats || ['jina','cohere','voyage']);
+}
+
+function _populateFormatDropdown(selectId, formats) {
+  const sel = document.getElementById(selectId);
+  if (!sel || sel.options.length > 0) return;
+  sel.innerHTML = formats.map(f => `<option value="${f}">${f}</option>`).join('');
+}
+
+function _getModelType(info) {
+  if (typeof info === 'string') return 'llm';
+  if (info.type) return info.type;
+  const caps = info.capabilities || ['text'];
+  if (caps.includes('embedding') && !caps.includes('text')) return 'embedding';
+  return 'llm';
+}
+
 function renderProviders() {
   const grid = document.getElementById('providerGrid');
   const providers = configData.providers || {};
@@ -2207,6 +2453,11 @@ function renderProviders() {
         typeName.toLowerCase().includes(query) ||
         (cfg.base_url || '').toLowerCase().includes(query);
     });
+  }
+
+  // Filter by capability
+  if (_providerFilter !== 'all') {
+    entries = entries.filter(([, cfg]) => _getProviderCaps(cfg).includes(_providerFilter));
   }
 
   // Update count
@@ -2244,20 +2495,33 @@ function renderProviders() {
          ${cfg.proxy ? `<div class="field">Proxy: <code>${esc(cfg.proxy)}</code></div>` : ''}
      ${cfg.url_template ? `<div class="field">URL Template: <code>${esc(cfg.url_template)}</code></div>` : ''}
      ${cfg.stream_url_template ? `<div class="field">Stream URL Template: <code>${esc(cfg.stream_url_template)}</code></div>` : ''}`;
+    const provCaps = _getProviderCaps(cfg);
+    const capBadges = _capBadgesHtml(provCaps);
+    const modelCount = _countModelsForProvider(name);
+    const modelLink = modelCount > 0
+      ? `<span class="model-link" onclick="goToModelsForProvider('${esc(name)}')">${modelCount} model${modelCount !== 1 ? 's' : ''} →</span>`
+      : '';
+    // Embedding/rerank endpoint info
+    let epFieldsHtml = '';
+    if (!isList) {
+      if (cfg.embedding_format) epFieldsHtml += `<div class="field">Embed: <code>${esc(cfg.embedding_format)}</code> → <code>${esc(cfg.embedding_path || '/v1/embeddings')}</code></div>`;
+      if (cfg.rerank_format) epFieldsHtml += `<div class="field">Rerank: <code>${esc(cfg.rerank_format)}</code> → <code>${esc(cfg.rerank_path || '/v1/rerank')}</code></div>`;
+    }
     return `
-    <div class="provider-card${enabled ? '' : ' disabled'}">
+    <div class="provider-card${enabled ? '' : ' disabled'}" data-provider="${esc(name)}" style="display:flex;flex-direction:column">
       <div class="card-header">
-        <div class="name">${logoHtml}${esc(name)}</div>
+        <div class="name" style="display:flex;align-items:center;gap:6px">${logoHtml}${esc(name)} ${capBadges}</div>
         <label class="toggle" title="${enabled ? t('provider.enabled') : t('provider.disabled')}">
           <input type="checkbox" ${enabled ? 'checked' : ''} onchange="toggleProvider('${esc(name)}')">
           <span class="slider"></span>
         </label>
       </div>
-      ${fieldsHtml}
-      <div class="actions">
+      ${fieldsHtml}${epFieldsHtml}
+      <div class="actions" style="margin-top:auto;padding-top:12px">
         <button class="btn btn-sm" onclick="copyProviderEntry('${esc(name)}')">${t('btn.clone')}</button>
         <button class="btn btn-sm" onclick="editProvider('${esc(name)}')">${t('btn.edit')}</button>
         <button class="btn btn-sm btn-danger" onclick="deleteProvider('${esc(name)}')">${t('btn.delete')}</button>
+        ${modelLink}
       </div>
     </div>`;
   }).join('');
@@ -2333,6 +2597,16 @@ function renderModels() {
     entries = entries.filter(e => e.name.toLowerCase().includes(query) || e.prov.toLowerCase().includes(query));
   }
 
+  // Filter by model type (domain)
+  if (_modelDomain !== 'all') {
+    entries = entries.filter(e => _getModelType(e.info) === _modelDomain);
+  }
+
+  // Show/hide reset button
+  const hasFilters = _modelDomain !== 'all' || selectedProv || query;
+  const resetBtn = document.getElementById('modelResetBtn');
+  if (resetBtn) resetBtn.classList.toggle('visible', !!hasFilters);
+
   // Sort
   const dir = _modelSortDir === 'asc' ? 1 : -1;
   entries.sort((a, b) => {
@@ -2369,6 +2643,9 @@ function renderModels() {
     const hasTools = caps.includes('tools');
     const hasReasoning = caps.includes('reasoning');
     const isEmbedding = caps.includes('embedding');
+    const modelType = _getModelType(info);
+    const typeBadgeCls = modelType === 'llm' ? 'cap-badge-llm' : modelType === 'embedding' ? 'cap-badge-embedding' : 'cap-badge-rerank';
+    const typeBadge = `<span class="cap-badge ${typeBadgeCls}">${_CAP_ICONS[modelType] || ''}${esc(modelType.toUpperCase())}</span>`;
     const upstream = (typeof info === 'object' && info.upstream_model) ? info.upstream_model : '';
     const upstreamTag = upstream ? ` <span style="font-size:11px;color:var(--text-dim)" title="Upstream: ${esc(upstream)}">→ ${esc(upstream)}</span>` : '';
     const urlTpl = (typeof info === 'object' && info.url_template) ? info.url_template : '';
@@ -2376,7 +2653,7 @@ function renderModels() {
     return `<tr${rowDimmed ? ' class="model-disabled"' : ''}>
       <td><input type="checkbox" class="row-check" data-model="${esc(name)}" onchange="updateModelBulk()"></td>
       <td><code class="copyable" title="Click to copy" onclick="copyText('${esc(name)}')">${esc(name)}</code>${upstreamTag}${urlTplTag} ${capBadges}</td>
-      <td>${esc(prov)}${provDisabled ? ` <span style="color:var(--text-dim);font-size:11px">(${t('provider.disabled')})</span>` : ''}</td>
+      <td><span class="provider-link" onclick="goToProviderFromModel('${esc(prov)}')">${esc(prov)}</span>${provDisabled ? ` <span style="color:var(--text-dim);font-size:11px">(${t('provider.disabled')})</span>` : ''}</td>
       <td style="text-align:right; white-space:nowrap">
         <div class="pill-toggle ${modelEnabled ? 'is-on' : 'is-off'}" onclick="toggleModel('${esc(name)}')" title="${modelEnabled ? t('model.enabled') : t('model.disabled')}"><span class="pill-on">${t('label.on')}</span><span class="pill-off">${t('label.off')}</span></div>
         <div class="test-group">
@@ -2428,6 +2705,21 @@ async function saveProvider() {
   if (streamUrlTemplate) body.stream_url_template = streamUrlTemplate;
   body.supports_custom_tools = document.getElementById('provCustomTools').checked;
   body.hoist_system_messages = document.getElementById('provHoistSystem').checked;
+  // Embedding/rerank endpoint config
+  if (document.getElementById('provCapEmbedding').checked) {
+    body.embedding_format = document.getElementById('provEmbeddingFormat').value;
+    body.embedding_path = document.getElementById('provEmbeddingPath').value.trim() || '/v1/embeddings';
+  } else {
+    body.embedding_format = '';
+    body.embedding_path = '';
+  }
+  if (document.getElementById('provCapRerank').checked) {
+    body.rerank_format = document.getElementById('provRerankFormat').value;
+    body.rerank_path = document.getElementById('provRerankPath').value.trim() || '/v1/rerank';
+  } else {
+    body.rerank_format = '';
+    body.rerank_path = '';
+  }
   const provTimeoutVal = document.getElementById('provTimeout').value.trim();
   if (provTimeoutVal) body.timeout = parseFloat(provTimeoutVal);
   // When api_key is empty and we're editing, omit it so backend keeps the original
@@ -2666,6 +2958,8 @@ async function saveModel() {
   let capabilities;
   if (modelType === 'embedding') {
     capabilities = ['embedding'];
+  } else if (modelType === 'rerank') {
+    capabilities = ['rerank'];
   } else {
     capabilities = [];
     if (document.getElementById('capText').checked) capabilities.push('text');
@@ -2675,6 +2969,7 @@ async function saveModel() {
     if (capabilities.length === 0) capabilities.push('text');
   }
   const body = {provider, capabilities};
+  if (modelType !== 'llm') body.type = modelType;
   const upstreamModel = document.getElementById('modelUpstream').value.trim();
   if (upstreamModel) body.upstream_model = upstreamModel;
   // Collect reasoning override if reasoning capability is enabled

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -2374,12 +2374,10 @@ function goToModelsForProvider(provName) {
   _modelDomain = 'all';
   const allSeg = document.querySelector('#modelTypeSeg > div:first-child');
   if (allSeg) _activateSegChild(allSeg);
+  renderModels();
   const filterSelect = document.getElementById('modelProviderFilter');
-  // Need to wait for renderModels to populate dropdown, then set value
-  setTimeout(() => {
-    filterSelect.value = provName;
-    renderModels();
-  }, 50);
+  filterSelect.value = provName;
+  renderModels();
 }
 
 function goToProviderFromModel(provName) {
@@ -2389,14 +2387,14 @@ function goToProviderFromModel(provName) {
   const allSeg = document.querySelector('#providerSeg > div:first-child');
   if (allSeg) _activateSegChild(allSeg);
   renderProviders();
-  setTimeout(() => {
+  requestAnimationFrame(() => {
     const card = document.querySelector(`[data-provider="${provName}"]`);
     if (card) {
       card.scrollIntoView({ behavior: 'smooth', block: 'center' });
       card.classList.add('highlight');
       setTimeout(() => card.classList.remove('highlight'), 2000);
     }
-  }, 50);
+  });
 }
 
 function toggleProvCapSection() {
@@ -2412,7 +2410,7 @@ function toggleProvCapSection() {
 
 function _populateFormatDropdown(selectId, formats) {
   const sel = document.getElementById(selectId);
-  if (!sel || sel.options.length > 0) return;
+  if (!sel) return;
   sel.innerHTML = formats.map(f => `<option value="${f}">${f}</option>`).join('');
 }
 
@@ -2652,7 +2650,7 @@ function renderModels() {
     const urlTplTag = urlTpl ? ` <span style="font-size:10px;color:var(--text-dim);background:var(--bg-card);padding:1px 4px;border-radius:3px;border:1px solid var(--border)" title="URL Template: ${esc(urlTpl)}">⛓ url</span>` : '';
     return `<tr${rowDimmed ? ' class="model-disabled"' : ''}>
       <td><input type="checkbox" class="row-check" data-model="${esc(name)}" onchange="updateModelBulk()"></td>
-      <td><code class="copyable" title="Click to copy" onclick="copyText('${esc(name)}')">${esc(name)}</code>${upstreamTag}${urlTplTag} ${capBadges}</td>
+      <td><code class="copyable" title="Click to copy" onclick="copyText('${esc(name)}')">${esc(name)}</code>${upstreamTag}${urlTplTag} ${_modelDomain === 'all' ? typeBadge + ' ' : ''}${capBadges}</td>
       <td><span class="provider-link" onclick="goToProviderFromModel('${esc(prov)}')">${esc(prov)}</span>${provDisabled ? ` <span style="color:var(--text-dim);font-size:11px">(${t('provider.disabled')})</span>` : ''}</td>
       <td style="text-align:right; white-space:nowrap">
         <div class="pill-toggle ${modelEnabled ? 'is-on' : 'is-off'}" onclick="toggleModel('${esc(name)}')" title="${modelEnabled ? t('model.enabled') : t('model.disabled')}"><span class="pill-on">${t('label.on')}</span><span class="pill-off">${t('label.off')}</span></div>

--- a/src/llm_rosetta/gateway/admin/routes/_shared.py
+++ b/src/llm_rosetta/gateway/admin/routes/_shared.py
@@ -137,6 +137,19 @@ def _build_provider_entry(
     if "timeout" in body and body["timeout"] not in (None, ""):
         entry["timeout"] = float(body["timeout"])
 
+    # Embedding/rerank endpoint config (unified provider format)
+    for ep_key in (
+        "embedding_format",
+        "embedding_path",
+        "rerank_format",
+        "rerank_path",
+    ):
+        val = body.get(ep_key)
+        if val:
+            entry[ep_key] = val
+        elif ep_key in body and not val:
+            entry.pop(ep_key, None)
+
     return entry
 
 

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -101,6 +101,8 @@ def _normalize_model_entry(value: Any) -> dict[str, Any]:
         "provider": value.get("provider", ""),
         "capabilities": value.get("capabilities", ["text"]),
     }
+    if value.get("type"):
+        entry["type"] = value["type"]
     for key in (
         "upstream_model",
         "reasoning_override",
@@ -182,6 +184,8 @@ async def get_config(request: Any) -> Response:
                 }
                 for s in list_shims()
             ],
+            "embedding_formats": ["openai", "cohere", "jina", "voyage"],
+            "rerank_formats": ["jina", "cohere", "voyage"],
         }
     )
 
@@ -517,10 +521,13 @@ async def bulk_update_models(request: Any) -> Response:
 
 def _build_model_entry(body: dict[str, Any], provider: str) -> dict[str, Any]:
     """Build a model config entry from request body."""
+    model_type = body.get("type", "llm")
     entry: dict[str, Any] = {
         "provider": provider,
         "capabilities": body.get("capabilities", ["text"]),
     }
+    if model_type != "llm":
+        entry["type"] = model_type
     for opt_key in ("upstream_model", "url_template", "stream_url_template"):
         if body.get(opt_key):
             entry[opt_key] = body[opt_key]

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -184,8 +184,8 @@ async def get_config(request: Any) -> Response:
                 }
                 for s in list_shims()
             ],
-            "embedding_formats": ["openai", "cohere", "jina", "voyage"],
-            "rerank_formats": ["jina", "cohere", "voyage"],
+            "embedding_formats": GatewayConfig.EMBEDDING_FORMATS,
+            "rerank_formats": GatewayConfig.RERANK_FORMATS,
         }
     )
 

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -281,27 +281,49 @@ class GatewayConfig:
         }
 
         # --- Rerank routing ---
+        # 1. Extract from unified providers (new format)
         (
             self.rerank_providers,
             self.rerank_provider_infos,
             self.rerank_models,
-        ) = self._parse_rerank_config(
+        ) = self._extract_rerank_from_providers(
+            self._raw_providers, global_proxy=self.proxy
+        )
+        # 2. Merge legacy rerank_providers / rerank_models (old format)
+        legacy_rp, legacy_ri, legacy_rm = self._parse_rerank_config(
             raw.get("rerank_providers", {}),
             raw.get("rerank_models", {}),
             global_proxy=self.proxy,
         )
+        for k, v in legacy_rp.items():
+            self.rerank_providers.setdefault(k, v)
+        for k, v in legacy_ri.items():
+            self.rerank_provider_infos.setdefault(k, v)
+        for k, v in legacy_rm.items():
+            self.rerank_models.setdefault(k, v)
         self.default_rerank_format: str = raw.get("default_rerank_format", "jina")
 
         # --- Embedding routing ---
+        # 1. Extract from unified providers (new format)
         (
             self.embedding_providers,
             self.embedding_provider_infos,
             self.embedding_models,
-        ) = self._parse_embedding_config(
+        ) = self._extract_embedding_from_providers(
+            self._raw_providers, global_proxy=self.proxy
+        )
+        # 2. Merge legacy embedding_providers / embedding_models (old format)
+        legacy_ep, legacy_ei, legacy_em = self._parse_embedding_config(
             raw.get("embedding_providers", {}),
             raw.get("embedding_models", {}),
             global_proxy=self.proxy,
         )
+        for k, v in legacy_ep.items():
+            self.embedding_providers.setdefault(k, v)
+        for k, v in legacy_ei.items():
+            self.embedding_provider_infos.setdefault(k, v)
+        for k, v in legacy_em.items():
+            self.embedding_models.setdefault(k, v)
         self.default_embedding_format: str = raw.get(
             "default_embedding_format", "openai"
         )
@@ -626,6 +648,73 @@ class GatewayConfig:
             pinfo = pinfo.with_timeout(model_timeout)
 
         return route, pinfo
+
+    # ---- Unified endpoint extraction ------------------------------------
+
+    @staticmethod
+    def _extract_rerank_from_providers(
+        raw_providers: dict[str, dict[str, Any]],
+        *,
+        global_proxy: str | None = None,
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, ProviderInfo], dict[str, str]]:
+        """Extract rerank endpoint config from unified providers.
+
+        Providers that have a ``rerank_format`` field are treated as rerank-capable.
+        """
+        from .transport.provider_info import openai_auth
+
+        providers: dict[str, dict[str, Any]] = {}
+        provider_infos: dict[str, ProviderInfo] = {}
+        for name, cfg in raw_providers.items():
+            if "rerank_format" not in cfg:
+                continue
+            rerank_path = cfg.get("rerank_path", "/v1/rerank")
+            providers[name] = {
+                "format": cfg["rerank_format"],
+                "rerank_path": rerank_path,
+            }
+            provider_infos[name] = ProviderInfo(
+                name=f"rerank:{name}",
+                api_key=cfg.get("api_key", ""),
+                base_url=cfg.get("base_url", "").rstrip("/"),
+                auth_header_fn=openai_auth,
+                url_template="{base_url}" + rerank_path,
+                proxy_url=cfg.get("proxy") or global_proxy,
+            )
+        return providers, provider_infos, {}
+
+    @staticmethod
+    def _extract_embedding_from_providers(
+        raw_providers: dict[str, dict[str, Any]],
+        *,
+        global_proxy: str | None = None,
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, ProviderInfo], dict[str, str]]:
+        """Extract embedding endpoint config from unified providers.
+
+        Providers that have an ``embedding_format`` field are treated as
+        embedding-capable.
+        """
+        from .transport.provider_info import openai_auth
+
+        providers: dict[str, dict[str, Any]] = {}
+        provider_infos: dict[str, ProviderInfo] = {}
+        for name, cfg in raw_providers.items():
+            if "embedding_format" not in cfg:
+                continue
+            embedding_path = cfg.get("embedding_path", "/v1/embeddings")
+            providers[name] = {
+                "format": cfg["embedding_format"],
+                "embedding_path": embedding_path,
+            }
+            provider_infos[name] = ProviderInfo(
+                name=f"embedding:{name}",
+                api_key=cfg.get("api_key", ""),
+                base_url=cfg.get("base_url", "").rstrip("/"),
+                auth_header_fn=openai_auth,
+                url_template="{base_url}" + embedding_path,
+                proxy_url=cfg.get("proxy") or global_proxy,
+            )
+        return providers, provider_infos, {}
 
     # ---- Rerank routing -------------------------------------------------
 

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -228,6 +228,8 @@ class GatewayConfig:
 
     # Default capabilities when not specified in config.
     DEFAULT_CAPABILITIES: list[str] = ["text"]
+    EMBEDDING_FORMATS: list[str] = ["openai", "cohere", "jina", "voyage"]
+    RERANK_FORMATS: list[str] = ["jina", "cohere", "voyage"]
 
     def __init__(self, raw: dict[str, Any]) -> None:
         all_providers: dict[str, dict[str, str]] = raw.get("providers", {})
@@ -286,8 +288,13 @@ class GatewayConfig:
             self.rerank_providers,
             self.rerank_provider_infos,
             self.rerank_models,
-        ) = self._extract_rerank_from_providers(
-            self._raw_providers, global_proxy=self.proxy
+        ) = self._extract_endpoint_from_providers(
+            self._raw_providers,
+            format_key="rerank_format",
+            path_key="rerank_path",
+            default_path="/v1/rerank",
+            info_prefix="rerank",
+            global_proxy=self.proxy,
         )
         # 2. Merge legacy rerank_providers / rerank_models (old format)
         legacy_rp, legacy_ri, legacy_rm = self._parse_rerank_config(
@@ -309,8 +316,13 @@ class GatewayConfig:
             self.embedding_providers,
             self.embedding_provider_infos,
             self.embedding_models,
-        ) = self._extract_embedding_from_providers(
-            self._raw_providers, global_proxy=self.proxy
+        ) = self._extract_endpoint_from_providers(
+            self._raw_providers,
+            format_key="embedding_format",
+            path_key="embedding_path",
+            default_path="/v1/embeddings",
+            info_prefix="embedding",
+            global_proxy=self.proxy,
         )
         # 2. Merge legacy embedding_providers / embedding_models (old format)
         legacy_ep, legacy_ei, legacy_em = self._parse_embedding_config(
@@ -356,6 +368,14 @@ class GatewayConfig:
             elif model_type == "rerank" and provider_name in self.rerank_providers:
                 self.rerank_models.setdefault(name, provider_name)
                 to_remove.append(name)
+            elif model_type in ("embedding", "rerank"):
+                logger.warning(
+                    "Model %r has type=%s but provider %r lacks %s_format — skipped",
+                    name,
+                    model_type,
+                    provider_name,
+                    model_type,
+                )
 
         # Remove from main LLM pool (they belong in the specialized pool)
         for name in to_remove:
@@ -686,66 +706,38 @@ class GatewayConfig:
     # ---- Unified endpoint extraction ------------------------------------
 
     @staticmethod
-    def _extract_rerank_from_providers(
+    def _extract_endpoint_from_providers(
         raw_providers: dict[str, dict[str, Any]],
         *,
+        format_key: str,
+        path_key: str,
+        default_path: str,
+        info_prefix: str,
         global_proxy: str | None = None,
     ) -> tuple[dict[str, dict[str, Any]], dict[str, ProviderInfo], dict[str, str]]:
-        """Extract rerank endpoint config from unified providers.
+        """Extract endpoint config from unified providers.
 
-        Providers that have a ``rerank_format`` field are treated as rerank-capable.
+        Providers that have the given *format_key* field are treated as
+        capable of the corresponding endpoint type.
         """
         from .transport.provider_info import openai_auth
 
         providers: dict[str, dict[str, Any]] = {}
         provider_infos: dict[str, ProviderInfo] = {}
         for name, cfg in raw_providers.items():
-            if "rerank_format" not in cfg:
+            if format_key not in cfg:
                 continue
-            rerank_path = cfg.get("rerank_path", "/v1/rerank")
+            path = cfg.get(path_key, default_path)
             providers[name] = {
-                "format": cfg["rerank_format"],
-                "rerank_path": rerank_path,
+                "format": cfg[format_key],
+                path_key: path,
             }
             provider_infos[name] = ProviderInfo(
-                name=f"rerank:{name}",
+                name=f"{info_prefix}:{name}",
                 api_key=cfg.get("api_key", ""),
                 base_url=cfg.get("base_url", "").rstrip("/"),
                 auth_header_fn=openai_auth,
-                url_template="{base_url}" + rerank_path,
-                proxy_url=cfg.get("proxy") or global_proxy,
-            )
-        return providers, provider_infos, {}
-
-    @staticmethod
-    def _extract_embedding_from_providers(
-        raw_providers: dict[str, dict[str, Any]],
-        *,
-        global_proxy: str | None = None,
-    ) -> tuple[dict[str, dict[str, Any]], dict[str, ProviderInfo], dict[str, str]]:
-        """Extract embedding endpoint config from unified providers.
-
-        Providers that have an ``embedding_format`` field are treated as
-        embedding-capable.
-        """
-        from .transport.provider_info import openai_auth
-
-        providers: dict[str, dict[str, Any]] = {}
-        provider_infos: dict[str, ProviderInfo] = {}
-        for name, cfg in raw_providers.items():
-            if "embedding_format" not in cfg:
-                continue
-            embedding_path = cfg.get("embedding_path", "/v1/embeddings")
-            providers[name] = {
-                "format": cfg["embedding_format"],
-                "embedding_path": embedding_path,
-            }
-            provider_infos[name] = ProviderInfo(
-                name=f"embedding:{name}",
-                api_key=cfg.get("api_key", ""),
-                base_url=cfg.get("base_url", "").rstrip("/"),
-                auth_header_fn=openai_auth,
-                url_template="{base_url}" + embedding_path,
+                url_template="{base_url}" + path,
                 proxy_url=cfg.get("proxy") or global_proxy,
             )
         return providers, provider_infos, {}

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -328,6 +328,40 @@ class GatewayConfig:
             "default_embedding_format", "openai"
         )
 
+        # --- Extract type-tagged models from unified models pool ---
+        self._distribute_typed_models(raw.get("models", {}))
+
+    def _distribute_typed_models(self, raw_models: dict[str, Any]) -> None:
+        """Move models with ``type: embedding`` or ``type: rerank`` from the
+        main models pool into the corresponding embedding/rerank models dicts.
+
+        Models whose provider lacks the corresponding endpoint config are
+        silently skipped (left in main pool or dropped).
+        """
+        to_remove: list[str] = []
+        for name, value in raw_models.items():
+            if not isinstance(value, dict):
+                continue
+            model_type = value.get("type", "llm")
+            if model_type == "llm":
+                continue
+            if value.get("enabled") is False:
+                continue
+
+            provider_name = value.get("provider", "")
+
+            if model_type == "embedding" and provider_name in self.embedding_providers:
+                self.embedding_models.setdefault(name, provider_name)
+                to_remove.append(name)
+            elif model_type == "rerank" and provider_name in self.rerank_providers:
+                self.rerank_models.setdefault(name, provider_name)
+                to_remove.append(name)
+
+        # Remove from main LLM pool (they belong in the specialized pool)
+        for name in to_remove:
+            self.models.pop(name, None)
+            self.model_capabilities.pop(name, None)
+
     @staticmethod
     def _parse_custom_tools_overrides(
         raw_providers: dict[str, dict[str, str]],

--- a/tests/gateway/test_unified_provider_config.py
+++ b/tests/gateway/test_unified_provider_config.py
@@ -1,0 +1,268 @@
+"""Tests for unified provider config with embedding/rerank capabilities."""
+
+from __future__ import annotations
+
+
+from llm_rosetta.gateway.config import GatewayConfig
+
+
+def _base_config(**overrides):
+    raw = {
+        "providers": {
+            "openai": {
+                "api_key": "sk-test",
+                "base_url": "https://api.openai.com",
+                "type": "openai",
+            },
+        },
+        "models": {"gpt-4o": "openai"},
+    }
+    raw.update(overrides)
+    return raw
+
+
+class TestUnifiedProviderEmbeddingRerank:
+    """Providers can declare embedding/rerank capabilities via unified fields."""
+
+    def test_embedding_format_creates_embedding_provider(self):
+        raw = _base_config()
+        raw["providers"]["openai"]["embedding_format"] = "openai"
+        raw["providers"]["openai"]["embedding_path"] = "/v1/embeddings"
+        cfg = GatewayConfig(raw)
+        assert "openai" in cfg.embedding_providers
+        assert cfg.embedding_providers["openai"]["format"] == "openai"
+        assert cfg.embedding_providers["openai"]["embedding_path"] == "/v1/embeddings"
+
+    def test_rerank_format_creates_rerank_provider(self):
+        raw = _base_config()
+        raw["providers"]["jina"] = {
+            "api_key": "jina-test",
+            "base_url": "https://api.jina.ai",
+            "type": "openai",
+            "rerank_format": "jina",
+            "rerank_path": "/v1/rerank",
+        }
+        cfg = GatewayConfig(raw)
+        assert "jina" in cfg.rerank_providers
+        assert cfg.rerank_providers["jina"]["format"] == "jina"
+
+    def test_default_paths(self):
+        raw = _base_config()
+        raw["providers"]["openai"]["embedding_format"] = "openai"
+        raw["providers"]["openai"]["rerank_format"] = "jina"
+        cfg = GatewayConfig(raw)
+        assert cfg.embedding_providers["openai"]["embedding_path"] == "/v1/embeddings"
+        assert cfg.rerank_providers["openai"]["rerank_path"] == "/v1/rerank"
+
+    def test_provider_info_constructed(self):
+        raw = _base_config()
+        raw["providers"]["openai"]["embedding_format"] = "openai"
+        cfg = GatewayConfig(raw)
+        pinfo = cfg.embedding_provider_infos["openai"]
+        assert pinfo.name == "embedding:openai"
+        assert "api.openai.com" in pinfo.base_url
+
+    def test_rerank_provider_info_constructed(self):
+        raw = _base_config()
+        raw["providers"]["jina"] = {
+            "api_key": "jina-test",
+            "base_url": "https://api.jina.ai",
+            "type": "openai",
+            "rerank_format": "jina",
+        }
+        cfg = GatewayConfig(raw)
+        pinfo = cfg.rerank_provider_infos["jina"]
+        assert pinfo.name == "rerank:jina"
+        assert "api.jina.ai" in pinfo.base_url
+
+
+class TestLegacyBackwardCompat:
+    """Old separate rerank_providers/embedding_providers keys still work."""
+
+    def test_legacy_rerank_providers(self):
+        raw = _base_config(
+            rerank_providers={
+                "jina": {
+                    "api_key": "jina-test",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                }
+            },
+            rerank_models={"jina-reranker": "jina"},
+        )
+        cfg = GatewayConfig(raw)
+        assert "jina" in cfg.rerank_providers
+        assert "jina-reranker" in cfg.rerank_models
+
+    def test_legacy_embedding_providers(self):
+        raw = _base_config(
+            embedding_providers={
+                "embed-prov": {
+                    "api_key": "e-test",
+                    "base_url": "https://embed.example.com",
+                    "format": "openai",
+                }
+            },
+            embedding_models={"text-embed": "embed-prov"},
+        )
+        cfg = GatewayConfig(raw)
+        assert "embed-prov" in cfg.embedding_providers
+        assert "text-embed" in cfg.embedding_models
+
+    def test_unified_takes_precedence_over_legacy(self):
+        raw = _base_config(
+            rerank_providers={
+                "cohere": {
+                    "api_key": "old-key",
+                    "base_url": "https://old.cohere.com",
+                    "format": "voyage",
+                }
+            },
+        )
+        raw["providers"]["cohere"] = {
+            "api_key": "new-key",
+            "base_url": "https://api.cohere.com",
+            "type": "openai",
+            "rerank_format": "cohere",
+            "rerank_path": "/v2/rerank",
+        }
+        cfg = GatewayConfig(raw)
+        assert cfg.rerank_providers["cohere"]["format"] == "cohere"
+
+    def test_legacy_fills_gaps(self):
+        raw = _base_config(
+            rerank_providers={
+                "voyage": {
+                    "api_key": "v-test",
+                    "base_url": "https://api.voyageai.com",
+                    "format": "voyage",
+                }
+            },
+            rerank_models={"rerank-lite": "voyage"},
+        )
+        cfg = GatewayConfig(raw)
+        assert "voyage" in cfg.rerank_providers
+        assert "rerank-lite" in cfg.rerank_models
+
+
+class TestModelTypeField:
+    """Models with type=embedding/rerank are routed to specialized pools."""
+
+    def test_embedding_model_moved_to_pool(self):
+        raw = _base_config()
+        raw["providers"]["openai"]["embedding_format"] = "openai"
+        raw["models"]["text-embed-3"] = {
+            "provider": "openai",
+            "type": "embedding",
+        }
+        cfg = GatewayConfig(raw)
+        assert "text-embed-3" in cfg.embedding_models
+        assert "text-embed-3" not in cfg.models
+
+    def test_rerank_model_moved_to_pool(self):
+        raw = _base_config()
+        raw["providers"]["jina"] = {
+            "api_key": "jina-test",
+            "base_url": "https://api.jina.ai",
+            "type": "openai",
+            "rerank_format": "jina",
+        }
+        raw["models"]["jina-reranker"] = {
+            "provider": "jina",
+            "type": "rerank",
+        }
+        cfg = GatewayConfig(raw)
+        assert "jina-reranker" in cfg.rerank_models
+        assert "jina-reranker" not in cfg.models
+
+    def test_llm_model_stays_in_main_pool(self):
+        raw = _base_config()
+        raw["models"]["gpt-4o"] = {
+            "provider": "openai",
+            "type": "llm",
+            "capabilities": ["text", "vision"],
+        }
+        cfg = GatewayConfig(raw)
+        assert "gpt-4o" in cfg.models
+        assert "gpt-4o" not in cfg.embedding_models
+        assert "gpt-4o" not in cfg.rerank_models
+
+    def test_default_type_is_llm(self):
+        raw = _base_config()
+        cfg = GatewayConfig(raw)
+        assert "gpt-4o" in cfg.models
+
+    def test_resolve_embedding_via_type(self):
+        raw = _base_config()
+        raw["providers"]["openai"]["embedding_format"] = "openai"
+        raw["providers"]["openai"]["embedding_path"] = "/v1/embeddings"
+        raw["models"]["text-embed-3"] = {
+            "provider": "openai",
+            "type": "embedding",
+        }
+        cfg = GatewayConfig(raw)
+        route = cfg.resolve_embedding("text-embed-3")
+        assert route.provider_name == "openai"
+        assert route.format == "openai"
+        assert route.embedding_path == "/v1/embeddings"
+
+    def test_resolve_rerank_via_type(self):
+        raw = _base_config()
+        raw["providers"]["jina"] = {
+            "api_key": "jina-test",
+            "base_url": "https://api.jina.ai",
+            "type": "openai",
+            "rerank_format": "jina",
+            "rerank_path": "/v1/rerank",
+        }
+        raw["models"]["jina-reranker"] = {
+            "provider": "jina",
+            "type": "rerank",
+        }
+        cfg = GatewayConfig(raw)
+        route = cfg.resolve_rerank("jina-reranker")
+        assert route.provider_name == "jina"
+        assert route.format == "jina"
+        assert route.rerank_path == "/v1/rerank"
+
+    def test_disabled_model_not_distributed(self):
+        raw = _base_config()
+        raw["providers"]["openai"]["embedding_format"] = "openai"
+        raw["models"]["text-embed-disabled"] = {
+            "provider": "openai",
+            "type": "embedding",
+            "enabled": False,
+        }
+        cfg = GatewayConfig(raw)
+        assert "text-embed-disabled" not in cfg.embedding_models
+        assert "text-embed-disabled" not in cfg.models
+
+
+class TestMultiCapProvider:
+    """A single provider can support LLM + embedding + rerank."""
+
+    def test_all_three_capabilities(self):
+        raw = _base_config()
+        raw["providers"]["cohere"] = {
+            "api_key": "co-test",
+            "base_url": "https://api.cohere.com",
+            "type": "openai",
+            "embedding_format": "cohere",
+            "embedding_path": "/v2/embed",
+            "rerank_format": "cohere",
+            "rerank_path": "/v2/rerank",
+        }
+        raw["models"].update(
+            {
+                "command-r": {"provider": "cohere", "capabilities": ["text", "tools"]},
+                "embed-v4": {"provider": "cohere", "type": "embedding"},
+                "rerank-v3": {"provider": "cohere", "type": "rerank"},
+            }
+        )
+        cfg = GatewayConfig(raw)
+        assert "command-r" in cfg.models
+        assert "embed-v4" in cfg.embedding_models
+        assert "rerank-v3" in cfg.rerank_models
+        assert "cohere" in cfg.providers
+        assert "cohere" in cfg.embedding_providers
+        assert "cohere" in cfg.rerank_providers


### PR DESCRIPTION
## Summary

- Unified provider config: providers can declare embedding/rerank capabilities via `embedding_format`/`rerank_format` fields alongside LLM config, eliminating the need for separate `rerank_providers`/`embedding_providers` top-level keys (old format fully backward-compatible)
- Model type field: models in the main `models` section support `"type": "embedding"` or `"type": "rerank"` for automatic routing to specialized pools
- Admin UI: provider capability badges (LLM/Embedding/Rerank with SVG icons), capability filter, edit modal with checkboxes toggling endpoint config sections
- Admin UI: model table with All/LLM/Embedding/Rerank type sub-tabs, reset filter button
- Admin UI: provider ↔ model cross-navigation (provider cards show "N models →" link, model table provider names are clickable)
- 17 new tests covering unified config, backward compat, model type routing, and multi-capability providers

Closes #530.

## Test plan

- [x] `make test` passes (2721 passed, 0 failed)
- [ ] Manual verification: start gateway, open admin UI, verify provider capability badges and filters
- [ ] Manual verification: add/edit provider with embedding/rerank checkboxes
- [ ] Manual verification: model type sub-tabs filter correctly
- [ ] Manual verification: provider ↔ model cross-navigation works
- [ ] Verify backward compat with existing config files (old format)