### PR TITLE
refactor(gateway): make create_app composable via GatewayExtensions

### DIFF
--- a/src/llm_rosetta/gateway/__init__.py
+++ b/src/llm_rosetta/gateway/__init__.py
@@ -9,7 +9,7 @@ Usage::
     python -m llm_rosetta.gateway --config config.jsonc
 
     # Programmatic usage
-    from llm_rosetta.gateway import create_app, GatewayConfig, load_config
+    from llm_rosetta.gateway import create_app, GatewayConfig, GatewayExtensions, load_config
 
     raw = load_config("config.jsonc")
     app = create_app(GatewayConfig(raw))
@@ -17,7 +17,7 @@ Usage::
 
 # httpserver and httpclient are vendored in _vendor/ — no external deps needed.
 
-from .app import create_app
+from .app import GatewayExtensions, create_app
 from .cli import main
 from .config import ConfigIO, GatewayConfig, JsoncConfigIO, discover_config, load_config
 from .proxy import ProviderMetadataStore
@@ -27,6 +27,7 @@ __all__ = [
     "GatewayConfig",
     "JsoncConfigIO",
     "ProviderMetadataStore",
+    "GatewayExtensions",
     "create_app",
     "discover_config",
     "load_config",

--- a/src/llm_rosetta/gateway/__init__.py
+++ b/src/llm_rosetta/gateway/__init__.py
@@ -25,9 +25,9 @@ from .proxy import ProviderMetadataStore
 __all__ = [
     "ConfigIO",
     "GatewayConfig",
+    "GatewayExtensions",
     "JsoncConfigIO",
     "ProviderMetadataStore",
-    "GatewayExtensions",
     "create_app",
     "discover_config",
     "load_config",

--- a/src/llm_rosetta/gateway/admin/js/auth.js
+++ b/src/llm_rosetta/gateway/admin/js/auth.js
@@ -410,6 +410,7 @@ async function checkAuthAndInit() {
 
 // --- Named exports for cross-module imports ---
 export {
+  openSettings,
   checkAuthAndInit,
   showLoginOverlay,
   _refreshTokenDisplay,

--- a/src/llm_rosetta/gateway/admin/js/init.js
+++ b/src/llm_rosetta/gateway/admin/js/init.js
@@ -4,7 +4,7 @@ import {
   setScheme, setMode, setTheme, api, showToast, closeModal, esc,
   _startInactivityTracking, _stopInactivityTracking,
 } from './core.js';
-import { checkAuthAndInit, showLoginOverlay } from './auth.js';
+import { checkAuthAndInit, showLoginOverlay, openSettings } from './auth.js';
 import { loadConfig, renderProviders } from './providers.js';
 import { renderModels } from './models.js';
 import './fetch-models.js';
@@ -28,6 +28,7 @@ function initApp() {
   stopTimers();
   if (S.currentTab === 'dashboard' && _tabEnabled('dashboard')) { loadMetrics(); S.dashboardTimer = (S._dashboardRefreshMs > 0 ? setInterval(loadMetrics, S._dashboardRefreshMs) : null); }
   if (S.currentTab === 'logs' && _tabEnabled('logs')) { S.logOffset = 0; loadLogs(); S.logTimer = setInterval(loadLogs, 5000); }
+  if (location.hash === "#change-password") { openSettings(); history.replaceState(null, "", location.pathname); }
 }
 
 // ===================== Tabs =====================

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -830,7 +830,7 @@ def create_app(
     for path, methods, handler in ext.extra_routes:
         app.route(path, methods=methods)(handler)
 
-    # --- .well-known ---
+    # --- .well-known (always registered, not a proxy route) ---
     @app.route("/.well-known/change-password", methods=["GET"])
     async def well_known_change_password(request: Any) -> Response:
         return Response(
@@ -856,8 +856,6 @@ def create_app(
     from .admin.routes import register_admin_routes
 
     register_admin_routes(app)
-
-    # --- Extension routes (post-admin, for overrides) ---
 
     # --- App-level state ---
     app.transport = transport  # type: ignore

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any
 
 from llm_rosetta._vendor.httpserver import (
@@ -643,91 +645,79 @@ def _install_root_redirect(app: App, target: str | None) -> None:
         return Response(body=b"", status_code=307, headers={"Location": target})
 
 
-def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
-    """Create the httpserver application."""
-    global _config
-    _config = config
+@dataclass
+class GatewayExtensions:
+    """Extension points for downstream projects that wrap the gateway.
 
-    # Expose global proxy as env vars so downstream code (e.g. image
-    # downloads in converters) can use it without threading config through.
-    import os
+    Pass an instance to :func:`create_app` to customise transport, auth,
+    middleware, routes, and admin panel without duplicating the factory.
+    All fields are optional — defaults preserve the standard gateway behaviour.
+    """
 
-    if config.proxy:
-        os.environ.setdefault("HTTP_PROXY", config.proxy)
-        os.environ.setdefault("HTTPS_PROXY", config.proxy)
+    transport: Any | None = None
+    """Pre-built transport instance.  When *None*, an :class:`HttpTransport`
+    is created from *config.upstream_timeout*."""
 
-    from .transport import HttpTransport
+    before_hooks: list[Callable] = field(default_factory=list)
+    """Extra ``before_request`` hooks registered **after** built-in auth."""
 
-    metadata_store = ProviderMetadataStore()
-    transport = HttpTransport(timeout=config.upstream_timeout)
+    after_hooks: list[Callable] = field(default_factory=list)
+    """Extra ``after_request`` hooks registered **after** built-in CORS."""
 
-    app = App(max_body_size=50_000_000, read_timeout=config.read_timeout)
+    extra_routes: list[tuple[str, list[str], Callable]] = field(default_factory=list)
+    """Additional routes as ``(path, methods, handler)`` tuples."""
 
-    # --- Routes ---
-    app.route("/v1/chat/completions", methods=["POST"])(handle_openai_chat)
-    app.route("/v1/embeddings", methods=["POST"])(handle_embeddings)
-    app.route("/v1/rerank", methods=["POST"])(handle_rerank)
-    app.route("/v2/rerank", methods=["POST"])(handle_rerank)
-    app.route("/v1/messages", methods=["POST"])(handle_anthropic)
-    app.route("/v1/responses", methods=["POST"])(handle_openai_responses)
-    app.route("/v1/models", methods=["GET"])(handle_list_models)
-    app.route("/v1beta/models", methods=["GET"])(handle_list_models_google)
-    app.route("/v1beta/models/<path:model_path>", methods=["POST"])(handle_google_genai)
-    app.route("/health", methods=["GET"])(handle_health)
-    app.route("/health/live", methods=["GET"])(handle_health_live)
-    app.route("/health/ready", methods=["GET"])(handle_health_ready)
+    branding: dict | None = None
+    """Admin panel branding dict forwarded to :func:`setup_admin`."""
 
-    _install_root_redirect(app, config.root_redirect)
+    custom_head: str | None = None
+    """Extra ``<head>`` HTML injected into the admin page."""
 
-    # --- Auth (SQLite keystore + config fallback) ---
-    internal_token, keystore, auth_state = _setup_auth(config, config_path)
-    app.before_request(create_auth_hook(auth_state))
+    disabled_tabs: list[str] | None = None
+    """Admin tabs to hide (e.g. ``["keys"]``)."""
 
-    # --- Rate Limiting (after auth so api_key_context_var is set) ---
-    from .ratelimit import (
-        RateLimitState,
-        create_rate_limit_hook,
-        create_rate_limit_after_hook,
-    )
+    config_io: Any | None = None
+    """Custom :class:`ConfigIO` for admin config persistence."""
 
-    rate_limit_state = RateLimitState()
-    rate_limit_state.rebuild(config)
-    app.before_request(create_rate_limit_hook(rate_limit_state))
-    app.rate_limit_state = rate_limit_state  # type: ignore
-    app.after_request(create_rate_limit_after_hook())
+    max_body_size: int | None = None
+    """Override the default 50 MB max request body size."""
 
-    # --- CORS ---
-    # Admin API endpoints are restricted to same-origin by default.
-    # /v1/* proxy endpoints remain open (Access-Control-Allow-Origin: *).
-    # The list of allowed origins for admin can be overridden via
-    # server.admin_cors_origins in config (default [] = same-origin only).
-    _admin_cors_origins: list[str] = config.admin_cors_origins
+    enable_rate_limiting: bool = True
+    """Set to *False* to skip built-in rate-limiting middleware."""
 
-    def _is_admin_path(path: str) -> bool:
-        return path.startswith("/admin/") or path == "/admin"
+    skip_default_routes: bool = False
+    """When *True*, the standard proxy routes are **not** registered.
+    Use this when the downstream project provides its own handlers."""
+
+    skip_builtin_auth: bool = False
+    """When *True*, the API-key auth hook is **not** registered.
+    ``_setup_auth`` still runs (admin needs *internal_token*)."""
+
+    skip_admin_setup: bool = False
+    """When *True*, :func:`setup_admin` is **not** called.
+    The downstream project is responsible for calling it later
+    (e.g. after async initialisation)."""
+
+
+def _is_admin_path(path: str) -> bool:
+    """Check whether *path* is an admin panel path."""
+    return path.startswith("/admin/") or path == "/admin"
+
+
+def _install_cors(app: App, admin_cors_origins: list[str]) -> None:
+    """Register CORS after-request hook and OPTIONS preflight handler."""
 
     def _apply_cors(response: Any, origin: str | None) -> None:
-        """Set CORS headers on *response* for admin requests.
-
-        When *_admin_cors_origins* is non-empty the request Origin is reflected
-        only if it matches the allow-list; otherwise no CORS header is emitted
-        so browsers fall back to same-origin behaviour.
-        """
-        if _admin_cors_origins and origin and origin in _admin_cors_origins:
+        if admin_cors_origins and origin and origin in admin_cors_origins:
             response.headers["Access-Control-Allow-Origin"] = origin
             response.headers["Vary"] = "Origin"
             response.headers["Access-Control-Allow-Methods"] = "*"
             response.headers["Access-Control-Allow-Headers"] = "*"
-        # Default: no header -> same-origin only (browser blocks cross-origin).
 
     @app.after_request
     async def add_cors_headers(request: Any, response: Any) -> Any:
         if _is_admin_path(request.path):
-            # Restricted CORS for admin endpoints: same-origin only by default,
-            # or explicit allow-list via server.admin_cors_origins.
             _apply_cors(response, request.headers.get("origin"))
-            # Prevent reverse-proxy caching of admin API responses (e.g. Caddy/Souin).
-            # Uses the full directive set that Souin recognises as NO-STORE-DIRECTIVE.
             if request.path.startswith("/admin/api/"):
                 response.headers.setdefault(
                     "Cache-Control", "no-cache, no-store, must-revalidate"
@@ -749,6 +739,104 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
             _apply_cors(resp, request.headers.get("origin"))
         return resp
 
+
+def _install_rate_limiting(app: App, config: GatewayConfig) -> None:
+    """Set up rate-limiting before/after hooks and attach state to *app*."""
+    from .ratelimit import (
+        RateLimitState,
+        create_rate_limit_after_hook,
+        create_rate_limit_hook,
+    )
+
+    rate_limit_state = RateLimitState()
+    rate_limit_state.rebuild(config)
+    app.before_request(create_rate_limit_hook(rate_limit_state))
+    app.rate_limit_state = rate_limit_state  # type: ignore
+    app.after_request(create_rate_limit_after_hook())
+
+
+def create_app(
+    config: GatewayConfig,
+    config_path: str | None = None,
+    extensions: GatewayExtensions | None = None,
+) -> App:
+    """Create the httpserver application."""
+    global _config
+    _config = config
+    ext = extensions or GatewayExtensions()
+
+    # Expose global proxy as env vars so downstream code (e.g. image
+    # downloads in converters) can use it without threading config through.
+    import os
+
+    if config.proxy:
+        os.environ.setdefault("HTTP_PROXY", config.proxy)
+        os.environ.setdefault("HTTPS_PROXY", config.proxy)
+
+    from .transport import HttpTransport
+
+    metadata_store = ProviderMetadataStore()
+    transport = (
+        ext.transport
+        if ext.transport is not None
+        else HttpTransport(timeout=config.upstream_timeout)
+    )
+
+    app = App(
+        max_body_size=ext.max_body_size
+        if ext.max_body_size is not None
+        else 50_000_000,
+        read_timeout=config.read_timeout,
+    )
+
+    # --- Routes ---
+    if not ext.skip_default_routes:
+        app.route("/v1/chat/completions", methods=["POST"])(handle_openai_chat)
+        app.route("/v1/embeddings", methods=["POST"])(handle_embeddings)
+        app.route("/v1/rerank", methods=["POST"])(handle_rerank)
+        app.route("/v2/rerank", methods=["POST"])(handle_rerank)
+        app.route("/v1/messages", methods=["POST"])(handle_anthropic)
+        app.route("/v1/responses", methods=["POST"])(handle_openai_responses)
+        app.route("/v1/models", methods=["GET"])(handle_list_models)
+        app.route("/v1beta/models", methods=["GET"])(handle_list_models_google)
+        app.route("/v1beta/models/<path:model_path>", methods=["POST"])(
+            handle_google_genai
+        )
+        app.route("/health", methods=["GET"])(handle_health)
+        app.route("/health/live", methods=["GET"])(handle_health_live)
+        app.route("/health/ready", methods=["GET"])(handle_health_ready)
+
+    _install_root_redirect(app, config.root_redirect)
+
+    # --- Auth (SQLite keystore + config fallback) ---
+    internal_token, keystore, auth_state = _setup_auth(config, config_path)
+    if not ext.skip_builtin_auth:
+        app.before_request(create_auth_hook(auth_state))
+
+    # --- Rate Limiting (after auth so api_key_context_var is set) ---
+    if ext.enable_rate_limiting:
+        _install_rate_limiting(app, config)
+
+    # --- Extension hooks (after built-in auth/rate-limit) ---
+    for hook in ext.before_hooks:
+        app.before_request(hook)
+
+    _install_cors(app, config.admin_cors_origins)
+
+    for hook in ext.after_hooks:
+        app.after_request(hook)
+
+    # --- Extension routes ---
+    for path, methods, handler in ext.extra_routes:
+        app.route(path, methods=methods)(handler)
+
+    # --- .well-known ---
+    @app.route("/.well-known/change-password", methods=["GET"])
+    async def well_known_change_password(request: Any) -> Response:
+        return Response(
+            body=b"", status_code=302, headers={"Location": "/admin#change-password"}
+        )
+
     @app.errorhandler(404)
     async def handle_404(request: Any, exc: Any) -> Response:
         resp = JSONResponse({"error": "Not Found"}, status_code=404)
@@ -769,6 +857,8 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
 
     register_admin_routes(app)
 
+    # --- Extension routes (post-admin, for overrides) ---
+
     # --- App-level state ---
     app.transport = transport  # type: ignore
     app.metadata_store = metadata_store  # type: ignore
@@ -776,7 +866,16 @@ def create_app(config: GatewayConfig, config_path: str | None = None) -> App:
     app.auth_state = auth_state  # type: ignore
     app.keystore = keystore  # type: ignore
 
-    setup_admin(app, config, config_path)
+    if not ext.skip_admin_setup:
+        setup_admin(
+            app,
+            config,
+            config_path,
+            config_io=ext.config_io,
+            disabled_tabs=ext.disabled_tabs,
+            custom_head=ext.custom_head,
+            branding=ext.branding,
+        )
 
     return app
 

--- a/src/llm_rosetta/gateway/auth.py
+++ b/src/llm_rosetta/gateway/auth.py
@@ -31,7 +31,7 @@ api_key_context_var: contextvars.ContextVar[KeyContext | None] = contextvars.Con
 )
 
 # Paths that never require authentication
-_PUBLIC_PATHS = frozenset({"/health", "/favicon.ico"})
+_PUBLIC_PATHS = frozenset({"/health", "/favicon.ico", "/.well-known/change-password"})
 
 # Route prefix → key extraction strategy
 _ROUTE_EXTRACTORS: list[tuple[str, str]] = [

--- a/tests/gateway/test_extensions.py
+++ b/tests/gateway/test_extensions.py
@@ -1,0 +1,185 @@
+"""Tests for GatewayExtensions — composable create_app."""
+
+from __future__ import annotations
+
+from llm_rosetta.gateway.app import GatewayExtensions, create_app
+from llm_rosetta.gateway.config import GatewayConfig
+
+
+def _minimal_cfg(**overrides) -> GatewayConfig:
+    raw: dict = {
+        "providers": {},
+        "server": {"open_on_no_keys": True},
+    }
+    raw.update(overrides)
+    return GatewayConfig(raw)
+
+
+def _route_patterns(app) -> set[str]:
+    """Collect all registered route regex patterns from the app."""
+    patterns = set()
+    for r in getattr(app, "_routes", []):
+        patterns.add(r.pattern.pattern)
+    for r in getattr(app, "_static_routes", []):
+        patterns.add(r.pattern.pattern)
+    return patterns
+
+
+class TestBackwardCompatibility:
+    def test_no_extensions(self):
+        app = create_app(_minimal_cfg())
+        assert hasattr(app, "auth_state")
+        assert hasattr(app, "transport")
+
+    def test_none_extensions(self):
+        app = create_app(_minimal_cfg(), extensions=None)
+        assert hasattr(app, "auth_state")
+
+
+class TestSkipDefaultRoutes:
+    def test_skip_default_routes(self):
+        ext = GatewayExtensions(skip_default_routes=True)
+        app = create_app(_minimal_cfg(), extensions=ext)
+        patterns = _route_patterns(app)
+        assert "^/v1/chat/completions$" not in patterns
+
+    def test_default_routes_present(self):
+        app = create_app(_minimal_cfg())
+        patterns = _route_patterns(app)
+        assert "^/v1/chat/completions$" in patterns
+
+
+class TestCustomTransport:
+    def test_custom_transport(self):
+        class MockTransport:
+            pass
+
+        ext = GatewayExtensions(transport=MockTransport())
+        app = create_app(_minimal_cfg(), extensions=ext)
+        assert isinstance(app.transport, MockTransport)  # ty: ignore[unresolved-attribute]
+
+    def test_default_transport(self):
+        from llm_rosetta.gateway.transport import HttpTransport
+
+        app = create_app(_minimal_cfg())
+        assert isinstance(app.transport, HttpTransport)  # ty: ignore[unresolved-attribute]
+
+
+class TestSkipBuiltinAuth:
+    def test_skip_builtin_auth(self):
+        ext = GatewayExtensions(skip_builtin_auth=True)
+        app = create_app(_minimal_cfg(), extensions=ext)
+        assert hasattr(app, "auth_state")
+        assert hasattr(app, "internal_token")
+
+    def test_builtin_auth_present_by_default(self):
+        app = create_app(_minimal_cfg())
+        assert hasattr(app, "auth_state")
+
+
+class TestRateLimiting:
+    def test_rate_limiting_disabled(self):
+        ext = GatewayExtensions(enable_rate_limiting=False)
+        app = create_app(_minimal_cfg(), extensions=ext)
+        assert not hasattr(app, "rate_limit_state")
+
+    def test_rate_limiting_enabled_by_default(self):
+        app = create_app(_minimal_cfg())
+        assert hasattr(app, "rate_limit_state")
+
+
+class TestMaxBodySize:
+    def test_custom_body_size(self):
+        ext = GatewayExtensions(max_body_size=100 * 1024 * 1024)
+        app = create_app(_minimal_cfg(), extensions=ext)
+        assert app.max_body_size == 100 * 1024 * 1024
+
+    def test_default_body_size(self):
+        app = create_app(_minimal_cfg())
+        assert app.max_body_size == 50_000_000
+
+
+class TestExtraRoutes:
+    def test_extra_routes_registered(self):
+        async def my_handler(request):
+            return {"ok": True}
+
+        ext = GatewayExtensions(
+            extra_routes=[("/custom/endpoint", ["GET"], my_handler)],
+        )
+        app = create_app(_minimal_cfg(), extensions=ext)
+        patterns = _route_patterns(app)
+        assert "^/custom/endpoint$" in patterns
+
+
+class TestExtraHooks:
+    def test_before_hooks_registered(self):
+        calls = []
+
+        async def my_hook(request):
+            calls.append("before")
+            return None
+
+        ext = GatewayExtensions(before_hooks=[my_hook])
+        app = create_app(_minimal_cfg(), extensions=ext)
+        assert app is not None
+
+    def test_after_hooks_registered(self):
+        async def my_hook(request, response):
+            return response
+
+        ext = GatewayExtensions(after_hooks=[my_hook])
+        app = create_app(_minimal_cfg(), extensions=ext)
+        assert app is not None
+
+
+class TestAdminSetup:
+    def test_skip_admin_setup(self):
+        ext = GatewayExtensions(skip_admin_setup=True)
+        app = create_app(_minimal_cfg(), extensions=ext)
+        assert not hasattr(app, "admin_custom_head")
+
+    def test_admin_branding_forwarded(self):
+        ext = GatewayExtensions(
+            branding={"title": "My Gateway", "subtitle": "admin"},
+            disabled_tabs=["keys"],
+        )
+        app = create_app(_minimal_cfg(), extensions=ext)
+        assert hasattr(app, "admin_custom_head")
+        assert "keys" in app.disabled_tabs  # ty: ignore[unresolved-attribute]
+
+
+class TestCombinedExtensions:
+    def test_full_downstream_config(self):
+        class CustomTransport:
+            pass
+
+        async def auth_hook(request):
+            return None
+
+        async def security_hook(request):
+            return None
+
+        async def custom_handler(request):
+            return {"ok": True}
+
+        ext = GatewayExtensions(
+            transport=CustomTransport(),
+            max_body_size=100 * 1024 * 1024,
+            skip_default_routes=True,
+            skip_builtin_auth=True,
+            enable_rate_limiting=False,
+            skip_admin_setup=True,
+            before_hooks=[auth_hook, security_hook],
+            extra_routes=[
+                ("/admin/api/custom/env", ["GET"], custom_handler),
+                ("/admin/api/custom/env", ["PUT"], custom_handler),
+            ],
+        )
+        app = create_app(_minimal_cfg(), extensions=ext)
+        assert isinstance(app.transport, CustomTransport)  # ty: ignore[unresolved-attribute]
+        assert app.max_body_size == 100 * 1024 * 1024
+        assert not hasattr(app, "rate_limit_state")
+        patterns = _route_patterns(app)
+        assert "^/v1/chat/completions$" not in patterns
+        assert "^/admin/api/custom/env$" in patterns

--- a/tests/gateway/test_extensions.py
+++ b/tests/gateway/test_extensions.py
@@ -41,11 +41,13 @@ class TestSkipDefaultRoutes:
         ext = GatewayExtensions(skip_default_routes=True)
         app = create_app(_minimal_cfg(), extensions=ext)
         patterns = _route_patterns(app)
+        assert patterns, "route introspection returned nothing"
         assert "^/v1/chat/completions$" not in patterns
 
     def test_default_routes_present(self):
         app = create_app(_minimal_cfg())
         patterns = _route_patterns(app)
+        assert patterns, "route introspection returned nothing"
         assert "^/v1/chat/completions$" in patterns
 
 
@@ -109,28 +111,28 @@ class TestExtraRoutes:
         )
         app = create_app(_minimal_cfg(), extensions=ext)
         patterns = _route_patterns(app)
+        assert patterns, "route introspection returned nothing"
         assert "^/custom/endpoint$" in patterns
 
 
 class TestExtraHooks:
-    def test_before_hooks_registered(self):
-        calls = []
-
+    def test_before_request_handlers_wired(self):
         async def my_hook(request):
-            calls.append("before")
             return None
 
         ext = GatewayExtensions(before_hooks=[my_hook])
         app = create_app(_minimal_cfg(), extensions=ext)
-        assert app is not None
+        hooks = getattr(app, "_before_request_handlers", [])
+        assert my_hook in hooks, "before_hook not found in app hook list"
 
-    def test_after_hooks_registered(self):
+    def test_after_request_handlers_wired(self):
         async def my_hook(request, response):
             return response
 
         ext = GatewayExtensions(after_hooks=[my_hook])
         app = create_app(_minimal_cfg(), extensions=ext)
-        assert app is not None
+        hooks = getattr(app, "_after_request_handlers", [])
+        assert my_hook in hooks, "after_hook not found in app hook list"
 
 
 class TestAdminSetup:
@@ -181,5 +183,6 @@ class TestCombinedExtensions:
         assert app.max_body_size == 100 * 1024 * 1024
         assert not hasattr(app, "rate_limit_state")
         patterns = _route_patterns(app)
+        assert patterns, "route introspection returned nothing"
         assert "^/v1/chat/completions$" not in patterns
         assert "^/admin/api/custom/env$" in patterns


### PR DESCRIPTION
## Summary

- Add `GatewayExtensions` dataclass with 13 extension points so downstream projects (e.g. argo-proxy) can call `create_app(config, extensions=ext)` instead of duplicating ~140 lines of app assembly
- Add `/.well-known/change-password` redirect (302 → `/admin#change-password`) with auto-open settings panel
- Extract `_install_cors` and `_install_rate_limiting` helpers to reduce `create_app` complexity below the C901 threshold

### Extension points

| Field | Purpose |
|-------|---------|
| `transport` | Override `HttpTransport` |
| `before_hooks` / `after_hooks` | Extra middleware |
| `extra_routes` | Additional route registrations |
| `skip_default_routes` | Omit built-in proxy routes |
| `skip_builtin_auth` | Omit API-key auth hook |
| `enable_rate_limiting` | Disable rate limiting |
| `skip_admin_setup` | Defer `setup_admin` to caller |
| `branding` / `custom_head` / `disabled_tabs` / `config_io` | Admin panel customization |
| `max_body_size` | Override request body limit |

All fields are optional — `create_app(config)` with no extensions preserves current behavior.

## Test plan

- [ ] 18 new tests in `test_extensions.py` covering each extension point
- [ ] Existing `test_timeout_config.py` and `test_root_redirect.py` pass unchanged (backward compat)
- [ ] Full suite: 2926 passed, 0 failed
- [ ] Manual: `.well-known/change-password` redirects and auto-opens settings panel in browser
- [ ] argo-proxy migration validated locally (30 insertions / 63 deletions in `app.py`)

Closes #578