### PR TITLE
fix(openai-responses): separate reasoning input lifecycle

### DIFF
--- a/src/llm_rosetta/converters/openai_responses/content_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/content_ops.py
@@ -244,33 +244,42 @@ class OpenAIResponsesContentOps(BaseContentOps):
     # ==================== Reasoning ====================
 
     @staticmethod
-    def ir_reasoning_to_p(ir_reasoning: ReasoningPart, **kwargs: Any) -> dict:
+    def ir_reasoning_to_p(
+        ir_reasoning: ReasoningPart,
+        *,
+        output_item: bool = False,
+        **kwargs: Any,
+    ) -> dict | None:
         """IR ReasoningPart → OpenAI Responses reasoning item.
 
         Args:
             ir_reasoning: IR reasoning part.
+            output_item: Whether to serialize a response output lifecycle item.
 
         Returns:
-            OpenAI Responses reasoning item dict.
+            OpenAI Responses reasoning item, or ``None`` when a request item has
+            no proven Responses-origin identity.
         """
+        metadata = ir_reasoning.get("provider_metadata") or {}
+        item_id = metadata.get("responses_reasoning_id")
+        if not output_item and not item_id:
+            return None
+
         result: dict[str, Any] = {
             "type": "reasoning",
         }
 
-        # Recover the original reasoning item id for round-trip fidelity.
-        metadata = ir_reasoning.get("provider_metadata") or {}
-        item_id = metadata.get("responses_reasoning_id")
         if not item_id:
             response_id = kwargs.get("response_id", "")
             reasoning_index = kwargs.get("reasoning_index", 0)
             item_id = generate_reasoning_id(response_id, reasoning_index)
         result["id"] = item_id
-        result["status"] = "completed"
+        if output_item:
+            result["status"] = "completed"
 
-        # Recover structured summary if available, otherwise use flat content.
-        summary = metadata.get("responses_reasoning_summary")
-        if summary:
-            result["summary"] = summary
+        # Preserve an explicit structured summary, including an empty list.
+        if "responses_reasoning_summary" in metadata:
+            result["summary"] = metadata["responses_reasoning_summary"]
         else:
             content = ir_reasoning.get("reasoning", "")
             # The Responses API uses a summary array, not a flat content field.
@@ -332,7 +341,7 @@ class OpenAIResponsesContentOps(BaseContentOps):
         raw_content = provider_reasoning.get("content")
         if raw_content:
             metadata["responses_reasoning_content"] = raw_content
-            if not reasoning_content:
+            if not reasoning_content and isinstance(raw_content, str):
                 reasoning_content = raw_content
 
         part = ReasoningPart(type="reasoning")

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -453,6 +453,7 @@ class OpenAIResponsesConverter(BaseConverter):
                     provider_response["output"].append(
                         self.content_ops.ir_reasoning_to_p(
                             part,
+                            output_item=True,
                             response_id=ir_response.get("id", ""),
                             reasoning_index=reasoning_index,
                         )

--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -151,8 +151,9 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
                 # Tool results become separate function_call_output items
                 extra_items.append(self.tool_ops.ir_tool_result_to_p(part))
             elif is_reasoning_part(part):
-                # Reasoning becomes a separate reasoning item
-                extra_items.append(self.content_ops.ir_reasoning_to_p(part))
+                reasoning_item = self.content_ops.ir_reasoning_to_p(part)
+                if reasoning_item is not None:
+                    extra_items.append(reasoning_item)
             else:
                 warnings.append(
                     f"Unsupported content part type in {role} message: {part.get('type')}"
@@ -209,17 +210,16 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
                 if pt_meta:
                     content_parts.append(pt_meta)
                     continue
-                # Check if it's reasoning text (legacy format)
+                # Legacy hidden reasoning text has no Responses item provenance.
                 if part.get("reasoning"):
-                    reasoning_items.append(
-                        {"type": "reasoning", "content": part["text"]}
-                    )
-                else:
-                    content_parts.append({"type": "output_text", "text": part["text"]})
+                    continue
+                content_parts.append({"type": "output_text", "text": part["text"]})
             elif is_tool_call_part(part):
                 tool_items.append(self.tool_ops.ir_tool_call_to_p(part))
             elif is_reasoning_part(part):
-                reasoning_items.append(self.content_ops.ir_reasoning_to_p(part))
+                reasoning_item = self.content_ops.ir_reasoning_to_p(part)
+                if reasoning_item is not None:
+                    reasoning_items.append(reasoning_item)
             else:
                 warnings.append(
                     f"Unsupported content part type in assistant message: "

--- a/src/llm_rosetta/converters/openai_responses/message_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/message_ops.py
@@ -210,9 +210,6 @@ class OpenAIResponsesMessageOps(BaseMessageOps):
                 if pt_meta:
                     content_parts.append(pt_meta)
                     continue
-                # Legacy hidden reasoning text has no Responses item provenance.
-                if part.get("reasoning"):
-                    continue
                 content_parts.append({"type": "output_text", "text": part["text"]})
             elif is_tool_call_part(part):
                 tool_items.append(self.tool_ops.ir_tool_call_to_p(part))

--- a/tests/converters/openai_responses/test_content_ops.py
+++ b/tests/converters/openai_responses/test_content_ops.py
@@ -253,17 +253,21 @@ class TestOpenAIResponsesContentOps:
 
     # ==================== Reasoning ====================
 
-    def test_ir_reasoning_to_p(self):
-        """Test IR ReasoningPart → OpenAI Responses reasoning item."""
+    def test_ir_reasoning_to_output_item(self):
+        """Test IR ReasoningPart → OpenAI Responses reasoning output item."""
         ir_reasoning = ReasoningPart(type="reasoning", reasoning="thinking...")
-        result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
+        result = OpenAIResponsesContentOps.ir_reasoning_to_p(
+            ir_reasoning, output_item=True
+        )
         assert result["type"] == "reasoning"
         assert result["summary"] == [{"type": "summary_text", "text": "thinking..."}]
 
-    def test_ir_reasoning_to_p_empty(self):
-        """Test IR ReasoningPart with no reasoning → empty summary."""
+    def test_ir_reasoning_to_output_item_empty(self):
+        """Test IR ReasoningPart with no reasoning → empty output summary."""
         ir_reasoning = cast(ReasoningPart, {"type": "reasoning"})
-        result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
+        result = OpenAIResponsesContentOps.ir_reasoning_to_p(
+            ir_reasoning, output_item=True
+        )
         assert result["type"] == "reasoning"
         assert result["summary"] == []
 
@@ -344,7 +348,9 @@ class TestOpenAIResponsesContentOps:
     def test_reasoning_round_trip(self):
         """Test reasoning round-trip: IR → Provider → IR."""
         original = ReasoningPart(type="reasoning", reasoning="Step by step analysis")
-        provider = OpenAIResponsesContentOps.ir_reasoning_to_p(original)
+        provider = OpenAIResponsesContentOps.ir_reasoning_to_p(
+            original, output_item=True
+        )
         restored = OpenAIResponsesContentOps.p_reasoning_to_ir(provider)
         assert restored is not None
         assert restored["reasoning"] == original["reasoning"]
@@ -454,54 +460,85 @@ class TestOpenAIResponsesContentOps:
         )
 
 
-class TestReasoningIdGeneration:
-    """Tests for reasoning item id and status generation (#407)."""
+class TestReasoningDirection:
+    """Tests for request provenance and response lifecycle fields."""
 
-    def test_generates_id_without_provider_metadata(self):
-        ir_reasoning = ReasoningPart(type="reasoning", reasoning="thinking...")
+    def test_request_without_responses_id_is_not_portable(self):
+        ir_reasoning = ReasoningPart(
+            type="reasoning",
+            reasoning="thinking...",
+            signature="arbitrary-signature",
+        )
         result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
-        assert "id" in result
+        assert result is None
+
+    def test_request_preserves_responses_origin_fields_without_status(self):
+        summary = [{"type": "summary_text", "text": "thinking..."}]
+        ir_reasoning = ReasoningPart(
+            type="reasoning",
+            reasoning="thinking...",
+            signature="real-encrypted-content",
+            provider_metadata={
+                "responses_reasoning_id": "rs_original_123",
+                "responses_reasoning_summary": summary,
+            },
+        )
+        result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
+        assert result is not None
+        assert result["id"] == "rs_original_123"
+        assert result["summary"] == summary
+        assert result["encrypted_content"] == "real-encrypted-content"
+        assert "status" not in result
+
+    def test_output_generates_id_and_status(self):
+        ir_reasoning = ReasoningPart(type="reasoning", reasoning="thinking...")
+        result = OpenAIResponsesContentOps.ir_reasoning_to_p(
+            ir_reasoning, output_item=True
+        )
+        assert result is not None
         assert result["id"].startswith("rs_")
-
-    def test_generates_status(self):
-        ir_reasoning = ReasoningPart(type="reasoning", reasoning="thinking...")
-        result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
         assert result["status"] == "completed"
 
-    def test_preserves_original_id(self):
+    def test_output_preserves_original_id(self):
         ir_reasoning = ReasoningPart(
             type="reasoning",
             reasoning="thinking...",
             provider_metadata={"responses_reasoning_id": "rs_original_123"},
         )
-        result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
+        result = OpenAIResponsesContentOps.ir_reasoning_to_p(
+            ir_reasoning, output_item=True
+        )
+        assert result is not None
         assert result["id"] == "rs_original_123"
         assert result["status"] == "completed"
 
-    def test_deterministic_with_response_id(self):
+    def test_output_id_deterministic_with_response_id(self):
         ir = ReasoningPart(type="reasoning", reasoning="test")
         r1 = OpenAIResponsesContentOps.ir_reasoning_to_p(
-            ir, response_id="resp_abc", reasoning_index=0
+            ir, output_item=True, response_id="resp_abc", reasoning_index=0
         )
         r2 = OpenAIResponsesContentOps.ir_reasoning_to_p(
-            ir, response_id="resp_abc", reasoning_index=0
+            ir, output_item=True, response_id="resp_abc", reasoning_index=0
         )
+        assert r1 is not None and r2 is not None
         assert r1["id"] == r2["id"]
 
-    def test_different_index_different_id(self):
+    def test_output_index_changes_generated_id(self):
         ir = ReasoningPart(type="reasoning", reasoning="test")
         r0 = OpenAIResponsesContentOps.ir_reasoning_to_p(
-            ir, response_id="resp_abc", reasoning_index=0
+            ir, output_item=True, response_id="resp_abc", reasoning_index=0
         )
         r1 = OpenAIResponsesContentOps.ir_reasoning_to_p(
-            ir, response_id="resp_abc", reasoning_index=1
+            ir, output_item=True, response_id="resp_abc", reasoning_index=1
         )
+        assert r0 is not None and r1 is not None
         assert r0["id"] != r1["id"]
 
-    def test_uuid_fallback_without_response_id(self):
+    def test_output_uuid_fallback_without_response_id(self):
         ir = ReasoningPart(type="reasoning", reasoning="test")
-        r1 = OpenAIResponsesContentOps.ir_reasoning_to_p(ir)
-        r2 = OpenAIResponsesContentOps.ir_reasoning_to_p(ir)
+        r1 = OpenAIResponsesContentOps.ir_reasoning_to_p(ir, output_item=True)
+        r2 = OpenAIResponsesContentOps.ir_reasoning_to_p(ir, output_item=True)
+        assert r1 is not None and r2 is not None
         assert r1["id"].startswith("rs_")
         assert r2["id"].startswith("rs_")
         assert r1["id"] != r2["id"]

--- a/tests/converters/openai_responses/test_content_ops.py
+++ b/tests/converters/openai_responses/test_content_ops.py
@@ -349,6 +349,20 @@ class TestOpenAIResponsesContentOps:
         assert result["signature"] == "enc_sig_xyz"
         assert result["provider_metadata"]["responses_reasoning_id"] == "rs_abc123"
 
+    def test_p_reasoning_to_ir_list_content_not_stringified(self):
+        """List content with empty summary stays structured, not stringified."""
+        raw_content = [{"type": "reasoning_text", "text": "raw"}]
+        provider = {
+            "type": "reasoning",
+            "id": "rs_abc",
+            "summary": [],
+            "content": raw_content,
+        }
+        result = OpenAIResponsesContentOps.p_reasoning_to_ir(provider)
+        assert result is not None
+        assert result.get("reasoning", "") == ""
+        assert result["provider_metadata"]["responses_reasoning_content"] == raw_content
+
     def test_reasoning_round_trip(self):
         """Test reasoning round-trip: IR → Provider → IR."""
         original = ReasoningPart(type="reasoning", reasoning="Step by step analysis")

--- a/tests/converters/openai_responses/test_content_ops.py
+++ b/tests/converters/openai_responses/test_content_ops.py
@@ -259,6 +259,7 @@ class TestOpenAIResponsesContentOps:
         result = OpenAIResponsesContentOps.ir_reasoning_to_p(
             ir_reasoning, output_item=True
         )
+        assert result is not None
         assert result["type"] == "reasoning"
         assert result["summary"] == [{"type": "summary_text", "text": "thinking..."}]
 
@@ -268,6 +269,7 @@ class TestOpenAIResponsesContentOps:
         result = OpenAIResponsesContentOps.ir_reasoning_to_p(
             ir_reasoning, output_item=True
         )
+        assert result is not None
         assert result["type"] == "reasoning"
         assert result["summary"] == []
 
@@ -279,6 +281,7 @@ class TestOpenAIResponsesContentOps:
             provider_metadata={"responses_reasoning_id": "rs_abc123"},
         )
         result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
+        assert result is not None
         assert result["type"] == "reasoning"
         assert result["id"] == "rs_abc123"
 
@@ -297,6 +300,7 @@ class TestOpenAIResponsesContentOps:
             },
         )
         result = OpenAIResponsesContentOps.ir_reasoning_to_p(ir_reasoning)
+        assert result is not None
         assert result["summary"] == original_summary
 
     def test_p_reasoning_to_ir_with_content(self):
@@ -365,6 +369,7 @@ class TestOpenAIResponsesContentOps:
         ir = OpenAIResponsesContentOps.p_reasoning_to_ir(provider)
         assert ir is not None
         restored = OpenAIResponsesContentOps.ir_reasoning_to_p(ir)
+        assert restored is not None
         assert restored["id"] == "rs_abc123"
         assert restored["summary"] == provider["summary"]
 

--- a/tests/converters/openai_responses/test_converter.py
+++ b/tests/converters/openai_responses/test_converter.py
@@ -728,6 +728,9 @@ class TestOpenAIResponsesConverter:
         types = [item["type"] for item in output]
         assert "reasoning" in types
         assert "message" in types
+        reasoning = next(item for item in output if item["type"] == "reasoning")
+        assert reasoning["id"].startswith("rs_")
+        assert reasoning["status"] == "completed"
 
     # ==================== messages_to_provider / messages_from_provider ====================
 

--- a/tests/converters/openai_responses/test_message_ops.py
+++ b/tests/converters/openai_responses/test_message_ops.py
@@ -192,8 +192,8 @@ class TestOpenAIResponsesMessageOps:
         assert result[0]["content"][0]["type"] == "output_text"
         assert result[1]["type"] == "function_call"
 
-    def test_assistant_reasoning_to_p(self):
-        """Test assistant with reasoning → reasoning item."""
+    def test_assistant_unproven_reasoning_is_not_request_portable(self):
+        """Assistant reasoning without Responses provenance is skipped."""
         messages = cast(
             list[Message],
             [
@@ -207,10 +207,12 @@ class TestOpenAIResponsesMessageOps:
             ],
         )
         result, warnings = self.message_ops.ir_messages_to_p(messages)
-        # Reasoning items come first, then message
-        assert len(result) == 2
-        assert result[0]["type"] == "reasoning"
-        assert result[1]["type"] == "message"
+        assert len(result) == 1
+        assert result[0]["type"] == "message"
+        assert result[0]["content"] == [
+            {"type": "output_text", "text": "The answer is 42"}
+        ]
+        assert warnings == []
 
     def test_tool_message_to_p(self):
         """Test IR tool message → function_call_output items."""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -510,6 +510,140 @@ class TestConversionPipeline:
         assert "messages" in target
         assert target["model"] == "gpt-4"
 
+    def test_chat_reasoning_request_omits_unproven_native_item(self):
+        """Chat reasoning is not portable as a native Responses input item."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        pipeline = ConversionPipeline("openai_chat", "openai_responses")
+        target = pipeline.convert_request(
+            {
+                "model": "gpt-5",
+                "messages": [
+                    {"role": "user", "content": "Question"},
+                    {
+                        "role": "assistant",
+                        "content": "Answer",
+                        "reasoning_content": "Thinking",
+                    },
+                    {"role": "user", "content": "Follow-up"},
+                ],
+            }
+        )
+        assert [item["type"] for item in target["input"]] == [
+            "message",
+            "message",
+            "message",
+        ]
+        assert [item["role"] for item in target["input"]] == [
+            "user",
+            "assistant",
+            "user",
+        ]
+        assistant = target["input"][1]
+        assert assistant["content"] == [{"type": "output_text", "text": "Answer"}]
+        visible_text = [
+            part["text"]
+            for item in target["input"]
+            for part in item.get("content", [])
+            if "text" in part
+        ]
+        assert "Thinking" not in visible_text
+        assert not any(
+            str(item.get("id", "")).startswith("rs_") for item in target["input"]
+        )
+        assert "store" not in target
+
+    def test_chat_function_call_request_keeps_completed_status(self):
+        """Reasoning status handling does not alter function-call request items."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        pipeline = ConversionPipeline("openai_chat", "openai_responses")
+        target = pipeline.convert_request(
+            {
+                "model": "gpt-5",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_status",
+                                "type": "function",
+                                "function": {"name": "lookup", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_status",
+                        "content": "result",
+                    },
+                ],
+            }
+        )
+        function_call = next(
+            item for item in target["input"] if item["type"] == "function_call"
+        )
+        assert function_call["status"] == "completed"
+
+    def test_responses_reasoning_request_preserves_fields_without_status(self):
+        """Request conversion preserves reasoning metadata except output-only status."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        summary = [{"type": "summary_text", "text": "Thinking"}]
+        pipeline = ConversionPipeline("openai_responses", "openai_responses")
+        target = pipeline.convert_request(
+            {
+                "model": "gpt-5",
+                "input": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_original",
+                        "summary": summary,
+                        "encrypted_content": "opaque-signature",
+                        "status": "completed",
+                    }
+                ],
+            }
+        )
+        assert [item["type"] for item in target["input"]] == ["reasoning"]
+        reasoning = target["input"][0]
+        assert reasoning["id"] == "rs_original"
+        assert reasoning["summary"] == summary
+        assert reasoning["encrypted_content"] == "opaque-signature"
+        assert "status" not in reasoning
+
+    def test_responses_reasoning_request_preserves_explicit_empty_summary(self):
+        """Responses provenance fields survive request round-trip exactly."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        raw_content = [{"type": "reasoning_text", "text": "Raw reasoning"}]
+        pipeline = ConversionPipeline("openai_responses", "openai_responses")
+        target = pipeline.convert_request(
+            {
+                "model": "gpt-5",
+                "input": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_empty_summary",
+                        "summary": [],
+                        "content": raw_content,
+                        "encrypted_content": "opaque-signature",
+                        "status": "completed",
+                    }
+                ],
+            }
+        )
+        assert target["input"] == [
+            {
+                "type": "reasoning",
+                "id": "rs_empty_summary",
+                "summary": [],
+                "content": raw_content,
+                "encrypted_content": "opaque-signature",
+            }
+        ]
+
     def test_chat_tool_list_content_to_responses(self):
         """Chat tool list content converts to Responses input blocks."""
         from llm_rosetta.pipeline import ConversionPipeline

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -644,6 +644,81 @@ class TestConversionPipeline:
             }
         ]
 
+    def test_anthropic_reasoning_request_omits_unproven_native_item(self):
+        """Anthropic thinking is not portable as a native Responses input item."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        pipeline = ConversionPipeline("anthropic", "openai_responses")
+        target = pipeline.convert_request(
+            {
+                "model": "claude-sonnet-4-20250514",
+                "max_tokens": 1024,
+                "messages": [
+                    {"role": "user", "content": "Question"},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "thinking",
+                                "thinking": "Let me reason about this",
+                                "signature": "sig_abc",
+                            },
+                            {"type": "text", "text": "Answer"},
+                        ],
+                    },
+                    {"role": "user", "content": "Follow-up"},
+                ],
+            }
+        )
+        assert [item["type"] for item in target["input"]] == [
+            "message",
+            "message",
+            "message",
+        ]
+        assistant = target["input"][1]
+        assert assistant["content"] == [{"type": "output_text", "text": "Answer"}]
+        assert not any(
+            str(item.get("id", "")).startswith("rs_") for item in target["input"]
+        )
+
+    def test_google_reasoning_request_omits_unproven_native_item(self):
+        """Google thought part is not portable as a native Responses input item."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        pipeline = ConversionPipeline("google", "openai_responses")
+        target = pipeline.convert_request(
+            {
+                "model": "gemini-2.5-flash",
+                "contents": [
+                    {
+                        "role": "user",
+                        "parts": [{"text": "Question"}],
+                    },
+                    {
+                        "role": "model",
+                        "parts": [
+                            {"thought": True, "text": "Internal reasoning"},
+                            {"text": "Answer"},
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "parts": [{"text": "Follow-up"}],
+                    },
+                ],
+            }
+        )
+        assert [item["type"] for item in target["input"]] == [
+            "message",
+            "message",
+            "message",
+        ]
+        assistant = target["input"][1]
+        assert assistant["content"] == [{"type": "output_text", "text": "Answer"}]
+        assert not any(
+            str(item.get("id", "")).startswith("rs_") for item in target["input"]
+        )
+
     def test_chat_tool_list_content_to_responses(self):
         """Chat tool list content converts to Responses input blocks."""
         from llm_rosetta.pipeline import ConversionPipeline


### PR DESCRIPTION
## Summary

- Separate Responses request reasoning from response output lifecycle with one explicit direction parameter.
- Omit native request reasoning when IR has no proven Responses-origin identity instead of synthesizing an `rs_...` ID.
- Preserve proven Responses-origin request identity, structured summary including `[]`, raw content, and encrypted content while stripping output-only status.
- Keep response output ID generation/preservation and `status: "completed"` unchanged.

## Problem

`OpenAIResponsesContentOps.ir_reasoning_to_p` serves both request `input` and response `output`. The output lifecycle behavior added through #407/#418/#419 generated a reasoning ID and `status: "completed"` unconditionally, so request serialization inherited server-output rules.

That creates three manifestations of the same direction-coupling bug:

1. strict Responses targets reject output-only status on request reasoning;
2. Chat/other IR reasoning becomes a native input item with a synthetic server-owned `rs_...` identity, which can produce `404 Item ... not found` when `store=false`;
3. proven Responses-origin round-trips can replace an explicit `summary=[]` with text synthesized from a stringified raw content list.

As documented in #403, output items require lifecycle identity, while input identity is optional and real reasoning identity/encryption must be preserved together. Enabling storage would mask one symptom but would not repair the converter contract.

## Design

The helper now accepts `output_item: bool = False`:

- request mode returns no native item unless `provider_metadata.responses_reasoning_id` proves Responses origin;
- proven request items preserve ID, summary key presence/value, raw content, and encrypted content without status;
- output mode preserves a real ID or generates one and includes completed lifecycle status.

`OpenAIResponsesMessageOps` filters only non-portable request reasoning. It does not expose hidden reasoning as assistant text and does not introduce a provider/model special case, `store` toggle, capability system, or warning framework.

Streaming identity/encrypted-content work and same-format item ordering are outside this PR. Their code paths are unchanged.

## Validation

Fresh validation was run after applying the seven-file patch to canonical `master` `f735e35dab25`.

- Sensitivity/RED: the 9-test focused set against unpatched current master failed 6 and passed 3 at the intended assertions.
- Focused direction/provenance tests: 9 passed.
- Changed converter/pipeline modules: 189 passed.
- Responses converter + pipeline suite: 446 passed.
- `make test`: 2905 passed, 4 skipped, 15 warnings.
- `pre-commit run --all-files`: passed (`ruff`, `ruff format`, `ty`, `complexipy`).
- `git diff --check`: passed.

The first CI run exposed missing static narrowing for the helper's new optional return type in five test assertions. The follow-up commit adds only `is not None` assertions; all counts above were rerun on the final head.

No endpoint, provider, model, or credential-backed integration request was made.

Closes #568

## AI assistance

AI tools materially assisted with diagnosis, implementation, test development, and PR drafting.
