### PR TITLE
fix(openai-responses): preserve completed reasoning state

### DIFF
--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -778,7 +778,7 @@ class OpenAIResponsesConverter(BaseConverter):
             isinstance(context, OpenAIResponsesStreamContext)
             and context._reasoning_item_id
         ):
-            cast(dict[str, Any], event)["provider_metadata"] = {
+            event["provider_metadata"] = {
                 "responses_reasoning_id": context._reasoning_item_id,
             }
         events.append(event)
@@ -925,10 +925,10 @@ class OpenAIResponsesConverter(BaseConverter):
                 event = ReasoningDeltaEvent(
                     type="reasoning_delta",
                     reasoning="",
-                    signature=str(encrypted_content),
+                    encrypted_content=str(encrypted_content),
                 )
                 if item_id:
-                    cast(dict[str, Any], event)["provider_metadata"] = {
+                    event["provider_metadata"] = {
                         "responses_reasoning_id": item_id,
                     }
                 events.append(event)
@@ -1380,7 +1380,7 @@ class OpenAIResponsesConverter(BaseConverter):
     ) -> list[dict[str, Any]]:
         results: list[dict[str, Any]] = []
         ctx = context if isinstance(context, OpenAIResponsesStreamContext) else None
-        provider_metadata = cast(dict[str, Any], event).get("provider_metadata") or {}
+        provider_metadata = event.get("provider_metadata") or {}
         source_item_id = provider_metadata.get("responses_reasoning_id", "")
         if not isinstance(source_item_id, str):
             source_item_id = ""
@@ -1415,9 +1415,9 @@ class OpenAIResponsesConverter(BaseConverter):
                 }
             )
 
-        signature = event.get("signature", "")
-        if ctx is not None and source_item_id and signature:
-            ctx._reasoning_encrypted_content = signature
+        enc = event.get("encrypted_content", "")
+        if ctx is not None and source_item_id and enc:
+            ctx._reasoning_encrypted_content = enc
             if not event["reasoning"]:
                 return results
 

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -834,6 +834,8 @@ class OpenAIResponsesConverter(BaseConverter):
             elif item_type == "reasoning" and isinstance(
                 context, OpenAIResponsesStreamContext
             ):
+                # Capture early so deltas can carry the source ID;
+                # done event re-confirms authoritatively.
                 item_id = item.get("id", "")
                 if item_id:
                     context._reasoning_item_id = item_id
@@ -922,6 +924,8 @@ class OpenAIResponsesConverter(BaseConverter):
             encrypted_content = item.get("encrypted_content")
             if encrypted_content:
                 context._reasoning_encrypted_content = str(encrypted_content)
+                # Zero-text delta carries encrypted_content through IR;
+                # suppressed on the outbound side when reasoning is empty.
                 event = ReasoningDeltaEvent(
                     type="reasoning_delta",
                     reasoning="",

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -770,12 +770,18 @@ class OpenAIResponsesConverter(BaseConverter):
         context: StreamContext | None,
         events: list[IRStreamEvent],
     ) -> None:
-        events.append(
-            ReasoningDeltaEvent(
-                type="reasoning_delta",
-                reasoning=chunk.get("delta", ""),
-            )
+        event = ReasoningDeltaEvent(
+            type="reasoning_delta",
+            reasoning=chunk.get("delta", ""),
         )
+        if (
+            isinstance(context, OpenAIResponsesStreamContext)
+            and context._reasoning_item_id
+        ):
+            cast(dict[str, Any], event)["provider_metadata"] = {
+                "responses_reasoning_id": context._reasoning_item_id,
+            }
+        events.append(event)
 
     def _handle_p_refusal_delta_to_ir(
         self,
@@ -824,6 +830,13 @@ class OpenAIResponsesConverter(BaseConverter):
                 if output_index is not None:
                     start_event_tc["tool_call_index"] = output_index
                 events.append(start_event_tc)
+
+            elif item_type == "reasoning" and isinstance(
+                context, OpenAIResponsesStreamContext
+            ):
+                item_id = item.get("id", "")
+                if item_id:
+                    context._reasoning_item_id = item_id
 
             elif item_type == "message":
                 # Message-level output item — no IR event needed.
@@ -900,6 +913,25 @@ class OpenAIResponsesConverter(BaseConverter):
                 call_id = item.get("call_id", "")
                 if call_id:
                     context.set_tool_call_args(call_id, item.get("input", ""))
+        elif item_type == "reasoning" and isinstance(
+            context, OpenAIResponsesStreamContext
+        ):
+            item_id = item.get("id", "")
+            if item_id:
+                context._reasoning_item_id = item_id
+            encrypted_content = item.get("encrypted_content")
+            if encrypted_content:
+                context._reasoning_encrypted_content = str(encrypted_content)
+                event = ReasoningDeltaEvent(
+                    type="reasoning_delta",
+                    reasoning="",
+                    signature=str(encrypted_content),
+                )
+                if item_id:
+                    cast(dict[str, Any], event)["provider_metadata"] = {
+                        "responses_reasoning_id": item_id,
+                    }
+                events.append(event)
 
     def _handle_p_function_call_args_delta_to_ir(
         self,
@@ -1348,11 +1380,17 @@ class OpenAIResponsesConverter(BaseConverter):
     ) -> list[dict[str, Any]]:
         results: list[dict[str, Any]] = []
         ctx = context if isinstance(context, OpenAIResponsesStreamContext) else None
+        provider_metadata = cast(dict[str, Any], event).get("provider_metadata") or {}
+        source_item_id = provider_metadata.get("responses_reasoning_id", "")
+        if not isinstance(source_item_id, str):
+            source_item_id = ""
 
         if ctx is not None and ctx._reasoning_item_id == "":
             output_index = ctx.next_output_index()
             ctx._reasoning_output_index = output_index
-            item_id = generate_reasoning_id(ctx.response_id, output_index)
+            item_id = source_item_id or generate_reasoning_id(
+                ctx.response_id, output_index
+            )
             ctx._reasoning_item_id = item_id
 
             results.append(
@@ -1376,6 +1414,12 @@ class OpenAIResponsesConverter(BaseConverter):
                     "part": {"type": "summary_text", "text": ""},
                 }
             )
+
+        signature = event.get("signature", "")
+        if ctx is not None and source_item_id and signature:
+            ctx._reasoning_encrypted_content = signature
+            if not event["reasoning"]:
+                return results
 
         reasoning_text = event["reasoning"]
         if ctx is not None:
@@ -1582,19 +1626,22 @@ class OpenAIResponsesConverter(BaseConverter):
 
         # Reasoning item comes first in output array
         if context._reasoning_item_id:
-            output.append(
-                {
-                    "id": context._reasoning_item_id,
-                    "type": "reasoning",
-                    "summary": [
-                        {
-                            "type": "summary_text",
-                            "text": context._reasoning_accumulated_text,
-                        }
-                    ],
-                    "status": "completed",
-                }
-            )
+            reasoning_item: dict[str, Any] = {
+                "id": context._reasoning_item_id,
+                "type": "reasoning",
+                "summary": [
+                    {
+                        "type": "summary_text",
+                        "text": context._reasoning_accumulated_text,
+                    }
+                ],
+                "status": "completed",
+            }
+            if context._reasoning_encrypted_content:
+                reasoning_item["encrypted_content"] = (
+                    context._reasoning_encrypted_content
+                )
+            output.append(reasoning_item)
 
         accumulated = context.accumulated_text
         if accumulated:
@@ -1715,16 +1762,19 @@ class OpenAIResponsesConverter(BaseConverter):
                 "part": {"type": "summary_text", "text": accumulated},
             }
         )
+        reasoning_item: dict[str, Any] = {
+            "id": item_id,
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": accumulated}],
+            "status": "completed",
+        }
+        if context._reasoning_encrypted_content:
+            reasoning_item["encrypted_content"] = context._reasoning_encrypted_content
         results.append(
             {
                 "type": ResponsesEventType.OUTPUT_ITEM_DONE,
                 "output_index": output_index,
-                "item": {
-                    "id": item_id,
-                    "type": "reasoning",
-                    "summary": [{"type": "summary_text", "text": accumulated}],
-                    "status": "completed",
-                },
+                "item": reasoning_item,
             }
         )
 

--- a/src/llm_rosetta/converters/openai_responses/stream_context.py
+++ b/src/llm_rosetta/converters/openai_responses/stream_context.py
@@ -49,6 +49,7 @@ class OpenAIResponsesStreamContext(StreamContext):
     _reasoning_item_id: str = ""
     _reasoning_output_index: int = -1
     _reasoning_accumulated_text: str = ""
+    _reasoning_encrypted_content: str = ""
 
     def next_output_index(self) -> int:
         """Allocate the next output_index.

--- a/src/llm_rosetta/types/ir/stream.py
+++ b/src/llm_rosetta/types/ir/stream.py
@@ -120,8 +120,10 @@ class ReasoningDeltaEvent(TypedDict):
     type: Required[Literal["reasoning_delta"]]
     reasoning: Required[str]  # The reasoning text delta
     signature: NotRequired[str]  # Anthropic thinking signature delta
+    encrypted_content: NotRequired[str]  # Responses reasoning encrypted state
     block_index: NotRequired[int]  # Provider content block index (e.g. Anthropic)
     choice_index: NotRequired[int]
+    provider_metadata: NotRequired[dict[str, Any]]
 
 
 class RefusalDeltaEvent(TypedDict):

--- a/tests/converters/openai_responses/test_stream.py
+++ b/tests/converters/openai_responses/test_stream.py
@@ -9,6 +9,7 @@ from llm_rosetta.converters.openai_responses import OpenAIResponsesConverter
 from llm_rosetta.converters.openai_responses.stream_context import (
     OpenAIResponsesStreamContext,
 )
+from llm_rosetta.pipeline import ConversionPipeline
 from llm_rosetta.types.ir.stream import (
     ContentBlockEndEvent,
     ContentBlockStartEvent,
@@ -597,6 +598,164 @@ class TestStreamRoundTrip:
         )
         assert restored["item_id"] == "call_abc"
         assert restored["delta"] == '{"q": "test"}'
+
+
+class TestForcedResponsesStreamPipeline:
+    """Forced Responses-to-Responses streaming through the public pipeline."""
+
+    @staticmethod
+    def _reasoning_chunks(
+        item_id: str, text: str, encrypted_content: str | None
+    ) -> list[dict[str, Any]]:
+        final_item = {
+            "id": item_id,
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": text}],
+            "status": "completed",
+        }
+        if encrypted_content is not None:
+            final_item["encrypted_content"] = encrypted_content
+        return [
+            {
+                "type": "response.created",
+                "response": {
+                    "id": "resp_source",
+                    "model": "gpt-test",
+                    "created_at": 1_700_000_000,
+                    "status": "in_progress",
+                    "output": [],
+                },
+            },
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {
+                    "id": item_id,
+                    "type": "reasoning",
+                    "summary": [],
+                    "status": "in_progress",
+                },
+            },
+            {
+                "type": "response.reasoning_summary_part.added",
+                "item_id": item_id,
+                "output_index": 0,
+                "summary_index": 0,
+                "part": {"type": "summary_text", "text": ""},
+            },
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "item_id": item_id,
+                "output_index": 0,
+                "summary_index": 0,
+                "delta": text,
+            },
+            {
+                "type": "response.reasoning_summary_text.done",
+                "item_id": item_id,
+                "output_index": 0,
+                "summary_index": 0,
+                "text": text,
+            },
+            {
+                "type": "response.reasoning_summary_part.done",
+                "item_id": item_id,
+                "output_index": 0,
+                "summary_index": 0,
+                "part": {"type": "summary_text", "text": text},
+            },
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": final_item,
+            },
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_source",
+                    "model": "gpt-test",
+                    "created_at": 1_700_000_000,
+                    "status": "completed",
+                    "output": [final_item],
+                },
+            },
+        ]
+
+    @staticmethod
+    def _run(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        pipeline = ConversionPipeline(
+            "openai_responses", "openai_responses", force_conversion=True
+        )
+        pipeline.convert_request(
+            {"model": "gpt-test", "input": "hello", "stream": True}
+        )
+        processor = pipeline.create_stream_processor()
+        return [event for chunk in chunks for event in processor.process_chunk(chunk)]
+
+    @staticmethod
+    def _reasoning_projection(events: list[dict[str, Any]]) -> dict[str, Any]:
+        added = next(
+            event
+            for event in events
+            if event["type"] == "response.output_item.added"
+            and event["item"]["type"] == "reasoning"
+        )
+        delta = next(
+            event
+            for event in events
+            if event["type"] == "response.reasoning_summary_text.delta"
+        )
+        done = next(
+            event
+            for event in events
+            if event["type"] == "response.output_item.done"
+            and event["item"]["type"] == "reasoning"
+        )
+        completed = next(
+            event for event in events if event["type"] == "response.completed"
+        )
+        completed_reasoning = next(
+            item
+            for item in completed["response"]["output"]
+            if item["type"] == "reasoning"
+        )
+        return {
+            "added_id": added["item"]["id"],
+            "delta_id": delta["item_id"],
+            "done_id": done["item"]["id"],
+            "done_blob": done["item"].get("encrypted_content"),
+            "completed_id": completed_reasoning["id"],
+            "completed_blob": completed_reasoning.get("encrypted_content"),
+        }
+
+    def test_reasoning_done_preserves_source_id_and_encrypted_content(self):
+        """The completed reasoning item is authoritative for its ID/blob pair."""
+        events = self._run(self._reasoning_chunks("rs_real", "step 1", "enc_final"))
+
+        assert self._reasoning_projection(events) == {
+            "added_id": "rs_real",
+            "delta_id": "rs_real",
+            "done_id": "rs_real",
+            "done_blob": "enc_final",
+            "completed_id": "rs_real",
+            "completed_blob": "enc_final",
+        }
+
+    def test_reasoning_without_encrypted_content_remains_valid(self):
+        """A valid no-blob stream stays consistent and gains no fabricated blob."""
+        events = self._run(self._reasoning_chunks("rs_plain", "plain", None))
+        observed = self._reasoning_projection(events)
+        item_ids = {
+            observed["added_id"],
+            observed["delta_id"],
+            observed["done_id"],
+            observed["completed_id"],
+        }
+
+        assert len(item_ids) == 1
+        assert next(iter(item_ids)).startswith("rs_")
+        assert observed["done_blob"] is None
+        assert observed["completed_blob"] is None
 
 
 class TestStreamResponseFromProviderWithContext:
@@ -2130,6 +2289,51 @@ class TestReasoningStreamingLifecycle:
         ]
         assert len(deltas) == 2
         assert deltas[0]["item_id"] == deltas[1]["item_id"]
+
+    def test_reasoning_without_responses_provenance_uses_generated_id(self):
+        """Cross-format reasoning uses one generated ID for its full lifecycle."""
+        events = self._run_stream(
+            [
+                {"type": "stream_start", "response_id": "resp_1", "model": "m"},
+                {"type": "reasoning_delta", "reasoning": "step 1"},
+                {"type": "finish", "finish_reason": {"reason": "stop"}},
+                {"type": "stream_end"},
+            ]
+        )
+        added = next(
+            event
+            for event in events
+            if event["type"] == "response.output_item.added"
+            and event["item"]["type"] == "reasoning"
+        )
+        delta = next(
+            event
+            for event in events
+            if event["type"] == "response.reasoning_summary_text.delta"
+        )
+        done = next(
+            event
+            for event in events
+            if event["type"] == "response.output_item.done"
+            and event["item"]["type"] == "reasoning"
+        )
+        completed = next(
+            event for event in events if event["type"] == "response.completed"
+        )
+        completed_reasoning = next(
+            item
+            for item in completed["response"]["output"]
+            if item["type"] == "reasoning"
+        )
+        item_ids = {
+            added["item"]["id"],
+            delta["item_id"],
+            done["item"]["id"],
+            completed_reasoning["id"],
+        }
+
+        assert len(item_ids) == 1
+        assert next(iter(item_ids)).startswith("rs_")
 
 
 class TestStreamingResponseIdPrefix:


### PR DESCRIPTION
## Summary

- Preserve the authoritative completed reasoning `encrypted_content` from `response.output_item.done` during forced same-format Responses streaming conversion.
- Preserve the source reasoning ID paired with that opaque blob through downstream added, delta, done, and completed events.
- Keep generated-ID behavior for reasoning without real Responses provenance, and keep valid no-blob streams unchanged without fabricating encrypted state.

## Problem

The affected path is conditional: an OpenAI Responses streaming client, an OpenAI Responses upstream, `force_conversion=True`, and a continuation that must replay completed encrypted reasoning state, such as `store: false`, zero data retention (ZDR), or other manual state management.

On that path, the Responses-to-IR streaming converter did not retain either the reasoning ID observed on `response.output_item.added` or the final `encrypted_content` on `response.output_item.done`. The IR-to-Responses side consequently synthesized a fresh ID and built downstream done/completed reasoning items from summary text only. Clients could receive a structurally complete lifecycle that lacked the opaque completed state needed for replay.

The official completed `response.output_item.done.item` is the authority for the final blob. Its source reasoning ID must remain paired with that blob through the synthesized lifecycle. The earlier added item does not need to carry the final blob.

This does not make ID normalization alone a general bug, and it does not imply that all proxies, prompt caching, or ordinary Responses streams are affected.

## Design

The patch stays inside the existing single-reasoning streaming state:

- record a real Responses reasoning ID from the source added item;
- attach that provenance to summary deltas so the existing downstream lifecycle reuses it;
- capture the final opaque state only from the official completed item-done event;
- include the final blob conditionally in downstream reasoning item-done and response-completed output.

No-provenance/cross-format reasoning still receives one generated, consistent `rs_` ID. A valid source lifecycle without `encrypted_content` remains valid and does not gain one.

## Validation

Fresh validation was run from canonical `master` `0b831be6c3c1c137391c0c8208bbdbcac6b8e1ba`.

- Sensitivity/RED through the public forced stream pipeline: 1 failed at the intended contract assertion. Added/delta/done/completed used a generated `rs_...` ID instead of `rs_real`; done/completed omitted `enc_final`.
- Exact GREEN after the causal fix: 1 passed.
- Final focused behavior plus two controls: 3 passed.
- Existing OpenAI Responses stream suite: 124 passed.
- Responses converter plus relevant pipeline/passthrough suite: 474 passed.
- Full credential-free non-integration suite: 2911 passed, 4 skipped, 15 warnings.
- `ruff check src/ tests/`: passed.
- `ruff format --check src/ tests/`: passed (306 files already formatted).
- `ty check`: passed.
- `pre-commit run --all-files`: passed (`ruff`, `ruff format`, `ty`, `complexipy`).
- `git diff --check`: passed.
- Fresh independent review of the three-file patch: no findings.

No endpoint, provider, model, credential-backed integration request, gateway activation, or production change was made.

## Explicit exclusions

This PR does not add a generic raw-event mirror, multi-item identity ledger, missing/conflict/out-of-order defenses, cross-provider state abstraction, provider/model special case, capability flag, gateway `force_conversion` change, passthrough-default change, raw proxy route, `store`/`previous_response_id` handling, ordering change, cache work, or prompt-cache work.

Closes #575

## AI assistance

AI tools materially assisted with diagnosis, implementation, test development, independent review, issue/PR drafting, and validation.
