### PR TITLE
fix(google): parse thinkingConfig from REST generationConfig

### DIFF
--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -394,9 +394,17 @@ class GoogleGenAIConverter(BaseConverter):
                 response_mime_source
             )
 
-        # Reasoning config (snake + camel)
-        if "thinking_config" in config or "thinkingConfig" in config:
-            ir_request["reasoning"] = self.config_ops.p_reasoning_config_to_ir(config)
+        # Reasoning config (snake + camel) — check SDK config, then REST generationConfig
+        reasoning_source = config
+        if not ("thinking_config" in config or "thinkingConfig" in config):
+            reasoning_source = gen_source
+        if (
+            "thinking_config" in reasoning_source
+            or "thinkingConfig" in reasoning_source
+        ):
+            ir_request["reasoning"] = self.config_ops.p_reasoning_config_to_ir(
+                reasoning_source
+            )
 
         return ir_request
 

--- a/tests/converters/google_genai/test_converter.py
+++ b/tests/converters/google_genai/test_converter.py
@@ -1239,6 +1239,45 @@ class TestGooglePromptBlockHandling:
         assert content[0]["type"] == "refusal"
         assert content[0]["refusal"] == "I cannot help."
 
+    def test_rest_thinking_config_round_trip(self):
+        """REST generationConfig.thinkingConfig survives request round-trip (regression for #584)."""
+        rest_request = {
+            "contents": [{"role": "user", "parts": [{"text": "What is 2+2?"}]}],
+            "generationConfig": {
+                "thinkingConfig": {
+                    "thinkingLevel": "low",
+                    "includeThoughts": True,
+                }
+            },
+        }
+        ir = self.converter.request_from_provider(rest_request)
+        assert ir["reasoning"]["effort"] == "low"
+        assert ir["reasoning"]["include_thoughts"] is True
+        target, _ = self.converter.request_to_provider(ir)
+        config = target.get("config", {})
+        assert config["thinking_config"]["thinking_level"] == "low"
+        assert config["thinking_config"]["include_thoughts"] is True
+
+    def test_rest_thinking_config_not_lost_in_pipeline(self):
+        """Pipeline Google→Google preserves thinkingConfig from REST format (regression for #584)."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        pipeline = ConversionPipeline("google", "google")
+        rest_request = {
+            "contents": [{"role": "user", "parts": [{"text": "test"}]}],
+            "generationConfig": {
+                "thinkingConfig": {
+                    "thinkingLevel": "high",
+                    "includeThoughts": True,
+                }
+            },
+        }
+        target = pipeline.convert_request(rest_request)
+        gen_config = target.get("generationConfig", {})
+        assert "thinkingConfig" in gen_config
+        assert gen_config["thinkingConfig"]["thinkingLevel"] == "high"
+        assert gen_config["thinkingConfig"]["includeThoughts"] is True
+
     def test_to_rest_body_preserves_thinking_config(self):
         """Test _to_rest_body lifts thinking_config to generationConfig.thinkingConfig."""
         sdk_request = {


### PR DESCRIPTION
## Summary

- The Google converter's `request_from_provider` only checked the SDK-format `config` dict for `thinking_config`/`thinkingConfig`, missing it when requests used REST format (where it's nested inside `generationConfig`)
- This caused the gateway to silently strip `thinkingConfig` during Google→Google conversion — upstream never received `includeThoughts`/`thinkingLevel`, so no thought parts were returned
- Fix: fall back to `gen_source` (which already resolves REST `generationConfig`) when SDK config has no thinking keys

## Root cause

```
REST request: generationConfig.thinkingConfig.includeThoughts: true
                         ↓ (gen_source already resolves this)
Reasoning parser only checked: config.thinking_config (SDK format) → empty → skipped
```

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (2951 passed)
- [x] Pipeline round-trip verified: `thinkingConfig` now survives Google→IR→Google
- [ ] Deploy dev and verify thought parts appear via llm-comply

Closes #584