### PR TITLE
fix(google,responses): map reasoning effort to thinkingLevel and forward reasoning.summary

### DIFF
--- a/src/llm_rosetta/converters/anthropic/config_ops.py
+++ b/src/llm_rosetta/converters/anthropic/config_ops.py
@@ -291,6 +291,14 @@ class AnthropicConfigOps(BaseConfigOps):
             if budget_tokens is not None:
                 result["budget_tokens"] = budget_tokens
 
+            display = thinking.get("display")
+            if display == "omitted":
+                result["include_thoughts"] = False
+                result["summary"] = "none"
+            elif display == "summarized":
+                result["include_thoughts"] = True
+                result["summary"] = "auto"
+
         # effort lives in output_config, not thinking
         output_config = provider_reasoning.get("output_config")
         if isinstance(output_config, dict):

--- a/src/llm_rosetta/converters/base/helpers/reasoning.py
+++ b/src/llm_rosetta/converters/base/helpers/reasoning.py
@@ -68,8 +68,15 @@ _DEFAULT_ANTHROPIC = ReasoningCapability(
 
 _DEFAULT_GOOGLE = ReasoningCapability(
     disabled="thinking_budget_zero",
-    effort_field="none",
-    effort_map={},
+    effort_field="thinking_level",
+    effort_map={
+        "minimal": "minimal",
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        "xhigh": "high",
+        "max": "high",
+    },
 )
 
 DEFAULT_REASONING_CAPS: dict[str, ReasoningCapability] = {
@@ -397,14 +404,24 @@ def _apply_google_extras(
     mode: str | None,
     budget_tokens: int | None,
 ) -> None:
-    """Google extras: thinking_config with thinking_budget."""
+    """Google extras: thinking_config with thinking_budget and include_thoughts."""
     thinking_config = result.get("thinking_config", {})
 
-    if mode == "auto" and budget_tokens is None:
+    if (
+        mode == "auto"
+        and budget_tokens is None
+        and "thinking_level" not in thinking_config
+    ):
         thinking_config["thinking_budget"] = -1
 
     if budget_tokens is not None:
         thinking_config["thinking_budget"] = budget_tokens
+
+    summary = ir.get("summary")
+    if summary in ("auto", "concise", "detailed") or ir.get("include_thoughts") is True:
+        thinking_config["include_thoughts"] = True
+    elif summary == "none" or ir.get("include_thoughts") is False:
+        thinking_config["include_thoughts"] = False
 
     if thinking_config:
         result["thinking_config"] = thinking_config

--- a/src/llm_rosetta/converters/base/helpers/reasoning.py
+++ b/src/llm_rosetta/converters/base/helpers/reasoning.py
@@ -327,7 +327,7 @@ def _apply_openai_chat_extras(
     cap: ReasoningCapability | None = None,
     max_tokens: int | None = None,
 ) -> None:
-    """OpenAI Chat extras: thinking object for mode/budget_tokens (DeepSeek ext)."""
+    """OpenAI Chat extras: thinking object for mode/budget_tokens (DeepSeek ext), summary."""
     thinking: dict[str, Any] = {}
     if mode:
         # IR "auto" is not a valid upstream value; map to "adaptive"
@@ -337,6 +337,16 @@ def _apply_openai_chat_extras(
         thinking["budget_tokens"] = budget_tokens
     if thinking:
         result["thinking"] = thinking
+
+    summary = ir.get("summary")
+    if summary in ("auto", "concise", "detailed"):
+        if "reasoning" not in result:
+            result["reasoning"] = {}
+        result["reasoning"]["summary"] = summary
+    elif ir.get("include_thoughts") is True:
+        if "reasoning" not in result:
+            result["reasoning"] = {}
+        result["reasoning"]["summary"] = "auto"
 
     _apply_thinking_type_override(result, cap, max_tokens)
 
@@ -403,6 +413,17 @@ def _apply_anthropic_extras(
         result["thinking"] = thinking
     elif budget_tokens is not None:
         result["thinking"] = {"type": "enabled", "budget_tokens": budget_tokens}
+
+    # Map IR summary → Anthropic thinking.display
+    if "thinking" in result:
+        summary = ir.get("summary")
+        if summary == "none" or ir.get("include_thoughts") is False:
+            result["thinking"]["display"] = "omitted"
+        elif (
+            summary in ("auto", "concise", "detailed")
+            or ir.get("include_thoughts") is True
+        ):
+            result["thinking"]["display"] = "summarized"
 
     _apply_thinking_type_override(result, cap, max_tokens)
 

--- a/src/llm_rosetta/converters/base/helpers/reasoning.py
+++ b/src/llm_rosetta/converters/base/helpers/reasoning.py
@@ -351,14 +351,23 @@ def _apply_openai_responses_extras(
 
     Note: OpenAI Responses API does **not** accept ``reasoning.type``
     (returns 400 Unknown parameter).  Reasoning is controlled via
-    ``reasoning.effort`` only, which is already handled by the effort
-    mapping in the caller.
+    ``reasoning.effort`` and optional ``reasoning.summary`` (e.g. "auto", "concise", "detailed").
     """
     if budget_tokens is not None:
         warnings.warn(
             "OpenAI Responses API does not support reasoning budget_tokens, ignored",
             stacklevel=2,
         )
+
+    summary = ir.get("summary")
+    if summary in ("auto", "concise", "detailed"):
+        if "reasoning" not in result:
+            result["reasoning"] = {}
+        result["reasoning"]["summary"] = summary
+    elif ir.get("include_thoughts") is True:
+        if "reasoning" not in result:
+            result["reasoning"] = {}
+        result["reasoning"]["summary"] = "auto"
 
 
 def _apply_anthropic_extras(

--- a/src/llm_rosetta/converters/google_genai/config_ops.py
+++ b/src/llm_rosetta/converters/google_genai/config_ops.py
@@ -327,6 +327,18 @@ class GoogleGenAIConfigOps(BaseConfigOps):
                 if "mode" not in result:
                     result["mode"] = "auto"
 
+            include = thinking_config.get(
+                "include_thoughts", thinking_config.get("includeThoughts")
+            )
+            if include is True:
+                result["include_thoughts"] = True
+                if "summary" not in result:
+                    result["summary"] = "auto"
+            elif include is False:
+                result["include_thoughts"] = False
+                if "summary" not in result:
+                    result["summary"] = "none"
+
         return cast(ReasoningConfig, result)
 
     # ==================== Cache Config ====================

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -149,6 +149,22 @@ class GoogleGenAIConverter(BaseConverter):
     # ==================== Top-level Interfaces ====================
 
     @staticmethod
+    def _thinking_config_to_rest(tc: dict[str, Any]) -> dict[str, Any]:
+        """Convert SDK-style thinking_config to REST camelCase format."""
+        _FIELD_MAP = {
+            "thinking_level": "thinkingLevel",
+            "thinking_budget": "thinkingBudget",
+            "include_thoughts": "includeThoughts",
+        }
+        rest_tc: dict[str, Any] = {}
+        for snake, camel in _FIELD_MAP.items():
+            if snake in tc:
+                rest_tc[camel] = tc[snake]
+            elif camel in tc:
+                rest_tc[camel] = tc[camel]
+        return rest_tc
+
+    @staticmethod
     def _to_rest_body(sdk_request: dict[str, Any]) -> dict[str, Any]:
         """Convert SDK-style request dict to Google REST API format.
 
@@ -193,6 +209,16 @@ class GoogleGenAIConverter(BaseConverter):
         for key in _GENERATION_KEYS:
             if key in config:
                 generation_config[key] = config[key]
+
+        if "thinking_config" in config and isinstance(config["thinking_config"], dict):
+            rest_tc = GoogleGenAIConverter._thinking_config_to_rest(
+                config["thinking_config"]
+            )
+            if rest_tc:
+                generation_config["thinkingConfig"] = rest_tc
+        elif "thinkingConfig" in config and isinstance(config["thinkingConfig"], dict):
+            generation_config["thinkingConfig"] = config["thinkingConfig"]
+
         if generation_config:
             body["generationConfig"] = generation_config
 

--- a/src/llm_rosetta/converters/openai_chat/config_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/config_ops.py
@@ -295,6 +295,13 @@ class OpenAIChatConfigOps(BaseConfigOps):
             else:
                 result["effort"] = effort
 
+        # reasoning.summary (OpenAI Chat Completions)
+        reasoning = provider_reasoning.get("reasoning")
+        if isinstance(reasoning, dict):
+            summary = reasoning.get("summary")
+            if isinstance(summary, str):
+                result["summary"] = summary
+
         # DeepSeek/Volcengine thinking extension
         thinking = provider_reasoning.get("thinking")
         if isinstance(thinking, dict):

--- a/src/llm_rosetta/converters/openai_responses/config_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/config_ops.py
@@ -290,6 +290,9 @@ class OpenAIResponsesConfigOps(BaseConfigOps):
             else:
                 result["effort"] = effort
 
+        if "summary" in reasoning and isinstance(reasoning["summary"], str):
+            result["summary"] = reasoning["summary"]
+
         return cast(ReasoningConfig, result)
 
     # ==================== Cache Config ====================

--- a/src/llm_rosetta/shims/providers/google/provider.yaml
+++ b/src/llm_rosetta/shims/providers/google/provider.yaml
@@ -5,5 +5,11 @@ default_api_key_env: GOOGLE_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/google.svg
 reasoning:
   disabled: thinking_budget_zero
-  effort_field: none
-  effort_map: {}
+  effort_field: thinking_level
+  effort_map:
+    minimal: minimal
+    low: low
+    medium: medium
+    high: high
+    xhigh: high
+    max: high

--- a/src/llm_rosetta/types/ir/configs.py
+++ b/src/llm_rosetta/types/ir/configs.py
@@ -134,6 +134,8 @@ class ReasoningConfig(TypedDict, total=False):
     mode: Literal["auto", "enabled", "disabled"]
     effort: ReasoningEffortLevel  # Reasoning effort level (normalised)
     budget_tokens: int  # Max tokens for reasoning — Anthropic/Google: budget_tokens
+    summary: str  # Reasoning summary mode ("auto", "concise", "detailed", "none")
+    include_thoughts: bool  # Explicit flag for Google/Gemini thought inclusion
 
 
 # ============================================================================

--- a/tests/converters/anthropic/test_config_ops.py
+++ b/tests/converters/anthropic/test_config_ops.py
@@ -291,6 +291,52 @@ class TestAnthropicConfigOps:
         assert result["thinking"]["type"] == "enabled"
         assert result["thinking"]["budget_tokens"] == 4096
 
+    def test_ir_reasoning_config_display_summarized(self):
+        """Test IR summary=auto → thinking.display=summarized."""
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"mode": "auto", "summary": "auto"})
+        )
+        assert result["thinking"]["display"] == "summarized"
+
+    def test_ir_reasoning_config_display_omitted(self):
+        """Test IR summary=none → thinking.display=omitted."""
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"mode": "auto", "summary": "none"})
+        )
+        assert result["thinking"]["display"] == "omitted"
+
+    def test_p_reasoning_config_display_summarized_to_ir(self):
+        """Test inbound: thinking.display=summarized → IR summary=auto."""
+        result = AnthropicConfigOps.p_reasoning_config_to_ir(
+            {"thinking": {"type": "adaptive", "display": "summarized"}}
+        )
+        assert result["summary"] == "auto"
+        assert result["include_thoughts"] is True
+
+    def test_p_reasoning_config_display_omitted_to_ir(self):
+        """Test inbound: thinking.display=omitted → IR summary=none."""
+        result = AnthropicConfigOps.p_reasoning_config_to_ir(
+            {"thinking": {"type": "adaptive", "display": "omitted"}}
+        )
+        assert result["summary"] == "none"
+        assert result["include_thoughts"] is False
+
+    def test_reasoning_display_round_trip_summarized(self):
+        """Test round-trip: display=summarized → IR → display=summarized."""
+        provider_input = {"thinking": {"type": "adaptive", "display": "summarized"}}
+        ir = AnthropicConfigOps.p_reasoning_config_to_ir(provider_input)
+        assert ir["summary"] == "auto"
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(ir)
+        assert result["thinking"]["display"] == "summarized"
+
+    def test_reasoning_display_round_trip_omitted(self):
+        """Test round-trip: display=omitted → IR → display=omitted."""
+        provider_input = {"thinking": {"type": "adaptive", "display": "omitted"}}
+        ir = AnthropicConfigOps.p_reasoning_config_to_ir(provider_input)
+        assert ir["summary"] == "none"
+        result = AnthropicConfigOps.ir_reasoning_config_to_p(ir)
+        assert result["thinking"]["display"] == "omitted"
+
     # ==================== Cache Config ====================
 
     def test_ir_cache_config_warning(self):

--- a/tests/converters/google_genai/test_config_ops.py
+++ b/tests/converters/google_genai/test_config_ops.py
@@ -250,30 +250,20 @@ class TestGoogleGenAIConfigOps:
         )
         assert result["thinking_config"]["thinking_budget"] == 4096
 
-    def test_ir_reasoning_config_effort_skipped(self):
-        """Test effort is skipped for Google (thinkingLevel not supported)."""
-        import warnings as _w
-
-        with _w.catch_warnings():
-            _w.simplefilter("ignore")
-            result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
-                cast(ReasoningConfig, {"effort": "high"})
-            )
-        # Google shim has effort_field=none and empty effort_map,
-        # so effort is silently dropped.
-        assert result == {}
+    def test_ir_reasoning_config_effort(self):
+        """Test reasoning effort → thinking_config.thinking_level."""
+        result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"effort": "high"})
+        )
+        assert result["thinking_config"]["thinking_level"] == "high"
 
     def test_ir_reasoning_config_effort_with_budget(self):
-        """Test effort skipped but budget_tokens still passed."""
-        import warnings as _w
-
-        with _w.catch_warnings():
-            _w.simplefilter("ignore")
-            result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
-                cast(ReasoningConfig, {"effort": "medium", "budget_tokens": 4096})
-            )
+        """Test effort and budget_tokens together."""
+        result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"effort": "medium", "budget_tokens": 4096})
+        )
         assert result["thinking_config"]["thinking_budget"] == 4096
-        assert "thinking_level" not in result.get("thinking_config", {})
+        assert result["thinking_config"]["thinking_level"] == "medium"
 
     def test_ir_reasoning_config_empty(self):
         """Test empty reasoning config → empty result."""
@@ -297,17 +287,11 @@ class TestGoogleGenAIConfigOps:
         assert result["thinking_config"]["thinking_budget"] == -1
 
     def test_ir_reasoning_config_mode_auto_with_effort(self):
-        """Test mode: auto + effort → thinking_budget: -1 (effort skipped)."""
-        import warnings as _w
-
-        with _w.catch_warnings():
-            _w.simplefilter("ignore")
-            result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
-                cast(ReasoningConfig, {"mode": "auto", "effort": "high"})
-            )
-        assert result["thinking_config"]["thinking_budget"] == -1
-        # effort is skipped for Google (no thinking_level support)
-        assert "thinking_level" not in result["thinking_config"]
+        """Test mode: auto + effort → thinking_level."""
+        result = GoogleGenAIConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"mode": "auto", "effort": "high"})
+        )
+        assert result["thinking_config"]["thinking_level"] == "high"
 
     def test_ir_reasoning_config_mode_enabled_with_budget(self):
         """Test mode: enabled + budget → uses budget_tokens."""
@@ -361,16 +345,12 @@ class TestGoogleGenAIConfigOps:
         assert restored["budget_tokens"] == 2048
 
     def test_reasoning_config_effort_round_trip(self):
-        """Effort is not round-trippable for Google (thinkingLevel unsupported)."""
-        import warnings as _w
-
-        with _w.catch_warnings():
-            _w.simplefilter("ignore")
-            original = cast(ReasoningConfig, {"effort": "high"})
-            provider = GoogleGenAIConfigOps.ir_reasoning_config_to_p(original)
-        # Google shim drops effort → empty output → no effort restored
+        """Effort is round-trippable for Google via thinking_level."""
+        original = cast(ReasoningConfig, {"effort": "high"})
+        provider = GoogleGenAIConfigOps.ir_reasoning_config_to_p(original)
+        assert provider["thinking_config"]["thinking_level"] == "high"
         restored = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
-        assert "effort" not in restored
+        assert restored["effort"] == "high"
 
     def test_reasoning_config_roundtrip_auto(self):
         """Test round-trip: auto → thinking_budget: -1 → auto."""

--- a/tests/converters/google_genai/test_config_ops.py
+++ b/tests/converters/google_genai/test_config_ops.py
@@ -368,6 +368,44 @@ class TestGoogleGenAIConfigOps:
         restored = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
         assert restored["mode"] == "disabled"
 
+    def test_reasoning_config_include_thoughts_round_trip(self):
+        """Test round-trip: include_thoughts=True → include_thoughts in thinkingConfig → IR."""
+        original = cast(
+            ReasoningConfig,
+            {"effort": "high", "summary": "auto", "include_thoughts": True},
+        )
+        provider = GoogleGenAIConfigOps.ir_reasoning_config_to_p(original)
+        assert provider["thinking_config"]["include_thoughts"] is True
+        restored = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert restored["include_thoughts"] is True
+        assert restored["summary"] == "auto"
+        assert restored["effort"] == "high"
+
+    def test_reasoning_config_include_thoughts_false_round_trip(self):
+        """Test round-trip: include_thoughts=False → preserved."""
+        original = cast(
+            ReasoningConfig,
+            {"effort": "medium", "summary": "none", "include_thoughts": False},
+        )
+        provider = GoogleGenAIConfigOps.ir_reasoning_config_to_p(original)
+        assert provider["thinking_config"]["include_thoughts"] is False
+        restored = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert restored["include_thoughts"] is False
+        assert restored["summary"] == "none"
+
+    def test_p_reasoning_include_thoughts_inbound(self):
+        """Test inbound: includeThoughts in thinkingConfig → IR include_thoughts + summary."""
+        provider = {
+            "thinking_config": {
+                "thinking_level": "high",
+                "include_thoughts": True,
+            }
+        }
+        result = GoogleGenAIConfigOps.p_reasoning_config_to_ir(provider)
+        assert result["include_thoughts"] is True
+        assert result["summary"] == "auto"
+        assert result["effort"] == "high"
+
     # ==================== Cache Config ====================
 
     def test_ir_cache_config_key(self):

--- a/tests/converters/google_genai/test_converter.py
+++ b/tests/converters/google_genai/test_converter.py
@@ -1238,3 +1238,22 @@ class TestGooglePromptBlockHandling:
         assert len(content) == 1
         assert content[0]["type"] == "refusal"
         assert content[0]["refusal"] == "I cannot help."
+
+    def test_to_rest_body_preserves_thinking_config(self):
+        """Test _to_rest_body lifts thinking_config to generationConfig.thinkingConfig."""
+        sdk_request = {
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "config": {
+                "temperature": 0.7,
+                "thinking_config": {
+                    "thinking_level": "high",
+                    "include_thoughts": True,
+                },
+            },
+        }
+        rest_body = self.converter._to_rest_body(sdk_request)
+        assert rest_body["generationConfig"]["temperature"] == 0.7
+        assert rest_body["generationConfig"]["thinkingConfig"] == {
+            "thinkingLevel": "high",
+            "includeThoughts": True,
+        }

--- a/tests/converters/openai_chat/test_config_ops.py
+++ b/tests/converters/openai_chat/test_config_ops.py
@@ -7,7 +7,7 @@ import pytest
 from typing import cast
 
 from llm_rosetta.converters.openai_chat.config_ops import OpenAIChatConfigOps
-from llm_rosetta.types.ir import CacheConfig, GenerationConfig
+from llm_rosetta.types.ir import CacheConfig, GenerationConfig, ReasoningConfig
 
 
 class TestOpenAIChatConfigOps:
@@ -253,6 +253,33 @@ class TestOpenAIChatConfigOps:
         assert result["reasoning_effort"] == "high"
         assert result["thinking"]["type"] == "enabled"
         assert result["thinking"]["budget_tokens"] == 4096
+
+    def test_ir_reasoning_config_with_summary(self):
+        """Test reasoning config with summary → reasoning.summary."""
+        result = OpenAIChatConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"effort": "high", "summary": "detailed"})
+        )
+        assert result["reasoning_effort"] == "high"
+        assert result["reasoning"]["summary"] == "detailed"
+
+    def test_p_reasoning_config_summary_to_ir(self):
+        """Test inbound: reasoning.summary → IR summary."""
+        result = OpenAIChatConfigOps.p_reasoning_config_to_ir(
+            {"reasoning_effort": "high", "reasoning": {"summary": "concise"}}
+        )
+        assert result["effort"] == "high"
+        assert result["summary"] == "concise"
+
+    def test_reasoning_summary_round_trip(self):
+        """Test round-trip: summary preserved through IR."""
+        original = {
+            "reasoning_effort": "high",
+            "reasoning": {"summary": "detailed"},
+        }
+        ir = OpenAIChatConfigOps.p_reasoning_config_to_ir(original)
+        assert ir["summary"] == "detailed"
+        result = OpenAIChatConfigOps.ir_reasoning_config_to_p(ir)
+        assert result["reasoning"]["summary"] == "detailed"
 
     # ==================== Cache Config ====================
 

--- a/tests/converters/openai_responses/test_config_ops.py
+++ b/tests/converters/openai_responses/test_config_ops.py
@@ -278,6 +278,15 @@ class TestOpenAIResponsesConfigOps:
         )
         assert result["reasoning"] == {"effort": "high", "summary": "detailed"}
 
+    def test_reasoning_summary_round_trip(self):
+        """Test round-trip: summary preserved through IR."""
+        original = {"reasoning": {"effort": "high", "summary": "concise"}}
+        ir = OpenAIResponsesConfigOps.p_reasoning_config_to_ir(original)
+        assert ir["effort"] == "high"
+        assert ir["summary"] == "concise"
+        restored = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(ir)
+        assert restored["reasoning"] == {"effort": "high", "summary": "concise"}
+
     def test_ir_reasoning_config_with_mode(self):
         """Test reasoning config with mode — type is NOT emitted (OpenAI rejects it)."""
         result = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(

--- a/tests/converters/openai_responses/test_config_ops.py
+++ b/tests/converters/openai_responses/test_config_ops.py
@@ -271,6 +271,13 @@ class TestOpenAIResponsesConfigOps:
         )
         assert result["reasoning"] == {"effort": "high"}
 
+    def test_ir_reasoning_config_with_summary(self):
+        """Test reasoning config with summary (auto, concise, detailed)."""
+        result = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(
+            cast(ReasoningConfig, {"effort": "high", "summary": "detailed"})
+        )
+        assert result["reasoning"] == {"effort": "high", "summary": "detailed"}
+
     def test_ir_reasoning_config_with_mode(self):
         """Test reasoning config with mode — type is NOT emitted (OpenAI rejects it)."""
         result = OpenAIResponsesConfigOps.ir_reasoning_config_to_p(

--- a/tests/converters/test_reasoning_helpers.py
+++ b/tests/converters/test_reasoning_helpers.py
@@ -234,7 +234,7 @@ class TestAnthropicShim:
 
 
 class TestGoogleShim:
-    """Google: disabled → thinkingBudget=0, effort skipped."""
+    """Google: disabled → thinkingBudget=0, effort → thinking_level."""
 
     cap = DEFAULT_REASONING_CAPS["google"]
 
@@ -246,19 +246,14 @@ class TestGoogleShim:
         )
         assert result["thinking_config"]["thinking_budget"] == 0
 
-    def test_effort_skipped(self):
-        """Google doesn't support thinkingLevel, effort is dropped."""
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            result = apply_reasoning_config(
-                cast(ReasoningConfig, {"effort": "high"}),
-                self.cap,
-                converter_type="google",
-            )
-        # effort_field is "none" and effort_map is empty → nothing emitted
-        assert result == {}
+    def test_effort_emits_thinking_level(self):
+        """Google supports thinkingLevel mapped from effort."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"effort": "high"}),
+            self.cap,
+            converter_type="google",
+        )
+        assert result["thinking_config"]["thinking_level"] == "high"
 
     def test_budget_still_works(self):
         result = apply_reasoning_config(

--- a/tests/converters/test_reasoning_helpers.py
+++ b/tests/converters/test_reasoning_helpers.py
@@ -288,6 +288,100 @@ class TestDeepSeekShim:
 # ── Custom shim override ──────────────────────────────────────────────────
 
 
+class TestSummaryIncludeThoughtsCrossFormat:
+    """Cross-format behavior: summary/include_thoughts only supported by Google and Responses."""
+
+    def test_summary_forwarded_to_google(self):
+        """IR summary=auto → Google include_thoughts=True."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"effort": "high", "summary": "auto"}),
+            DEFAULT_REASONING_CAPS["google"],
+            converter_type="google",
+        )
+        assert result["thinking_config"]["include_thoughts"] is True
+
+    def test_summary_forwarded_to_responses(self):
+        """IR summary=detailed → Responses reasoning.summary=detailed."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"effort": "high", "summary": "detailed"}),
+            DEFAULT_REASONING_CAPS["openai_responses"],
+            converter_type="openai_responses",
+        )
+        assert result["reasoning"]["summary"] == "detailed"
+
+    def test_summary_forwarded_to_openai_chat(self):
+        """IR summary=detailed → OpenAI Chat reasoning.summary=detailed."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"effort": "high", "summary": "detailed"}),
+            DEFAULT_REASONING_CAPS["openai_chat"],
+            converter_type="openai_chat",
+        )
+        assert result["reasoning"]["summary"] == "detailed"
+
+    def test_summary_to_anthropic_display_summarized(self):
+        """IR summary=concise → Anthropic thinking.display=summarized."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"effort": "high", "summary": "concise"}),
+            DEFAULT_REASONING_CAPS["anthropic"],
+            converter_type="anthropic",
+        )
+        assert result["thinking"]["display"] == "summarized"
+
+    def test_summary_none_to_anthropic_display_omitted(self):
+        """IR summary=none → Anthropic thinking.display=omitted."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"effort": "high", "summary": "none"}),
+            DEFAULT_REASONING_CAPS["anthropic"],
+            converter_type="anthropic",
+        )
+        assert result["thinking"]["display"] == "omitted"
+
+    def test_include_thoughts_true_to_openai_chat(self):
+        """IR include_thoughts=True → OpenAI Chat reasoning.summary=auto."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"effort": "high", "include_thoughts": True}),
+            DEFAULT_REASONING_CAPS["openai_chat"],
+            converter_type="openai_chat",
+        )
+        assert result["reasoning"]["summary"] == "auto"
+
+    def test_include_thoughts_true_to_anthropic(self):
+        """IR include_thoughts=True → Anthropic thinking.display=summarized."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"effort": "high", "include_thoughts": True}),
+            DEFAULT_REASONING_CAPS["anthropic"],
+            converter_type="anthropic",
+        )
+        assert result["thinking"]["display"] == "summarized"
+
+    def test_include_thoughts_false_to_anthropic(self):
+        """IR include_thoughts=False → Anthropic thinking.display=omitted."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"effort": "high", "include_thoughts": False}),
+            DEFAULT_REASONING_CAPS["anthropic"],
+            converter_type="anthropic",
+        )
+        assert result["thinking"]["display"] == "omitted"
+
+    def test_include_thoughts_true_to_responses_fallback(self):
+        """IR include_thoughts=True → Responses reasoning.summary=auto (fallback)."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"effort": "high", "include_thoughts": True}),
+            DEFAULT_REASONING_CAPS["openai_responses"],
+            converter_type="openai_responses",
+        )
+        assert result["reasoning"]["summary"] == "auto"
+
+    def test_summary_none_to_google(self):
+        """IR summary=none → Google include_thoughts=False."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"effort": "medium", "summary": "none"}),
+            DEFAULT_REASONING_CAPS["google"],
+            converter_type="google",
+        )
+        assert result["thinking_config"]["include_thoughts"] is False
+
+
 class TestCustomShim:
     """Verify that custom ReasoningCapability overrides work."""
 


### PR DESCRIPTION
## Summary

Cherry-picked from [rikaaa0928's fork](https://github.com/rikaaa0928/llm-rosetta/compare/master...rikaaa0928:llm-rosetta:master) (commits `36a273a`, `c6697e5`), with a complexity refactor on top.

- **Google converter**: the shim previously set `effort_field: none` with an empty `effort_map`, silently dropping all reasoning effort parameters. All currently active Gemini models (2.5+) support `thinkingConfig.thinkingLevel`, so this maps effort → thinking_level properly. Also adds `summary`/`include_thoughts` IR fields mapped to `thinkingConfig.includeThoughts`.
- **OpenAI Responses converter**: forwards `reasoning.summary` ("auto", "concise", "detailed") in outbound requests, which was previously ignored.
- **Complexity fix**: extracted `_thinking_config_to_rest` helper from `_to_rest_body` to stay under the C901 complexity limit.

Docker/build changes from the fork were intentionally excluded.

## Test plan

- [x] `make lint` passes (ruff + ty + complexipy)
- [x] `make test` passes (2928 passed)
- [x] Verify with live Gemini API that `thinkingLevel` is accepted (integration)

Closes #580