### PR TITLE
feat(config): versioned migration framework with auto-upgrade on load

### DIFF
--- a/examples/gateway/config.jsonc
+++ b/examples/gateway/config.jsonc
@@ -1,10 +1,17 @@
 {
+  "config_version": 1,
+
   // Provider credentials and base URLs.
   // API keys support ${ENV_VAR} syntax for environment variable substitution.
+  // Providers can declare LLM, embedding, and rerank capabilities via
+  // their respective fields (type, embedding_format, rerank_format).
   "providers": {
     "openai_chat": {
       "api_key": "${OPENAI_API_KEY}",
-      "base_url": "https://api.openai.com/v1"
+      "base_url": "https://api.openai.com/v1",
+      // Embedding endpoint on the same provider
+      "embedding_format": "openai",
+      "embedding_path": "/v1/embeddings"
     },
     "openai_responses": {
       "api_key": "${OPENAI_API_KEY}",
@@ -17,12 +24,35 @@
     "google": {
       "api_key": "${GOOGLE_API_KEY}",
       "base_url": "https://generativelanguage.googleapis.com"
+    },
+    "jina": {
+      "api_key": "${JINA_API_KEY}",
+      "base_url": "https://api.jina.ai",
+      "embedding_format": "jina",
+      "embedding_path": "/v1/embeddings",
+      "rerank_format": "jina",
+      "rerank_path": "/v1/rerank"
+    },
+    "cohere": {
+      "api_key": "${COHERE_API_KEY}",
+      "base_url": "https://api.cohere.com",
+      "embedding_format": "cohere",
+      "embedding_path": "/v2/embed",
+      "rerank_format": "cohere",
+      "rerank_path": "/v2/rerank"
+    },
+    "voyage": {
+      "api_key": "${VOYAGE_API_KEY}",
+      "base_url": "https://api.voyageai.com",
+      "embedding_format": "voyage",
+      "embedding_path": "/v1/embeddings",
+      "rerank_format": "voyage",
+      "rerank_path": "/v1/rerank"
     }
   },
 
   // Model → provider routing table.
-  // When a request arrives with a given model name, the gateway
-  // looks up the target provider here.
+  // Models use "type" to declare their function: "llm" (default), "embedding", or "rerank".
   "models": {
     "gpt-4o": "openai_chat",
     "gpt-4o-mini": "openai_chat",
@@ -33,81 +63,17 @@
     "claude-3-5-haiku-20241022": "anthropic",
     "gemini-2.0-flash": "google",
     "gemini-2.5-pro": "google",
-    "gemini-2.5-flash": "google"
+    "gemini-2.5-flash": "google",
+    // Embedding models
+    "text-embedding-3-small": { "provider": "openai_chat", "type": "embedding" },
+    "jina-embeddings-v3": { "provider": "jina", "type": "embedding" },
+    "embed-v4.0": { "provider": "cohere", "type": "embedding" },
+    "voyage-3-lite": { "provider": "voyage", "type": "embedding" },
+    // Rerank models
+    "jina-reranker-v2-base-multilingual": { "provider": "jina", "type": "rerank" },
+    "rerank-v3.5": { "provider": "cohere", "type": "rerank" },
+    "rerank-2-lite": { "provider": "voyage", "type": "rerank" }
   },
-
-  // Rerank providers — each entry specifies the upstream format and endpoint path.
-  // "format" maps to a converter: "jina", "cohere", or "voyage".
-  "rerank_providers": {
-    "jina": {
-      "api_key": "${JINA_API_KEY}",
-      "base_url": "https://api.jina.ai",
-      "format": "jina",
-      "rerank_path": "/v1/rerank"
-    },
-    "cohere": {
-      "api_key": "${COHERE_API_KEY}",
-      "base_url": "https://api.cohere.com",
-      "format": "cohere",
-      "rerank_path": "/v2/rerank"
-    },
-    "voyage": {
-      "api_key": "${VOYAGE_API_KEY}",
-      "base_url": "https://api.voyageai.com",
-      "format": "voyage",
-      "rerank_path": "/v1/rerank"
-    }
-  },
-
-  // Rerank model → provider routing table.
-  "rerank_models": {
-    "jina-reranker-v2-base-multilingual": "jina",
-    "rerank-v3.5": "cohere",
-    "rerank-2-lite": "voyage"
-  },
-
-  // Default format for incoming rerank requests (jina, cohere, or voyage).
-  "default_rerank_format": "jina",
-
-  // Embedding providers — each entry specifies the upstream format and endpoint path.
-  // "format" maps to a converter: "openai", "cohere", "jina", or "voyage".
-  "embedding_providers": {
-    "openai": {
-      "api_key": "${OPENAI_API_KEY}",
-      "base_url": "https://api.openai.com",
-      "format": "openai",
-      "embedding_path": "/v1/embeddings"
-    },
-    "jina": {
-      "api_key": "${JINA_API_KEY}",
-      "base_url": "https://api.jina.ai",
-      "format": "jina",
-      "embedding_path": "/v1/embeddings"
-    },
-    "cohere": {
-      "api_key": "${COHERE_API_KEY}",
-      "base_url": "https://api.cohere.com",
-      "format": "cohere",
-      "embedding_path": "/v2/embed"
-    },
-    "voyage": {
-      "api_key": "${VOYAGE_API_KEY}",
-      "base_url": "https://api.voyageai.com",
-      "format": "voyage",
-      "embedding_path": "/v1/embeddings"
-    }
-  },
-
-  // Embedding model → provider routing table.
-  "embedding_models": {
-    "text-embedding-3-small": "openai",
-    "jina-embeddings-v3": "jina",
-    "embed-v4.0": "cohere",
-    "voyage-3-lite": "voyage"
-  },
-
-  // Default format for incoming embedding requests.
-  "default_embedding_format": "openai",
 
   // Server settings
   "server": {

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -191,16 +191,35 @@ class ConfigIO(Protocol):
 
 
 class JsoncConfigIO:
-    """Default :class:`ConfigIO` — reads/writes JSONC with env-var substitution."""
+    """Default :class:`ConfigIO` — reads/writes JSONC with env-var substitution.
+
+    On load, applies any pending config migrations and writes back the
+    migrated config if changes were made.
+    """
 
     def load(self, path: str) -> dict[str, Any]:
-        return load_config(path)
+        raw = load_config(path)
+        return self._apply_migrations(raw, path)
 
     def load_raw(self, path: str) -> dict[str, Any]:
-        return load_config_raw(path)
+        raw = load_config_raw(path)
+        return self._apply_migrations(raw, path)
 
     def save(self, path: str, data: dict[str, Any]) -> None:
         write_config(path, data)
+
+    @staticmethod
+    def _apply_migrations(raw: dict[str, Any], path: str) -> dict[str, Any]:
+        from .migrations import migrate
+
+        raw, changed = migrate(raw)
+        if changed:
+            with config_lock(path):
+                write_config(path, raw)
+            logger.info(
+                "config: migrated %s to version %s", path, raw.get("config_version")
+            )
+        return raw
 
 
 def discover_config(explicit_path: str | None = None) -> str | None:

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -199,25 +199,40 @@ class JsoncConfigIO:
 
     def load(self, path: str) -> dict[str, Any]:
         raw = load_config(path)
-        return self._apply_migrations(raw, path)
+        return self._apply_migrations(raw, path, is_raw=False)
 
     def load_raw(self, path: str) -> dict[str, Any]:
         raw = load_config_raw(path)
-        return self._apply_migrations(raw, path)
+        return self._apply_migrations(raw, path, is_raw=True)
 
     def save(self, path: str, data: dict[str, Any]) -> None:
         write_config(path, data)
 
     @staticmethod
-    def _apply_migrations(raw: dict[str, Any], path: str) -> dict[str, Any]:
+    def _apply_migrations(
+        raw: dict[str, Any], path: str, *, is_raw: bool = False
+    ) -> dict[str, Any]:
         from .migrations import migrate
 
         raw, changed = migrate(raw)
         if changed:
+            if is_raw:
+                disk_data = raw
+            else:
+                disk_data = load_config_raw(path)
+                migrate(disk_data)
+            import shutil
+
+            bak = path + ".pre-migration.bak"
+            if not os.path.exists(bak):
+                shutil.copy2(path, bak)
+                logger.info("config: backed up original to %s", bak)
             with config_lock(path):
-                write_config(path, raw)
+                write_config(path, disk_data)
             logger.info(
-                "config: migrated %s to version %s", path, raw.get("config_version")
+                "config: migrated %s to version %s",
+                path,
+                disk_data.get("config_version"),
             )
         return raw
 

--- a/src/llm_rosetta/gateway/migrations.py
+++ b/src/llm_rosetta/gateway/migrations.py
@@ -1,0 +1,133 @@
+"""Versioned config migration framework.
+
+Each migration is a function that transforms a raw config dict from one
+schema version to the next.  Migrations are registered in ``_MIGRATIONS``
+and run sequentially by :func:`migrate`.  The ``config_version`` key
+tracks which migrations have been applied.
+
+To add a new migration:
+  1. Write a function ``_migrate_vN_to_vM(raw)`` that mutates *raw* in-place.
+  2. Append ``(N, _migrate_vN_to_vM)`` to ``_MIGRATIONS``.
+  3. Bump ``CURRENT_VERSION`` to ``M``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("llm-rosetta-gateway")
+
+CURRENT_VERSION = 1
+
+
+def _migrate_v0_to_v1(raw: dict[str, Any]) -> None:
+    """Merge legacy rerank/embedding separate-pool config into unified providers.
+
+    Before (v0):
+        rerank_providers:   {name: {api_key, base_url, format, rerank_path}}
+        rerank_models:      {model: provider | {provider}}
+        embedding_providers: {name: {api_key, base_url, format, embedding_path}}
+        embedding_models:    {model: provider | {provider}}
+        default_rerank_format: str
+        default_embedding_format: str
+
+    After (v1):
+        providers.{name}.rerank_format / rerank_path  (merged onto existing or new)
+        providers.{name}.embedding_format / embedding_path
+        models.{model}.type = "rerank" | "embedding"
+    """
+    providers = raw.setdefault("providers", {})
+    models = raw.setdefault("models", {})
+
+    # --- Merge rerank_providers ---
+    for name, cfg in raw.get("rerank_providers", {}).items():
+        if not isinstance(cfg, dict):
+            continue
+        if name in providers:
+            prov = providers[name]
+            prov.setdefault("rerank_format", cfg.get("format", "jina"))
+            prov.setdefault("rerank_path", cfg.get("rerank_path", "/v1/rerank"))
+        else:
+            providers[name] = {
+                "api_key": cfg.get("api_key", ""),
+                "base_url": cfg.get("base_url", ""),
+                "rerank_format": cfg.get("format", "jina"),
+                "rerank_path": cfg.get("rerank_path", "/v1/rerank"),
+            }
+            if cfg.get("enabled") is False:
+                providers[name]["enabled"] = False
+
+    # --- Merge embedding_providers ---
+    for name, cfg in raw.get("embedding_providers", {}).items():
+        if not isinstance(cfg, dict):
+            continue
+        if name in providers:
+            prov = providers[name]
+            prov.setdefault("embedding_format", cfg.get("format", "openai"))
+            prov.setdefault(
+                "embedding_path", cfg.get("embedding_path", "/v1/embeddings")
+            )
+        else:
+            providers[name] = {
+                "api_key": cfg.get("api_key", ""),
+                "base_url": cfg.get("base_url", ""),
+                "embedding_format": cfg.get("format", "openai"),
+                "embedding_path": cfg.get("embedding_path", "/v1/embeddings"),
+            }
+            if cfg.get("enabled") is False:
+                providers[name]["enabled"] = False
+
+    # --- Merge rerank_models ---
+    for model_name, value in raw.get("rerank_models", {}).items():
+        if model_name in models:
+            continue
+        prov = value if isinstance(value, str) else value.get("provider", "")
+        models[model_name] = {"provider": prov, "type": "rerank"}
+
+    # --- Merge embedding_models ---
+    for model_name, value in raw.get("embedding_models", {}).items():
+        if model_name in models:
+            continue
+        prov = value if isinstance(value, str) else value.get("provider", "")
+        models[model_name] = {"provider": prov, "type": "embedding"}
+
+    # --- Remove legacy keys ---
+    for key in (
+        "rerank_providers",
+        "rerank_models",
+        "default_rerank_format",
+        "embedding_providers",
+        "embedding_models",
+        "default_embedding_format",
+    ):
+        raw.pop(key, None)
+
+
+_MIGRATIONS: list[tuple[int, Any]] = [
+    (0, _migrate_v0_to_v1),
+]
+
+
+def migrate(raw: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Apply all pending migrations to *raw* config dict.
+
+    Returns:
+        Tuple of (migrated_dict, changed) where *changed* is True if any
+        migration was applied.
+    """
+    version = raw.get("config_version", 0)
+    if version >= CURRENT_VERSION:
+        return raw, False
+
+    changed = False
+    for from_version, migration_fn in _MIGRATIONS:
+        if version <= from_version:
+            logger.info(
+                "config: applying migration v%d → v%d", from_version, from_version + 1
+            )
+            migration_fn(raw)
+            changed = True
+
+    raw["config_version"] = CURRENT_VERSION
+    return raw, changed

--- a/src/llm_rosetta/gateway/migrations.py
+++ b/src/llm_rosetta/gateway/migrations.py
@@ -40,19 +40,22 @@ def _migrate_v0_to_v1(raw: dict[str, Any]) -> None:
     providers = raw.setdefault("providers", {})
     models = raw.setdefault("models", {})
 
+    default_rerank_fmt = raw.get("default_rerank_format", "jina")
+    default_embed_fmt = raw.get("default_embedding_format", "openai")
+
     # --- Merge rerank_providers ---
     for name, cfg in raw.get("rerank_providers", {}).items():
         if not isinstance(cfg, dict):
             continue
         if name in providers:
             prov = providers[name]
-            prov.setdefault("rerank_format", cfg.get("format", "jina"))
+            prov.setdefault("rerank_format", cfg.get("format", default_rerank_fmt))
             prov.setdefault("rerank_path", cfg.get("rerank_path", "/v1/rerank"))
         else:
             providers[name] = {
                 "api_key": cfg.get("api_key", ""),
                 "base_url": cfg.get("base_url", ""),
-                "rerank_format": cfg.get("format", "jina"),
+                "rerank_format": cfg.get("format", default_rerank_fmt),
                 "rerank_path": cfg.get("rerank_path", "/v1/rerank"),
             }
             if cfg.get("enabled") is False:
@@ -64,7 +67,7 @@ def _migrate_v0_to_v1(raw: dict[str, Any]) -> None:
             continue
         if name in providers:
             prov = providers[name]
-            prov.setdefault("embedding_format", cfg.get("format", "openai"))
+            prov.setdefault("embedding_format", cfg.get("format", default_embed_fmt))
             prov.setdefault(
                 "embedding_path", cfg.get("embedding_path", "/v1/embeddings")
             )
@@ -72,7 +75,7 @@ def _migrate_v0_to_v1(raw: dict[str, Any]) -> None:
             providers[name] = {
                 "api_key": cfg.get("api_key", ""),
                 "base_url": cfg.get("base_url", ""),
-                "embedding_format": cfg.get("format", "openai"),
+                "embedding_format": cfg.get("format", default_embed_fmt),
                 "embedding_path": cfg.get("embedding_path", "/v1/embeddings"),
             }
             if cfg.get("enabled") is False:
@@ -116,13 +119,13 @@ def migrate(raw: dict[str, Any]) -> tuple[dict[str, Any], bool]:
         Tuple of (migrated_dict, changed) where *changed* is True if any
         migration was applied.
     """
-    version = raw.get("config_version", 0)
-    if version >= CURRENT_VERSION:
+    initial_version = raw.get("config_version", 0)
+    if initial_version >= CURRENT_VERSION:
         return raw, False
 
     changed = False
     for from_version, migration_fn in _MIGRATIONS:
-        if version <= from_version:
+        if initial_version <= from_version:
             logger.info(
                 "config: applying migration v%d → v%d", from_version, from_version + 1
             )

--- a/tests/gateway/test_migrations.py
+++ b/tests/gateway/test_migrations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 
 
 from llm_rosetta.gateway.migrations import CURRENT_VERSION, migrate
@@ -306,3 +307,63 @@ class TestConfigIOIntegration:
         assert raw["providers"]["openai"]["api_key"] == "${OPENAI_API_KEY}"
         assert raw["providers"]["openai"]["embedding_format"] == "openai"
         assert "embedding_providers" not in raw
+
+    def test_load_does_not_write_substituted_env_vars(self, tmp_path, monkeypatch):
+        """Critical: load() must not write substituted secrets back to disk."""
+        monkeypatch.setenv("TEST_API_KEY", "sk-real-secret-value")
+        config_path = str(tmp_path / "config.jsonc")
+        old_config = {
+            "providers": {},
+            "models": {},
+            "rerank_providers": {
+                "jina": {
+                    "api_key": "${TEST_API_KEY}",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                }
+            },
+            "rerank_models": {"jina-reranker": "jina"},
+        }
+        with open(config_path, "w") as f:
+            json.dump(old_config, f)
+
+        from llm_rosetta.gateway.config import JsoncConfigIO
+
+        io = JsoncConfigIO()
+        raw = io.load(config_path)
+
+        # Runtime should have the substituted value
+        assert raw["providers"]["jina"]["api_key"] == "sk-real-secret-value"
+
+        # Disk should still have the placeholder
+        with open(config_path) as f:
+            on_disk = json.load(f)
+        assert on_disk["providers"]["jina"]["api_key"] == "${TEST_API_KEY}"
+        assert on_disk["config_version"] == CURRENT_VERSION
+
+    def test_backup_created_on_migration(self, tmp_path):
+        config_path = str(tmp_path / "config.jsonc")
+        old_config = {
+            "providers": {},
+            "models": {},
+            "rerank_providers": {
+                "jina": {
+                    "api_key": "j-test",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                }
+            },
+        }
+        with open(config_path, "w") as f:
+            json.dump(old_config, f)
+
+        from llm_rosetta.gateway.config import JsoncConfigIO
+
+        io = JsoncConfigIO()
+        io.load(config_path)
+
+        bak_path = config_path + ".pre-migration.bak"
+        assert os.path.exists(bak_path)
+        with open(bak_path) as f:
+            bak_data = json.load(f)
+        assert "rerank_providers" in bak_data

--- a/tests/gateway/test_migrations.py
+++ b/tests/gateway/test_migrations.py
@@ -1,0 +1,308 @@
+"""Tests for the config migration framework."""
+
+from __future__ import annotations
+
+import json
+
+
+from llm_rosetta.gateway.migrations import CURRENT_VERSION, migrate
+
+
+class TestMigrationFramework:
+    """Core migration framework behavior."""
+
+    def test_no_version_treated_as_v0(self):
+        raw = {"providers": {}, "models": {}}
+        _, changed = migrate(raw)
+        assert changed
+        assert raw["config_version"] == CURRENT_VERSION
+
+    def test_current_version_is_noop(self):
+        raw = {"config_version": CURRENT_VERSION, "providers": {}, "models": {}}
+        _, changed = migrate(raw)
+        assert not changed
+
+    def test_idempotent(self):
+        raw = {
+            "providers": {
+                "openai": {"api_key": "sk-test", "base_url": "https://api.openai.com"}
+            },
+            "models": {"gpt-4o": "openai"},
+            "rerank_providers": {
+                "jina": {
+                    "api_key": "j-test",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                }
+            },
+            "rerank_models": {"jina-reranker": "jina"},
+        }
+        migrate(raw)
+        snapshot = json.dumps(raw, sort_keys=True)
+        migrate(raw)
+        assert json.dumps(raw, sort_keys=True) == snapshot
+
+
+class TestMigrationV0ToV1:
+    """Migration 001: merge legacy rerank/embedding into unified providers."""
+
+    def test_rerank_provider_merged_onto_existing(self):
+        raw = {
+            "providers": {
+                "jina": {"api_key": "j-test", "base_url": "https://api.jina.ai"}
+            },
+            "models": {},
+            "rerank_providers": {
+                "jina": {
+                    "api_key": "j-old",
+                    "base_url": "https://old.jina.ai",
+                    "format": "jina",
+                    "rerank_path": "/v1/rerank",
+                }
+            },
+        }
+        migrate(raw)
+        prov = raw["providers"]["jina"]
+        assert prov["rerank_format"] == "jina"
+        assert prov["rerank_path"] == "/v1/rerank"
+        assert prov["api_key"] == "j-test"
+        assert "rerank_providers" not in raw
+
+    def test_rerank_provider_created_if_new(self):
+        raw = {
+            "providers": {},
+            "models": {},
+            "rerank_providers": {
+                "jina": {
+                    "api_key": "j-test",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                }
+            },
+        }
+        migrate(raw)
+        assert "jina" in raw["providers"]
+        assert raw["providers"]["jina"]["rerank_format"] == "jina"
+        assert raw["providers"]["jina"]["api_key"] == "j-test"
+
+    def test_embedding_provider_merged(self):
+        raw = {
+            "providers": {
+                "openai": {"api_key": "sk-test", "base_url": "https://api.openai.com"}
+            },
+            "models": {},
+            "embedding_providers": {
+                "openai": {
+                    "api_key": "sk-old",
+                    "base_url": "https://old.openai.com",
+                    "format": "openai",
+                    "embedding_path": "/v1/embeddings",
+                }
+            },
+        }
+        migrate(raw)
+        prov = raw["providers"]["openai"]
+        assert prov["embedding_format"] == "openai"
+        assert prov["embedding_path"] == "/v1/embeddings"
+        assert prov["api_key"] == "sk-test"
+
+    def test_rerank_models_migrated(self):
+        raw = {
+            "providers": {
+                "jina": {"api_key": "j-test", "base_url": "https://api.jina.ai"}
+            },
+            "models": {"gpt-4o": "openai"},
+            "rerank_providers": {"jina": {"format": "jina"}},
+            "rerank_models": {
+                "jina-reranker": "jina",
+                "reranker-dict": {"provider": "jina"},
+            },
+        }
+        migrate(raw)
+        assert raw["models"]["jina-reranker"] == {"provider": "jina", "type": "rerank"}
+        assert raw["models"]["reranker-dict"] == {"provider": "jina", "type": "rerank"}
+        assert "rerank_models" not in raw
+
+    def test_embedding_models_migrated(self):
+        raw = {
+            "providers": {},
+            "models": {},
+            "embedding_providers": {"openai": {"format": "openai"}},
+            "embedding_models": {"text-embed-3": "openai"},
+        }
+        migrate(raw)
+        assert raw["models"]["text-embed-3"] == {
+            "provider": "openai",
+            "type": "embedding",
+        }
+
+    def test_existing_model_not_overwritten(self):
+        raw = {
+            "providers": {},
+            "models": {
+                "text-embed-3": {
+                    "provider": "openai",
+                    "type": "embedding",
+                    "custom": True,
+                }
+            },
+            "embedding_models": {"text-embed-3": "openai"},
+        }
+        migrate(raw)
+        assert raw["models"]["text-embed-3"]["custom"] is True
+
+    def test_legacy_keys_removed(self):
+        raw = {
+            "providers": {},
+            "models": {},
+            "rerank_providers": {},
+            "rerank_models": {},
+            "default_rerank_format": "jina",
+            "embedding_providers": {},
+            "embedding_models": {},
+            "default_embedding_format": "openai",
+        }
+        migrate(raw)
+        for key in (
+            "rerank_providers",
+            "rerank_models",
+            "default_rerank_format",
+            "embedding_providers",
+            "embedding_models",
+            "default_embedding_format",
+        ):
+            assert key not in raw
+
+    def test_env_var_placeholders_preserved(self):
+        raw = {
+            "providers": {},
+            "models": {},
+            "rerank_providers": {
+                "jina": {
+                    "api_key": "${JINA_API_KEY}",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                }
+            },
+            "rerank_models": {"jina-reranker": "jina"},
+        }
+        migrate(raw)
+        assert raw["providers"]["jina"]["api_key"] == "${JINA_API_KEY}"
+
+    def test_disabled_provider_preserved(self):
+        raw = {
+            "providers": {},
+            "models": {},
+            "rerank_providers": {
+                "jina": {
+                    "api_key": "j-test",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                    "enabled": False,
+                }
+            },
+        }
+        migrate(raw)
+        assert raw["providers"]["jina"]["enabled"] is False
+
+    def test_full_migration_roundtrip(self):
+        """Migrated config should parse correctly in GatewayConfig."""
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        raw = {
+            "providers": {
+                "openai": {
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com",
+                    "type": "openai",
+                }
+            },
+            "models": {"gpt-4o": "openai"},
+            "rerank_providers": {
+                "jina": {
+                    "api_key": "j-test",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                }
+            },
+            "rerank_models": {"jina-reranker": "jina"},
+            "embedding_providers": {
+                "openai": {
+                    "api_key": "sk-test",
+                    "base_url": "https://api.openai.com",
+                    "format": "openai",
+                }
+            },
+            "embedding_models": {"text-embed-3": "openai"},
+        }
+        migrate(raw)
+        cfg = GatewayConfig(raw)
+        assert "jina-reranker" in cfg.rerank_models
+        assert "text-embed-3" in cfg.embedding_models
+        route = cfg.resolve_rerank("jina-reranker")
+        assert route.provider_name == "jina"
+
+
+class TestConfigIOIntegration:
+    """JsoncConfigIO applies migrations on load and writes back."""
+
+    def test_load_migrates_and_writes_back(self, tmp_path):
+        config_path = str(tmp_path / "config.jsonc")
+        old_config = {
+            "providers": {
+                "openai": {"api_key": "sk-test", "base_url": "https://api.openai.com"}
+            },
+            "models": {"gpt-4o": "openai"},
+            "rerank_providers": {
+                "jina": {
+                    "api_key": "j-test",
+                    "base_url": "https://api.jina.ai",
+                    "format": "jina",
+                }
+            },
+            "rerank_models": {"jina-reranker": "jina"},
+        }
+        with open(config_path, "w") as f:
+            json.dump(old_config, f)
+
+        from llm_rosetta.gateway.config import JsoncConfigIO
+
+        io = JsoncConfigIO()
+        raw = io.load(config_path)
+
+        assert raw["config_version"] == CURRENT_VERSION
+        assert "rerank_providers" not in raw
+        assert "jina" in raw["providers"]
+        assert raw["providers"]["jina"]["rerank_format"] == "jina"
+
+        # Verify written back to disk
+        with open(config_path) as f:
+            on_disk = json.load(f)
+        assert on_disk["config_version"] == CURRENT_VERSION
+        assert "rerank_providers" not in on_disk
+
+    def test_load_raw_migrates_preserving_env_vars(self, tmp_path):
+        config_path = str(tmp_path / "config.jsonc")
+        old_config = {
+            "providers": {},
+            "models": {},
+            "embedding_providers": {
+                "openai": {
+                    "api_key": "${OPENAI_API_KEY}",
+                    "base_url": "https://api.openai.com",
+                    "format": "openai",
+                }
+            },
+            "embedding_models": {"text-embed": "openai"},
+        }
+        with open(config_path, "w") as f:
+            json.dump(old_config, f)
+
+        from llm_rosetta.gateway.config import JsoncConfigIO
+
+        io = JsoncConfigIO()
+        raw = io.load_raw(config_path)
+
+        assert raw["providers"]["openai"]["api_key"] == "${OPENAI_API_KEY}"
+        assert raw["providers"]["openai"]["embedding_format"] == "openai"
+        assert "embedding_providers" not in raw


### PR DESCRIPTION
## Summary

- New `gateway/migrations.py` module: versioned config migration framework with ordered registry
- Migration 001 (v0→v1): merges legacy `rerank_providers`/`embedding_providers`/`rerank_models`/`embedding_models` into unified `providers`/`models` format
- `JsoncConfigIO.load()`/`load_raw()` auto-apply pending migrations and write back atomically — existing configs upgrade in-place on first start
- Example config updated to unified v1 format
- 15 new tests

Follow-up to #530 — provides the smooth auto-migration that was missing.

## Test plan

- [x] `make test` passes (2736 passed)
- [ ] Start gateway with old-format config → verify it's migrated on disk
- [ ] Verify `${ENV_VAR}` placeholders survive migration round-trip
- [ ] Already-migrated config (has `config_version: 1`) → verify no-op