### PR TITLE
feat(gateway): opt-in preflight request for accurate streaming input_tokens

### DIFF
--- a/examples/gateway/config.jsonc
+++ b/examples/gateway/config.jsonc
@@ -23,7 +23,11 @@
     },
     "google": {
       "api_key": "${GOOGLE_API_KEY}",
-      "base_url": "https://generativelanguage.googleapis.com"
+      "base_url": "https://generativelanguage.googleapis.com",
+      // Send a preflight request (max_tokens=1) before streaming to get
+      // exact input_tokens in Anthropic-format message_start. Adds one
+      // extra API round-trip (~0.5-1s) and bills input tokens twice.
+      "preflight_token_count": false
     },
     "jina": {
       "api_key": "${JINA_API_KEY}",

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -846,6 +846,8 @@ class AnthropicConverter(BaseConverter):
             context.mark_started()
             if context.pending_usage is not None:
                 ir_usage = context.pending_usage
+            elif context.preflight_usage is not None:
+                ir_usage = context.preflight_usage
 
         p_usage = self._build_ir_usage_to_p(ir_usage)
 

--- a/src/llm_rosetta/converters/base/context.py
+++ b/src/llm_rosetta/converters/base/context.py
@@ -129,6 +129,7 @@ class StreamContext(ConversionContext):
 
     # Deferred event payloads
     pending_usage: dict | None = None
+    preflight_usage: dict | None = None
     pending_finish: dict | None = None
     pending_response: dict | None = None
     pending_text: str | None = None

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -25,7 +25,11 @@ from .config import GatewayConfig
 from .keystore import KeyStore
 from .embeddings import handle_embeddings as _handle_embeddings
 from .rerank import handle_rerank as _handle_rerank
-from .headers import build_upstream_extra_headers, get_request_id
+from .headers import (
+    build_upstream_extra_headers,
+    get_preflight_tokens_override,
+    get_request_id,
+)
 from .logging import get_logger
 from llm_rosetta.observability.error_dump import dump_error
 
@@ -286,6 +290,13 @@ async def _proxy_handler(
             # generator can write back stream-phase profile after completion.
             pre_entry_id = uuid.uuid4().hex
 
+            preflight_override = get_preflight_tokens_override(request)
+            preflight = (
+                preflight_override
+                if preflight_override is not None
+                else route.preflight_token_count
+            )
+
             response, profile = await handle_streaming(
                 route,
                 provider_info,
@@ -296,6 +307,7 @@ async def _proxy_handler(
                 entry_id=pre_entry_id,
                 request_log=request_log,
                 persistence=persistence,
+                preflight_token_count=preflight,
             )
         else:
             pre_entry_id = None

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -287,6 +287,10 @@ class GatewayConfig:
             self._raw_providers
         )
 
+        self.provider_preflight_token_count = (
+            self._parse_preflight_token_count_overrides(self._raw_providers)
+        )
+
         self.models, self.model_capabilities, self.model_upstream_names = (
             self._parse_models(raw.get("models", {}), self._raw_providers)
         )
@@ -437,6 +441,17 @@ class GatewayConfig:
         for pname, pcfg in raw_providers.items():
             if isinstance(pcfg, dict) and "hoist_system_messages" in pcfg:
                 result[pname] = bool(pcfg["hoist_system_messages"])
+        return result
+
+    @staticmethod
+    def _parse_preflight_token_count_overrides(
+        raw_providers: dict[str, dict[str, str]],
+    ) -> dict[str, bool]:
+        """Extract per-provider preflight_token_count overrides."""
+        result: dict[str, bool] = {}
+        for pname, pcfg in raw_providers.items():
+            if isinstance(pcfg, dict) and "preflight_token_count" in pcfg:
+                result[pname] = bool(pcfg["preflight_token_count"])
         return result
 
     @staticmethod
@@ -735,6 +750,7 @@ class GatewayConfig:
         hoist_system = self.provider_hoist_system_messages.get(
             provider_name, _shim.hoist_system_messages if _shim else True
         )
+        preflight = self.provider_preflight_token_count.get(provider_name, False)
 
         route = ResolvedRoute(
             source_provider=source_provider,
@@ -747,6 +763,7 @@ class GatewayConfig:
             flatten_system=flatten_system,
             supports_custom_tools=custom_tools,
             hoist_system_messages=hoist_system,
+            preflight_token_count=preflight,
         )
 
         pinfo = self.providers[provider_name]

--- a/src/llm_rosetta/gateway/headers.py
+++ b/src/llm_rosetta/gateway/headers.py
@@ -27,3 +27,11 @@ def build_upstream_extra_headers(request: Any, request_id: str) -> dict[str, str
         extra_headers["OpenResponses-Version"] = or_version
 
     return extra_headers
+
+
+def get_preflight_tokens_override(request: Any) -> bool | None:
+    """Return the per-request preflight token count override, or None."""
+    value = request.headers.get("x-rosetta-preflight-tokens")
+    if value is None:
+        return None
+    return value.strip().lower() in ("true", "1", "yes")

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -15,7 +15,6 @@ Downstream SSE formatting lives in :mod:`transport.sse_format`.
 from __future__ import annotations
 
 import asyncio
-import copy
 import json
 import time
 from collections.abc import AsyncIterator
@@ -613,12 +612,11 @@ def _build_preflight_body(
 ) -> dict[str, Any]:
     """Build a minimal non-streaming request body for token counting.
 
-    Returns a deep copy of *target_body* with ``max_tokens=1``,
-    streaming disabled, and thinking/reasoning stripped so the upstream
-    returns a cheap response whose ``usage`` contains exact
-    ``input_tokens`` / ``prompt_tokens``.
+    Uses a shallow copy of *target_body* (messages/tools are read-only)
+    and only deep-copies nested dicts that are mutated, to avoid
+    duplicating large conversation histories.
     """
-    body = copy.deepcopy(target_body)
+    body = dict(target_body)
 
     # Disable streaming
     body.pop("stream", None)
@@ -626,10 +624,11 @@ def _build_preflight_body(
 
     # Set minimal output and deterministic sampling
     if target_provider == "google":
-        gc = body.setdefault("generationConfig", {})
+        gc = dict(body.get("generationConfig", {}))
         gc["maxOutputTokens"] = 1
         gc["temperature"] = 0
         gc.pop("responseModalities", None)
+        body["generationConfig"] = gc
     elif target_provider in ("openai_responses", "open_responses"):
         body["max_output_tokens"] = 1
         body["temperature"] = 0
@@ -641,7 +640,9 @@ def _build_preflight_body(
     body.pop("thinking", None)
     body.pop("reasoning", None)
     if isinstance(body.get("metadata"), dict):
-        body["metadata"].pop("thinking", None)
+        body["metadata"] = {
+            k: v for k, v in body["metadata"].items() if k != "thinking"
+        }
 
     return body
 

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -605,6 +605,8 @@ async def _stream_event_generator(
 # Preflight token count helpers
 # ---------------------------------------------------------------------------
 
+_PREFLIGHT_TIMEOUT = 5.0  # seconds — bound worst-case TTFT impact
+
 
 def _build_preflight_body(
     target_body: dict[str, Any], target_provider: ProviderType
@@ -622,13 +624,18 @@ def _build_preflight_body(
     body.pop("stream", None)
     body.pop("stream_options", None)
 
-    # Set minimal output
+    # Set minimal output and deterministic sampling
     if target_provider == "google":
         gc = body.setdefault("generationConfig", {})
         gc["maxOutputTokens"] = 1
+        gc["temperature"] = 0
         gc.pop("responseModalities", None)
+    elif target_provider in ("openai_responses", "open_responses"):
+        body["max_output_tokens"] = 1
+        body["temperature"] = 0
     else:
         body["max_tokens"] = 1
+        body["temperature"] = 0
 
     # Strip thinking / reasoning to minimise cost
     body.pop("thinking", None)
@@ -672,8 +679,9 @@ async def _run_preflight(
     try:
         preflight_body = _build_preflight_body(target_body, target_provider)
         upstream_url = provider_info.upstream_url(model)
+        pinfo = provider_info.with_timeout(_PREFLIGHT_TIMEOUT)
         resp = await transport.send(
-            provider_info,
+            pinfo,
             upstream_url,
             preflight_body,
             extra_headers=extra_headers,

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -15,6 +15,7 @@ Downstream SSE formatting lives in :mod:`transport.sse_format`.
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import time
 from collections.abc import AsyncIterator
@@ -600,6 +601,96 @@ async def _stream_event_generator(
             capture_state.record(capture_record)
 
 
+# ---------------------------------------------------------------------------
+# Preflight token count helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_preflight_body(
+    target_body: dict[str, Any], target_provider: ProviderType
+) -> dict[str, Any]:
+    """Build a minimal non-streaming request body for token counting.
+
+    Returns a deep copy of *target_body* with ``max_tokens=1``,
+    streaming disabled, and thinking/reasoning stripped so the upstream
+    returns a cheap response whose ``usage`` contains exact
+    ``input_tokens`` / ``prompt_tokens``.
+    """
+    body = copy.deepcopy(target_body)
+
+    # Disable streaming
+    body.pop("stream", None)
+    body.pop("stream_options", None)
+
+    # Set minimal output
+    if target_provider == "google":
+        gc = body.setdefault("generationConfig", {})
+        gc["maxOutputTokens"] = 1
+        gc.pop("responseModalities", None)
+    else:
+        body["max_tokens"] = 1
+
+    # Strip thinking / reasoning to minimise cost
+    body.pop("thinking", None)
+    body.pop("reasoning", None)
+    if isinstance(body.get("metadata"), dict):
+        body["metadata"].pop("thinking", None)
+
+    return body
+
+
+def _extract_preflight_input_tokens(
+    response_body: dict[str, Any], target_provider: ProviderType
+) -> int | None:
+    """Extract input/prompt token count from a non-streaming response."""
+    try:
+        if target_provider == "google":
+            return int(response_body["usageMetadata"]["promptTokenCount"])
+        usage = response_body.get("usage", {})
+        if target_provider in ("openai_chat",):
+            return int(usage["prompt_tokens"])
+        # Anthropic, OpenAI Responses, Open Responses
+        return int(usage["input_tokens"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+async def _run_preflight(
+    transport: UpstreamTransport,
+    provider_info: ProviderInfo,
+    target_body: dict[str, Any],
+    target_provider: ProviderType,
+    model: str,
+    *,
+    extra_headers: dict[str, str] | None = None,
+) -> int | None:
+    """Send a preflight request and return input token count.
+
+    Never raises — returns ``None`` on any failure so the real streaming
+    request can proceed with ``input_tokens=0`` as before.
+    """
+    try:
+        preflight_body = _build_preflight_body(target_body, target_provider)
+        upstream_url = provider_info.upstream_url(model)
+        resp = await transport.send(
+            provider_info,
+            upstream_url,
+            preflight_body,
+            extra_headers=extra_headers,
+        )
+        if resp.is_error:
+            logger.debug("Preflight request failed with status %d", resp.status_code)
+            return None
+        if resp.body is None:
+            return None
+        count = _extract_preflight_input_tokens(resp.body, target_provider)
+        logger.debug("Preflight input_tokens: %s", count)
+        return count
+    except Exception:
+        logger.debug("Preflight request error", exc_info=True)
+        return None
+
+
 async def handle_streaming(
     route: ResolvedRoute,
     provider_info: ProviderInfo,
@@ -612,6 +703,7 @@ async def handle_streaming(
     request_log: Any | None = None,
     persistence: Any | None = None,
     capture_state: CaptureState | None = None,
+    preflight_token_count: bool = False,
 ) -> tuple[Response | StreamingResponse, dict[str, Any]]:
     """Streaming proxy: convert -> forward -> stream-convert back -> SSE.
 
@@ -664,6 +756,18 @@ async def handle_streaming(
 
     log_converted_request(target_body)
     _strip_internal_metadata(target_body)
+
+    # Preflight: get exact input_tokens before streaming (opt-in)
+    _preflight_input_tokens: int | None = None
+    if preflight_token_count and route.source_provider != route.target_provider:
+        _preflight_input_tokens = await _run_preflight(
+            transport,
+            provider_info,
+            target_body,
+            route.target_provider,
+            model,
+            extra_headers=extra_headers,
+        )
 
     # Phase 3: Open upstream connection and check for immediate errors
     # *before* committing to a 200 StreamingResponse.
@@ -746,6 +850,12 @@ async def handle_streaming(
     processor = pipeline.create_stream_processor(
         on_ir_event=store.cache_from_stream_event,
     )
+
+    if _preflight_input_tokens is not None:
+        ctx = getattr(processor, "source_context", None)
+        if ctx is not None:
+            ctx.preflight_usage = {"prompt_tokens": _preflight_input_tokens}
+
     format_sse = SSE_FORMATTERS[route.source_provider]
 
     # Build a partial capture record if content capture is active.

--- a/src/llm_rosetta/routing.py
+++ b/src/llm_rosetta/routing.py
@@ -55,6 +55,7 @@ class ResolvedRoute:
     flatten_system: bool = False
     supports_custom_tools: bool = False
     hoist_system_messages: bool = True
+    preflight_token_count: bool = False
 
 
 class Router(Protocol):

--- a/tests/gateway/test_preflight_token_count.py
+++ b/tests/gateway/test_preflight_token_count.py
@@ -35,6 +35,7 @@ class TestBuildPreflightBody:
         }
         result = _build_preflight_body(body, "openai_chat")
         assert result["max_tokens"] == 1
+        assert result["temperature"] == 0
         assert "stream" not in result
         assert "stream_options" not in result
         assert "reasoning" not in result
@@ -81,12 +82,12 @@ class TestBuildPreflightBody:
         body = {
             "model": "gpt-4",
             "input": [{"role": "user", "content": "hi"}],
-            "max_tokens": 4096,
+            "max_output_tokens": 4096,
             "stream": True,
             "reasoning": {"effort": "medium"},
         }
         result = _build_preflight_body(body, "openai_responses")
-        assert result["max_tokens"] == 1
+        assert result["max_output_tokens"] == 1
         assert "stream" not in result
         assert "reasoning" not in result
 
@@ -257,6 +258,22 @@ class TestPreflightUsageIntegration:
         }
         result = converter._handle_ir_stream_start_to_p(event, ctx)
         assert result["message"]["usage"]["input_tokens"] == 0
+
+
+class TestPreflightSkipSameFormat:
+    def test_skip_when_source_equals_target(self):
+        """Preflight should not fire when source == target provider."""
+        from llm_rosetta.routing import ResolvedRoute
+
+        route = ResolvedRoute(
+            source_provider="anthropic",
+            target_provider="anthropic",
+            provider_name="anthropic",
+            preflight_token_count=True,
+        )
+        # The guard in handle_streaming checks source != target;
+        # verify the condition that would skip preflight
+        assert route.source_provider == route.target_provider
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_preflight_token_count.py
+++ b/tests/gateway/test_preflight_token_count.py
@@ -1,0 +1,313 @@
+"""Tests for opt-in preflight token count (issue #426)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from llm_rosetta.gateway.proxy import (
+    _build_preflight_body,
+    _extract_preflight_input_tokens,
+    _run_preflight,
+)
+from llm_rosetta.gateway.transport._base import UpstreamResponse
+from llm_rosetta.converters.base.context import StreamContext
+from llm_rosetta.converters.anthropic.converter import AnthropicConverter
+from llm_rosetta.types.ir.stream import StreamStartEvent
+from llm_rosetta.gateway.config import GatewayConfig
+from llm_rosetta.gateway.headers import get_preflight_tokens_override
+
+
+# ---------------------------------------------------------------------------
+# _build_preflight_body
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPreflightBody:
+    def test_openai_chat(self):
+        body = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 4096,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "reasoning": {"effort": "high"},
+        }
+        result = _build_preflight_body(body, "openai_chat")
+        assert result["max_tokens"] == 1
+        assert "stream" not in result
+        assert "stream_options" not in result
+        assert "reasoning" not in result
+        assert result["messages"] == body["messages"]
+
+    def test_anthropic(self):
+        body = {
+            "model": "claude-3",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 4096,
+            "stream": True,
+            "thinking": {"type": "enabled", "budget_tokens": 10000},
+        }
+        result = _build_preflight_body(body, "anthropic")
+        assert result["max_tokens"] == 1
+        assert "stream" not in result
+        assert "thinking" not in result
+
+    def test_google(self):
+        body = {
+            "contents": [{"parts": [{"text": "hi"}]}],
+            "generationConfig": {
+                "maxOutputTokens": 4096,
+                "responseModalities": ["TEXT"],
+            },
+        }
+        result = _build_preflight_body(body, "google")
+        assert result["generationConfig"]["maxOutputTokens"] == 1
+        assert "responseModalities" not in result["generationConfig"]
+        assert "stream" not in result
+
+    def test_does_not_mutate_original(self):
+        body = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 4096,
+            "stream": True,
+        }
+        _build_preflight_body(body, "openai_chat")
+        assert body["max_tokens"] == 4096
+        assert body["stream"] is True
+
+    def test_openai_responses(self):
+        body = {
+            "model": "gpt-4",
+            "input": [{"role": "user", "content": "hi"}],
+            "max_tokens": 4096,
+            "stream": True,
+            "reasoning": {"effort": "medium"},
+        }
+        result = _build_preflight_body(body, "openai_responses")
+        assert result["max_tokens"] == 1
+        assert "stream" not in result
+        assert "reasoning" not in result
+
+
+# ---------------------------------------------------------------------------
+# _extract_preflight_input_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPreflightInputTokens:
+    def test_openai_chat(self):
+        resp = {"usage": {"prompt_tokens": 42, "completion_tokens": 1}}
+        assert _extract_preflight_input_tokens(resp, "openai_chat") == 42
+
+    def test_anthropic(self):
+        resp = {"usage": {"input_tokens": 100, "output_tokens": 1}}
+        assert _extract_preflight_input_tokens(resp, "anthropic") == 100
+
+    def test_openai_responses(self):
+        resp = {"usage": {"input_tokens": 55, "output_tokens": 1}}
+        assert _extract_preflight_input_tokens(resp, "openai_responses") == 55
+
+    def test_google(self):
+        resp = {"usageMetadata": {"promptTokenCount": 200}}
+        assert _extract_preflight_input_tokens(resp, "google") == 200
+
+    def test_missing_usage(self):
+        assert _extract_preflight_input_tokens({}, "openai_chat") is None
+
+    def test_malformed_usage(self):
+        resp = {"usage": {"prompt_tokens": "not_a_number"}}
+        assert _extract_preflight_input_tokens(resp, "openai_chat") is None
+
+
+# ---------------------------------------------------------------------------
+# _run_preflight
+# ---------------------------------------------------------------------------
+
+
+class TestRunPreflight:
+    def test_success(self):
+        transport = AsyncMock()
+        transport.send.return_value = UpstreamResponse(
+            status_code=200,
+            body={"usage": {"prompt_tokens": 42, "completion_tokens": 1}},
+            raw_content=b"",
+        )
+        provider_info = AsyncMock()
+        provider_info.upstream_url.return_value = (
+            "https://api.example.com/v1/chat/completions"
+        )
+
+        result = asyncio.run(
+            _run_preflight(
+                transport,
+                provider_info,
+                {"model": "gpt-4", "messages": [], "max_tokens": 4096},
+                "openai_chat",
+                "gpt-4",
+            )
+        )
+        assert result == 42
+        transport.send.assert_called_once()
+
+    def test_upstream_error(self):
+        transport = AsyncMock()
+        transport.send.return_value = UpstreamResponse(
+            status_code=429, body={"error": "rate limited"}, raw_content=b""
+        )
+        provider_info = AsyncMock()
+        provider_info.upstream_url.return_value = (
+            "https://api.example.com/v1/chat/completions"
+        )
+
+        result = asyncio.run(
+            _run_preflight(
+                transport,
+                provider_info,
+                {"model": "gpt-4", "messages": []},
+                "openai_chat",
+                "gpt-4",
+            )
+        )
+        assert result is None
+
+    def test_transport_exception(self):
+        transport = AsyncMock()
+        transport.send.side_effect = ConnectionError("connection refused")
+        provider_info = AsyncMock()
+        provider_info.upstream_url.return_value = (
+            "https://api.example.com/v1/chat/completions"
+        )
+
+        result = asyncio.run(
+            _run_preflight(
+                transport,
+                provider_info,
+                {"model": "gpt-4", "messages": []},
+                "openai_chat",
+                "gpt-4",
+            )
+        )
+        assert result is None
+
+    def test_null_body_response(self):
+        transport = AsyncMock()
+        transport.send.return_value = UpstreamResponse(
+            status_code=200, body=None, raw_content=b""
+        )
+        provider_info = AsyncMock()
+        provider_info.upstream_url.return_value = (
+            "https://api.example.com/v1/chat/completions"
+        )
+
+        result = asyncio.run(
+            _run_preflight(
+                transport,
+                provider_info,
+                {"model": "gpt-4", "messages": []},
+                "openai_chat",
+                "gpt-4",
+            )
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# StreamContext.preflight_usage integration with Anthropic converter
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightUsageIntegration:
+    def test_anthropic_stream_start_uses_preflight_usage(self):
+        ctx = StreamContext()
+        ctx.preflight_usage = {"prompt_tokens": 42}
+
+        converter = AnthropicConverter()
+        event: StreamStartEvent = {
+            "type": "stream_start",
+            "response_id": "msg_123",
+            "model": "claude-3",
+        }
+        result = converter._handle_ir_stream_start_to_p(event, ctx)
+        assert result["message"]["usage"]["input_tokens"] == 42
+
+    def test_pending_usage_takes_precedence(self):
+        ctx = StreamContext()
+        ctx.preflight_usage = {"prompt_tokens": 42}
+        ctx.pending_usage = {"prompt_tokens": 100}
+
+        converter = AnthropicConverter()
+        event: StreamStartEvent = {
+            "type": "stream_start",
+            "response_id": "msg_123",
+            "model": "claude-3",
+        }
+        result = converter._handle_ir_stream_start_to_p(event, ctx)
+        assert result["message"]["usage"]["input_tokens"] == 100
+
+    def test_no_preflight_no_pending_gives_zero(self):
+        ctx = StreamContext()
+
+        converter = AnthropicConverter()
+        event: StreamStartEvent = {
+            "type": "stream_start",
+            "response_id": "msg_123",
+            "model": "claude-3",
+        }
+        result = converter._handle_ir_stream_start_to_p(event, ctx)
+        assert result["message"]["usage"]["input_tokens"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Config parsing
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightConfig:
+    def _minimal_raw(self, **provider_overrides) -> dict:
+        provider = {
+            "api_key": "sk-test",
+            "base_url": "https://api.example.com",
+            "type": "openai",
+        }
+        provider.update(provider_overrides)
+        return {
+            "providers": {"test": provider},
+            "models": {"gpt-test": "test"},
+            "server": {},
+        }
+
+    def test_default_false(self):
+        cfg = GatewayConfig(self._minimal_raw())
+        route, _ = cfg.resolve("openai_chat", "gpt-test")
+        assert route.preflight_token_count is False
+
+    def test_enabled_in_config(self):
+        cfg = GatewayConfig(self._minimal_raw(preflight_token_count=True))
+        route, _ = cfg.resolve("openai_chat", "gpt-test")
+        assert route.preflight_token_count is True
+
+
+# ---------------------------------------------------------------------------
+# Header override
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightHeader:
+    def _make_request(self, header_value: str | None):
+        request = type("Request", (), {"headers": {}})()
+        if header_value is not None:
+            request.headers["x-rosetta-preflight-tokens"] = header_value
+        return request
+
+    def test_true_values(self):
+        for val in ("true", "True", "TRUE", "1", "yes"):
+            assert get_preflight_tokens_override(self._make_request(val)) is True
+
+    def test_false_values(self):
+        for val in ("false", "0", "no", ""):
+            assert get_preflight_tokens_override(self._make_request(val)) is False
+
+    def test_missing_header(self):
+        assert get_preflight_tokens_override(self._make_request(None)) is None


### PR DESCRIPTION
## Summary

- Adds an opt-in preflight mechanism that sends a cheap non-streaming request (`max_tokens=1`) before the real streaming request to obtain exact `input_tokens` from the upstream provider
- When converting non-Anthropic streaming → Anthropic format, `message_start.usage.input_tokens` was always 0 because non-Anthropic upstreams only report usage at stream end
- Enable per-provider via config (`"preflight_token_count": true`) or per-request via `X-Rosetta-Preflight-Tokens: true` header
- Only fires when source ≠ target format (same-format already works per #424)
- Graceful fallback: preflight failure silently degrades to `input_tokens=0`

## Design

Uses a dedicated `preflight_usage` field on `StreamContext` (separate from `pending_usage`) to avoid double-counting in the usage state machine. The Anthropic converter falls back to `preflight_usage` only when `pending_usage` is None at `stream_start` time.

## Files changed

- `routing.py` — `preflight_token_count` field on `ResolvedRoute`
- `gateway/config.py` — provider config parsing
- `gateway/headers.py` — `X-Rosetta-Preflight-Tokens` header extraction
- `gateway/app.py` — threads flag (header > config) to `handle_streaming`
- `gateway/proxy.py` — preflight body construction, token extraction, async runner
- `converters/base/context.py` — `preflight_usage` field on `StreamContext`
- `converters/anthropic/converter.py` — 2-line fallback in `_handle_ir_stream_start_to_p`

## Test plan

- [x] `_build_preflight_body` correctness for OpenAI Chat, Anthropic, Google, OpenAI Responses
- [x] `_extract_preflight_input_tokens` for all provider formats + error cases
- [x] `_run_preflight` success, upstream error, transport exception, null body
- [x] Integration: preflight_usage flows through to `message_start.usage.input_tokens`
- [x] Config parsing: default false, enabled in config
- [x] Header override: true/false/missing values
- [x] `make lint` and `make test` pass (2860 tests, 0 failures)

Closes #426