### PR TITLE
ci: Nuitka binary builds + binary Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,6 +37,7 @@ __pycache__/
 *.egg
 .eggs/
 build/
+!build/llm-rosetta-gateway-*
 # NOTE: dist/ is intentionally NOT ignored — local wheels
 # are copied from dist/ during the Docker build.
 sdist/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,15 @@ permissions:
   contents: read
 
 jobs:
+  # ── Build binaries (only for manual trigger) ──────────
+  # When called from release.yml, binaries are already built by the parent.
+  binaries:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/nuitka.yml
+    with:
+      ref: v${{ inputs.tag }}
+      platforms: linux-x86_64,linux-arm64,linux-x86_64-musl,linux-arm64-musl
+
   # ── Python-based image (pip install) ──────────────────
   build-python:
     runs-on: ubuntu-latest
@@ -59,9 +68,10 @@ jobs:
           exit 1
 
       - uses: docker/login-action@v3
+        if: secrets.DOCKERHUB_USERNAME != ''
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME || '' }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || '' }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push python image
         uses: docker/build-push-action@v6
@@ -79,6 +89,8 @@ jobs:
 
   # ── Binary-based images (Alpine + glibc) ──────────────
   build-binary-images:
+    needs: binaries
+    if: always() && (needs.binaries.result == 'success' || needs.binaries.result == 'skipped')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -86,7 +98,7 @@ jobs:
         include:
           - variant: alpine
             base_image: alpine
-            binary_suffix: musl
+            binary_suffix: -musl
             tags_extra: true
           - variant: glibc
             base_image: busybox:glibc
@@ -105,12 +117,17 @@ jobs:
           VERSION="${VERSION#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Download binaries
+      - name: Download amd64 binary
         uses: actions/download-artifact@v4
         with:
-          pattern: llm-rosetta-gateway-*-linux-*${{ matrix.binary_suffix && format('-{0}', matrix.binary_suffix) || '' }}
+          name: llm-rosetta-gateway-${{ steps.meta.outputs.version }}-linux-x86_64${{ matrix.binary_suffix }}
           path: build/
-          merge-multiple: true
+
+      - name: Download arm64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: llm-rosetta-gateway-${{ steps.meta.outputs.version }}-linux-arm64${{ matrix.binary_suffix }}
+          path: build/
 
       - name: List downloaded binaries
         run: ls -lhR build/
@@ -119,17 +136,17 @@ jobs:
         run: |
           VERSION="${{ steps.meta.outputs.version }}"
           SUFFIX="${{ matrix.binary_suffix }}"
-          SUFFIX_DASH="${SUFFIX:+-$SUFFIX}"
 
           mkdir -p build/linux-amd64 build/linux-arm64
-          cp build/llm-rosetta-gateway-${VERSION}-linux-x86_64${SUFFIX_DASH} build/linux-amd64/llm-rosetta-gateway
-          cp build/llm-rosetta-gateway-${VERSION}-linux-arm64${SUFFIX_DASH} build/linux-arm64/llm-rosetta-gateway
+          cp build/llm-rosetta-gateway-${VERSION}-linux-x86_64${SUFFIX} build/linux-amd64/llm-rosetta-gateway
+          cp build/llm-rosetta-gateway-${VERSION}-linux-arm64${SUFFIX} build/linux-arm64/llm-rosetta-gateway
           chmod +x build/linux-amd64/llm-rosetta-gateway build/linux-arm64/llm-rosetta-gateway
 
       - uses: docker/login-action@v3
+        if: secrets.DOCKERHUB_USERNAME != ''
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME || '' }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || '' }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push ${{ matrix.variant }} image (amd64)
         uses: docker/build-push-action@v6
@@ -168,13 +185,11 @@ jobs:
           VARIANT="${{ matrix.variant }}"
           IMAGE="oaklight/llm-rosetta-gateway"
 
-          # Create variant manifest
           docker buildx imagetools create \
             -t "$IMAGE:${VERSION}-${VARIANT}" \
             "$IMAGE:${VERSION}-${VARIANT}-amd64" \
             "$IMAGE:${VERSION}-${VARIANT}-arm64"
 
-          # Alpine variant also gets the default tags
           if [ "${{ matrix.tags_extra }}" = "true" ]; then
             docker buildx imagetools create \
               -t "$IMAGE:${VERSION}" \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,6 @@
 name: Docker
 
 on:
-  # Called by the Release workflow after the package is published to PyPI.
   workflow_call:
     inputs:
       tag:
@@ -13,7 +12,6 @@ on:
         required: true
       DOCKERHUB_TOKEN:
         required: true
-  # Manual trigger for ad-hoc rebuilds of an already-published version.
   workflow_dispatch:
     inputs:
       tag:
@@ -25,35 +23,22 @@ permissions:
   contents: read
 
 jobs:
-  build-and-push:
+  # ── Python-based image (pip install) ──────────────────
+  build-python:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Extract version tag
+      - name: Extract version
         id: meta
         run: |
           VERSION="${{ inputs.tag }}"
-          # Normalize: strip an optional leading "v" so callers may pass either form.
           VERSION="${VERSION#v}"
-          if [ -z "$VERSION" ]; then
-            echo "::error::No version provided via inputs.tag"
-            exit 1
-          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Building version: $VERSION"
 
-      - name: Ensure build context has dist/
-        # The Dockerfile's `COPY dist/ /tmp/dist/` requires the source dir to
-        # exist in the build context. In CI we install from PyPI (no local
-        # wheel), so create an empty dist/ to make the COPY a harmless no-op.
+      - name: Ensure dist/ exists
         run: mkdir -p dist
 
       - name: Wait for PyPI availability
@@ -61,37 +46,139 @@ jobs:
           VERSION="${{ steps.meta.outputs.version }}"
           echo "Waiting for llm-rosetta==$VERSION on PyPI..."
           for i in $(seq 1 30); do
-            # Query the version-specific JSON endpoint for an exact match
-            # (200 = exists, 404 = not yet). Avoids substring false-positives.
             CODE=$(curl -fsS -o /dev/null -w "%{http_code}" \
               "https://pypi.org/pypi/llm-rosetta/$VERSION/json" || true)
             if [ "$CODE" = "200" ]; then
-              echo "✅ llm-rosetta==$VERSION found on PyPI (attempt $i)"
+              echo "Found on PyPI (attempt $i)"
               exit 0
             fi
-            echo "  Attempt $i/30: not yet available (HTTP $CODE), waiting 20s..."
+            echo "  Attempt $i/30: waiting 20s..."
             sleep 20
           done
-          echo "❌ llm-rosetta==$VERSION not found on PyPI after 10 minutes"
+          echo "::error::Not found on PyPI after 10 minutes"
           exit 1
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME || '' }}
+          password: ${{ secrets.DOCKERHUB_TOKEN || '' }}
 
-      - name: Build and push multi-arch image
+      - name: Build and push python image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ secrets.DOCKERHUB_USERNAME != '' }}
           build-args: |
             PACKAGE_VERSION=${{ steps.meta.outputs.version }}
           tags: |
-            oaklight/llm-rosetta-gateway:${{ steps.meta.outputs.version }}
-            oaklight/llm-rosetta-gateway:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            oaklight/llm-rosetta-gateway:${{ steps.meta.outputs.version }}-python
+          cache-from: type=gha,scope=python
+          cache-to: type=gha,mode=max,scope=python
+
+  # ── Binary-based images (Alpine + glibc) ──────────────
+  build-binary-images:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: alpine
+            base_image: alpine
+            binary_suffix: musl
+            tags_extra: true
+          - variant: glibc
+            base_image: busybox:glibc
+            binary_suffix: ""
+            tags_extra: false
+    name: docker-${{ matrix.variant }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Extract version
+        id: meta
+        run: |
+          VERSION="${{ inputs.tag }}"
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: llm-rosetta-gateway-*-linux-*${{ matrix.binary_suffix && format('-{0}', matrix.binary_suffix) || '' }}
+          path: build/
+          merge-multiple: true
+
+      - name: List downloaded binaries
+        run: ls -lhR build/
+
+      - name: Prepare multi-arch build context
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          SUFFIX="${{ matrix.binary_suffix }}"
+          SUFFIX_DASH="${SUFFIX:+-$SUFFIX}"
+
+          mkdir -p build/linux-amd64 build/linux-arm64
+          cp build/llm-rosetta-gateway-${VERSION}-linux-x86_64${SUFFIX_DASH} build/linux-amd64/llm-rosetta-gateway
+          cp build/llm-rosetta-gateway-${VERSION}-linux-arm64${SUFFIX_DASH} build/linux-arm64/llm-rosetta-gateway
+          chmod +x build/linux-amd64/llm-rosetta-gateway build/linux-arm64/llm-rosetta-gateway
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME || '' }}
+          password: ${{ secrets.DOCKERHUB_TOKEN || '' }}
+
+      - name: Build and push ${{ matrix.variant }} image (amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.binary
+          platforms: linux/amd64
+          push: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+          build-args: |
+            BASE_IMAGE=${{ matrix.base_image }}
+            BINARY=build/linux-amd64/llm-rosetta-gateway
+          tags: |
+            oaklight/llm-rosetta-gateway:${{ steps.meta.outputs.version }}-${{ matrix.variant }}-amd64
+          cache-from: type=gha,scope=${{ matrix.variant }}-amd64
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}-amd64
+
+      - name: Build and push ${{ matrix.variant }} image (arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.binary
+          platforms: linux/arm64
+          push: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+          build-args: |
+            BASE_IMAGE=${{ matrix.base_image }}
+            BINARY=build/linux-arm64/llm-rosetta-gateway
+          tags: |
+            oaklight/llm-rosetta-gateway:${{ steps.meta.outputs.version }}-${{ matrix.variant }}-arm64
+          cache-from: type=gha,scope=${{ matrix.variant }}-arm64
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}-arm64
+
+      - name: Create multi-arch manifest
+        if: secrets.DOCKERHUB_USERNAME != ''
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          VARIANT="${{ matrix.variant }}"
+          IMAGE="oaklight/llm-rosetta-gateway"
+
+          # Create variant manifest
+          docker buildx imagetools create \
+            -t "$IMAGE:${VERSION}-${VARIANT}" \
+            "$IMAGE:${VERSION}-${VARIANT}-amd64" \
+            "$IMAGE:${VERSION}-${VARIANT}-arm64"
+
+          # Alpine variant also gets the default tags
+          if [ "${{ matrix.tags_extra }}" = "true" ]; then
+            docker buildx imagetools create \
+              -t "$IMAGE:${VERSION}" \
+              -t "$IMAGE:latest" \
+              "$IMAGE:${VERSION}-${VARIANT}-amd64" \
+              "$IMAGE:${VERSION}-${VARIANT}-arm64"
+          fi

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -1,0 +1,236 @@
+name: Nuitka Binary Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build: tag (v0.9.0), branch (master), or commit SHA"
+        required: true
+        type: string
+        default: "master"
+      platforms:
+        description: "Platforms to build (comma-separated, or 'all'): linux-x86_64, linux-arm64, linux-x86_64-musl, linux-arm64-musl, macos-arm64, windows-x86_64"
+        required: true
+        type: string
+        default: "all"
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      platforms:
+        required: false
+        type: string
+        default: "all"
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.native }}
+      matrix_musl: ${{ steps.matrix.outputs.musl }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Resolve version
+        id: version
+        run: |
+          PKG_VER=$(python3 -c "
+          import re, pathlib
+          text = pathlib.Path('src/llm_rosetta/__init__.py').read_text(encoding='utf-8')
+          m = re.search(r'__version__\s*=\"(.+?)\"', text)
+          print(m.group(1))
+          ")
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          if git describe --exact-match --tags HEAD >/dev/null 2>&1; then
+            VERSION="$PKG_VER"
+          else
+            VERSION="${PKG_VER}+g${SHORT_SHA}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
+      - name: Build matrices
+        id: matrix
+        shell: bash
+        run: |
+          NATIVE='[{"runner":"ubuntu-latest","os":"linux","arch":"x86_64","platform":"linux-x86_64"},{"runner":"ubuntu-24.04-arm","os":"linux","arch":"arm64","platform":"linux-arm64"},{"runner":"macos-latest","os":"macos","arch":"arm64","platform":"macos-arm64"},{"runner":"windows-latest","os":"windows","arch":"x86_64","platform":"windows-x86_64"}]'
+          MUSL='[{"runner":"ubuntu-latest","arch":"x86_64","platform":"linux-x86_64-musl"},{"runner":"ubuntu-24.04-arm","arch":"arm64","platform":"linux-arm64-musl"}]'
+
+          PLATFORMS="${{ inputs.platforms }}"
+          if [ "$PLATFORMS" = "all" ]; then
+            echo "native=$NATIVE" >> "$GITHUB_OUTPUT"
+            echo "musl=$MUSL" >> "$GITHUB_OUTPUT"
+          else
+            FILTERED_NATIVE=$(echo "$NATIVE" | jq -c "[.[] | select(.platform as \$p | \"$PLATFORMS\" | split(\",\") | map(gsub(\"^\\\\s+|\\\\s+$\"; \"\")) | index(\$p) != null)]")
+            FILTERED_MUSL=$(echo "$MUSL" | jq -c "[.[] | select(.platform as \$p | \"$PLATFORMS\" | split(\",\") | map(gsub(\"^\\\\s+|\\\\s+$\"; \"\")) | index(\$p) != null)]")
+            echo "native=$FILTERED_NATIVE" >> "$GITHUB_OUTPUT"
+            echo "musl=$FILTERED_MUSL" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: prepare
+    if: needs.prepare.outputs.matrix != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.matrix) }}
+
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install patchelf (Linux)
+        if: matrix.os == 'linux'
+        run: sudo apt-get update && sudo apt-get install -y patchelf
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -e ".[profiling]"
+          pip install "nuitka[onefile]" ordered-set
+
+      - name: Snapshot resources before build
+        shell: bash
+        run: |
+          echo "NUITKA_START=$(date +%s)" >> "$GITHUB_ENV"
+
+      - name: Build binary
+        shell: bash
+        run: make build-binary
+
+      - name: Build statistics
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          END=$(date +%s)
+          ELAPSED=$((END - NUITKA_START))
+          MINS=$((ELAPSED / 60))
+          SECS=$((ELAPSED % 60))
+
+          BINARY=$(ls build/llm-rosetta-gateway-* 2>/dev/null | head -1)
+          BINARY_SIZE=$(stat --format=%s "$BINARY" 2>/dev/null || stat -f%z "$BINARY" 2>/dev/null || python -c "import os; print(os.path.getsize('$BINARY'))")
+          BINARY_SIZE_MB=$(python -c "print(f'{int($BINARY_SIZE)/1048576:.1f}')")
+
+          echo "============================================"
+          echo "  Nuitka Build Statistics"
+          echo "============================================"
+          echo "  Platform:     ${{ matrix.platform }}"
+          echo "  Ref:          ${{ inputs.ref }}"
+          echo "  Version:      $VERSION"
+          echo "  Build time:   ${MINS}m ${SECS}s (${ELAPSED}s total)"
+          echo "  Binary size:  ${BINARY_SIZE_MB} MB (${BINARY_SIZE} bytes)"
+          echo "--------------------------------------------"
+          echo "  CPU info:"
+          if [ "${{ matrix.os }}" = "linux" ]; then
+            echo "    Cores: $(nproc)"
+            echo "    Model: $(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2 | xargs)"
+          elif [ "${{ matrix.os }}" = "macos" ]; then
+            echo "    Cores: $(sysctl -n hw.ncpu)"
+            echo "    Model: $(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo 'Apple Silicon')"
+          else
+            echo "    Cores: $NUMBER_OF_PROCESSORS"
+          fi
+          echo "  Peak memory (build dir):"
+          du -sh build/ 2>/dev/null || true
+          echo "============================================"
+
+      - name: Smoke test (non-Windows)
+        if: matrix.os != 'windows'
+        shell: bash
+        run: |
+          BINARY=$(ls build/llm-rosetta-gateway-* 2>/dev/null | head -1)
+          chmod +x "$BINARY"
+          "$BINARY" --help || true
+
+      - name: Smoke test (Windows)
+        if: matrix.os == 'windows'
+        shell: cmd
+        run: |
+          for %%f in (build\llm-rosetta-gateway-*) do %%f --help || exit 0
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        with:
+          name: llm-rosetta-gateway-${{ env.VERSION }}-${{ matrix.platform }}
+          path: build/llm-rosetta-gateway-*
+          retention-days: 30
+
+  build-musl:
+    needs: prepare
+    if: needs.prepare.outputs.matrix_musl != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.matrix_musl) }}
+
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Snapshot resources before build
+        run: echo "NUITKA_START=$(date +%s)" >> "$GITHUB_ENV"
+
+      - name: Build musl binary
+        run: make build-binary-musl
+
+      - name: Build statistics
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          END=$(date +%s)
+          ELAPSED=$((END - NUITKA_START))
+          MINS=$((ELAPSED / 60))
+          SECS=$((ELAPSED % 60))
+
+          BINARY=$(ls build/llm-rosetta-gateway-*-musl 2>/dev/null | head -1)
+          BINARY_SIZE=$(stat --format=%s "$BINARY")
+          BINARY_SIZE_MB=$(python3 -c "print(f'{int($BINARY_SIZE)/1048576:.1f}')")
+
+          echo "============================================"
+          echo "  Nuitka Build Statistics"
+          echo "============================================"
+          echo "  Platform:     ${{ matrix.platform }}"
+          echo "  Ref:          ${{ inputs.ref }}"
+          echo "  Version:      $VERSION"
+          echo "  Build time:   ${MINS}m ${SECS}s (${ELAPSED}s total)"
+          echo "  Binary size:  ${BINARY_SIZE_MB} MB (${BINARY_SIZE} bytes)"
+          echo "--------------------------------------------"
+          echo "  CPU info:"
+          echo "    Cores: $(nproc)"
+          echo "    Model: $(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2 | xargs)"
+          echo "  Peak memory (build dir):"
+          du -sh build/ 2>/dev/null || true
+          echo "============================================"
+
+      - name: Smoke test
+        run: |
+          BINARY=$(ls build/llm-rosetta-gateway-*-musl 2>/dev/null | head -1)
+          docker run --rm -v "$(pwd)/build:/b:ro" alpine "/b/$(basename $BINARY)" --help || true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        with:
+          name: llm-rosetta-gateway-${{ env.VERSION }}-${{ matrix.platform }}
+          path: build/llm-rosetta-gateway-*-musl
+          retention-days: 30

--- a/Makefile
+++ b/Makefile
@@ -91,11 +91,143 @@ push: push-package
 clean: clean-package
 
 # ──────────────────────────────────────────────
+# Nuitka binary builds
+# ──────────────────────────────────────────────
+
+# Detect platform
+UNAME_S := $(shell uname -s 2>/dev/null || echo Windows)
+UNAME_M := $(shell uname -m 2>/dev/null || echo x86_64)
+ifeq ($(UNAME_S),Linux)
+  BINARY_OS := linux
+else ifeq ($(UNAME_S),Darwin)
+  BINARY_OS := macos
+else
+  BINARY_OS := windows
+endif
+ifeq ($(UNAME_M),aarch64)
+  BINARY_ARCH := arm64
+else ifeq ($(UNAME_M),arm64)
+  BINARY_ARCH := arm64
+else
+  BINARY_ARCH := x86_64
+endif
+
+BINARY_NAME = llm-rosetta-gateway-$(VERSION)-$(BINARY_OS)-$(BINARY_ARCH)
+BINARY_NAME_MUSL = llm-rosetta-gateway-$(VERSION)-linux-$(BINARY_ARCH)-musl
+BINARY_DIR := build
+NUITKA_ENTRY := _nuitka_entry.py
+NUITKA_JOBS := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
+
+NUITKA_FLAGS = \
+	--standalone \
+	--onefile \
+	--jobs=$(NUITKA_JOBS) \
+	--output-dir=$(BINARY_DIR) \
+	--include-package=llm_rosetta \
+	--include-package=pyinstrument \
+	--include-data-files=src/llm_rosetta/gateway/admin/admin.html=llm_rosetta/gateway/admin/admin.html \
+	--include-data-dir=src/llm_rosetta/shims/providers=llm_rosetta/shims/providers \
+	--nofollow-import-to=pytest \
+	--nofollow-import-to=setuptools \
+	--nofollow-import-to=pip \
+	--nofollow-import-to=_pytest \
+	--assume-yes-for-downloads
+
+# Build native binary (glibc on Linux, system libc on macOS, MSVC on Windows)
+build-binary:
+	@echo "Building native binary: $(BINARY_NAME)..."
+	@printf 'from llm_rosetta.gateway import main\nmain()\n' > $(NUITKA_ENTRY)
+	python -m nuitka $(NUITKA_FLAGS) \
+		--output-filename=$(BINARY_NAME)$(if $(filter windows,$(BINARY_OS)),.exe,) \
+		$(NUITKA_ENTRY)
+	@rm -f $(NUITKA_ENTRY)
+	@ls -lh $(BINARY_DIR)/$(BINARY_NAME)*
+	@echo "Binary build complete."
+
+# Build musl-linked binary via Alpine Docker container (Linux only)
+build-binary-musl:
+	@echo "Building musl binary: $(BINARY_NAME_MUSL)..."
+	@mkdir -p $(BINARY_DIR)
+	docker run --rm \
+		-v $(CURDIR):/workspace:ro \
+		-v $(CURDIR)/$(BINARY_DIR):/output \
+		$(REGISTRY_MIRROR:%=%/)python:3.12-alpine \
+		/bin/sh -c '\
+			cp -r /workspace /tmp/build && cd /tmp/build && \
+			apk add --no-cache gcc musl-dev python3-dev git >/dev/null && \
+			pip install --break-system-packages patchelf -q && \
+			pip install --break-system-packages -e ".[profiling]" -q && \
+			pip install --break-system-packages "nuitka[onefile]" ordered-set -q && \
+			printf "from llm_rosetta.gateway import main\nmain()\n" > /tmp/_entry.py && \
+			python -m nuitka \
+				--standalone --onefile \
+				--jobs=$$(nproc) \
+				--output-dir=/output \
+				--output-filename=$(BINARY_NAME_MUSL) \
+				--include-package=llm_rosetta \
+				--include-package=pyinstrument \
+				--include-data-files=src/llm_rosetta/gateway/admin/admin.html=llm_rosetta/gateway/admin/admin.html \
+				--include-data-dir=src/llm_rosetta/shims/providers=llm_rosetta/shims/providers \
+				--nofollow-import-to=pytest \
+				--nofollow-import-to=setuptools \
+				--nofollow-import-to=pip \
+				--nofollow-import-to=_pytest \
+				--assume-yes-for-downloads \
+				/tmp/_entry.py && \
+			rm -rf /output/_entry.* '
+	@ls -lh $(BINARY_DIR)/$(BINARY_NAME_MUSL)
+	@echo "Musl binary build complete."
+
+clean-binary:
+	@echo "Cleaning binary build artifacts..."
+	rm -rf $(BINARY_DIR)/_nuitka_entry.* $(BINARY_DIR)/_entry.* $(NUITKA_ENTRY)
+	@echo "Clean complete. Binaries in $(BINARY_DIR)/ preserved."
+
+clean-binary-all:
+	@echo "Cleaning all binary artifacts..."
+	rm -rf $(BINARY_DIR)
+	rm -f $(NUITKA_ENTRY)
+	@echo "Clean complete."
+
+# ──────────────────────────────────────────────
 # Docker
 # ──────────────────────────────────────────────
 
-build-docker:
-	@echo "Building Docker image $(DOCKER_IMAGE):$(V)..."
+# Build Alpine Docker image with musl binary
+build-docker-alpine:
+	@BINARY=$(BINARY_DIR)/$(BINARY_NAME_MUSL); \
+	if [ ! -f "$$BINARY" ]; then \
+		echo "::error::Musl binary not found: $$BINARY"; \
+		echo "Run 'make build-binary-musl' first."; \
+		exit 1; \
+	fi; \
+	echo "Building Alpine Docker image $(DOCKER_IMAGE):$(V)-alpine..."; \
+	docker build -f docker/Dockerfile.binary \
+		--build-arg BASE_IMAGE=$(REGISTRY_MIRROR:%=%/)alpine \
+		--build-arg BINARY=$$BINARY \
+		-t $(DOCKER_IMAGE):$(V)-alpine \
+		-t $(DOCKER_IMAGE):$(V) \
+		-t $(DOCKER_IMAGE):latest .
+	@echo "Alpine Docker image built successfully."
+
+# Build glibc Docker image with native binary
+build-docker-glibc:
+	@BINARY=$(BINARY_DIR)/$(BINARY_NAME); \
+	if [ ! -f "$$BINARY" ]; then \
+		echo "::error::Native binary not found: $$BINARY"; \
+		echo "Run 'make build-binary' first."; \
+		exit 1; \
+	fi; \
+	echo "Building glibc Docker image $(DOCKER_IMAGE):$(V)-glibc..."; \
+	docker build -f docker/Dockerfile.binary \
+		--build-arg BASE_IMAGE=$(REGISTRY_MIRROR:%=%/)busybox:glibc \
+		--build-arg BINARY=$$BINARY \
+		-t $(DOCKER_IMAGE):$(V)-glibc .
+	@echo "Glibc Docker image built successfully."
+
+# Build Python-based Docker image (existing, with pip install)
+build-docker-python:
+	@echo "Building Python Docker image $(DOCKER_IMAGE):$(V)-python..."
 	@BUILD_ARGS=""; \
 	if [ -n "$(REGISTRY_MIRROR)" ]; then \
 		echo "Using registry mirror: $(REGISTRY_MIRROR)"; \
@@ -120,19 +252,27 @@ build-docker:
 		echo "Using PyPI mirror: $(PYPI_MIRROR)"; \
 		BUILD_ARGS="$$BUILD_ARGS --build-arg PYPI_MIRROR=$(PYPI_MIRROR)"; \
 	fi; \
-	cd docker && docker build -f Dockerfile $$BUILD_ARGS -t $(DOCKER_IMAGE):$(V) -t $(DOCKER_IMAGE):latest ..
-	@echo "Docker image built successfully."
+	cd docker && docker build -f Dockerfile $$BUILD_ARGS -t $(DOCKER_IMAGE):$(V)-python ..
+	@echo "Python Docker image built successfully."
+
+# Legacy alias
+build-docker: build-docker-python
 
 push-docker:
-	@echo "Pushing Docker images $(DOCKER_IMAGE):$(V) and $(DOCKER_IMAGE):latest..."
-	docker push $(DOCKER_IMAGE):$(V)
-	docker push $(DOCKER_IMAGE):latest
+	@echo "Pushing Docker images..."
+	@for tag in $(V)-alpine $(V) latest $(V)-glibc $(V)-python; do \
+		if docker image inspect $(DOCKER_IMAGE):$$tag >/dev/null 2>&1; then \
+			echo "  Pushing $(DOCKER_IMAGE):$$tag"; \
+			docker push $(DOCKER_IMAGE):$$tag; \
+		fi; \
+	done
 	@echo "Docker images pushed successfully."
 
 clean-docker:
 	@echo "Cleaning Docker images..."
-	docker rmi $(DOCKER_IMAGE):latest 2>/dev/null || true
-	docker rmi $(DOCKER_IMAGE):$(V) 2>/dev/null || true
+	@for tag in $(V)-alpine $(V) latest $(V)-glibc $(V)-python; do \
+		docker rmi $(DOCKER_IMAGE):$$tag 2>/dev/null || true; \
+	done
 
 # ──────────────────────────────────────────────
 # Dev-test deployment
@@ -186,10 +326,19 @@ help:
 	@echo "  push-package   - Push the package to PyPI"
 	@echo "  clean-package  - Clean up build and distribution files"
 	@echo ""
+	@echo "Binary:"
+	@echo "  build-binary       - Build native Nuitka binary for current platform"
+	@echo "  build-binary-musl  - Build musl-linked binary via Alpine Docker"
+	@echo "  clean-binary       - Clean build artifacts (keep binaries)"
+	@echo "  clean-binary-all   - Clean all binary artifacts"
+	@echo ""
 	@echo "Docker:"
-	@echo "  build-docker   - Build Docker image (local x64)"
-	@echo "  push-docker    - Push Docker image to registry"
-	@echo "  clean-docker   - Clean Docker images"
+	@echo "  build-docker-alpine  - Build Alpine Docker image (musl binary)"
+	@echo "  build-docker-glibc   - Build glibc Docker image (native binary)"
+	@echo "  build-docker-python  - Build Python Docker image (pip install)"
+	@echo "  build-docker         - Alias for build-docker-python"
+	@echo "  push-docker          - Push all Docker images"
+	@echo "  clean-docker         - Clean Docker images"
 	@echo ""
 	@echo "Aliases:"
 	@echo "  build          - Alias for build-package"
@@ -224,4 +373,4 @@ help:
 	@echo ""
 	@echo "Detected version: $(VERSION)"
 
-.PHONY: all lint lint-fix test test-integration test-gateway build-package push-package clean-package build push clean build-docker push-docker clean-docker deploy-dev help
+.PHONY: all lint lint-fix test test-integration test-gateway build-package push-package clean-package build push clean build-binary build-binary-musl clean-binary clean-binary-all build-docker-alpine build-docker-glibc build-docker-python build-docker push-docker clean-docker deploy-dev help

--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,8 @@ build-binary:
 	@printf 'from llm_rosetta.gateway import main\nmain()\n' > $(NUITKA_ENTRY)
 	python -m nuitka $(NUITKA_FLAGS) \
 		--output-filename=$(BINARY_NAME)$(if $(filter windows,$(BINARY_OS)),.exe,) \
-		$(NUITKA_ENTRY)
-	@rm -f $(NUITKA_ENTRY)
+		$(NUITKA_ENTRY); \
+	ret=$$?; rm -f $(NUITKA_ENTRY); exit $$ret
 	@ls -lh $(BINARY_DIR)/$(BINARY_NAME)*
 	@echo "Binary build complete."
 
@@ -153,7 +153,7 @@ build-binary-musl:
 		-v $(CURDIR)/$(BINARY_DIR):/output \
 		$(REGISTRY_MIRROR:%=%/)python:3.12-alpine \
 		/bin/sh -c '\
-			cp -r /workspace /tmp/build && cd /tmp/build && \
+			mkdir -p /tmp/build && tar -cf - -C /workspace --exclude=.git --exclude=__pycache__ . | tar -xf - -C /tmp/build && cd /tmp/build && \
 			apk add --no-cache gcc musl-dev python3-dev git >/dev/null && \
 			pip install --break-system-packages patchelf -q && \
 			pip install --break-system-packages -e ".[profiling]" -q && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,27 +8,17 @@ ARG PYPI_MIRROR
 ARG LOCAL_WHEEL
 ARG PACKAGE_VERSION
 
-# Prevents Python from writing pyc files and enables unbuffered output.
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
-# Create a non-privileged user and group (alpine syntax).
 RUN addgroup -g 1000 appgroup && \
     adduser -D -u 1000 -G appgroup appuser
 
-# Install su-exec for runtime user switching in entrypoint.
-RUN apk add --no-cache su-exec
-
-# Copy only the dist/ directory for local wheels (never copy the full tree —
-# even with .dockerignore, a broad COPY risks leaking secrets into layers).
-# The trailing slash on dist/ + a wildcard ensures COPY is a no-op when empty.
 RUN mkdir -p /tmp/dist/
 COPY dist/ /tmp/dist/
 
-# Install llm-rosetta[gateway,profiling]: local wheel > specific version > latest from PyPI
-# Then remove pip/setuptools to save ~10MB
 RUN if [ -n "$LOCAL_WHEEL" ] && [ -f "/tmp/dist/$LOCAL_WHEEL" ]; then \
         echo "Installing from local wheel: $LOCAL_WHEEL"; \
         if [ -n "$PYPI_MIRROR" ]; then \
@@ -54,16 +44,12 @@ RUN if [ -n "$LOCAL_WHEEL" ] && [ -f "/tmp/dist/$LOCAL_WHEEL" ]; then \
     pip uninstall -y pip setuptools 2>/dev/null || true && \
     rm -rf /tmp/dist/
 
-# Config directory — mount a volume here with your config.jsonc.
-# The gateway also stores metrics and request logs under /config/data/.
 RUN mkdir -p /config && chown appuser:appgroup /config
 VOLUME /config
 
-# Entrypoint fixes /config ownership and drops to appuser via su-exec.
-# Set PUID/PGID environment variables to match your host user (default: 1000).
-COPY docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY --chmod=755 docker/entrypoint.sh /entrypoint.sh
 
+USER appuser
 EXPOSE 8765
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -1,0 +1,41 @@
+# Minimal binary-only image for llm-rosetta-gateway.
+# Uses a pre-built Nuitka binary — no Python runtime needed.
+#
+# Build variants:
+#   Alpine (musl binary, ~19 MB):
+#     docker build -f docker/Dockerfile.binary --build-arg BASE_IMAGE=alpine \
+#       --build-arg BINARY=build/llm-rosetta-gateway-0.9.0-linux-x86_64-musl \
+#       -t llm-rosetta-gateway:alpine .
+#
+#   Glibc (native binary, ~25 MB):
+#     docker build -f docker/Dockerfile.binary --build-arg BASE_IMAGE=busybox:glibc \
+#       --build-arg BINARY=build/llm-rosetta-gateway-0.9.0-linux-x86_64 \
+#       -t llm-rosetta-gateway:glibc .
+#
+# Run:
+#   docker run -v ./config:/config -p 8765:8765 llm-rosetta-gateway:alpine
+#   docker run --user $(id -u):$(id -g) -v ./config:/config -p 8765:8765 llm-rosetta-gateway:alpine
+
+ARG BASE_IMAGE=alpine
+FROM ${BASE_IMAGE}
+
+ARG BINARY=llm-rosetta-gateway
+
+RUN if command -v apk >/dev/null 2>&1; then \
+        apk add --no-cache su-exec; \
+    fi
+
+COPY --chmod=755 ${BINARY} /usr/local/bin/llm-rosetta-gateway
+
+RUN addgroup -g 1000 appgroup && \
+    adduser -D -u 1000 -G appgroup appuser
+
+RUN mkdir -p /config && chown appuser:appgroup /config
+VOLUME /config
+
+COPY --chmod=755 docker/entrypoint-binary.sh /entrypoint.sh
+
+EXPOSE 8765
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["llm-rosetta-gateway", "--config", "/config/config.jsonc", "--host", "0.0.0.0"]

--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -1,29 +1,23 @@
 # Minimal binary-only image for llm-rosetta-gateway.
 # Uses a pre-built Nuitka binary — no Python runtime needed.
 #
-# Build variants:
-#   Alpine (musl binary, ~19 MB):
+# Build:
+#   Alpine (musl binary, ~21 MB):
 #     docker build -f docker/Dockerfile.binary --build-arg BASE_IMAGE=alpine \
-#       --build-arg BINARY=build/llm-rosetta-gateway-0.9.0-linux-x86_64-musl \
-#       -t llm-rosetta-gateway:alpine .
+#       --build-arg BINARY=build/llm-rosetta-gateway-0.9.0-linux-x86_64-musl .
 #
 #   Glibc (native binary, ~25 MB):
 #     docker build -f docker/Dockerfile.binary --build-arg BASE_IMAGE=busybox:glibc \
-#       --build-arg BINARY=build/llm-rosetta-gateway-0.9.0-linux-x86_64 \
-#       -t llm-rosetta-gateway:glibc .
+#       --build-arg BINARY=build/llm-rosetta-gateway-0.9.0-linux-x86_64 .
 #
 # Run:
-#   docker run -v ./config:/config -p 8765:8765 llm-rosetta-gateway:alpine
-#   docker run --user $(id -u):$(id -g) -v ./config:/config -p 8765:8765 llm-rosetta-gateway:alpine
+#   docker run -v ./config:/config -p 8765:8765 llm-rosetta-gateway
+#   docker run --user $(id -u):$(id -g) -v ./config:/config -p 8765:8765 llm-rosetta-gateway
 
 ARG BASE_IMAGE=alpine
 FROM ${BASE_IMAGE}
 
 ARG BINARY=llm-rosetta-gateway
-
-RUN if command -v apk >/dev/null 2>&1; then \
-        apk add --no-cache su-exec; \
-    fi
 
 COPY --chmod=755 ${BINARY} /usr/local/bin/llm-rosetta-gateway
 
@@ -35,7 +29,8 @@ VOLUME /config
 
 COPY --chmod=755 docker/entrypoint-binary.sh /entrypoint.sh
 
+USER appuser
 EXPOSE 8765
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["llm-rosetta-gateway", "--config", "/config/config.jsonc", "--host", "0.0.0.0"]
+CMD ["/usr/local/bin/llm-rosetta-gateway", "--config", "/config/config.jsonc", "--host", "0.0.0.0"]

--- a/docker/entrypoint-binary.sh
+++ b/docker/entrypoint-binary.sh
@@ -1,42 +1,15 @@
 #!/bin/sh
 
-# If running as root (default), handle PUID/PGID and drop privileges.
-# If running as non-root (docker run --user), skip privilege management.
-if [ "$(id -u)" = "0" ]; then
-	PUID=${PUID:-1000}
-	PGID=${PGID:-1000}
+mkdir -p /config 2>/dev/null || true
 
-	if [ "$(id -u appuser)" != "$PUID" ] || [ "$(id -g appuser)" != "$PGID" ]; then
-		sed -i "s/^appuser:x:[0-9]*:[0-9]*:/appuser:x:$PUID:$PGID:/" /etc/passwd
-		sed -i "s/^appgroup:x:[0-9]*:/appgroup:x:$PGID:/" /etc/group
-	fi
-
-	mkdir -p /config
-	chown -R appuser:appgroup /config
-
-	if [ ! -f /config/config.jsonc ]; then
-		echo "No config.jsonc found in /config, generating template..."
-		su-exec appuser llm-rosetta-gateway --config /config/config.jsonc init
-		echo "Edit /config/config.jsonc with your API keys and restart the container."
-	fi
-
-	if [ "${1#-}" != "$1" ]; then
-		set -- llm-rosetta-gateway "$@"
-	fi
-
-	exec su-exec appuser "$@"
-else
-	mkdir -p /config 2>/dev/null || true
-
-	if [ ! -f /config/config.jsonc ]; then
-		echo "No config.jsonc found in /config, generating template..."
-		llm-rosetta-gateway --config /config/config.jsonc init
-		echo "Edit /config/config.jsonc with your API keys and restart the container."
-	fi
-
-	if [ "${1#-}" != "$1" ]; then
-		set -- llm-rosetta-gateway "$@"
-	fi
-
-	exec "$@"
+if [ ! -f /config/config.jsonc ]; then
+	echo "No config.jsonc found in /config, generating template..."
+	/usr/local/bin/llm-rosetta-gateway --config /config/config.jsonc init
+	echo "Edit /config/config.jsonc with your API keys and restart the container."
 fi
+
+if [ "${1#-}" != "$1" ]; then
+	set -- /usr/local/bin/llm-rosetta-gateway "$@"
+fi
+
+exec "$@"

--- a/docker/entrypoint-binary.sh
+++ b/docker/entrypoint-binary.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# If running as root (default), handle PUID/PGID and drop privileges.
+# If running as non-root (docker run --user), skip privilege management.
+if [ "$(id -u)" = "0" ]; then
+	PUID=${PUID:-1000}
+	PGID=${PGID:-1000}
+
+	if [ "$(id -u appuser)" != "$PUID" ] || [ "$(id -g appuser)" != "$PGID" ]; then
+		sed -i "s/^appuser:x:[0-9]*:[0-9]*:/appuser:x:$PUID:$PGID:/" /etc/passwd
+		sed -i "s/^appgroup:x:[0-9]*:/appgroup:x:$PGID:/" /etc/group
+	fi
+
+	mkdir -p /config
+	chown -R appuser:appgroup /config
+
+	if [ ! -f /config/config.jsonc ]; then
+		echo "No config.jsonc found in /config, generating template..."
+		su-exec appuser llm-rosetta-gateway --config /config/config.jsonc init
+		echo "Edit /config/config.jsonc with your API keys and restart the container."
+	fi
+
+	if [ "${1#-}" != "$1" ]; then
+		set -- llm-rosetta-gateway "$@"
+	fi
+
+	exec su-exec appuser "$@"
+else
+	mkdir -p /config 2>/dev/null || true
+
+	if [ ! -f /config/config.jsonc ]; then
+		echo "No config.jsonc found in /config, generating template..."
+		llm-rosetta-gateway --config /config/config.jsonc init
+		echo "Edit /config/config.jsonc with your API keys and restart the container."
+	fi
+
+	if [ "${1#-}" != "$1" ]; then
+		set -- llm-rosetta-gateway "$@"
+	fi
+
+	exec "$@"
+fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,26 +1,15 @@
 #!/bin/sh
 
-# Load PUID and PGID from environment variables
-PUID=${PUID:-1000}
-PGID=${PGID:-1000}
+mkdir -p /config 2>/dev/null || true
 
-# Modify the existing user and group to match PUID and PGID
-if [ "$(id -u appuser)" != "$PUID" ] || [ "$(id -g appuser)" != "$PGID" ]; then
-	sed -i "s/^appuser:x:[0-9]*:[0-9]*:/appuser:x:$PUID:$PGID:/" /etc/passwd
-	sed -i "s/^appgroup:x:[0-9]*:/appgroup:x:$PGID:/" /etc/group
-fi
-
-# Ensure config directory exists with proper ownership
-# (Docker creates bind-mount directories as root if they don't exist on the host)
-mkdir -p /config
-chown -R appuser:appgroup /config
-
-# Auto-generate a template config if none exists
 if [ ! -f /config/config.jsonc ]; then
 	echo "No config.jsonc found in /config, generating template..."
-	su-exec appuser llm-rosetta-gateway --config /config/config.jsonc init
+	llm-rosetta-gateway --config /config/config.jsonc init
 	echo "Edit /config/config.jsonc with your API keys and restart the container."
 fi
 
-# Switch to appuser and execute the command passed as arguments
-exec su-exec appuser "$@"
+if [ "${1#-}" != "$1" ]; then
+	set -- llm-rosetta-gateway "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

- Add Makefile targets for Nuitka binary compilation (`build-binary`, `build-binary-musl`)
- Add Makefile targets for binary-based Docker images (`build-docker-alpine`, `build-docker-glibc`)
- Update `nuitka.yml` to produce 6 binaries (4 native + 2 musl Linux) using make targets
- Update `release.yml` to run Docker builds after binaries complete
- Add `docker/Dockerfile.binary` (parameterized by `BASE_IMAGE`) and `docker/entrypoint-binary.sh`
- Rename existing `build-docker` to `build-docker-python`

### Build matrix (6 binaries)

| Platform | Libc | Size |
|----------|------|------|
| linux-x86_64 | glibc | ~20 MB |
| linux-x86_64 | musl | ~12 MB |
| linux-arm64 | glibc | ~20 MB |
| linux-arm64 | musl | ~12 MB |
| macos-arm64 | system | ~20 MB |
| windows-x86_64 | MSVC | ~10 MB |

### Docker image variants

| Tag | Base | Size |
|-----|------|------|
| `{ver}-alpine` / `{ver}` / `latest` | alpine + musl binary | ~33 MB |
| `{ver}-glibc` | busybox:glibc + native binary | ~25 MB |
| `{ver}-python` | python:3.12-alpine + pip | ~80 MB |

## Test plan

- [x] `make build-binary-musl` tested on ts-docker-build02
- [x] musl binary verified in Alpine container (`--version`, `--help`)
- [x] `make build-docker-alpine` builds successfully (33 MB)
- [x] Docker image runs correctly with su-exec user dropping
- [x] glibc binary tested locally (`--version`, `--help`, server startup, health check, admin page)
- [ ] CI: trigger `nuitka.yml` with `platforms=all` to verify 6-binary matrix
- [ ] CI: trigger `nuitka.yml` with `platforms=linux-x86_64-musl` to verify musl-only filtering