### PR TITLE
fix(gateway): remap upstream_model in embedding-specific route

### DIFF
--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -73,6 +73,9 @@ def _resolve_embedding_provider(
             if source_format != route.format
             else None
         )
+        upstream_model = config.model_upstream_names.get(model)
+        if upstream_model:
+            body["model"] = upstream_model
         return _ResolvedEmbedding(
             provider_info=route.provider_info,
             upstream_url=f"{route.provider_info.base_url}{route.embedding_path}",


### PR DESCRIPTION
## Summary

- Fix embedding-specific route to apply `upstream_model` remapping from `model_upstream_names`, matching the behavior of the chat fallback route
- Without this fix, providers that use model aliases different from upstream names (e.g. `argo:text-embedding-3-small` → `v3small`) get 404s from upstream

One-line change in `_resolve_embedding_provider`.

## Test plan

- [ ] 2956 existing tests pass
- [ ] Manual: embedding requests with aliased models resolve correctly