### PR TITLE
feat(gateway): independent log/error-dump cleanup + error dump export

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -2040,7 +2040,10 @@ async function doExportDumps() {
     const blob = await r.blob();
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
-    a.download = 'error-dumps.tar.gz';
+    const parts = ['error-dumps'];
+    if (start) parts.push(start);
+    if (end) parts.push('to', end);
+    a.download = parts.join('-') + '.tar.gz';
     a.click();
     URL.revokeObjectURL(a.href);
     showToast(t('toast.exported'));

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -787,6 +787,7 @@ body { padding-bottom: 26px; }
           <div style="display:inline-block;position:relative">
             <button class="btn btn-sm" onclick="toggleDumpMoreMenu(this)" style="padding:3px 8px">⋯</button>
             <div id="dumpMoreMenu" style="display:none;position:absolute;right:0;top:calc(100% + 4px);min-width:140px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.3);z-index:10;overflow:hidden">
+              <div style="padding:8px 14px;font-size:13px;cursor:pointer" onmouseenter="this.style.background='var(--bg-hover)'" onmouseleave="this.style.background=''" onclick="document.getElementById('dumpMoreMenu').style.display='none';openExportDumpsModal()" data-i18n="btn.export">Export...</div>
               <div style="padding:8px 14px;font-size:13px;cursor:pointer;color:var(--red)" onmouseenter="this.style.background='var(--bg-hover)'" onmouseleave="this.style.background=''" onclick="document.getElementById('dumpMoreMenu').style.display='none';openClearDumpsConfirm()" data-i18n="btn.clearAll">Clear All</div>
             </div>
           </div>
@@ -871,6 +872,23 @@ body { padding-bottom: 26px; }
       <div class="modal-actions">
         <button class="btn" onclick="closeModal('clearDumpsModal')" data-i18n="btn.cancel">Cancel</button>
         <button class="btn btn-danger" id="clearDumpsBtn" onclick="confirmClearDumps()" disabled style="opacity:0.4;cursor:not-allowed" data-i18n="btn.clearAll">Clear All</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Export Error Dumps Modal -->
+  <div class="modal-overlay" id="exportDumpsModal">
+    <div class="modal" style="width:400px">
+      <h3 data-i18n="export.title">Export Error Dumps</h3>
+      <p style="font-size:13px;color:var(--text-dim);margin-bottom:12px" data-i18n="export.hint">Select a date range (optional). Leave empty to export all.</p>
+      <div style="display:flex;gap:8px;align-items:center;margin-bottom:16px">
+        <input type="date" id="exportStartDate" style="flex:1;padding:8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);color:var(--text)">
+        <span style="color:var(--text-dim)">—</span>
+        <input type="date" id="exportEndDate" style="flex:1;padding:8px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);color:var(--text)">
+      </div>
+      <div class="modal-actions">
+        <button class="btn" onclick="closeModal('exportDumpsModal')" data-i18n="btn.cancel">Cancel</button>
+        <button class="btn" onclick="doExportDumps()" style="background:var(--accent);color:#fff" data-i18n="btn.export">Export</button>
       </div>
     </div>
   </div>
@@ -962,7 +980,9 @@ body { padding-bottom: 26px; }
     <div class="settings-popup-item">
       <label data-i18n="label.maxAgeDays">Max Age (days)</label>
       <input type="number" id="settingsMaxAgeDays" min="1" step="1" value="90">
-      <button class="btn btn-sm" onclick="openCleanupConfirm()" style="background:var(--red);color:#fff" data-i18n="btn.cleanup">Cleanup</button>
+      <button class="btn btn-sm" onclick="openCleanupConfirm('logs')" style="background:var(--red);color:#fff" data-i18n="btn.cleanupLogs">Cleanup Logs</button>
+      <button class="btn btn-sm" onclick="openCleanupConfirm('errors')" style="background:var(--red);color:#fff" data-i18n="btn.cleanupErrors">Cleanup Errors</button>
+      <button class="btn btn-sm" onclick="openCleanupConfirm('all')" style="background:var(--red);color:#fff" data-i18n="btn.cleanupAll">Cleanup All</button>
     </div>
     <div class="settings-divider"></div>
     <!-- Admin Token -->
@@ -1460,7 +1480,7 @@ const I18N = {
     'btn.save':'Save', 'btn.copy':'Copy', 'btn.change':'Change', 'modal.settings':'Settings', 'label.theme':'Theme', 'label.language':'Language', 'theme.light':'Light', 'theme.dark':'Dark', 'btn.cancel':'Cancel', 'btn.close':'Close',
     'label.logLevel':'Log Level', 'logLevel.normal':'Normal', 'logLevel.verbose':'Verbose', 'logLevel.debug':'Debug (bodies)',
     'label.autoRefresh':'Auto-Refresh', 'label.off':'Off', 'label.credentialReveal':'Credential Reveal', 'label.errorDumps':'Error Detail Log', 'label.enabled':'Enabled',
-    'label.logRetention':'Log Retention', 'label.successMax':'Success', 'label.errorMax':'Error',
+    'label.logRetention':'Log Retention', 'label.successMax':'Success', 'label.errorMax':'Error', 'label.maxAgeDays':'Max Age (days)', 'btn.cleanup':'Cleanup', 'btn.cleanupLogs':'Cleanup Logs', 'btn.cleanupErrors':'Cleanup Errors', 'btn.cleanupAll':'Cleanup All', 'btn.export':'Export...', 'confirm.cleanupTitle':'Database Cleanup', 'confirm.cleanupMsg':'This will permanently delete all records older than <strong>{days} days</strong>. Type <strong>CLEANUP</strong> to confirm.', 'confirm.cleanupLogsMsg':'This will permanently delete all request logs older than <strong>{days} days</strong>. Type <strong>CLEANUP</strong> to confirm.', 'confirm.cleanupErrorsMsg':'This will permanently delete all error dumps older than <strong>{days} days</strong>. Type <strong>CLEANUP</strong> to confirm.', 'toast.cleanupDone':'Cleaned up: {rl} logs, {ed} error dumps, {db} bodies removed. Freed {freed}.', 'toast.cleanupLogsDone':'Cleaned up {count} log entries. Freed {freed}.', 'toast.cleanupErrorsDone':'Cleaned up {ed} error dumps, {db} bodies. Freed {freed}.', 'toast.cleanupNone':'Nothing to clean up — no records older than {days} days.', 'toast.exported':'Export downloaded.', 'export.title':'Export Error Dumps', 'export.hint':'Select a date range (optional). Leave empty to export all.',
     'label.adminToken':'Admin Token', 'label.rotatingIn':'Rotating in <span class="cd-time">{time}</span>',
     'label.changePassword':'Change Password', 'label.currentPw':'Current', 'label.newPw':'New', 'label.confirmPw':'Confirm',
     'pw.required':'Both current and new password required', 'pw.mismatch':'Passwords do not match', 'pw.tooShort':'Password too short (min 4)', 'pw.changed':'Password changed',
@@ -1602,7 +1622,7 @@ const I18N = {
     'btn.save':'\u4fdd\u5b58', 'btn.copy':'\u590d\u5236', 'btn.change':'\u4fee\u6539', 'btn.cancel':'\u53d6\u6d88', 'btn.close':'\u5173\u95ed',
     'label.logLevel':'\u65e5\u5fd7\u7ea7\u522b', 'logLevel.normal':'\u6b63\u5e38', 'logLevel.verbose':'\u8be6\u7ec6', 'logLevel.debug':'\u8c03\u8bd5 (\u542b\u8bf7\u6c42\u4f53)',
     'label.autoRefresh':'\u81ea\u52a8\u5237\u65b0', 'label.off':'\u5173\u95ed', 'label.credentialReveal':'\u51ed\u8bc1\u53ef\u89c1', 'label.errorDumps':'\u9519\u8bef\u8be6\u60c5\u8bb0\u5f55', 'label.enabled':'\u5df2\u542f\u7528',
-    'label.logRetention':'\u65e5\u5fd7\u4fdd\u7559', 'label.successMax':'\u6210\u529f', 'label.errorMax':'\u5931\u8d25', 'label.maxAgeDays':'\u6700\u5927\u4fdd\u7559\u5929\u6570', 'btn.cleanup':'\u6e05\u7406', 'confirm.cleanupTitle':'\u6570\u636e\u5e93\u6e05\u7406', 'confirm.cleanupMsg':'\u6b64\u64cd\u4f5c\u5c06\u6c38\u4e45\u5220\u9664\u8d85\u8fc7 <strong>{days} \u5929</strong>\u7684\u6240\u6709\u8bf7\u6c42\u65e5\u5fd7\u548c\u9519\u8bef\u8f6c\u50a8\u3002\u8bf7\u8f93\u5165 <strong>CLEANUP</strong> \u786e\u8ba4\u3002', 'toast.cleanupDone':'\u5df2\u6e05\u7406\uff1a{rl} \u6761\u65e5\u5fd7\u3001{ed} \u6761\u9519\u8bef\u8f6c\u50a8\u3001{db} \u4e2a Body\u3002\u91ca\u653e {freed}\u3002', 'toast.cleanupNone':'\u65e0\u9700\u6e05\u7406\u2014\u2014\u6ca1\u6709\u8d85\u8fc7 {days} \u5929\u7684\u8bb0\u5f55\u3002',
+    'label.logRetention':'\u65e5\u5fd7\u4fdd\u7559', 'label.successMax':'\u6210\u529f', 'label.errorMax':'\u5931\u8d25', 'label.maxAgeDays':'\u6700\u5927\u4fdd\u7559\u5929\u6570', 'btn.cleanup':'\u6e05\u7406', 'confirm.cleanupTitle':'\u6570\u636e\u5e93\u6e05\u7406', 'confirm.cleanupMsg':'\u6b64\u64cd\u4f5c\u5c06\u6c38\u4e45\u5220\u9664\u8d85\u8fc7 <strong>{days} \u5929</strong>\u7684\u6240\u6709\u8bf7\u6c42\u65e5\u5fd7\u548c\u9519\u8bef\u8f6c\u50a8\u3002\u8bf7\u8f93\u5165 <strong>CLEANUP</strong> \u786e\u8ba4\u3002', 'toast.cleanupDone':'\u5df2\u6e05\u7406\uff1a{rl} \u6761\u65e5\u5fd7\u3001{ed} \u6761\u9519\u8bef\u8f6c\u50a8\u3001{db} \u4e2a Body\u3002\u91ca\u653e {freed}\u3002', 'toast.cleanupNone':'\u65e0\u9700\u6e05\u7406\u2014\u2014\u6ca1\u6709\u8d85\u8fc7 {days} \u5929\u7684\u8bb0\u5f55\u3002', 'btn.cleanupLogs':'\u6e05\u7406\u65e5\u5fd7', 'btn.cleanupErrors':'\u6e05\u7406\u9519\u8bef', 'btn.cleanupAll':'\u6e05\u7406\u5168\u90e8', 'btn.export':'\u5bfc\u51fa...', 'confirm.cleanupLogsMsg':'\u6b64\u64cd\u4f5c\u5c06\u6c38\u4e45\u5220\u9664\u8d85\u8fc7 <strong>{days} \u5929</strong>\u7684\u6240\u6709\u8bf7\u6c42\u65e5\u5fd7\u3002\u8bf7\u8f93\u5165 <strong>CLEANUP</strong> \u786e\u8ba4\u3002', 'confirm.cleanupErrorsMsg':'\u6b64\u64cd\u4f5c\u5c06\u6c38\u4e45\u5220\u9664\u8d85\u8fc7 <strong>{days} \u5929</strong>\u7684\u6240\u6709\u9519\u8bef\u8f6c\u50a8\u3002\u8bf7\u8f93\u5165 <strong>CLEANUP</strong> \u786e\u8ba4\u3002', 'toast.cleanupLogsDone':'\u5df2\u6e05\u7406 {count} \u6761\u65e5\u5fd7\u3002\u91ca\u653e {freed}\u3002', 'toast.cleanupErrorsDone':'\u5df2\u6e05\u7406 {ed} \u6761\u9519\u8bef\u8f6c\u50a8\u3001{db} \u4e2a Body\u3002\u91ca\u653e {freed}\u3002', 'toast.exported':'\u5bfc\u51fa\u5df2\u4e0b\u8f7d\u3002', 'export.title':'\u5bfc\u51fa\u9519\u8bef\u8bb0\u5f55', 'export.hint':'\u9009\u62e9\u65e5\u671f\u8303\u56f4\uff08\u53ef\u9009\uff09\u3002\u7559\u7a7a\u5bfc\u51fa\u5168\u90e8\u3002',
     'label.adminToken':'\u7ba1\u7406 Token', 'label.rotatingIn':'<span class="cd-time">{time}</span> \u540e\u8f6e\u6362',
     'label.changePassword':'\u4fee\u6539\u5bc6\u7801', 'label.currentPw':'\u5f53\u524d\u5bc6\u7801', 'label.newPw':'\u65b0\u5bc6\u7801', 'label.confirmPw':'\u786e\u8ba4\u5bc6\u7801',
     'pw.required':'\u8bf7\u586b\u5199\u5f53\u524d\u5bc6\u7801\u548c\u65b0\u5bc6\u7801', 'pw.mismatch':'\u4e24\u6b21\u8f93\u5165\u4e0d\u4e00\u81f4', 'pw.tooShort':'\u5bc6\u7801\u592a\u77ed\uff08\u81f3\u5c114\u4f4d\uff09', 'pw.changed':'\u5bc6\u7801\u5df2\u4fee\u6539',
@@ -1947,10 +1967,16 @@ async function saveLogRetention() {
 }
 
 // --- Database Cleanup ---
-function openCleanupConfirm() {
+let _cleanupTarget = 'all';
+
+function openCleanupConfirm(target) {
+  _cleanupTarget = target || 'all';
   const days = parseInt(document.getElementById('settingsMaxAgeDays')?.value || '90', 10);
   if (days < 1) { showToast(t('toast.error'), 'error'); return; }
-  document.getElementById('cleanupConfirmMsg').innerHTML = t('confirm.cleanupMsg', {days});
+  const msgKey = target === 'logs' ? 'confirm.cleanupLogsMsg'
+    : target === 'errors' ? 'confirm.cleanupErrorsMsg'
+    : 'confirm.cleanupMsg';
+  document.getElementById('cleanupConfirmMsg').innerHTML = t(msgKey, {days});
   document.getElementById('cleanupConfirmInput').value = '';
   document.getElementById('cleanupConfirmBtn').disabled = true;
   const btn = document.getElementById('cleanupConfirmBtn');
@@ -1971,18 +1997,53 @@ function onCleanupConfirmInput() {
 async function onCleanupConfirmClick() {
   const days = parseInt(document.getElementById('settingsMaxAgeDays')?.value || '90', 10);
   closeModal('cleanupConfirmModal');
+  const target = _cleanupTarget;
   try {
-    const res = await api.post('/admin/api/db/cleanup', { max_age_days: days });
-    const d = res;
-    const total = d.request_log_deleted + d.error_dumps_deleted + d.dump_bodies_deleted;
-    if (total === 0) {
-      showToast(t('toast.cleanupNone', {days}));
+    const url = target === 'logs' ? '/admin/api/requests/cleanup'
+      : target === 'errors' ? '/admin/api/error-dumps/cleanup'
+      : '/admin/api/db/cleanup';
+    const d = await api.post(url, { max_age_days: days });
+    if (target === 'logs') {
+      if (d.deleted === 0) showToast(t('toast.cleanupNone', {days}));
+      else showToast(t('toast.cleanupLogsDone', {count: d.deleted, freed: _fmtBytes(d.freed_bytes)}));
+    } else if (target === 'errors') {
+      const total = d.error_dumps_deleted + d.dump_bodies_deleted;
+      if (total === 0) showToast(t('toast.cleanupNone', {days}));
+      else showToast(t('toast.cleanupErrorsDone', {ed: d.error_dumps_deleted, db: d.dump_bodies_deleted, freed: _fmtBytes(d.freed_bytes)}));
     } else {
-      showToast(t('toast.cleanupDone', {
-        rl: d.request_log_deleted, ed: d.error_dumps_deleted,
-        db: d.dump_bodies_deleted, freed: _fmtBytes(d.freed_bytes)
-      }));
+      const total = d.request_log_deleted + d.error_dumps_deleted + d.dump_bodies_deleted;
+      if (total === 0) showToast(t('toast.cleanupNone', {days}));
+      else showToast(t('toast.cleanupDone', {rl: d.request_log_deleted, ed: d.error_dumps_deleted, db: d.dump_bodies_deleted, freed: _fmtBytes(d.freed_bytes)}));
     }
+  } catch { showToast(t('toast.error'), 'error'); }
+}
+
+// --- Error Dump Export ---
+function openExportDumpsModal() {
+  document.getElementById('exportStartDate').value = '';
+  document.getElementById('exportEndDate').value = '';
+  document.getElementById('exportDumpsModal').classList.add('open');
+}
+
+async function doExportDumps() {
+  closeModal('exportDumpsModal');
+  const start = document.getElementById('exportStartDate').value;
+  const end = document.getElementById('exportEndDate').value;
+  let url = '/admin/api/error-dumps/export';
+  const params = [];
+  if (start) params.push('start=' + encodeURIComponent(start + 'T00:00:00Z'));
+  if (end) params.push('end=' + encodeURIComponent(end + 'T23:59:59Z'));
+  if (params.length) url += '?' + params.join('&');
+  try {
+    const r = await fetch(url, {headers: _adminHeaders()});
+    if (!r.ok) { showToast(t('toast.error'), 'error'); return; }
+    const blob = await r.blob();
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'error-dumps.tar.gz';
+    a.click();
+    URL.revokeObjectURL(a.href);
+    showToast(t('toast.exported'));
   } catch { showToast(t('toast.error'), 'error'); }
 }
 

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -57,9 +57,12 @@ from .keys import (
     update_api_key,
 )
 from .observability import (
+    cleanup_error_dumps_by_age,
+    cleanup_requests_by_age,
     clear_error_dumps,
     clear_requests,
     db_cleanup,
+    export_error_dumps,
     get_error_dump_body,
     get_error_dump_detail,
     get_error_dumps,
@@ -182,6 +185,13 @@ def register_admin_routes(app: Any) -> None:
     )
     app.route("/admin/api/error-dumps", methods=["DELETE"])(clear_error_dumps)
     app.route("/admin/api/db/cleanup", methods=["POST"])(db_cleanup)
+    app.route("/admin/api/requests/cleanup", methods=["POST"])(
+        _guard("logs", cleanup_requests_by_age)
+    )
+    app.route("/admin/api/error-dumps/cleanup", methods=["POST"])(
+        cleanup_error_dumps_by_age
+    )
+    app.route("/admin/api/error-dumps/export", methods=["GET"])(export_error_dumps)
     # API key management (keys tab)
     app.route("/admin/api/keys", methods=["GET"])(_guard("keys", get_api_keys))
     app.route("/admin/api/keys", methods=["POST"])(_guard("keys", create_api_key))

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -185,9 +185,7 @@ def register_admin_routes(app: Any) -> None:
     )
     app.route("/admin/api/error-dumps", methods=["DELETE"])(clear_error_dumps)
     app.route("/admin/api/db/cleanup", methods=["POST"])(db_cleanup)
-    app.route("/admin/api/requests/cleanup", methods=["POST"])(
-        _guard("logs", cleanup_requests_by_age)
-    )
+    app.route("/admin/api/requests/cleanup", methods=["POST"])(cleanup_requests_by_age)
     app.route("/admin/api/error-dumps/cleanup", methods=["POST"])(
         cleanup_error_dumps_by_age
     )

--- a/src/llm_rosetta/gateway/admin/routes/observability.py
+++ b/src/llm_rosetta/gateway/admin/routes/observability.py
@@ -374,3 +374,64 @@ async def db_cleanup(request: Any) -> Response:
 
     result = persistence.cleanup_by_age(max_age_days)
     return JSONResponse({"ok": True, **result})
+
+
+async def cleanup_requests_by_age(request: Any) -> Response:
+    """Delete request log entries older than max_age_days."""
+    persistence = getattr(request.app, "persistence", None)
+    if persistence is None:
+        return JSONResponse({"error": "No persistence configured"}, status_code=400)
+
+    try:
+        body = request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    max_age_days = body.get("max_age_days", 90)
+    if not isinstance(max_age_days, int) or max_age_days < 1:
+        return JSONResponse(
+            {"error": "max_age_days must be a positive integer"}, status_code=400
+        )
+
+    result = persistence.cleanup_logs_by_age(max_age_days)
+    return JSONResponse({"ok": True, **result})
+
+
+async def cleanup_error_dumps_by_age(request: Any) -> Response:
+    """Delete error dumps older than max_age_days."""
+    persistence = getattr(request.app, "persistence", None)
+    if persistence is None:
+        return JSONResponse({"error": "No persistence configured"}, status_code=400)
+
+    try:
+        body = request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    max_age_days = body.get("max_age_days", 90)
+    if not isinstance(max_age_days, int) or max_age_days < 1:
+        return JSONResponse(
+            {"error": "max_age_days must be a positive integer"}, status_code=400
+        )
+
+    result = persistence.cleanup_error_dumps_by_age(max_age_days)
+    return JSONResponse({"ok": True, **result})
+
+
+async def export_error_dumps(request: Any) -> Response:
+    """Export error dumps in a date range as tar.gz."""
+    persistence = getattr(request.app, "persistence", None)
+    if persistence is None:
+        return JSONResponse({"error": "No persistence configured"}, status_code=400)
+
+    start = _qp(request, "start")
+    end = _qp(request, "end")
+
+    data = persistence.export_error_dumps(start=start, end=end)
+
+    return Response(
+        body=data,
+        status_code=200,
+        content_type="application/gzip",
+        headers={"Content-Disposition": "attachment; filename=error-dumps.tar.gz"},
+    )

--- a/src/llm_rosetta/gateway/cli.py
+++ b/src/llm_rosetta/gateway/cli.py
@@ -289,6 +289,104 @@ def _cmd_db_cleanup(args: argparse.Namespace) -> None:
     )
 
 
+def _cmd_db_cleanup_logs(args: argparse.Namespace) -> None:
+    """Run age-based request log cleanup."""
+    from llm_rosetta.observability import PersistenceManager
+
+    config_path = discover_config(args.config)
+    if config_path is None:
+        print("No config file found. Use --config to specify one.", file=sys.stderr)
+        sys.exit(1)
+
+    data_dir = os.path.join(os.path.dirname(config_path), "data")
+    db_path = os.path.join(data_dir, "gateway.db")
+    if not os.path.exists(db_path):
+        print(f"Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    pm = PersistenceManager(data_dir)
+    result = pm.cleanup_logs_by_age(args.max_age_days)
+    pm.close()
+
+    if result["deleted"] == 0:
+        print(f"Nothing to clean up — no logs older than {args.max_age_days} days.")
+        return
+
+    freed_mb = result["freed_bytes"] / (1024 * 1024)
+    print(f"Cleaned up logs older than {args.max_age_days} days:")
+    print(f"  Log entries deleted:  {result['deleted']}")
+    print(f"  Space freed:          {freed_mb:.1f} MB")
+    print(
+        f"  DB size:              {result['size_before'] / (1024 * 1024):.1f} MB"
+        f" → {result['size_after'] / (1024 * 1024):.1f} MB"
+    )
+
+
+def _cmd_db_cleanup_errors(args: argparse.Namespace) -> None:
+    """Run age-based error dump cleanup."""
+    from llm_rosetta.observability import PersistenceManager
+
+    config_path = discover_config(args.config)
+    if config_path is None:
+        print("No config file found. Use --config to specify one.", file=sys.stderr)
+        sys.exit(1)
+
+    data_dir = os.path.join(os.path.dirname(config_path), "data")
+    db_path = os.path.join(data_dir, "gateway.db")
+    if not os.path.exists(db_path):
+        print(f"Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    pm = PersistenceManager(data_dir)
+    result = pm.cleanup_error_dumps_by_age(args.max_age_days)
+    pm.close()
+
+    total = result["error_dumps_deleted"] + result["dump_bodies_deleted"]
+    if total == 0:
+        print(
+            f"Nothing to clean up — no error dumps older than {args.max_age_days} days."
+        )
+        return
+
+    freed_mb = result["freed_bytes"] / (1024 * 1024)
+    print(f"Cleaned up error dumps older than {args.max_age_days} days:")
+    print(f"  Error dumps deleted:  {result['error_dumps_deleted']}")
+    print(f"  Dump bodies deleted:  {result['dump_bodies_deleted']}")
+    print(f"  Space freed:          {freed_mb:.1f} MB")
+    print(
+        f"  DB size:              {result['size_before'] / (1024 * 1024):.1f} MB"
+        f" → {result['size_after'] / (1024 * 1024):.1f} MB"
+    )
+
+
+def _cmd_db_export_errors(args: argparse.Namespace) -> None:
+    """Export error dumps to a tar.gz file."""
+    from llm_rosetta.observability import PersistenceManager
+
+    config_path = discover_config(args.config)
+    if config_path is None:
+        print("No config file found. Use --config to specify one.", file=sys.stderr)
+        sys.exit(1)
+
+    data_dir = os.path.join(os.path.dirname(config_path), "data")
+    db_path = os.path.join(data_dir, "gateway.db")
+    if not os.path.exists(db_path):
+        print(f"Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    start = f"{args.start}T00:00:00Z" if args.start else None
+    end = f"{args.end}T23:59:59Z" if args.end else None
+
+    pm = PersistenceManager(data_dir)
+    data = pm.export_error_dumps(start=start, end=end)
+    pm.close()
+
+    output = args.output or "error-dumps.tar.gz"
+    with open(output, "wb") as f:
+        f.write(data)
+    print(f"Exported {len(data)} bytes to {output}")
+
+
 def _dispatch_subcommand(args: argparse.Namespace, sub: Any) -> bool:
     """Handle subcommands; return True if one matched."""
     if args.command == "init":
@@ -308,6 +406,12 @@ def _dispatch_subcommand(args: argparse.Namespace, sub: Any) -> bool:
     if args.command == "db":
         if args.db_type == "cleanup":
             _cmd_db_cleanup(args)
+        elif args.db_type == "cleanup-logs":
+            _cmd_db_cleanup_logs(args)
+        elif args.db_type == "cleanup-errors":
+            _cmd_db_cleanup_errors(args)
+        elif args.db_type == "export-errors":
+            _cmd_db_export_errors(args)
         else:
             sub.choices["db"].print_help()
         return True
@@ -408,13 +512,33 @@ def main() -> None:
     db_parser = sub.add_parser("db", help="Database maintenance commands")
     db_sub = db_parser.add_subparsers(dest="db_type")
     cleanup_parser = db_sub.add_parser(
-        "cleanup", help="Delete records older than max-age-days and vacuum"
+        "cleanup", help="Delete all records older than max-age-days and vacuum"
     )
     cleanup_parser.add_argument(
         "--max-age-days",
         type=int,
         default=90,
         help="Delete records older than this many days (default: 90)",
+    )
+    cl_parser = db_sub.add_parser(
+        "cleanup-logs", help="Delete request logs older than max-age-days"
+    )
+    cl_parser.add_argument(
+        "--max-age-days", type=int, default=90, help="Max age in days (default: 90)"
+    )
+    ce_parser = db_sub.add_parser(
+        "cleanup-errors", help="Delete error dumps older than max-age-days"
+    )
+    ce_parser.add_argument(
+        "--max-age-days", type=int, default=90, help="Max age in days (default: 90)"
+    )
+    export_parser = db_sub.add_parser(
+        "export-errors", help="Export error dumps to a tar.gz file"
+    )
+    export_parser.add_argument("--start", default=None, help="Start date (YYYY-MM-DD)")
+    export_parser.add_argument("--end", default=None, help="End date (YYYY-MM-DD)")
+    export_parser.add_argument(
+        "-o", "--output", default=None, help="Output file (default: error-dumps.tar.gz)"
     )
 
     args = parser.parse_args()

--- a/src/llm_rosetta/observability/persistence.py
+++ b/src/llm_rosetta/observability/persistence.py
@@ -637,18 +637,84 @@ class PersistenceManager:
         )
         self._conn.commit()
 
+    def _vacuum(self) -> bool:
+        """Run VACUUM; return True on success, False if locked."""
+        try:
+            self._conn.execute("VACUUM")
+        except sqlite3.OperationalError:
+            logger.warning("VACUUM skipped — database is locked by another connection")
+            return False
+        return True
+
+    def cleanup_logs_by_age(self, max_age_days: int) -> dict[str, Any]:
+        """Delete request_log rows older than *max_age_days* and vacuum."""
+        from datetime import datetime, timedelta, timezone
+
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=max_age_days)).isoformat()
+        size_before = self.db_path.stat().st_size
+
+        cur = self._conn.execute(
+            "DELETE FROM request_log WHERE timestamp < ?", (cutoff,)
+        )
+        deleted = cur.rowcount
+        self._conn.commit()
+        vacuum_ok = self._vacuum()
+        size_after = self.db_path.stat().st_size
+
+        return {
+            "deleted": deleted,
+            "freed_bytes": max(0, size_before - size_after),
+            "size_before": size_before,
+            "size_after": size_after,
+            "max_age_days": max_age_days,
+            "vacuum": vacuum_ok,
+        }
+
+    def cleanup_error_dumps_by_age(self, max_age_days: int) -> dict[str, Any]:
+        """Delete error_dumps and orphaned dump_bodies older than *max_age_days*."""
+        from datetime import datetime, timedelta, timezone
+
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=max_age_days)).isoformat()
+        size_before = self.db_path.stat().st_size
+
+        cur = self._conn.execute(
+            "DELETE FROM error_dumps WHERE timestamp < ?", (cutoff,)
+        )
+        error_dumps_deleted = cur.rowcount
+
+        # Remove orphaned dump_bodies (global, not age-scoped — intentional)
+        cur = self._conn.execute(
+            "DELETE FROM dump_bodies WHERE hash NOT IN ("
+            "    SELECT body_hash FROM error_dumps "
+            "    WHERE body_hash IS NOT NULL"
+            "    UNION "
+            "    SELECT converted_body_hash FROM error_dumps "
+            "    WHERE converted_body_hash IS NOT NULL"
+            ")"
+        )
+        dump_bodies_deleted = cur.rowcount
+        self._conn.commit()
+        vacuum_ok = self._vacuum()
+        size_after = self.db_path.stat().st_size
+
+        return {
+            "error_dumps_deleted": error_dumps_deleted,
+            "dump_bodies_deleted": dump_bodies_deleted,
+            "freed_bytes": max(0, size_before - size_after),
+            "size_before": size_before,
+            "size_after": size_after,
+            "max_age_days": max_age_days,
+            "vacuum": vacuum_ok,
+        }
+
     def cleanup_by_age(self, max_age_days: int = 90) -> dict[str, Any]:
-        """Delete records older than *max_age_days* and vacuum the database.
+        """Delete all records older than *max_age_days* and vacuum.
 
-        This is a manual operation — it is never called automatically.
-
-        Returns:
-            Dict with deletion counts and bytes freed.
+        Convenience method that cleans both request logs and error dumps.
         """
         from datetime import datetime, timedelta, timezone
 
         cutoff = (datetime.now(timezone.utc) - timedelta(days=max_age_days)).isoformat()
-
         size_before = self.db_path.stat().st_size
 
         cur = self._conn.execute(
@@ -661,7 +727,6 @@ class PersistenceManager:
         )
         error_dumps_deleted = cur.rowcount
 
-        # Remove orphaned dump_bodies
         cur = self._conn.execute(
             "DELETE FROM dump_bodies WHERE hash NOT IN ("
             "    SELECT body_hash FROM error_dumps "
@@ -672,17 +737,8 @@ class PersistenceManager:
             ")"
         )
         dump_bodies_deleted = cur.rowcount
-
         self._conn.commit()
-
-        # VACUUM reclaims space; may fail under concurrent load
-        vacuum_ok = True
-        try:
-            self._conn.execute("VACUUM")
-        except sqlite3.OperationalError:
-            vacuum_ok = False
-            logger.warning("VACUUM skipped — database is locked by another connection")
-
+        vacuum_ok = self._vacuum()
         size_after = self.db_path.stat().st_size
 
         return {
@@ -695,6 +751,92 @@ class PersistenceManager:
             "max_age_days": max_age_days,
             "vacuum": vacuum_ok,
         }
+
+    def export_error_dumps(
+        self, *, start: str | None = None, end: str | None = None
+    ) -> bytes:
+        """Export error dumps in a date range as tar.gz bytes.
+
+        Args:
+            start: ISO timestamp lower bound (inclusive). None = no lower bound.
+            end: ISO timestamp upper bound (inclusive). None = no upper bound.
+
+        Returns:
+            In-memory tar.gz archive with metadata.json and bodies/<hash>.bin.
+        """
+        import io
+        import tarfile
+
+        where_clauses: list[str] = []
+        params: list[str] = []
+        if start:
+            where_clauses.append("timestamp >= ?")
+            params.append(start)
+        if end:
+            where_clauses.append("timestamp <= ?")
+            params.append(end)
+
+        where_sql = ""
+        if where_clauses:
+            where_sql = "WHERE " + " AND ".join(where_clauses)
+
+        cols = (
+            "id, request_log_id, timestamp, model, source_provider, "
+            "target_provider, provider_name, status_code, error_phase, "
+            "body_hash, response_text, upstream_url, converted_body_hash"
+        )
+        col_names = [
+            "id",
+            "request_log_id",
+            "timestamp",
+            "model",
+            "source_provider",
+            "target_provider",
+            "provider_name",
+            "status_code",
+            "error_phase",
+            "body_hash",
+            "response_text",
+            "upstream_url",
+            "converted_body_hash",
+        ]
+        rows = self._conn.execute(
+            f"SELECT {cols} FROM error_dumps {where_sql} ORDER BY timestamp DESC",
+            params,
+        ).fetchall()
+
+        entries = [
+            {k: v for k, v in zip(col_names, row) if v is not None} for row in rows
+        ]
+
+        # Collect unique body hashes
+        hashes: set[str] = set()
+        for e in entries:
+            if e.get("body_hash"):
+                hashes.add(e["body_hash"])
+            if e.get("converted_body_hash"):
+                hashes.add(e["converted_body_hash"])
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            # metadata.json
+            meta_bytes = json.dumps(entries, indent=2, ensure_ascii=False).encode()
+            info = tarfile.TarInfo(name="metadata.json")
+            info.size = len(meta_bytes)
+            tar.addfile(info, io.BytesIO(meta_bytes))
+
+            # bodies/<hash>.bin
+            for h in sorted(hashes):
+                row = self._conn.execute(
+                    "SELECT data FROM dump_bodies WHERE hash = ?", (h,)
+                ).fetchone()
+                if row and row[0]:
+                    data = row[0]
+                    info = tarfile.TarInfo(name=f"bodies/{h}.bin")
+                    info.size = len(data)
+                    tar.addfile(info, io.BytesIO(data))
+
+        return buf.getvalue()
 
     def _prune_error_dumps(self) -> None:
         """Remove oldest error dumps beyond the retention cap.

--- a/src/llm_rosetta/observability/persistence.py
+++ b/src/llm_rosetta/observability/persistence.py
@@ -637,6 +637,19 @@ class PersistenceManager:
         )
         self._conn.commit()
 
+    def _delete_orphan_bodies(self) -> int:
+        """Delete dump_bodies not referenced by any error_dumps."""
+        cur = self._conn.execute(
+            "DELETE FROM dump_bodies WHERE hash NOT IN ("
+            "    SELECT body_hash FROM error_dumps "
+            "    WHERE body_hash IS NOT NULL"
+            "    UNION "
+            "    SELECT converted_body_hash FROM error_dumps "
+            "    WHERE converted_body_hash IS NOT NULL"
+            ")"
+        )
+        return cur.rowcount
+
     def _vacuum(self) -> bool:
         """Run VACUUM; return True on success, False if locked."""
         try:
@@ -682,17 +695,7 @@ class PersistenceManager:
         )
         error_dumps_deleted = cur.rowcount
 
-        # Remove orphaned dump_bodies (global, not age-scoped — intentional)
-        cur = self._conn.execute(
-            "DELETE FROM dump_bodies WHERE hash NOT IN ("
-            "    SELECT body_hash FROM error_dumps "
-            "    WHERE body_hash IS NOT NULL"
-            "    UNION "
-            "    SELECT converted_body_hash FROM error_dumps "
-            "    WHERE converted_body_hash IS NOT NULL"
-            ")"
-        )
-        dump_bodies_deleted = cur.rowcount
+        dump_bodies_deleted = self._delete_orphan_bodies()
         self._conn.commit()
         vacuum_ok = self._vacuum()
         size_after = self.db_path.stat().st_size
@@ -727,16 +730,7 @@ class PersistenceManager:
         )
         error_dumps_deleted = cur.rowcount
 
-        cur = self._conn.execute(
-            "DELETE FROM dump_bodies WHERE hash NOT IN ("
-            "    SELECT body_hash FROM error_dumps "
-            "    WHERE body_hash IS NOT NULL"
-            "    UNION "
-            "    SELECT converted_body_hash FROM error_dumps "
-            "    WHERE converted_body_hash IS NOT NULL"
-            ")"
-        )
-        dump_bodies_deleted = cur.rowcount
+        dump_bodies_deleted = self._delete_orphan_bodies()
         self._conn.commit()
         vacuum_ok = self._vacuum()
         size_after = self.db_path.stat().st_size

--- a/tests/gateway/test_persistence_sqlite.py
+++ b/tests/gateway/test_persistence_sqlite.py
@@ -611,3 +611,183 @@ class TestCleanupByAge:
         rows = pm._conn.execute("SELECT id FROM request_log").fetchall()
         assert len(rows) == 1
         pm.close()
+
+
+class TestCleanupLogsIndependent:
+    def test_only_logs_deleted(self, tmp_path):
+        """cleanup_logs_by_age deletes logs but leaves error dumps untouched."""
+        from datetime import datetime, timedelta, timezone
+
+        pm = PersistenceManager(str(tmp_path))
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=100)).isoformat()
+
+        pm._conn.execute(
+            "INSERT INTO request_log (id, timestamp, model, source_provider, "
+            "target_provider, is_stream, status_code, duration_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("old-log", old_ts, "gpt-4o", "openai_chat", "openai_chat", 0, 200, 100),
+        )
+        pm._conn.execute(
+            "INSERT INTO error_dumps (id, timestamp, model, source_provider, "
+            "target_provider, provider_name, status_code) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("old-dump", old_ts, "gpt-4o", "openai_chat", "openai_chat", "openai", 500),
+        )
+        pm._conn.commit()
+
+        result = pm.cleanup_logs_by_age(90)
+        assert result["deleted"] == 1
+
+        # Error dump should still be there
+        dumps = pm._conn.execute("SELECT id FROM error_dumps").fetchall()
+        assert len(dumps) == 1
+        assert dumps[0][0] == "old-dump"
+        pm.close()
+
+
+class TestCleanupErrorsIndependent:
+    def test_only_errors_deleted(self, tmp_path):
+        """cleanup_error_dumps_by_age deletes dumps but leaves logs untouched."""
+        from datetime import datetime, timedelta, timezone
+
+        pm = PersistenceManager(str(tmp_path))
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=100)).isoformat()
+
+        pm._conn.execute(
+            "INSERT INTO request_log (id, timestamp, model, source_provider, "
+            "target_provider, is_stream, status_code, duration_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("old-log", old_ts, "gpt-4o", "openai_chat", "openai_chat", 0, 200, 100),
+        )
+        pm._conn.execute(
+            "INSERT INTO dump_bodies (hash, data, orig_bytes, created) "
+            "VALUES (?, ?, ?, ?)",
+            ("hash-old", b"body data", 9, old_ts),
+        )
+        pm._conn.execute(
+            "INSERT INTO error_dumps (id, timestamp, model, source_provider, "
+            "target_provider, provider_name, status_code, body_hash) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "old-dump",
+                old_ts,
+                "gpt-4o",
+                "openai_chat",
+                "openai_chat",
+                "openai",
+                500,
+                "hash-old",
+            ),
+        )
+        pm._conn.commit()
+
+        result = pm.cleanup_error_dumps_by_age(90)
+        assert result["error_dumps_deleted"] == 1
+        assert result["dump_bodies_deleted"] == 1
+
+        # Request log should still be there
+        logs = pm._conn.execute("SELECT id FROM request_log").fetchall()
+        assert len(logs) == 1
+        assert logs[0][0] == "old-log"
+        pm.close()
+
+
+class TestExportErrorDumps:
+    def test_export_creates_valid_archive(self, tmp_path):
+        """export_error_dumps returns a valid tar.gz with metadata and bodies."""
+        import io
+        import tarfile
+        from datetime import datetime, timezone
+
+        pm = PersistenceManager(str(tmp_path))
+        ts = datetime.now(timezone.utc).isoformat()
+
+        pm._conn.execute(
+            "INSERT INTO dump_bodies (hash, data, orig_bytes, created) "
+            "VALUES (?, ?, ?, ?)",
+            ("abc123", b"test body content", 17, ts),
+        )
+        pm._conn.execute(
+            "INSERT INTO error_dumps (id, timestamp, model, source_provider, "
+            "target_provider, provider_name, status_code, body_hash) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "dump-1",
+                ts,
+                "gpt-4o",
+                "openai_chat",
+                "openai_chat",
+                "openai",
+                500,
+                "abc123",
+            ),
+        )
+        pm._conn.commit()
+
+        data = pm.export_error_dumps()
+        assert len(data) > 0
+
+        with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+            names = tar.getnames()
+            assert "metadata.json" in names
+            assert "bodies/abc123.bin" in names
+
+            f = tar.extractfile("metadata.json")
+            assert f is not None
+            meta = json.loads(f.read())
+            assert len(meta) == 1
+            assert meta[0]["id"] == "dump-1"
+            assert meta[0]["body_hash"] == "abc123"
+
+            f = tar.extractfile("bodies/abc123.bin")
+            assert f is not None
+            body = f.read()
+            assert body == b"test body content"
+        pm.close()
+
+    def test_export_with_date_range(self, tmp_path):
+        """export_error_dumps respects start/end filters."""
+
+        pm = PersistenceManager(str(tmp_path))
+
+        pm._conn.execute(
+            "INSERT INTO error_dumps (id, timestamp, model, source_provider, "
+            "target_provider, provider_name, status_code) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("old", "2026-01-01T00:00:00Z", "gpt-4o", "oc", "oc", "openai", 500),
+        )
+        pm._conn.execute(
+            "INSERT INTO error_dumps (id, timestamp, model, source_provider, "
+            "target_provider, provider_name, status_code) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("new", "2026-08-01T00:00:00Z", "gpt-4o", "oc", "oc", "openai", 500),
+        )
+        pm._conn.commit()
+
+        data = pm.export_error_dumps(start="2026-07-01T00:00:00Z")
+        import io
+        import tarfile
+
+        with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+            f = tar.extractfile("metadata.json")
+            assert f is not None
+            meta = json.loads(f.read())
+            assert len(meta) == 1
+            assert meta[0]["id"] == "new"
+        pm.close()
+
+    def test_export_empty(self, tmp_path):
+        """export_error_dumps returns valid empty archive when no matches."""
+        import io
+        import tarfile
+
+        pm = PersistenceManager(str(tmp_path))
+        data = pm.export_error_dumps()
+        assert len(data) > 0
+
+        with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+            f = tar.extractfile("metadata.json")
+            assert f is not None
+            meta = json.loads(f.read())
+            assert meta == []
+        pm.close()


### PR DESCRIPTION
## Summary

- Split `cleanup_by_age()` into `cleanup_logs_by_age()` and `cleanup_error_dumps_by_age()` for independent operation
- Add `export_error_dumps(start, end)` — generates tar.gz with metadata.json + bodies/<hash>.bin (all stdlib)
- Three separate cleanup buttons in admin Settings (Logs / Errors / All), each with CLEANUP confirmation
- Export modal in error dumps `⋯` menu with date range picker → browser download
- CLI: `db cleanup-logs`, `db cleanup-errors`, `db export-errors --start --end -o`
- Backward compat: `cleanup_by_age()` and `POST /admin/api/db/cleanup` unchanged

Closes #551

## Test plan

- [x] 5 new unit tests (independent log cleanup, independent error cleanup, export archive, export with date filter, empty export)
- [x] All 48 persistence tests pass
- [x] Full test suite: 2837 passed
- [x] `make lint` passes
- [ ] Manual: admin Settings → test each cleanup button independently
- [ ] Manual: error dumps `⋯` → Export → verify tar.gz download
- [ ] Manual: CLI `db cleanup-logs`, `db export-errors`