### PR TITLE
fix(openai-chat): normalize direct tool-result image blocks

### DIFF
--- a/src/llm_rosetta/converters/openai_chat/message_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/message_ops.py
@@ -39,6 +39,7 @@ from ..base.helpers.multimodal_tool_patch import (
     pack_multimodal_tool_result,
     unpack_tool_content,
 )
+from ..base.helpers.tool_content import convert_content_blocks_to_ir
 from .content_ops import OpenAIChatContentOps
 from .tool_ops import OpenAIChatToolOps
 
@@ -618,8 +619,8 @@ class OpenAIChatMessageOps(BaseMessageOps):
 
         If unpacked multimodal content exists for this tool_call_id (from a
         synthetic user message), the visual content blocks are converted to IR
-        and used as the result. Otherwise, the tool message content string is
-        used as-is.
+        and used as the result. Otherwise, direct list content is normalized to
+        IR and scalar content is used as-is.
 
         Args:
             msg: OpenAI tool role message dict.
@@ -644,13 +645,17 @@ class OpenAIChatMessageOps(BaseMessageOps):
                 ],
             }
 
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content = convert_content_blocks_to_ir(content, OpenAIChatContentOps)
+
         return {
             "role": "tool",
             "content": [
                 ToolResultPart(
                     type="tool_result",
                     tool_call_id=call_id,
-                    result=msg.get("content", ""),
+                    result=content,
                 )
             ],
         }

--- a/tests/converters/openai_chat/test_message_ops.py
+++ b/tests/converters/openai_chat/test_message_ops.py
@@ -617,6 +617,40 @@ class TestOpenAIChatMessageOps:
         assert result[0]["content"][0]["tool_call_id"] == "call_1"
         assert result[0]["content"][0]["result"] == "42"
 
+    def test_p_tool_list_content_to_ir(self):
+        """Direct tool list content normalizes provider blocks to IR."""
+        data_url = "data:image/png;base64,aW1hZ2U="
+        result = cast(
+            list[Any],
+            self.message_ops.p_messages_to_ir(
+                [
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_multimodal",
+                        "content": [
+                            {"type": "text", "text": "Screenshot result"},
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": data_url, "detail": "high"},
+                            },
+                        ],
+                    }
+                ]
+            ),
+        )
+
+        tool_result = result[0]["content"][0]
+        assert result[0]["role"] == "tool"
+        assert tool_result["type"] == "tool_result"
+        assert tool_result["tool_call_id"] == "call_multimodal"
+        assert [part["type"] for part in tool_result["result"]] == ["text", "image"]
+        assert tool_result["result"][0]["text"] == "Screenshot result"
+        assert tool_result["result"][1]["image_data"] == {
+            "data": "aW1hZ2U=",
+            "media_type": "image/png",
+        }
+        assert tool_result["result"][1]["detail"] == "high"
+
     def test_p_function_to_ir(self):
         """Test OpenAI deprecated function role → IR ToolMessage."""
         result = cast(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -764,3 +764,52 @@ class TestConversionPipeline:
         result = pipeline.convert_response(upstream_response)
         # Source converter adds resp_ prefix back
         assert result["id"] == "resp_pipeline_test_123"
+
+    def test_chat_tool_list_content_round_trip(self):
+        """Chat tool list content survives A→IR→A round-trip via packing."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        data_url = "data:image/png;base64,aW1hZ2U="
+        pipeline = ConversionPipeline("openai_chat", "openai_chat")
+        target = pipeline.convert_request(
+            {
+                "model": "gpt-4o",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_rt",
+                                "type": "function",
+                                "function": {"name": "screenshot", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_rt",
+                        "content": [
+                            {"type": "text", "text": "Screenshot captured"},
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": data_url, "detail": "high"},
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+
+        # Chat packing moves image to synthetic user message
+        tool_msg = [m for m in target["messages"] if m.get("role") == "tool"][0]
+        content = tool_msg["content"]
+        # Tool message retains text only (image packed out)
+        assert isinstance(content, list)
+        assert content == [{"type": "text", "text": "Screenshot captured"}]
+
+        # Image appears in the synthetic user message
+        user_msgs = [m for m in target["messages"] if m.get("role") == "user"]
+        synthetic = user_msgs[-1]
+        assert isinstance(synthetic["content"], list)
+        assert any(p.get("type") == "image_url" for p in synthetic["content"])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -510,6 +510,53 @@ class TestConversionPipeline:
         assert "messages" in target
         assert target["model"] == "gpt-4"
 
+    def test_chat_tool_list_content_to_responses(self):
+        """Chat tool list content converts to Responses input blocks."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        data_url = "data:image/png;base64,aW1hZ2U="
+        pipeline = ConversionPipeline("openai_chat", "openai_responses")
+        target = pipeline.convert_request(
+            {
+                "model": "gpt-5",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_multimodal",
+                                "type": "function",
+                                "function": {"name": "inspect", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_multimodal",
+                        "content": [
+                            {"type": "text", "text": "Screenshot result"},
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": data_url, "detail": "high"},
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+
+        tool_output = next(
+            item for item in target["input"] if item["type"] == "function_call_output"
+        )
+        assert tool_output["type"] == "function_call_output"
+        assert tool_output["call_id"] == "call_multimodal"
+        assert tool_output["output"] == [
+            {"type": "input_text", "text": "Screenshot result"},
+            {"type": "input_image", "image_url": data_url, "detail": "high"},
+        ]
+        assert all(block["type"] != "image_url" for block in tool_output["output"])
+
     def test_convert_response_openai_to_openai(self):
         """Response round-trip produces valid source response."""
         from llm_rosetta.pipeline import ConversionPipeline


### PR DESCRIPTION
## Summary

- Normalize list-valued OpenAI Chat tool-result content before constructing the intermediate representation.
- Reuse the existing content conversion path so Chat `image_url` blocks become IR `image` blocks.
- Preserve scalar tool results and the existing synthetic multimodal path.

## Problem

OpenAI Chat tool results may contain content arrays with `image_url` parts. The direct tool-message path previously stored those provider-specific parts unchanged in `ToolResultPart.result`. A later OpenAI Responses conversion therefore emitted `image_url` inside `function_call_output.output`, which the Responses API rejects.

Following the source-boundary normalization pattern used in #107 for #92, this change normalizes direct tool-result content at the Chat input boundary. The existing Responses converter then emits `input_image` without adding target-side compatibility handling.

## Validation

- Added a source-normalization test covering text plus `image_url` tool-result content.
- Added a Chat-to-Responses pipeline test covering `input_text` and `input_image` output.
- `make lint`
- `make test` — 2723 passed, 21 skipped
- Manual end-to-end validation confirmed that the previously failing conversation could continue after deployment.

## AI assistance

AI tools materially assisted with diagnosis, implementation, and test development.

Fixes #543
