### PR TITLE
security(gateway): block upstream redirects and scrub credentials from error paths

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,0 +1,3 @@
+paths-ignore:
+  - "tests/gateway/test_credential_sanitize.py"
+  - "tests/gateway/test_redirect_security.py"

--- a/src/llm_rosetta/gateway/logging.py
+++ b/src/llm_rosetta/gateway/logging.py
@@ -583,6 +583,9 @@ def log_upstream_error(
     model: str | None = None,
 ) -> None:
     """Log an upstream API error in a structured format."""
+    from .sanitize import scrub_credential_patterns
+
+    error_text = scrub_credential_patterns(error_text)
     request_type = "streaming" if is_streaming else "non-streaming"
     extra = _structured_extra(
         request_id=request_id,

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -38,6 +38,7 @@ from .logging import (
     log_stream_summary,
     log_upstream_error,
 )
+from .sanitize import sanitize_upstream_error
 from .transport import (
     ProviderInfo,
     UpstreamConnectionError,
@@ -416,7 +417,7 @@ async def handle_non_streaming(
             )
         return (
             Response(
-                body=resp.raw_content,
+                body=sanitize_upstream_error(resp.raw_content),
                 status_code=resp.status_code,
                 content_type="application/json",
             ),
@@ -734,9 +735,7 @@ async def handle_streaming(
         )
         return (
             Response(
-                body=error_text.encode("utf-8")
-                if isinstance(error_text, str)
-                else error_text,
+                body=sanitize_upstream_error(error_text),
                 status_code=stream.status_code,
                 content_type="application/json",
             ),

--- a/src/llm_rosetta/gateway/sanitize.py
+++ b/src/llm_rosetta/gateway/sanitize.py
@@ -16,7 +16,7 @@ _AUTH_HEADER_NAMES = frozenset(
 _CREDENTIAL_PATTERNS = re.compile(
     r"|".join(
         [
-            r"Bearer\s+\S+",
+            r"Bearer\s+[A-Za-z0-9_\-./+]+",
             r"sk-ant-[A-Za-z0-9_-]{20,}",
             r"sk-[A-Za-z0-9_-]{20,}",
             r"AIza[A-Za-z0-9_-]{30,}",

--- a/src/llm_rosetta/gateway/sanitize.py
+++ b/src/llm_rosetta/gateway/sanitize.py
@@ -1,0 +1,52 @@
+"""Credential sanitization for upstream error bodies and headers."""
+
+from __future__ import annotations
+
+import re
+
+_AUTH_HEADER_NAMES = frozenset(
+    {
+        "authorization",
+        "x-api-key",
+        "x-goog-api-key",
+        "proxy-authorization",
+    }
+)
+
+_CREDENTIAL_PATTERNS = re.compile(
+    r"|".join(
+        [
+            r"Bearer\s+\S+",
+            r"sk-ant-[A-Za-z0-9_-]{20,}",
+            r"sk-[A-Za-z0-9_-]{20,}",
+            r"AIza[A-Za-z0-9_-]{30,}",
+        ]
+    )
+)
+
+
+def sanitize_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Return a copy of *headers* with auth values redacted."""
+    result = {}
+    for k, v in headers.items():
+        if k.lower() in _AUTH_HEADER_NAMES:
+            result[k] = "[REDACTED]"
+        else:
+            result[k] = v
+    return result
+
+
+def scrub_credential_patterns(text: str) -> str:
+    """Replace credential-shaped strings in *text* with ``[REDACTED]``."""
+    return _CREDENTIAL_PATTERNS.sub("[REDACTED]", text)
+
+
+def sanitize_upstream_error(raw: str | bytes) -> str | bytes:
+    """Scrub credentials from an upstream error body, preserving type."""
+    if isinstance(raw, bytes):
+        try:
+            decoded = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return raw
+        return scrub_credential_patterns(decoded).encode("utf-8")
+    return scrub_credential_patterns(raw)

--- a/src/llm_rosetta/gateway/transport/http/client_pool.py
+++ b/src/llm_rosetta/gateway/transport/http/client_pool.py
@@ -27,6 +27,7 @@ class HttpClientPool:
             self._clients[proxy_url] = AsyncClient(
                 timeout=self._timeout,
                 proxy=proxy_url,
+                max_redirects=0,
             )
         return self._clients[proxy_url]
 

--- a/src/llm_rosetta/gateway/transport/http/transport.py
+++ b/src/llm_rosetta/gateway/transport/http/transport.py
@@ -21,6 +21,7 @@ from llm_rosetta._vendor.httpclient import (
     HttpTimeoutError,
     Response as HttpResponse,
     StreamingResponse as HttpStreamingResponse,
+    TooManyRedirects,
 )
 from llm_rosetta._vendor.sse import AsyncEventSource
 
@@ -119,6 +120,10 @@ class HttpTransport:
             if provider_info.timeout is not None:
                 kwargs["timeout"] = provider_info.timeout
             resp = await client.post(url, json=body, headers=headers, **kwargs)
+        except TooManyRedirects:
+            raise UpstreamConnectionError(
+                f"Upstream {url} returned a redirect (blocked for security)"
+            )
         except HttpTimeoutError as exc:
             raise UpstreamTimeoutError(str(exc)) from exc
         except HttpClientError as exc:
@@ -148,6 +153,10 @@ class HttpTransport:
                 kwargs["timeout"] = provider_info.timeout
             resp = await client.post(
                 url, json=body, headers=headers, stream=True, **kwargs
+            )
+        except TooManyRedirects:
+            raise UpstreamConnectionError(
+                f"Upstream {url} returned a redirect (blocked for security)"
             )
         except HttpTimeoutError as exc:
             raise UpstreamTimeoutError(str(exc)) from exc

--- a/src/llm_rosetta/observability/error_dump.py
+++ b/src/llm_rosetta/observability/error_dump.py
@@ -230,9 +230,13 @@ def _dump_error_impl(
                 converted_body_hash, compressed_conv, orig_conv
             )
 
-    # --- Truncate response_text if excessively large ---
-    if response_text and len(response_text) > 64 * 1024:
-        response_text = response_text[: 64 * 1024] + "\n…[truncated]"
+    # --- Scrub credential patterns and truncate if excessively large ---
+    if response_text:
+        from llm_rosetta.gateway.sanitize import scrub_credential_patterns
+
+        response_text = scrub_credential_patterns(response_text)
+        if len(response_text) > 64 * 1024:
+            response_text = response_text[: 64 * 1024] + "\n…[truncated]"
 
     # --- Insert the error dump record ---
     persistence.insert_error_dump(

--- a/tests/gateway/test_credential_sanitize.py
+++ b/tests/gateway/test_credential_sanitize.py
@@ -99,6 +99,11 @@ class TestScrubCredentialPatterns:
         assert result.startswith("before ")
         assert result.endswith(" after")
 
+    def test_bearer_does_not_eat_json_quotes(self):
+        text = '{"error":"Bearer sk-proj-abc123def456ghijklmno","code":"err"}'
+        result = scrub_credential_patterns(text)
+        assert result == '{"error":"[REDACTED]","code":"err"}'
+
 
 class TestSanitizeUpstreamError:
     def test_str_input_returns_str(self):

--- a/tests/gateway/test_credential_sanitize.py
+++ b/tests/gateway/test_credential_sanitize.py
@@ -1,0 +1,132 @@
+"""Tests for credential sanitization: header redaction and pattern scrubbing."""
+
+from __future__ import annotations
+
+from llm_rosetta.gateway.sanitize import (
+    sanitize_headers,
+    sanitize_upstream_error,
+    scrub_credential_patterns,
+)
+
+
+class TestSanitizeHeaders:
+    def test_redacts_authorization(self):
+        headers = {
+            "Authorization": "Bearer sk-abc123",
+            "Content-Type": "application/json",
+        }
+        result = sanitize_headers(headers)
+        assert result["Authorization"] == "[REDACTED]"
+        assert result["Content-Type"] == "application/json"
+
+    def test_redacts_x_api_key(self):
+        result = sanitize_headers({"x-api-key": "sk-ant-secret"})
+        assert result["x-api-key"] == "[REDACTED]"
+
+    def test_redacts_x_goog_api_key(self):
+        result = sanitize_headers({"x-goog-api-key": "AIzaSyAbcdefghijklmnop"})
+        assert result["x-goog-api-key"] == "[REDACTED]"
+
+    def test_redacts_proxy_authorization(self):
+        result = sanitize_headers({"Proxy-Authorization": "Basic dXNlcjpwYXNz"})
+        assert result["Proxy-Authorization"] == "[REDACTED]"
+
+    def test_case_insensitive(self):
+        result = sanitize_headers({"AUTHORIZATION": "Bearer token", "X-API-KEY": "key"})
+        assert result["AUTHORIZATION"] == "[REDACTED]"
+        assert result["X-API-KEY"] == "[REDACTED]"
+
+    def test_preserves_non_auth_headers(self):
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": "test/1.0",
+            "x-request-id": "abc-123",
+        }
+        result = sanitize_headers(headers)
+        assert result == headers
+
+    def test_returns_copy(self):
+        headers = {"Authorization": "Bearer token"}
+        result = sanitize_headers(headers)
+        assert result is not headers
+        assert headers["Authorization"] == "Bearer token"
+
+
+class TestScrubCredentialPatterns:
+    def test_scrubs_bearer_token(self):
+        text = "error: Authorization: Bearer sk-proj-abc123def456"
+        result = scrub_credential_patterns(text)
+        assert "sk-proj-abc123def456" not in result
+        assert "[REDACTED]" in result
+
+    def test_scrubs_openai_key(self):
+        text = "Invalid API key: sk-abcdefghijklmnopqrstuvwx"
+        result = scrub_credential_patterns(text)
+        assert "sk-abcdefghijklmnopqrstuvwx" not in result
+        assert "[REDACTED]" in result
+
+    def test_scrubs_anthropic_key(self):
+        text = "key=sk-ant-api03-abcdefghijklmnopqrstuvwx"
+        result = scrub_credential_patterns(text)
+        assert "sk-ant-api03" not in result
+        assert "[REDACTED]" in result
+
+    def test_scrubs_google_key(self):
+        text = "x-goog-api-key: AIzaSyB1234567890abcdefghijklmnopqrst"
+        result = scrub_credential_patterns(text)
+        assert "AIzaSyB1234567890" not in result
+        assert "[REDACTED]" in result
+
+    def test_scrubs_multiple_patterns(self):
+        text = "key1=sk-abc123defghijklmnopqrst key2=Bearer token123456789012"
+        result = scrub_credential_patterns(text)
+        assert "sk-abc123" not in result
+        assert "token123456789012" not in result
+
+    def test_no_false_positives_on_normal_json(self):
+        text = '{"error": {"message": "Context length exceeded", "type": "invalid_request_error", "code": "context_length_exceeded"}}'
+        result = scrub_credential_patterns(text)
+        assert result == text
+
+    def test_no_false_positives_on_short_sk(self):
+        text = "sk-short"
+        result = scrub_credential_patterns(text)
+        assert result == text
+
+    def test_preserves_surrounding_text(self):
+        text = "before Bearer sk-proj-abc123def456ghijklmno after"
+        result = scrub_credential_patterns(text)
+        assert result.startswith("before ")
+        assert result.endswith(" after")
+
+
+class TestSanitizeUpstreamError:
+    def test_str_input_returns_str(self):
+        text = "error with Bearer sk-abc123def456ghijklmno"
+        result = sanitize_upstream_error(text)
+        assert isinstance(result, str)
+        assert "sk-abc123" not in result
+
+    def test_bytes_input_returns_bytes(self):
+        raw = b"error with Bearer sk-abc123def456ghijklmno"
+        result = sanitize_upstream_error(raw)
+        assert isinstance(result, bytes)
+        assert b"sk-abc123" not in result
+
+    def test_non_utf8_bytes_returned_unchanged(self):
+        raw = b"\x80\x81\x82\xff"
+        result = sanitize_upstream_error(raw)
+        assert result == raw
+
+    def test_empty_string(self):
+        assert sanitize_upstream_error("") == ""
+
+    def test_empty_bytes(self):
+        assert sanitize_upstream_error(b"") == b""
+
+    def test_real_provider_error_body(self):
+        body = '{"error":{"message":"Incorrect API key provided: sk-proj-abc123defghijklmnop. You can find your API key at https://platform.openai.com/account/api-keys.","type":"invalid_request_error","param":null,"code":"invalid_api_key"}}'
+        result = sanitize_upstream_error(body)
+        assert isinstance(result, str)
+        assert "sk-proj-abc123" not in result
+        assert "invalid_api_key" in result

--- a/tests/gateway/test_redirect_security.py
+++ b/tests/gateway/test_redirect_security.py
@@ -25,6 +25,7 @@ def _test_provider() -> ProviderInfo:
 
 
 class TestClientPoolRedirects:
+    # Intentionally access private attr — security-critical setting with no public accessor
     def test_pool_creates_client_with_zero_redirects(self):
         pool = HttpClientPool()
         client = pool.get()

--- a/tests/gateway/test_redirect_security.py
+++ b/tests/gateway/test_redirect_security.py
@@ -1,0 +1,105 @@
+"""Tests for redirect security: upstream redirects are blocked to prevent credential leakage."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from llm_rosetta._vendor.httpclient import TooManyRedirects
+from llm_rosetta.gateway.transport.http.client_pool import HttpClientPool
+from llm_rosetta.gateway.transport.http.transport import HttpTransport
+from llm_rosetta.gateway.transport._base import UpstreamConnectionError
+from llm_rosetta.gateway.transport.provider_info import ProviderInfo, openai_auth
+
+
+def _test_provider() -> ProviderInfo:
+    return ProviderInfo(
+        name="test",
+        api_key="sk-test-key-12345",
+        base_url="https://api.example.com",
+        auth_header_fn=openai_auth,
+        url_template="{base_url}/v1/chat/completions",
+    )
+
+
+class TestClientPoolRedirects:
+    def test_pool_creates_client_with_zero_redirects(self):
+        pool = HttpClientPool()
+        client = pool.get()
+        assert client._max_redirects == 0
+
+    def test_pool_creates_proxy_client_with_zero_redirects(self):
+        pool = HttpClientPool()
+        client = pool.get("socks5://proxy:1080")
+        assert client._max_redirects == 0
+
+
+class TestTransportRedirectBlocking:
+    def test_send_raises_on_redirect(self):
+        transport = HttpTransport(timeout=10.0)
+        provider = _test_provider()
+        url = provider.upstream_url("gpt-4")
+
+        async def run():
+            with patch.object(
+                transport._pool.get(provider.proxy_url),
+                "post",
+                side_effect=TooManyRedirects(url, 0),
+            ):
+                with pytest.raises(UpstreamConnectionError, match="redirect"):
+                    await transport.send(provider, url, {"model": "gpt-4"})
+
+        asyncio.run(run())
+
+    def test_send_streaming_raises_on_redirect(self):
+        transport = HttpTransport(timeout=10.0)
+        provider = _test_provider()
+        url = provider.upstream_url("gpt-4")
+
+        async def run():
+            with patch.object(
+                transport._pool.get(provider.proxy_url),
+                "post",
+                side_effect=TooManyRedirects(url, 0),
+            ):
+                with pytest.raises(UpstreamConnectionError, match="redirect"):
+                    await transport.send_streaming(provider, url, {"model": "gpt-4"})
+
+        asyncio.run(run())
+
+    def test_redirect_error_includes_security_message(self):
+        transport = HttpTransport(timeout=10.0)
+        provider = _test_provider()
+        url = provider.upstream_url("gpt-4")
+
+        async def run():
+            with patch.object(
+                transport._pool.get(provider.proxy_url),
+                "post",
+                side_effect=TooManyRedirects(url, 0),
+            ):
+                with pytest.raises(
+                    UpstreamConnectionError, match="blocked for security"
+                ):
+                    await transport.send(provider, url, {"model": "gpt-4"})
+
+        asyncio.run(run())
+
+    def test_redirect_error_does_not_leak_api_key(self):
+        transport = HttpTransport(timeout=10.0)
+        provider = _test_provider()
+        url = provider.upstream_url("gpt-4")
+
+        async def run():
+            with patch.object(
+                transport._pool.get(provider.proxy_url),
+                "post",
+                side_effect=TooManyRedirects(url, 0),
+            ):
+                with pytest.raises(UpstreamConnectionError) as exc_info:
+                    await transport.send(provider, url, {"model": "gpt-4"})
+                assert "sk-test-key-12345" not in str(exc_info.value)
+
+        asyncio.run(run())


### PR DESCRIPTION
## Summary

- **Block upstream redirects** (`max_redirects=0`): no supported LLM provider (OpenAI, Anthropic, Google) legitimately redirects API calls, so redirect-following is disabled entirely. Previously, the vendored HTTP client followed up to 10 redirects while reusing auth headers unchanged across cross-origin hops — a malicious 307/308 redirect could leak provider API keys.
- **Scrub credentials from error paths**: add `scrub_credential_patterns()` to sanitize upstream error bodies before they reach three sinks (client response, application log, error dump DB). Covers Bearer tokens, `sk-*`, `sk-ant-*`, and `AIza*` patterns.
- **`sanitize_headers()` utility**: redacts auth header values for safe logging/debugging use.

Addresses #398 workstreams 3 (provider redirect security) and 7 (transport credential boundary hardening).

## Changes

| File | Change |
|------|--------|
| `gateway/transport/http/client_pool.py` | `max_redirects=0` on `AsyncClient` |
| `gateway/transport/http/transport.py` | Catch `TooManyRedirects` with security-specific error |
| `gateway/sanitize.py` | NEW — `sanitize_headers`, `scrub_credential_patterns`, `sanitize_upstream_error` |
| `gateway/proxy.py` | Wire `sanitize_upstream_error` on both error passthrough paths |
| `gateway/logging.py` | Scrub `error_text` in `log_upstream_error` |
| `observability/error_dump.py` | Scrub `response_text` before persistence |

No `_vendor/` edits needed — the vendored client already exposes `max_redirects` as a constructor param.

## Test plan

- [x] `test_redirect_security.py` — pool creates clients with `max_redirects=0`, transport raises `UpstreamConnectionError` on redirect, error message doesn't leak API keys
- [x] `test_credential_sanitize.py` — header redaction (4 auth header names, case-insensitive), credential pattern scrubbing (Bearer, sk-*, sk-ant-*, AIza*), no false positives on normal JSON, bytes/str type preservation, real provider error body scrubbing
- [x] `make test` — 2765 passed, 0 failed
- [x] `make lint` — clean