### PR TITLE
refactor(admin-ui): typography scale, button consistency, elevation normalization

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -350,7 +350,7 @@
       <input type="text" id="clearDumpsInput" oninput="onClearDumpsInput()" placeholder="Type CLEAR" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);color:var(--text);font-size:14px;font-family:var(--mono)">
       <div class="modal-actions">
         <button class="btn" onclick="closeModal('clearDumpsModal')" data-i18n="btn.cancel">Cancel</button>
-        <button class="btn btn-danger" id="clearDumpsBtn" onclick="confirmClearDumps()" disabled style="opacity:0.4;cursor:not-allowed" data-i18n="btn.clearAll">Clear All</button>
+        <button class="btn btn-danger" id="clearDumpsBtn" onclick="confirmClearDumps()" disabled data-i18n="btn.clearAll">Clear All</button>
       </div>
     </div>
   </div>
@@ -605,7 +605,7 @@
     </div>
     <!-- Version & Links -->
     <div style="text-align:center;padding:4px 0 2px">
-      <div id="brandFooterName" style="font-size:15px;font-weight:600;margin-bottom:2px">llm-rosetta</div>
+      <div id="brandFooterName" style="font-size:14px;font-weight:600;margin-bottom:2px">llm-rosetta</div>
       <div id="settingsVersion" style="font-size:11px;color:var(--text-dim);margin-bottom:8px"></div>
       <div id="brandFooterLinks" style="display:flex;justify-content:center;gap:8px;flex-wrap:wrap">
         <a href="https://github.com/Oaklight/llm-rosetta" target="_blank" rel="noopener" class="about-link"><svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M12 .3a12 12 0 0 0-3.8 23.38c.6.12.83-.26.83-.57L9 20.86c-3.37.73-4.08-1.63-4.08-1.63-.55-1.4-1.34-1.77-1.34-1.77-1.1-.75.08-.73.08-.73 1.21.08 1.85 1.24 1.85 1.24 1.08 1.85 2.83 1.32 3.52 1 .1-.78.42-1.32.76-1.62-2.69-.3-5.52-1.34-5.52-5.98 0-1.32.47-2.4 1.24-3.24-.12-.3-.54-1.54.12-3.2 0 0 1.01-.33 3.3 1.24a11.5 11.5 0 0 1 6.02 0c2.3-1.57 3.3-1.24 3.3-1.24.66 1.66.24 2.9.12 3.2a4.65 4.65 0 0 1 1.24 3.24c0 4.65-2.83 5.67-5.53 5.97.43.37.82 1.1.82 2.22l-.01 3.29c0 .31.22.69.83.57A12 12 0 0 0 12 .3"/></svg> GitHub</a>
@@ -920,7 +920,7 @@ Rules:..."</code><br><br>Some upstream providers don't support content arrays in
     <div class="modal-actions">
       <button class="btn" onclick="closeModal('cleanupConfirmModal')" data-i18n="btn.cancel">Cancel</button>
       <button class="btn" id="cleanupConfirmBtn" onclick="onCleanupConfirmClick()" disabled
-        style="background:var(--border);color:var(--text-dim);cursor:not-allowed" data-i18n="btn.cleanup">Cleanup</button>
+        data-i18n="btn.cleanup">Cleanup</button>
     </div>
   </div>
 </div>
@@ -938,7 +938,7 @@ Rules:..."</code><br><br>Some upstream providers don't support content arrays in
     <div class="modal-actions">
       <button class="btn" onclick="closeModal('deleteConfirmModal')" data-i18n="btn.cancel">Cancel</button>
       <button class="btn" id="deleteConfirmBtn" onclick="onDeleteConfirmClick()" disabled
-        style="background:var(--border);color:var(--text-dim);cursor:not-allowed" data-i18n="btn.delete">Delete</button>
+        data-i18n="btn.delete">Delete</button>
     </div>
   </div>
 </div>

--- a/src/llm_rosetta/gateway/admin/css/base.css
+++ b/src/llm_rosetta/gateway/admin/css/base.css
@@ -141,7 +141,7 @@ a { color: var(--accent); text-decoration: none; }
 .settings-popup-panel::-webkit-scrollbar-track { background: transparent; }
 .settings-popup-panel::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
 .settings-popup-panel h3 {
-  margin-bottom: 20px; font-size: 17px; font-weight: 600; letter-spacing: -0.01em;
+  margin-bottom: 20px; font-size: 16px; font-weight: 600; letter-spacing: -0.01em;
   display: flex; align-items: center; gap: 8px;
 }
 .settings-popup-panel h3::before {
@@ -151,10 +151,10 @@ a { color: var(--accent); text-decoration: none; }
 .settings-section {
   background: var(--bg); border: 1px solid var(--border);
   border-radius: 8px; padding: 16px 18px; margin-bottom: 10px;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
-  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  
+  transition: border-color 0.2s ease;
 }
-.settings-section:hover { box-shadow: 0 4px 16px rgba(0,0,0,0.08); }
+.settings-section:hover { border-color: var(--text-dim); }
 .settings-section-title {
   font-size: 11px; font-weight: 700; color: var(--text-dim);
   text-transform: uppercase; letter-spacing: 0.6px; margin-bottom: 10px;

--- a/src/llm_rosetta/gateway/admin/css/components.css
+++ b/src/llm_rosetta/gateway/admin/css/components.css
@@ -12,7 +12,7 @@
 .btn-danger-fill { background: var(--red); color: #fff; border-color: var(--red); }
 .btn-danger-fill:hover { background: color-mix(in srgb, var(--red) 85%, #000); border-color: color-mix(in srgb, var(--red) 85%, #000); color: #fff; }
 .btn-sm { padding: 4px 10px; font-size: 12px; }
-.btn-disabled, .btn[disabled] { background: var(--border); color: var(--text-dim); cursor: not-allowed; border-color: var(--border); opacity: 0.6; pointer-events: none; }
+.btn-disabled, .btn[disabled] { background: var(--border); color: var(--text-dim); cursor: not-allowed; border-color: var(--border); opacity: 0.6; }
 
 /* Tables */
 table { width: 100%; border-collapse: collapse; }
@@ -166,10 +166,10 @@ code.copyable:hover { background: var(--bg-hover); }
 .form-group { margin-bottom: 14px; }
 .form-group label { display: block; font-size: 12px; color: var(--text-dim); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
 .form-group input, .form-group select {
-.form-group input { font-family: var(--mono); }
   width: 100%; padding: 8px 12px; background: var(--bg); border: 1px solid var(--border);
   border-radius: var(--radius); color: var(--text); font-size: 14px;
 }
+.form-group input { font-family: var(--mono); }
 .form-group input:focus, .form-group select:focus, .form-group textarea:focus { outline: none; border-color: var(--accent); }
 /* Multi-key entry list (auto-switches from single input when comma-separated keys detected) */
 .multi-key-list { display:flex;flex-direction:column;gap:4px;margin-top:4px; }

--- a/src/llm_rosetta/gateway/admin/css/components.css
+++ b/src/llm_rosetta/gateway/admin/css/components.css
@@ -12,6 +12,7 @@
 .btn-danger-fill { background: var(--red); color: #fff; border-color: var(--red); }
 .btn-danger-fill:hover { background: color-mix(in srgb, var(--red) 85%, #000); border-color: color-mix(in srgb, var(--red) 85%, #000); color: #fff; }
 .btn-sm { padding: 4px 10px; font-size: 12px; }
+.btn-disabled, .btn[disabled] { background: var(--border); color: var(--text-dim); cursor: not-allowed; border-color: var(--border); opacity: 0.6; pointer-events: none; }
 
 /* Tables */
 table { width: 100%; border-collapse: collapse; }
@@ -32,7 +33,7 @@ tr:hover td { background: var(--bg-hover); }
   background: var(--bg-card); border: 1px solid var(--border);
   border-radius: var(--radius); padding: 16px;
 }
-.provider-card .name { font-size: 15px; font-weight: 600; margin-bottom: 8px; }
+.provider-card .name { font-size: 14px; font-weight: 600; margin-bottom: 8px; }
 .provider-card .field { font-size: 12px; color: var(--text-dim); margin-bottom: 4px; }
 .provider-card .field code {
   font-family: var(--mono); color: var(--text); background: var(--bg);
@@ -165,8 +166,9 @@ code.copyable:hover { background: var(--bg-hover); }
 .form-group { margin-bottom: 14px; }
 .form-group label { display: block; font-size: 12px; color: var(--text-dim); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
 .form-group input, .form-group select {
+.form-group input { font-family: var(--mono); }
   width: 100%; padding: 8px 12px; background: var(--bg); border: 1px solid var(--border);
-  border-radius: var(--radius); color: var(--text); font-size: 14px; font-family: var(--mono);
+  border-radius: var(--radius); color: var(--text); font-size: 14px;
 }
 .form-group input:focus, .form-group select:focus, .form-group textarea:focus { outline: none; border-color: var(--accent); }
 /* Multi-key entry list (auto-switches from single input when comma-separated keys detected) */
@@ -401,7 +403,7 @@ th.sortable.desc::after { content:'\25BC';opacity:.8; }
   z-index: 50;
   padding: 4px 12px;
   font-size: 11px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--mono);
   color: var(--text-dim);
   background: var(--bg-card);
   border-top: 1px solid var(--border);


### PR DESCRIPTION
## Summary

- **Typography**: consolidate to 7 discrete sizes — 17px→16px (settings h3), 15px→14px (card name, branding)
- **Buttons**: extract `.btn-disabled` / `.btn[disabled]` class, remove all inline disabled styles from HTML
- **Elevation**: remove box-shadow from `.settings-section` (was only card with shadow), normalize to border-hover pattern
- **Form fonts**: inputs keep `var(--mono)`, selects use default sans; replace hardcoded `ui-monospace` stack with `var(--mono)`

Closes #560
Part of #557

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (2900 passed)
- [x] No visual regressions expected — changes are subtle size/style normalization