### PR TITLE
ci: add llm-comply spec compliance workflow

### DIFF
--- a/.github/workflows/comply.yml
+++ b/.github/workflows/comply.yml
@@ -1,0 +1,54 @@
+name: Spec Compliance
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model to test against"
+        default: "gemini-3.1-flash-lite"
+        type: string
+
+jobs:
+  comply:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        format: [openai-chat, open-responses, anthropic, google-genai]
+    name: comply (${{ matrix.format }})
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install gateway + llm-comply
+        run: |
+          pip install -e ".[gateway]"
+          pip install llm-comply>=0.3.0
+
+      - name: Start gateway
+        env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+        run: |
+          llm-rosetta-gateway --config ci/comply-gateway-config.jsonc --no-banner &
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:18765/health/ready > /dev/null 2>&1; then
+              echo "Gateway ready"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Run compliance tests (${{ matrix.format }})
+        run: |
+          llm-comply \
+            --base-url http://127.0.0.1:18765/v1 \
+            --api-key dummy \
+            --format ${{ matrix.format }} \
+            --model ${{ inputs.model || 'gemini-3.1-flash-lite' }} \
+            --timeout 120 \
+            --delay 5

--- a/.github/workflows/comply.yml
+++ b/.github/workflows/comply.yml
@@ -42,6 +42,7 @@ jobs:
             fi
             sleep 1
           done
+          curl -sf http://127.0.0.1:18765/health/ready > /dev/null || { echo "::error::Gateway failed to start"; exit 1; }
 
       - name: Run compliance tests (${{ matrix.format }})
         run: |

--- a/ci/comply-gateway-config.jsonc
+++ b/ci/comply-gateway-config.jsonc
@@ -1,0 +1,26 @@
+// Minimal gateway config for llm-comply spec compliance testing.
+// Used by .github/workflows/comply.yml — not for production.
+//
+// Upstream: Google Gemini free tier via ${GOOGLE_API_KEY}.
+// All 4 client formats (openai-chat, open-responses, anthropic, google-genai)
+// route to the same Google upstream through format conversion.
+{
+  "config_version": 1,
+
+  "providers": {
+    "google": {
+      "api_key": "${GOOGLE_API_KEY}",
+      "base_url": "https://generativelanguage.googleapis.com"
+    }
+  },
+
+  "models": {
+    "gemini-3.1-flash-lite": "google"
+  },
+
+  "server": {
+    "host": "127.0.0.1",
+    "port": 18765,
+    "open_on_no_keys": true
+  }
+}


### PR DESCRIPTION
## Summary

- Add a `workflow_dispatch`-only CI workflow that starts the gateway with a Google Gemini free-tier upstream and runs [llm-comply](https://github.com/Oaklight/llm-comply) against all 4 API formats
- Each format (openai-chat, open-responses, anthropic, google-genai) runs as a separate matrix job with `max-parallel: 1` and `--delay 5` to respect the free-tier 15 RPM limit
- Requires `GOOGLE_API_KEY` in repo secrets (already configured)

### Validated locally against rosetta-dev (argo:gpt-5-nano)

| Format | Result |
|--------|--------|
| openai-chat | 8/8 |
| anthropic | 8/8 (1 advisory warning) |
| google-genai | 8/8 |
| open-responses | 10/12 (2 advisory: compaction endpoint not implemented) |

### Files added

- `ci/comply-gateway-config.jsonc` — minimal gateway config for compliance testing
- `.github/workflows/comply.yml` — the workflow

## Test plan

- [x] Validated all 4 formats against live rosetta-dev deployment
- [x] Gateway config parses correctly (`GatewayConfig` validation)
- [x] `--delay` option tested (llm-comply@d027fc4)

Closes #413