### PR TITLE
feat(gateway): add age-based database cleanup with admin UI and CLI

### DIFF
--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from llm_rosetta.observability import (
     DEFAULT_ERROR_MAX,
+    DEFAULT_MAX_AGE_DAYS,
     DEFAULT_SUCCESS_MAX,
     MetricsCollector,
     PersistenceManager,
@@ -22,8 +23,8 @@ __all__ = ["setup_admin", "MetricsCollector", "RequestLog", "PersistenceManager"
 logger = logging.getLogger("llm-rosetta-gateway")
 
 
-def _resolve_log_caps(config: GatewayConfig) -> tuple[int, int]:
-    """Resolve (success_max, error_max) from env vars and config.
+def _resolve_log_caps(config: GatewayConfig) -> tuple[int, int, int]:
+    """Resolve (success_max, error_max, max_age_days) from env vars and config.
 
     Precedence: env vars > config.request_log.{success,error}_max >
     legacy config.request_log.max_entries > built-in defaults.
@@ -42,11 +43,14 @@ def _resolve_log_caps(config: GatewayConfig) -> tuple[int, int]:
 
     success_max = _parse_int_env("REQUEST_LOG_SUCCESS_MAX")
     error_max = _parse_int_env("REQUEST_LOG_ERROR_MAX")
+    max_age_days = _parse_int_env("REQUEST_LOG_MAX_AGE_DAYS")
 
     if success_max is None:
         success_max = rl_cfg.get("success_max")
     if error_max is None:
         error_max = rl_cfg.get("error_max")
+    if max_age_days is None:
+        max_age_days = rl_cfg.get("max_age_days")
 
     legacy = rl_cfg.get("max_entries")
     if legacy is not None and success_max is None:
@@ -59,6 +63,7 @@ def _resolve_log_caps(config: GatewayConfig) -> tuple[int, int]:
     return (
         int(success_max) if success_max is not None else DEFAULT_SUCCESS_MAX,
         int(error_max) if error_max is not None else DEFAULT_ERROR_MAX,
+        int(max_age_days) if max_age_days is not None else DEFAULT_MAX_AGE_DAYS,
     )
 
 
@@ -127,7 +132,7 @@ def setup_admin(
     persistence: PersistenceManager | None = None
     if config_path:
         data_dir = os.path.join(os.path.dirname(config_path), "data")
-        success_max, error_max = _resolve_log_caps(config)
+        success_max, error_max, max_age_days = _resolve_log_caps(config)
         persistence = PersistenceManager(
             data_dir, success_max=success_max, error_max=error_max
         )

--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 
 from llm_rosetta.observability import (
     DEFAULT_ERROR_MAX,
-    DEFAULT_MAX_AGE_DAYS,
     DEFAULT_SUCCESS_MAX,
     MetricsCollector,
     PersistenceManager,
@@ -23,8 +22,8 @@ __all__ = ["setup_admin", "MetricsCollector", "RequestLog", "PersistenceManager"
 logger = logging.getLogger("llm-rosetta-gateway")
 
 
-def _resolve_log_caps(config: GatewayConfig) -> tuple[int, int, int]:
-    """Resolve (success_max, error_max, max_age_days) from env vars and config.
+def _resolve_log_caps(config: GatewayConfig) -> tuple[int, int]:
+    """Resolve (success_max, error_max) from env vars and config.
 
     Precedence: env vars > config.request_log.{success,error}_max >
     legacy config.request_log.max_entries > built-in defaults.
@@ -43,15 +42,10 @@ def _resolve_log_caps(config: GatewayConfig) -> tuple[int, int, int]:
 
     success_max = _parse_int_env("REQUEST_LOG_SUCCESS_MAX")
     error_max = _parse_int_env("REQUEST_LOG_ERROR_MAX")
-    max_age_days = _parse_int_env("REQUEST_LOG_MAX_AGE_DAYS")
-
     if success_max is None:
         success_max = rl_cfg.get("success_max")
     if error_max is None:
         error_max = rl_cfg.get("error_max")
-    if max_age_days is None:
-        max_age_days = rl_cfg.get("max_age_days")
-
     legacy = rl_cfg.get("max_entries")
     if legacy is not None and success_max is None:
         logger.warning(
@@ -63,7 +57,6 @@ def _resolve_log_caps(config: GatewayConfig) -> tuple[int, int, int]:
     return (
         int(success_max) if success_max is not None else DEFAULT_SUCCESS_MAX,
         int(error_max) if error_max is not None else DEFAULT_ERROR_MAX,
-        int(max_age_days) if max_age_days is not None else DEFAULT_MAX_AGE_DAYS,
     )
 
 
@@ -132,7 +125,7 @@ def setup_admin(
     persistence: PersistenceManager | None = None
     if config_path:
         data_dir = os.path.join(os.path.dirname(config_path), "data")
-        success_max, error_max, max_age_days = _resolve_log_caps(config)
+        success_max, error_max = _resolve_log_caps(config)
         persistence = PersistenceManager(
             data_dir, success_max=success_max, error_max=error_max
         )

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -959,6 +959,11 @@ body { padding-bottom: 26px; }
       <input type="number" id="settingsErrorMax" min="5000" step="5000" value="10000">
       <button class="btn btn-sm" onclick="saveLogRetention()" data-i18n="btn.save">Save</button>
     </div>
+    <div class="settings-popup-item">
+      <label data-i18n="label.maxAgeDays">Max Age (days)</label>
+      <input type="number" id="settingsMaxAgeDays" min="1" step="1" value="90">
+      <button class="btn btn-sm" onclick="openCleanupConfirm()" style="background:var(--red);color:#fff" data-i18n="btn.cleanup">Cleanup</button>
+    </div>
     <div class="settings-divider"></div>
     <!-- Admin Token -->
     <div class="settings-section-title" data-i18n="label.adminToken">Admin Token</div>
@@ -1293,6 +1298,24 @@ Rules:..."</code><br><br>Some upstream providers don't support content arrays in
   </div>
 </div>
 
+<!-- Cleanup Confirmation Modal -->
+<div class="modal-overlay" id="cleanupConfirmModal">
+  <div class="modal">
+    <h3 data-i18n="confirm.cleanupTitle">Database Cleanup</h3>
+    <p id="cleanupConfirmMsg" style="margin:8px 0 12px;color:var(--text-dim);font-size:13px"></p>
+    <div class="form-group">
+      <input id="cleanupConfirmInput" autocomplete="off" spellcheck="false"
+        oninput="onCleanupConfirmInput()" style="font-family:monospace"
+        placeholder="CLEANUP">
+    </div>
+    <div class="modal-actions">
+      <button class="btn" onclick="closeModal('cleanupConfirmModal')" data-i18n="btn.cancel">Cancel</button>
+      <button class="btn" id="cleanupConfirmBtn" onclick="onCleanupConfirmClick()" disabled
+        style="background:#ccc;color:#888;cursor:not-allowed" data-i18n="btn.cleanup">Cleanup</button>
+    </div>
+  </div>
+</div>
+
 <!-- Delete Confirmation Modal -->
 <div class="modal-overlay" id="deleteConfirmModal">
   <div class="modal">
@@ -1579,7 +1602,7 @@ const I18N = {
     'btn.save':'\u4fdd\u5b58', 'btn.copy':'\u590d\u5236', 'btn.change':'\u4fee\u6539', 'btn.cancel':'\u53d6\u6d88', 'btn.close':'\u5173\u95ed',
     'label.logLevel':'\u65e5\u5fd7\u7ea7\u522b', 'logLevel.normal':'\u6b63\u5e38', 'logLevel.verbose':'\u8be6\u7ec6', 'logLevel.debug':'\u8c03\u8bd5 (\u542b\u8bf7\u6c42\u4f53)',
     'label.autoRefresh':'\u81ea\u52a8\u5237\u65b0', 'label.off':'\u5173\u95ed', 'label.credentialReveal':'\u51ed\u8bc1\u53ef\u89c1', 'label.errorDumps':'\u9519\u8bef\u8be6\u60c5\u8bb0\u5f55', 'label.enabled':'\u5df2\u542f\u7528',
-    'label.logRetention':'\u65e5\u5fd7\u4fdd\u7559', 'label.successMax':'\u6210\u529f', 'label.errorMax':'\u5931\u8d25',
+    'label.logRetention':'\u65e5\u5fd7\u4fdd\u7559', 'label.successMax':'\u6210\u529f', 'label.errorMax':'\u5931\u8d25', 'label.maxAgeDays':'\u6700\u5927\u4fdd\u7559\u5929\u6570', 'btn.cleanup':'\u6e05\u7406', 'confirm.cleanupTitle':'\u6570\u636e\u5e93\u6e05\u7406', 'confirm.cleanupMsg':'\u6b64\u64cd\u4f5c\u5c06\u6c38\u4e45\u5220\u9664\u8d85\u8fc7 <strong>{days} \u5929</strong>\u7684\u6240\u6709\u8bf7\u6c42\u65e5\u5fd7\u548c\u9519\u8bef\u8f6c\u50a8\u3002\u8bf7\u8f93\u5165 <strong>CLEANUP</strong> \u786e\u8ba4\u3002', 'toast.cleanupDone':'\u5df2\u6e05\u7406\uff1a{rl} \u6761\u65e5\u5fd7\u3001{ed} \u6761\u9519\u8bef\u8f6c\u50a8\u3001{db} \u4e2a Body\u3002\u91ca\u653e {freed}\u3002', 'toast.cleanupNone':'\u65e0\u9700\u6e05\u7406\u2014\u2014\u6ca1\u6709\u8d85\u8fc7 {days} \u5929\u7684\u8bb0\u5f55\u3002',
     'label.adminToken':'\u7ba1\u7406 Token', 'label.rotatingIn':'<span class="cd-time">{time}</span> \u540e\u8f6e\u6362',
     'label.changePassword':'\u4fee\u6539\u5bc6\u7801', 'label.currentPw':'\u5f53\u524d\u5bc6\u7801', 'label.newPw':'\u65b0\u5bc6\u7801', 'label.confirmPw':'\u786e\u8ba4\u5bc6\u7801',
     'pw.required':'\u8bf7\u586b\u5199\u5f53\u524d\u5bc6\u7801\u548c\u65b0\u5bc6\u7801', 'pw.mismatch':'\u4e24\u6b21\u8f93\u5165\u4e0d\u4e00\u81f4', 'pw.tooShort':'\u5bc6\u7801\u592a\u77ed\uff08\u81f3\u5c114\u4f4d\uff09', 'pw.changed':'\u5bc6\u7801\u5df2\u4fee\u6539',
@@ -1864,8 +1887,10 @@ function openSettings() {
   if (configData?.server?.request_log) {
     const sm = document.getElementById('settingsSuccessMax');
     const em = document.getElementById('settingsErrorMax');
+    const mad = document.getElementById('settingsMaxAgeDays');
     if (sm) sm.value = configData.server.request_log.success_max || 50000;
     if (em) em.value = configData.server.request_log.error_max || 10000;
+    if (mad) mad.value = configData.server.request_log.max_age_days || 90;
   }
   // Sync token
   _refreshTokenDisplay();
@@ -1912,10 +1937,52 @@ function saveAutoRefresh(val) {
 async function saveLogRetention() {
   const sm = parseInt(document.getElementById('settingsSuccessMax')?.value || '50000', 10);
   const em = parseInt(document.getElementById('settingsErrorMax')?.value || '10000', 10);
+  const mad = parseInt(document.getElementById('settingsMaxAgeDays')?.value || '90', 10);
   if (sm < 50000 || em < 5000) { showToast(t('toast.retentionMin'), 'error'); return; }
+  if (mad < 1) { showToast(t('toast.error'), 'error'); return; }
   try {
-    await api.put('/admin/api/config/server', { request_log: { success_max: sm, error_max: em } });
+    await api.put('/admin/api/config/server', { request_log: { success_max: sm, error_max: em, max_age_days: mad } });
     await loadConfig(); showToast(t('toast.saved'));
+  } catch { showToast(t('toast.error'), 'error'); }
+}
+
+// --- Database Cleanup ---
+function openCleanupConfirm() {
+  const days = parseInt(document.getElementById('settingsMaxAgeDays')?.value || '90', 10);
+  if (days < 1) { showToast(t('toast.error'), 'error'); return; }
+  document.getElementById('cleanupConfirmMsg').innerHTML = t('confirm.cleanupMsg', {days});
+  document.getElementById('cleanupConfirmInput').value = '';
+  document.getElementById('cleanupConfirmBtn').disabled = true;
+  const btn = document.getElementById('cleanupConfirmBtn');
+  btn.style.background = '#ccc'; btn.style.color = '#888'; btn.style.cursor = 'not-allowed';
+  document.getElementById('cleanupConfirmModal').classList.add('open');
+  document.getElementById('cleanupConfirmInput').focus();
+}
+
+function onCleanupConfirmInput() {
+  const matched = document.getElementById('cleanupConfirmInput').value === 'CLEANUP';
+  const btn = document.getElementById('cleanupConfirmBtn');
+  btn.disabled = !matched;
+  btn.style.background = matched ? 'var(--red)' : '#ccc';
+  btn.style.color = matched ? '#fff' : '#888';
+  btn.style.cursor = matched ? 'pointer' : 'not-allowed';
+}
+
+async function onCleanupConfirmClick() {
+  const days = parseInt(document.getElementById('settingsMaxAgeDays')?.value || '90', 10);
+  closeModal('cleanupConfirmModal');
+  try {
+    const res = await api.post('/admin/api/db/cleanup', { max_age_days: days });
+    const d = res;
+    const total = d.request_log_deleted + d.error_dumps_deleted + d.dump_bodies_deleted;
+    if (total === 0) {
+      showToast(t('toast.cleanupNone', {days}));
+    } else {
+      showToast(t('toast.cleanupDone', {
+        rl: d.request_log_deleted, ed: d.error_dumps_deleted,
+        db: d.dump_bodies_deleted, freed: _fmtBytes(d.freed_bytes)
+      }));
+    }
   } catch { showToast(t('toast.error'), 'error'); }
 }
 

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -59,6 +59,7 @@ from .keys import (
 from .observability import (
     clear_error_dumps,
     clear_requests,
+    db_cleanup,
     get_error_dump_body,
     get_error_dump_detail,
     get_error_dumps,
@@ -180,6 +181,7 @@ def register_admin_routes(app: Any) -> None:
         get_error_dump_body
     )
     app.route("/admin/api/error-dumps", methods=["DELETE"])(clear_error_dumps)
+    app.route("/admin/api/db/cleanup", methods=["POST"])(db_cleanup)
     # API key management (keys tab)
     app.route("/admin/api/keys", methods=["GET"])(_guard("keys", get_api_keys))
     app.route("/admin/api/keys", methods=["POST"])(_guard("keys", create_api_key))

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -724,6 +724,8 @@ async def put_server_settings(request: Any) -> Response:  # noqa: C901
                 rl_cfg["success_max"] = max(50000, int(rl["success_max"]))
             if "error_max" in rl:
                 rl_cfg["error_max"] = max(5000, int(rl["error_max"]))
+            if "max_age_days" in rl:
+                rl_cfg["max_age_days"] = max(1, int(rl["max_age_days"]))
 
         # Debug / log level
         debug = data.setdefault("debug", {})

--- a/src/llm_rosetta/gateway/admin/routes/observability.py
+++ b/src/llm_rosetta/gateway/admin/routes/observability.py
@@ -353,3 +353,24 @@ async def clear_error_dumps(request: Any) -> Response:
 
     persistence.clear_error_dumps()
     return JSONResponse({"ok": True})
+
+
+async def db_cleanup(request: Any) -> Response:
+    """Delete records older than max_age_days and vacuum the database."""
+    persistence = getattr(request.app, "persistence", None)
+    if persistence is None:
+        return JSONResponse({"error": "No persistence configured"}, status_code=400)
+
+    try:
+        body = request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    max_age_days = body.get("max_age_days", 90)
+    if not isinstance(max_age_days, int) or max_age_days < 1:
+        return JSONResponse(
+            {"error": "max_age_days must be a positive integer"}, status_code=400
+        )
+
+    result = persistence.cleanup_by_age(max_age_days)
+    return JSONResponse({"ok": True, **result})

--- a/src/llm_rosetta/gateway/cli.py
+++ b/src/llm_rosetta/gateway/cli.py
@@ -250,6 +250,70 @@ def _cmd_set_password(args: argparse.Namespace) -> None:
 _KNOWN_PROVIDERS = known_provider_types()
 
 
+def _cmd_db_cleanup(args: argparse.Namespace) -> None:
+    """Run age-based database cleanup."""
+    from llm_rosetta.observability import PersistenceManager
+
+    config_path = discover_config(args.config)
+    if config_path is None:
+        print("No config file found. Use --config to specify one.", file=sys.stderr)
+        sys.exit(1)
+
+    data_dir = os.path.join(os.path.dirname(config_path), "data")
+    db_path = os.path.join(data_dir, "gateway.db")
+    if not os.path.exists(db_path):
+        print(f"Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    pm = PersistenceManager(data_dir)
+    result = pm.cleanup_by_age(args.max_age_days)
+    pm.close()
+
+    total = (
+        result["request_log_deleted"]
+        + result["error_dumps_deleted"]
+        + result["dump_bodies_deleted"]
+    )
+    if total == 0:
+        print(f"Nothing to clean up — no records older than {args.max_age_days} days.")
+        return
+
+    freed_mb = result["freed_bytes"] / (1024 * 1024)
+    print(f"Cleaned up records older than {args.max_age_days} days:")
+    print(f"  Request logs deleted:  {result['request_log_deleted']}")
+    print(f"  Error dumps deleted:   {result['error_dumps_deleted']}")
+    print(f"  Dump bodies deleted:   {result['dump_bodies_deleted']}")
+    print(f"  Space freed:           {freed_mb:.1f} MB")
+    print(
+        f"  DB size:               {result['size_before'] / (1024 * 1024):.1f} MB → {result['size_after'] / (1024 * 1024):.1f} MB"
+    )
+
+
+def _dispatch_subcommand(args: argparse.Namespace, sub: Any) -> bool:
+    """Handle subcommands; return True if one matched."""
+    if args.command == "init":
+        _cmd_init(args)
+        return True
+    if args.command == "add":
+        if args.add_type == "provider":
+            _cmd_add_provider(args)
+        elif args.add_type == "model":
+            _cmd_add_model(args)
+        else:
+            sub.choices["add"].print_help()
+        return True
+    if args.command == "set-password":
+        _cmd_set_password(args)
+        return True
+    if args.command == "db":
+        if args.db_type == "cleanup":
+            _cmd_db_cleanup(args)
+        else:
+            sub.choices["db"].print_help()
+        return True
+    return False
+
+
 def main() -> None:
     """Parse CLI arguments and either run a subcommand or start the server."""
     from .app import create_app
@@ -340,6 +404,19 @@ def main() -> None:
         "config", nargs="?", default=None, help="Path to config file"
     )
 
+    # ``db`` subcommands
+    db_parser = sub.add_parser("db", help="Database maintenance commands")
+    db_sub = db_parser.add_subparsers(dest="db_type")
+    cleanup_parser = db_sub.add_parser(
+        "cleanup", help="Delete records older than max-age-days and vacuum"
+    )
+    cleanup_parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=90,
+        help="Delete records older than this many days (default: 90)",
+    )
+
     args = parser.parse_args()
 
     # --- edit mode ---
@@ -347,24 +424,8 @@ def main() -> None:
         _open_in_editor(args.config)
         return
 
-    # --- init subcommand ---
-    if args.command == "init":
-        _cmd_init(args)
-        return
-
-    # --- add subcommand ---
-    if args.command == "add":
-        if args.add_type == "provider":
-            _cmd_add_provider(args)
-        elif args.add_type == "model":
-            _cmd_add_model(args)
-        else:
-            sub.choices["add"].print_help()
-        return
-
-    # --- set-password subcommand ---
-    if args.command == "set-password":
-        _cmd_set_password(args)
+    # --- subcommands ---
+    if _dispatch_subcommand(args, sub):
         return
 
     # --- normal server startup ---

--- a/src/llm_rosetta/observability/__init__.py
+++ b/src/llm_rosetta/observability/__init__.py
@@ -33,7 +33,12 @@ from .error_dump import (
 )
 from .capture import CapturedRequest, CaptureState
 from .metrics import MetricsCollector
-from .persistence import DEFAULT_ERROR_MAX, DEFAULT_SUCCESS_MAX, PersistenceManager
+from .persistence import (
+    DEFAULT_ERROR_MAX,
+    DEFAULT_MAX_AGE_DAYS,
+    DEFAULT_SUCCESS_MAX,
+    PersistenceManager,
+)
 from .profiling import ProfilerState
 from .request_log import RequestLog, RequestLogEntry
 
@@ -41,6 +46,7 @@ __all__ = [
     "CapturedRequest",
     "CaptureState",
     "DEFAULT_ERROR_MAX",
+    "DEFAULT_MAX_AGE_DAYS",
     "DEFAULT_SUCCESS_MAX",
     "MetricsCollector",
     "PersistenceManager",

--- a/src/llm_rosetta/observability/persistence.py
+++ b/src/llm_rosetta/observability/persistence.py
@@ -675,8 +675,13 @@ class PersistenceManager:
 
         self._conn.commit()
 
-        # VACUUM reclaims space but requires no active transactions
-        self._conn.execute("VACUUM")
+        # VACUUM reclaims space; may fail under concurrent load
+        vacuum_ok = True
+        try:
+            self._conn.execute("VACUUM")
+        except sqlite3.OperationalError:
+            vacuum_ok = False
+            logger.warning("VACUUM skipped — database is locked by another connection")
 
         size_after = self.db_path.stat().st_size
 
@@ -688,6 +693,7 @@ class PersistenceManager:
             "size_before": size_before,
             "size_after": size_after,
             "max_age_days": max_age_days,
+            "vacuum": vacuum_ok,
         }
 
     def _prune_error_dumps(self) -> None:

--- a/src/llm_rosetta/observability/persistence.py
+++ b/src/llm_rosetta/observability/persistence.py
@@ -32,6 +32,8 @@ _LEGACY_METRICS = "metrics.json"
 DEFAULT_SUCCESS_MAX = 50000
 DEFAULT_ERROR_MAX = 10000
 
+DEFAULT_MAX_AGE_DAYS = 90
+
 
 class PersistenceManager:
     """SQLite-backed persistence for request logs and metrics.
@@ -634,6 +636,59 @@ class PersistenceManager:
             " WHERE converted_body_hash IS NOT NULL)"
         )
         self._conn.commit()
+
+    def cleanup_by_age(self, max_age_days: int = 90) -> dict[str, Any]:
+        """Delete records older than *max_age_days* and vacuum the database.
+
+        This is a manual operation — it is never called automatically.
+
+        Returns:
+            Dict with deletion counts and bytes freed.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=max_age_days)).isoformat()
+
+        size_before = self.db_path.stat().st_size
+
+        cur = self._conn.execute(
+            "DELETE FROM request_log WHERE timestamp < ?", (cutoff,)
+        )
+        request_log_deleted = cur.rowcount
+
+        cur = self._conn.execute(
+            "DELETE FROM error_dumps WHERE timestamp < ?", (cutoff,)
+        )
+        error_dumps_deleted = cur.rowcount
+
+        # Remove orphaned dump_bodies
+        cur = self._conn.execute(
+            "DELETE FROM dump_bodies WHERE hash NOT IN ("
+            "    SELECT body_hash FROM error_dumps "
+            "    WHERE body_hash IS NOT NULL"
+            "    UNION "
+            "    SELECT converted_body_hash FROM error_dumps "
+            "    WHERE converted_body_hash IS NOT NULL"
+            ")"
+        )
+        dump_bodies_deleted = cur.rowcount
+
+        self._conn.commit()
+
+        # VACUUM reclaims space but requires no active transactions
+        self._conn.execute("VACUUM")
+
+        size_after = self.db_path.stat().st_size
+
+        return {
+            "request_log_deleted": request_log_deleted,
+            "error_dumps_deleted": error_dumps_deleted,
+            "dump_bodies_deleted": dump_bodies_deleted,
+            "freed_bytes": max(0, size_before - size_after),
+            "size_before": size_before,
+            "size_after": size_after,
+            "max_age_days": max_age_days,
+        }
 
     def _prune_error_dumps(self) -> None:
         """Remove oldest error dumps beyond the retention cap.

--- a/tests/gateway/test_persistence_sqlite.py
+++ b/tests/gateway/test_persistence_sqlite.py
@@ -513,3 +513,101 @@ class TestRequestLogWithPersistence:
         assert entries[0]["model"] == "second"
         assert entries[1]["model"] == "first"
         pm.close()
+
+
+class TestCleanupByAge:
+    def test_deletes_old_records(self, tmp_path):
+        """Records older than max_age_days are deleted."""
+        from datetime import datetime, timedelta, timezone
+
+        pm = PersistenceManager(str(tmp_path))
+
+        # Insert entries with explicit old timestamps
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=100)).isoformat()
+        new_ts = datetime.now(timezone.utc).isoformat()
+
+        pm._conn.execute(
+            "INSERT INTO request_log (id, timestamp, model, source_provider, "
+            "target_provider, is_stream, status_code, duration_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("old-1", old_ts, "gpt-4o", "openai_chat", "openai_chat", 0, 200, 100),
+        )
+        pm._conn.execute(
+            "INSERT INTO request_log (id, timestamp, model, source_provider, "
+            "target_provider, is_stream, status_code, duration_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("new-1", new_ts, "gpt-4o", "openai_chat", "openai_chat", 0, 200, 50),
+        )
+        pm._conn.commit()
+
+        result = pm.cleanup_by_age(90)
+        assert result["request_log_deleted"] == 1
+        assert result["max_age_days"] == 90
+
+        # Only the new entry remains
+        rows = pm._conn.execute("SELECT id FROM request_log").fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "new-1"
+        pm.close()
+
+    def test_cleans_orphaned_dump_bodies(self, tmp_path):
+        """Orphaned dump_bodies are removed after error_dumps are deleted."""
+        from datetime import datetime, timedelta, timezone
+
+        pm = PersistenceManager(str(tmp_path))
+
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=100)).isoformat()
+
+        pm._conn.execute(
+            "INSERT INTO dump_bodies (hash, data, orig_bytes, created) "
+            "VALUES (?, ?, ?, ?)",
+            ("hash-old", b"old body data", 13, old_ts),
+        )
+        pm._conn.execute(
+            "INSERT INTO error_dumps (id, timestamp, model, source_provider, "
+            "target_provider, provider_name, status_code, body_hash) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "ed-1",
+                old_ts,
+                "gpt-4o",
+                "openai_chat",
+                "openai_chat",
+                "openai",
+                500,
+                "hash-old",
+            ),
+        )
+        pm._conn.commit()
+
+        result = pm.cleanup_by_age(90)
+        assert result["error_dumps_deleted"] == 1
+        assert result["dump_bodies_deleted"] == 1
+
+        bodies = pm._conn.execute("SELECT hash FROM dump_bodies").fetchall()
+        assert len(bodies) == 0
+        pm.close()
+
+    def test_nothing_deleted_when_all_recent(self, tmp_path):
+        """No records are deleted when everything is within the age window."""
+        from datetime import datetime, timezone
+
+        pm = PersistenceManager(str(tmp_path))
+
+        new_ts = datetime.now(timezone.utc).isoformat()
+        pm._conn.execute(
+            "INSERT INTO request_log (id, timestamp, model, source_provider, "
+            "target_provider, is_stream, status_code, duration_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("new-1", new_ts, "gpt-4o", "openai_chat", "openai_chat", 0, 200, 50),
+        )
+        pm._conn.commit()
+
+        result = pm.cleanup_by_age(90)
+        assert result["request_log_deleted"] == 0
+        assert result["error_dumps_deleted"] == 0
+        assert result["dump_bodies_deleted"] == 0
+
+        rows = pm._conn.execute("SELECT id FROM request_log").fetchall()
+        assert len(rows) == 1
+        pm.close()


### PR DESCRIPTION
## Summary

- Add `PersistenceManager.cleanup_by_age()` — deletes `request_log`, `error_dumps`, and orphaned `dump_bodies` older than `max_age_days`, then VACUUMs
- Add `POST /admin/api/db/cleanup` API endpoint
- Add admin UI: `max_age_days` number input in Settings + red "Cleanup" button with `CLEANUP` confirmation popup (EN/ZH i18n)
- Add CLI: `llm-rosetta-gateway db cleanup --max-age-days 90`
- Add config field: `server.request_log.max_age_days` (default 90)
- Cleanup is **never automatic** — always requires explicit user action (admin UI confirmation or CLI)

Motivated by production `gateway.db` reaching 114MB after ~3 months with no time-based pruning.

Closes #549

## Test plan

- [x] 3 new unit tests for `cleanup_by_age()` (old records deleted, orphaned bodies cleaned, no-op when all recent)
- [x] `make lint` passes
- [x] `make test` passes (2783 passed)
- [ ] Manual: start gateway, open admin Settings, verify max_age_days input and Cleanup button
- [ ] Manual: type CLEANUP in confirmation popup, verify toast shows deletion stats
- [ ] Manual: test CLI `llm-rosetta-gateway db cleanup --max-age-days 90`