### PR TITLE
feat(admin-ui): Track B — responsive layout, UI polish, accessibility

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -38,18 +38,18 @@
 </div>
 
 <div class="tabs" role="tablist">
-  <div class="tab active" role="tab" tabindex="0" aria-selected="true" data-tab="providers" data-i18n="tab.providers">Providers</div>
-  <div class="tab" role="tab" tabindex="-1" aria-selected="false" data-tab="models" data-i18n="tab.models">Models</div>
-  <div class="tab" role="tab" tabindex="-1" aria-selected="false" data-tab="keys" data-i18n="tab.keys">API Keys</div>
-  <div class="tab" role="tab" tabindex="-1" aria-selected="false" data-tab="dashboard" data-i18n="tab.dashboard">Dashboard</div>
-  <div class="tab" role="tab" tabindex="-1" aria-selected="false" data-tab="logs" data-i18n="tab.logs">Request Log</div>
+  <div class="tab active" role="tab" id="tabBtn-providers" tabindex="0" aria-selected="true" aria-controls="tab-providers" data-tab="providers" data-i18n="tab.providers">Providers</div>
+  <div class="tab" role="tab" id="tabBtn-models" tabindex="-1" aria-selected="false" aria-controls="tab-models" data-tab="models" data-i18n="tab.models">Models</div>
+  <div class="tab" role="tab" id="tabBtn-keys" tabindex="-1" aria-selected="false" aria-controls="tab-keys" data-tab="keys" data-i18n="tab.keys">API Keys</div>
+  <div class="tab" role="tab" id="tabBtn-dashboard" tabindex="-1" aria-selected="false" aria-controls="tab-dashboard" data-tab="dashboard" data-i18n="tab.dashboard">Dashboard</div>
+  <div class="tab" role="tab" id="tabBtn-logs" tabindex="-1" aria-selected="false" aria-controls="tab-logs" data-tab="logs" data-i18n="tab.logs">Request Log</div>
   <div style="flex:1"></div>
   <div class="config-path" id="configPath"></div>
 </div>
 
 <div class="content">
   <!-- Providers Tab -->
-  <div class="tab-panel active" id="tab-providers" role="tabpanel">
+  <div class="tab-panel active" id="tab-providers" role="tabpanel" aria-labelledby="tabBtn-providers">
     <div class="section">
       <div class="section-header">
         <h2 data-i18n="section.server">Server Settings</h2>
@@ -93,7 +93,7 @@
   </div>
 
   <!-- Models Tab -->
-  <div class="tab-panel" id="tab-models" role="tabpanel">
+  <div class="tab-panel" id="tab-models" role="tabpanel" aria-labelledby="tabBtn-models">
     <div class="section">
       <!-- Row 1: Title + count + buttons -->
       <div class="section-header">
@@ -141,7 +141,7 @@
   </div>
 
   <!-- API Keys Tab -->
-  <div class="tab-panel" id="tab-keys" role="tabpanel">
+  <div class="tab-panel" id="tab-keys" role="tabpanel" aria-labelledby="tabBtn-keys">
     <div class="section">
       <div class="section-header">
         <h2 data-i18n="section.apiKeys">API Keys</h2>
@@ -161,7 +161,7 @@
   </div>
 
   <!-- Dashboard Tab -->
-  <div class="tab-panel" id="tab-dashboard" role="tabpanel">
+  <div class="tab-panel" id="tab-dashboard" role="tabpanel" aria-labelledby="tabBtn-dashboard">
     <div class="stats-grid" id="statsGrid"></div>
     <div class="chart-row">
       <div class="chart-box">
@@ -358,7 +358,7 @@
   </div>
 
   <!-- Request Log Tab -->
-  <div class="tab-panel" id="tab-logs" role="tabpanel">
+  <div class="tab-panel" id="tab-logs" role="tabpanel" aria-labelledby="tabBtn-logs">
     <div class="filters">
       <select id="filterModel"><option value="" data-i18n="filter.allModels">All Models</option></select>
       <select id="filterProvider"><option value="" data-i18n="filter.allProviders">All Providers</option></select>

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>llm-rosetta Gateway — Admin</title>
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔀</text></svg>">
 <link rel="stylesheet" href="/admin/static/css/base.css">
 <link rel="stylesheet" href="/admin/static/css/components.css">
 </head>
@@ -36,19 +37,19 @@
   </div>
 </div>
 
-<div class="tabs">
-  <div class="tab active" data-tab="providers" data-i18n="tab.providers">Providers</div>
-  <div class="tab" data-tab="models" data-i18n="tab.models">Models</div>
-  <div class="tab" data-tab="keys" data-i18n="tab.keys">API Keys</div>
-  <div class="tab" data-tab="dashboard" data-i18n="tab.dashboard">Dashboard</div>
-  <div class="tab" data-tab="logs" data-i18n="tab.logs">Request Log</div>
+<div class="tabs" role="tablist">
+  <div class="tab active" role="tab" tabindex="0" aria-selected="true" data-tab="providers" data-i18n="tab.providers">Providers</div>
+  <div class="tab" role="tab" tabindex="-1" aria-selected="false" data-tab="models" data-i18n="tab.models">Models</div>
+  <div class="tab" role="tab" tabindex="-1" aria-selected="false" data-tab="keys" data-i18n="tab.keys">API Keys</div>
+  <div class="tab" role="tab" tabindex="-1" aria-selected="false" data-tab="dashboard" data-i18n="tab.dashboard">Dashboard</div>
+  <div class="tab" role="tab" tabindex="-1" aria-selected="false" data-tab="logs" data-i18n="tab.logs">Request Log</div>
   <div style="flex:1"></div>
   <div class="config-path" id="configPath"></div>
 </div>
 
 <div class="content">
   <!-- Providers Tab -->
-  <div class="tab-panel active" id="tab-providers">
+  <div class="tab-panel active" id="tab-providers" role="tabpanel">
     <div class="section">
       <div class="section-header">
         <h2 data-i18n="section.server">Server Settings</h2>
@@ -71,11 +72,11 @@
     <div class="section">
       <div class="section-header">
         <h2 data-i18n="section.providers">Providers</h2>
-        <div class="seg-control" id="providerSeg">
-          <div class="active" onclick="switchProviderFilter(this,'all')"><span data-i18n="filter.all">All</span></div>
-          <div onclick="switchProviderFilter(this,'llm')"><span data-i18n="label.llm">LLM</span></div>
-          <div onclick="switchProviderFilter(this,'embedding')"><span data-i18n="label.embedding">Embedding</span></div>
-          <div onclick="switchProviderFilter(this,'rerank')"><span data-i18n="label.rerank">Rerank</span></div>
+        <div class="seg-control" id="providerSeg" role="radiogroup" aria-label="Provider filter">
+          <div class="active" role="radio" aria-checked="true" tabindex="0" onclick="switchProviderFilter(this,'all')"><span data-i18n="filter.all">All</span></div>
+          <div role="radio" aria-checked="false" tabindex="-1" onclick="switchProviderFilter(this,'llm')"><span data-i18n="label.llm">LLM</span></div>
+          <div role="radio" aria-checked="false" tabindex="-1" onclick="switchProviderFilter(this,'embedding')"><span data-i18n="label.embedding">Embedding</span></div>
+          <div role="radio" aria-checked="false" tabindex="-1" onclick="switchProviderFilter(this,'rerank')"><span data-i18n="label.rerank">Rerank</span></div>
         </div>
       </div>
       <div class="provider-toolbar" id="providerToolbar">
@@ -92,7 +93,7 @@
   </div>
 
   <!-- Models Tab -->
-  <div class="tab-panel" id="tab-models">
+  <div class="tab-panel" id="tab-models" role="tabpanel">
     <div class="section">
       <!-- Row 1: Title + count + buttons -->
       <div class="section-header">
@@ -108,11 +109,11 @@
         <select id="modelProviderFilter" onchange="renderModels()">
           <option value="" data-i18n="filter.allProviders">All Providers</option>
         </select>
-        <div class="seg-control" id="modelTypeSeg">
-          <div class="active" onclick="switchModelDomain(this,'all')"><span data-i18n="filter.all">All</span></div>
-          <div onclick="switchModelDomain(this,'llm')"><span data-i18n="label.llm">LLM</span></div>
-          <div onclick="switchModelDomain(this,'embedding')"><span data-i18n="label.embedding">Embedding</span></div>
-          <div onclick="switchModelDomain(this,'rerank')"><span data-i18n="label.rerank">Rerank</span></div>
+        <div class="seg-control" id="modelTypeSeg" role="radiogroup" aria-label="Model type filter">
+          <div class="active" role="radio" aria-checked="true" tabindex="0" onclick="switchModelDomain(this,'all')"><span data-i18n="filter.all">All</span></div>
+          <div role="radio" aria-checked="false" tabindex="-1" onclick="switchModelDomain(this,'llm')"><span data-i18n="label.llm">LLM</span></div>
+          <div role="radio" aria-checked="false" tabindex="-1" onclick="switchModelDomain(this,'embedding')"><span data-i18n="label.embedding">Embedding</span></div>
+          <div role="radio" aria-checked="false" tabindex="-1" onclick="switchModelDomain(this,'rerank')"><span data-i18n="label.rerank">Rerank</span></div>
         </div>
         <input id="modelSearch" placeholder="Search models..." oninput="renderModels()" data-i18n-placeholder="label.searchModels" style="max-width:200px">
         <button class="btn-reset" id="modelResetBtn" onclick="resetModelFilters()" data-i18n="btn.resetFilters">✕ Reset</button>
@@ -140,7 +141,7 @@
   </div>
 
   <!-- API Keys Tab -->
-  <div class="tab-panel" id="tab-keys">
+  <div class="tab-panel" id="tab-keys" role="tabpanel">
     <div class="section">
       <div class="section-header">
         <h2 data-i18n="section.apiKeys">API Keys</h2>
@@ -160,7 +161,7 @@
   </div>
 
   <!-- Dashboard Tab -->
-  <div class="tab-panel" id="tab-dashboard">
+  <div class="tab-panel" id="tab-dashboard" role="tabpanel">
     <div class="stats-grid" id="statsGrid"></div>
     <div class="chart-row">
       <div class="chart-box">
@@ -204,7 +205,10 @@
         </tr></thead>
         <tbody id="profilingResults"></tbody>
       </table></div>
-      <div id="profilingEmpty" class="empty" data-i18n="profiling.empty">No profiling results. Enable profiling and send requests.</div>
+      <div id="profilingEmpty" class="empty-state">
+        <div class="empty-state-icon">📊</div>
+        <div class="empty-state-text" data-i18n="profiling.empty">No profiling results. Enable profiling and send requests.</div>
+      </div>
     </div>
     <div class="section" id="captureSection">
       <h2 style="margin-bottom:12px" data-i18n="section.capture">Content Capture</h2>
@@ -228,7 +232,10 @@
         </tr></thead>
         <tbody id="captureResults"></tbody>
       </table></div>
-      <div id="captureEmpty" class="empty" data-i18n="capture.empty">No captures. Enable capture and send requests.</div>
+      <div id="captureEmpty" class="empty-state">
+        <div class="empty-state-icon">📸</div>
+        <div class="empty-state-text" data-i18n="capture.empty">No captures. Enable capture and send requests.</div>
+      </div>
     </div>
 
     <!-- Error Dumps Section -->
@@ -308,7 +315,10 @@
         </tr></thead>
         <tbody id="dumpTable"></tbody>
       </table></div>
-      <div id="dumpEmpty" class="empty" data-i18n="dump.empty">No error dumps recorded.</div>
+      <div id="dumpEmpty" class="empty-state">
+        <div class="empty-state-icon">🗂️</div>
+        <div class="empty-state-text" data-i18n="dump.empty">No error dumps recorded.</div>
+      </div>
       <div style="display:flex;align-items:center;justify-content:center;gap:12px;margin-top:16px;font-size:13px;color:var(--text-dim)">
         <button class="btn btn-sm" onclick="changeDumpPage(-1)" id="dumpPrevPage" disabled>← Prev</button>
         <span id="dumpPageInfo">Page 1 / 1</span>
@@ -318,7 +328,7 @@
   </div>
 
   <!-- Clear Dumps Confirm Modal -->
-  <div class="modal-overlay" id="clearDumpsModal">
+  <div class="modal-overlay" role="dialog" aria-modal="true" id="clearDumpsModal">
     <div class="modal" style="width:400px">
       <h3 data-i18n="confirm.clearDumps">Clear All Error Dumps</h3>
       <p style="font-size:13px;color:var(--text-dim);margin-bottom:16px" data-i18n-html="confirm.clearDumpsHint">This will permanently delete all error dump records. Type <strong style="color:var(--red)">CLEAR</strong> to confirm.</p>
@@ -331,7 +341,7 @@
   </div>
 
   <!-- Export Error Dumps Modal -->
-  <div class="modal-overlay" id="exportDumpsModal">
+  <div class="modal-overlay" role="dialog" aria-modal="true" id="exportDumpsModal">
     <div class="modal" style="width:400px">
       <h3 data-i18n="export.title">Export Error Dumps</h3>
       <p style="font-size:13px;color:var(--text-dim);margin-bottom:12px" data-i18n="export.hint">Select a date range (optional). Leave empty to export all.</p>
@@ -348,7 +358,7 @@
   </div>
 
   <!-- Request Log Tab -->
-  <div class="tab-panel" id="tab-logs">
+  <div class="tab-panel" id="tab-logs" role="tabpanel">
     <div class="filters">
       <select id="filterModel"><option value="" data-i18n="filter.allModels">All Models</option></select>
       <select id="filterProvider"><option value="" data-i18n="filter.allProviders">All Providers</option></select>
@@ -373,7 +383,7 @@
 </div>
 
 <!-- Settings Popup (wide section-card layout) -->
-<div class="settings-popup" id="settingsPopup" onclick="this.classList.remove('open')">
+<div class="settings-popup" id="settingsPopup" role="dialog" aria-modal="true" onclick="this.classList.remove('open')">
   <div class="settings-popup-panel" onclick="event.stopPropagation()">
     <h3 data-i18n="modal.settings">Settings</h3>
 
@@ -586,7 +596,7 @@
 </div>
 
 <!-- Provider Modal -->
-<div class="modal-overlay" id="providerModal">
+<div class="modal-overlay" role="dialog" aria-modal="true" id="providerModal">
   <div class="modal modal-wide">
     <h3 id="providerModalTitle" data-i18n="modal.addProvider">Add Provider</h3>
 
@@ -711,7 +721,7 @@
 </div>
 
 <!-- Model Modal -->
-<div class="modal-overlay" id="modelModal">
+<div class="modal-overlay" role="dialog" aria-modal="true" id="modelModal">
   <div class="modal">
     <h3 id="modelModalTitle" data-i18n="modal.addModel">Add Model</h3>
 
@@ -830,7 +840,7 @@ Rules:..."</code><br><br>Some upstream providers don't support content arrays in
 </div>
 
 <!-- Fetch Models Modal -->
-<div class="modal-overlay" id="fetchModelsModal">
+<div class="modal-overlay" role="dialog" aria-modal="true" id="fetchModelsModal">
   <div class="modal modal-wide">
     <h3 data-i18n="modal.fetchModels">Fetch Models from Provider</h3>
     <div class="form-group">
@@ -876,7 +886,7 @@ Rules:..."</code><br><br>Some upstream providers don't support content arrays in
 </div>
 
 <!-- Cleanup Confirmation Modal -->
-<div class="modal-overlay" id="cleanupConfirmModal">
+<div class="modal-overlay" role="dialog" aria-modal="true" id="cleanupConfirmModal">
   <div class="modal">
     <h3 data-i18n="confirm.cleanupTitle">Database Cleanup</h3>
     <p id="cleanupConfirmMsg" style="margin:8px 0 12px;color:var(--text-dim);font-size:13px"></p>
@@ -894,7 +904,7 @@ Rules:..."</code><br><br>Some upstream providers don't support content arrays in
 </div>
 
 <!-- Delete Confirmation Modal -->
-<div class="modal-overlay" id="deleteConfirmModal">
+<div class="modal-overlay" role="dialog" aria-modal="true" id="deleteConfirmModal">
   <div class="modal">
     <h3 data-i18n="confirm.deleteProviderTitle">Delete Provider</h3>
     <p id="deleteConfirmMsg" style="margin:8px 0 12px;color:var(--text-dim);font-size:13px"></p>
@@ -912,7 +922,7 @@ Rules:..."</code><br><br>Some upstream providers don't support content arrays in
 </div>
 
 <!-- Matryoshka Dimensions Modal -->
-<div class="modal-overlay" id="matryoshkaModal">
+<div class="modal-overlay" role="dialog" aria-modal="true" id="matryoshkaModal">
   <div class="modal" style="max-width:360px">
     <h3 data-i18n="test.matryoshka">Matryoshka</h3>
     <div class="form-group">
@@ -927,7 +937,7 @@ Rules:..."</code><br><br>Some upstream providers don't support content arrays in
 </div>
 
 <!-- Test Result Modal -->
-<div class="modal-overlay" id="testModal">
+<div class="modal-overlay" role="dialog" aria-modal="true" id="testModal">
   <div class="modal modal-wide">
     <h3 id="testModalTitle">Test Result</h3>
     <div class="test-meta" id="testMeta"></div>
@@ -951,7 +961,7 @@ Rules:..."</code><br><br>Some upstream providers don't support content arrays in
 </div>
 
 <!-- API Key Modal -->
-<div class="modal-overlay" id="keyModal">
+<div class="modal-overlay" role="dialog" aria-modal="true" id="keyModal">
   <div class="modal">
     <h3 id="keyModalTitle" data-i18n="modal.generateKey">Generate API Key</h3>
     <div class="form-group">
@@ -974,7 +984,7 @@ Rules:..."</code><br><br>Some upstream providers don't support content arrays in
 </div>
 
 <!-- Key Created Modal -->
-<div class="modal-overlay" id="keyCreatedModal">
+<div class="modal-overlay" role="dialog" aria-modal="true" id="keyCreatedModal">
   <div class="modal">
     <h3 data-i18n="modal.keyCreated">Key Created</h3>
     <p style="font-size:13px;color:var(--text-dim);margin-bottom:12px" data-i18n="keys.copyWarning">Copy this key now. It will not be shown again in full.</p>

--- a/src/llm_rosetta/gateway/admin/css/base.css
+++ b/src/llm_rosetta/gateway/admin/css/base.css
@@ -165,7 +165,10 @@ a { color: var(--accent); text-decoration: none; }
 .rl-warning.visible { display: block; }
 .rl-fields.disabled { opacity: 0.35; pointer-events: none; transition: opacity 0.3s ease; }
 .rl-fields { transition: opacity 0.3s ease; }
-@media (max-width: 600px) { .settings-grid { grid-template-columns: 1fr; } }
+@media (max-width: 600px) {
+  .settings-grid { grid-template-columns: 1fr; }
+  .settings-popup-panel { padding: 16px; }
+}
 .about-link {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 6px 14px; font-size: 13px; color: var(--text);
@@ -182,7 +185,10 @@ a { color: var(--accent); text-decoration: none; }
 .tabs {
   display: flex; gap: 0; border-bottom: 1px solid var(--border);
   padding: 0 24px; align-items: center;
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
 }
+.tabs::-webkit-scrollbar { display: none; }
 .tab {
   padding: 12px 20px; cursor: pointer; font-size: 14px; color: var(--text-dim);
   border-bottom: 2px solid transparent; transition: all 0.15s;
@@ -192,7 +198,7 @@ a { color: var(--accent); text-decoration: none; }
 .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
 
 /* Content */
-.content { padding: 24px; max-width: 1200px; margin: 0 auto; }
+.content { padding: 24px; max-width: 1400px; margin: 0 auto; }
 .tab-panel { display: none; }
 .tab-panel.active { display: block; }
 

--- a/src/llm_rosetta/gateway/admin/css/components.css
+++ b/src/llm_rosetta/gateway/admin/css/components.css
@@ -21,10 +21,11 @@ th, td {
 }
 th { color: var(--text-dim); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; }
 tr:hover td { background: var(--bg-hover); }
+.table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 
 /* Provider cards */
 .provider-grid {
-  display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 16px;
 }
 .provider-card {
@@ -181,7 +182,7 @@ code.copyable:hover { background: var(--bg-hover); }
 
 /* Toast */
 .toast {
-  position: fixed; bottom: 30px; right: 10px;
+  position: fixed; bottom: 30px; left: 50%; transform: translateX(-50%);
   padding: 12px 20px; border-radius: var(--radius); font-size: 13px;
   z-index: 200; opacity: 0; transition: opacity 0.3s;
 }
@@ -366,6 +367,16 @@ th.sortable.desc::after { content:'\25BC';opacity:.8; }
 }
 .login-box button:hover { background:var(--accent-hover); }
 
+/* Empty states */
+.empty-state {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  padding: 40px 20px; color: var(--text-dim); text-align: center;
+}
+.empty-state-icon {
+  font-size: 36px; margin-bottom: 12px; opacity: 0.4;
+}
+.empty-state-text { font-size: 13px; line-height: 1.5; }
+
 /* Responsive */
 @media (max-width: 768px) {
   .header { padding: 12px 16px; }
@@ -378,7 +389,6 @@ th.sortable.desc::after { content:'\25BC';opacity:.8; }
   .provider-grid { grid-template-columns: 1fr; }
   .provider-grid.list-view .provider-card { grid-template-columns: 1fr; }
   .stats-grid { grid-template-columns: repeat(2, 1fr); }
-  .table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
   .section-header { flex-wrap: wrap; gap: 8px; }
 }
 

--- a/src/llm_rosetta/gateway/admin/js/init.js
+++ b/src/llm_rosetta/gateway/admin/js/init.js
@@ -31,26 +31,45 @@ function initApp() {
 }
 
 // ===================== Tabs =====================
-document.querySelectorAll('.tab').forEach(tab => {
-  tab.addEventListener('click', () => {
-    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
-    document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
-    tab.classList.add('active');
-    const id = tab.dataset.tab;
-    document.getElementById('tab-' + id).classList.add('active');
-    S.currentTab = id;
-    localStorage.setItem('llm-rosetta-tab', id);
-    stopTimers();
-    if (id === 'dashboard' && _tabEnabled('dashboard')) { loadMetrics(); loadDumps(); S.dashboardTimer = (S._dashboardRefreshMs > 0 ? setInterval(loadMetrics, S._dashboardRefreshMs) : null); }
-    if (id === 'logs' && _tabEnabled('logs')) { S.logOffset = 0; loadLogs(); S.logTimer = setInterval(loadLogs, 5000); }
-    if (id === 'providers' || id === 'models') { loadConfig(); }
-    if (id === 'keys' && _tabEnabled('keys')) { loadKeys(); }
+function activateTab(tab) {
+  const allTabs = document.querySelectorAll('.tab[role="tab"]');
+  allTabs.forEach(t => {
+    t.classList.remove('active');
+    t.setAttribute('aria-selected', 'false');
+    t.setAttribute('tabindex', '-1');
+  });
+  document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+  tab.classList.add('active');
+  tab.setAttribute('aria-selected', 'true');
+  tab.setAttribute('tabindex', '0');
+  const id = tab.dataset.tab;
+  document.getElementById('tab-' + id).classList.add('active');
+  S.currentTab = id;
+  localStorage.setItem('llm-rosetta-tab', id);
+  stopTimers();
+  if (id === 'dashboard' && _tabEnabled('dashboard')) { loadMetrics(); loadDumps(); S.dashboardTimer = (S._dashboardRefreshMs > 0 ? setInterval(loadMetrics, S._dashboardRefreshMs) : null); }
+  if (id === 'logs' && _tabEnabled('logs')) { S.logOffset = 0; loadLogs(); S.logTimer = setInterval(loadLogs, 5000); }
+  if (id === 'providers' || id === 'models') { loadConfig(); }
+  if (id === 'keys' && _tabEnabled('keys')) { loadKeys(); }
+}
+
+document.querySelectorAll('.tab[role="tab"]').forEach(tab => {
+  tab.addEventListener('click', () => activateTab(tab));
+  tab.addEventListener('keydown', (e) => {
+    const tabs = Array.from(document.querySelectorAll('.tab[role="tab"]'));
+    const idx = tabs.indexOf(tab);
+    let target = null;
+    if (e.key === 'ArrowRight') target = tabs[(idx + 1) % tabs.length];
+    else if (e.key === 'ArrowLeft') target = tabs[(idx - 1 + tabs.length) % tabs.length];
+    else if (e.key === 'Home') target = tabs[0];
+    else if (e.key === 'End') target = tabs[tabs.length - 1];
+    if (target) { e.preventDefault(); target.focus(); activateTab(target); }
   });
 });
 
 if (S.currentTab !== 'providers') {
   const savedTab = document.querySelector(`.tab[data-tab="${S.currentTab}"]`);
-  if (savedTab) savedTab.click();
+  if (savedTab) activateTab(savedTab);
 }
 
 function stopTimers() {
@@ -81,7 +100,12 @@ document.addEventListener('keydown', e => {
 // ===================== System Clock =====================
 (function initClock() {
   const el = document.getElementById('systemClock');
-  function tick() { el.textContent = new Date().toLocaleTimeString(); }
+  function tick() {
+    const now = new Date();
+    const time = now.toLocaleTimeString();
+    const tz = now.toLocaleTimeString('en-US', { timeZoneName: 'short' }).split(' ').pop();
+    el.textContent = time + ' ' + tz;
+  }
   tick();
   setInterval(tick, 1000);
 })();
@@ -149,6 +173,31 @@ document.addEventListener('click', function(e) {
   if (!e.target.closest('.model-more-menu')) {
     document.querySelectorAll('.more-menu').forEach(m => m.style.display = 'none');
   }
+});
+
+// ===================== Seg-control keyboard navigation =====================
+document.querySelectorAll('.seg-control[role="radiogroup"]').forEach(group => {
+  group.addEventListener('keydown', (e) => {
+    const items = Array.from(group.querySelectorAll('[role="radio"]'));
+    const idx = items.indexOf(e.target);
+    if (idx < 0) return;
+    let target = null;
+    if (e.key === 'ArrowRight') target = items[(idx + 1) % items.length];
+    else if (e.key === 'ArrowLeft') target = items[(idx - 1 + items.length) % items.length];
+    if (target) { e.preventDefault(); target.focus(); target.click(); }
+  });
+});
+
+// ===================== Modal focus trap =====================
+document.querySelectorAll('.modal-overlay, .settings-popup').forEach(overlay => {
+  overlay.addEventListener('keydown', (e) => {
+    if (e.key !== 'Tab') return;
+    const focusable = overlay.querySelectorAll('button, [href], input:not([type="hidden"]), select, textarea, [tabindex]:not([tabindex="-1"])');
+    if (!focusable.length) return;
+    const first = focusable[0], last = focusable[focusable.length - 1];
+    if (e.shiftKey) { if (document.activeElement === first) { e.preventDefault(); last.focus(); } }
+    else { if (document.activeElement === last) { e.preventDefault(); first.focus(); } }
+  });
 });
 
 // ===================== Start =====================

--- a/src/llm_rosetta/gateway/admin/js/models.js
+++ b/src/llm_rosetta/gateway/admin/js/models.js
@@ -6,8 +6,12 @@ import { api, showToast, closeModal, esc, inlineConfirm } from './core.js';
 // ── helpers (module-private) ──
 
 function _activateSegChild(el) {
-  el.parentElement.querySelectorAll(':scope > div').forEach(s => s.classList.remove('active'));
+  el.parentElement.querySelectorAll(':scope > div').forEach(s => {
+    s.classList.remove('active');
+    if (s.hasAttribute('role')) { s.setAttribute('aria-checked', 'false'); s.setAttribute('tabindex', '-1'); }
+  });
   el.classList.add('active');
+  if (el.hasAttribute('role')) { el.setAttribute('aria-checked', 'true'); el.setAttribute('tabindex', '0'); }
 }
 
 function _getModelType(info) {

--- a/src/llm_rosetta/gateway/admin/js/providers.js
+++ b/src/llm_rosetta/gateway/admin/js/providers.js
@@ -304,8 +304,12 @@ async function copyModalKey() {
 // ── Provider filter / view ──────────────────────────────────────────
 
 function _activateSegChild(el) {
-  el.parentElement.querySelectorAll(':scope > div').forEach(s => s.classList.remove('active'));
+  el.parentElement.querySelectorAll(':scope > div').forEach(s => {
+    s.classList.remove('active');
+    if (s.hasAttribute('role')) { s.setAttribute('aria-checked', 'false'); s.setAttribute('tabindex', '-1'); }
+  });
   el.classList.add('active');
+  if (el.hasAttribute('role')) { el.setAttribute('aria-checked', 'true'); el.setAttribute('tabindex', '0'); }
 }
 
 function switchProviderFilter(el, filter) {
@@ -664,7 +668,10 @@ async function loadConfig() {
   try {
     S.configData = await api.get('/admin/api/config');
     S._credentialVisible = S.configData.credential_visible !== false;
-    document.getElementById('configPath').textContent = S.configData.config_path || '';
+    const cpEl = document.getElementById('configPath');
+    const fullPath = S.configData.config_path || '';
+    cpEl.textContent = fullPath.split('/').pop() || fullPath;
+    cpEl.title = fullPath;
     document.getElementById('globalProxy').value = (S.configData.server && S.configData.server.proxy) || '';
     renderProviders();
     window.renderModels();

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -34,6 +34,7 @@ from .auth import (
     rotate_token,
     serve_admin_html,
     serve_admin_static,
+    serve_favicon,
 )
 from .config import (
     bulk_add_models,
@@ -122,10 +123,11 @@ def _guard(tab_id: str, handler: Any) -> Any:
 
 def register_admin_routes(app: Any) -> None:
     """Register all admin panel routes on the httpserver App."""
-    # HTML
+    # HTML + favicon
     app.route("/admin", methods=["GET"])(serve_admin_html)
     app.route("/admin/", methods=["GET"])(serve_admin_html)
     app.route("/admin/static/<path:path>", methods=["GET"])(serve_admin_static)
+    app.route("/favicon.ico", methods=["GET"])(serve_favicon)
     # Admin auth
     app.route("/admin/api/login", methods=["POST"])(admin_login)
     app.route("/admin/api/auth-check", methods=["GET"])(admin_check)

--- a/src/llm_rosetta/gateway/admin/routes/auth.py
+++ b/src/llm_rosetta/gateway/admin/routes/auth.py
@@ -13,6 +13,22 @@ from ..static import load_admin_html, load_static_file
 # Cached HTML — loaded once on first request, per custom_head value.
 _admin_html_cache: dict[str, str] = {}
 
+_FAVICON_SVG = (
+    b"<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>"
+    b"<text y='.9em' font-size='90'>\xf0\x9f\x94\x80</text></svg>"
+)
+
+
+async def serve_favicon(request: Any) -> Response:
+    """Serve an inline SVG favicon (unauthenticated)."""
+    return Response(
+        body=_FAVICON_SVG,
+        status_code=200,
+        content_type="image/svg+xml",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
 # Cached static assets (CSS/JS) — populated on first request per path.
 _static_cache: dict[str, tuple[bytes, str]] = {}
 

--- a/src/llm_rosetta/gateway/auth.py
+++ b/src/llm_rosetta/gateway/auth.py
@@ -31,7 +31,7 @@ api_key_context_var: contextvars.ContextVar[KeyContext | None] = contextvars.Con
 )
 
 # Paths that never require authentication
-_PUBLIC_PATHS = frozenset({"/health"})
+_PUBLIC_PATHS = frozenset({"/health", "/favicon.ico"})
 
 # Route prefix → key extraction strategy
 _ROUTE_EXTRACTORS: list[tuple[str, str]] = [


### PR DESCRIPTION
## Summary

Implements all three Track B issues from the admin UI audit (#557):

- **#562 — Responsive layout**: tab bar overflow scroll on mobile, table-scroll moved to global CSS, content max-width 1400px, provider card grid 280px min for 4-col, settings popup padding reduced on mobile
- **#563 — UI polish**: inline SVG favicon (no more 401/403), styled empty states with icons, centered toast, config path abbreviated (filename only, full path in tooltip), clock timezone appended
- **#561 — Accessibility**: ARIA roles (tablist/tab/tabpanel, radiogroup/radio, dialog), arrow key navigation for tabs and segmented controls, focus trap for modals and settings popup

### Not included

- Loading indicators (#563 item 6) — larger scope, deferred as follow-up
- Toggle `role="switch"` (#561) — existing hidden checkbox pattern is acceptable per issue description
- Provider card action button `aria-label` context (#561) — requires JS render changes, deferred

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (2900 passed)
- [ ] Manual verification at 375px: tab bar scrolls, tables scroll, settings popup padding
- [ ] Manual verification at 1440px: content area uses 1400px, provider grid shows 4 columns
- [ ] Verify favicon loads without console errors
- [ ] Verify empty states render with icons on Dashboard tab
- [ ] Verify toast appears centered
- [ ] Verify config path shows filename only with tooltip
- [ ] Verify clock shows timezone abbreviation
- [ ] Verify tab arrow key navigation works
- [ ] Verify segmented control arrow key navigation works
- [ ] Verify modal focus trap cycles correctly

Closes #562, closes #563, closes #561