### PR TITLE
refactor(gateway): normalize base_url to prevent double version prefixes

### DIFF
--- a/src/llm_rosetta/gateway/admin/js/providers.js
+++ b/src/llm_rosetta/gateway/admin/js/providers.js
@@ -486,6 +486,7 @@ function renderProviders() {
       <div class="actions" style="margin-top:auto;padding-top:12px">
         <button class="btn btn-sm" onclick="copyProviderEntry('${esc(name)}')">${t('btn.clone')}</button>
         <button class="btn btn-sm" onclick="editProvider('${esc(name)}')">${t('btn.edit')}</button>
+        <button class="btn btn-sm btn-test-conn" onclick="testProviderConnectivity('${esc(name)}')">${t('btn.test')}</button>
         <button class="btn btn-sm btn-danger" onclick="deleteProvider('${esc(name)}')">${t('btn.delete')}</button>
         ${modelLink}
       </div>
@@ -698,8 +699,44 @@ Object.assign(window, {
   saveProvider, deleteProvider, onDeleteConfirmInput, onDeleteConfirmClick,
   confirmDeleteProvider, toggleProvider, editProvider, copyProviderEntry,
   saveServerSettings, runNetDiag, loadConfig,
-  goToModelsForProvider, goToProviderFromModel,
+  goToModelsForProvider, goToProviderFromModel, testProviderConnectivity,
   _activateSegChild,
 });
 
 export { renderProviders, loadConfig, _activateSegChild, _getProviderCaps };
+
+// ── Provider Connectivity Test ──────────────────────────────────────
+
+async function testProviderConnectivity(name) {
+  const card = document.querySelector(`.provider-card[data-provider="${name}"]`);
+  const btn = card?.querySelector('.btn-test-conn');
+  if (btn) { btn.disabled = true; btn.textContent = '⏳'; }
+  try {
+    const r = await api.post(`/admin/api/config/providers/${encodeURIComponent(name)}/test-connectivity`, {});
+    let msg = '';
+    if (r.reachable) {
+      msg += `✅ ${name}: reachable (${r.base_status})`;
+    } else {
+      msg += `❌ ${name}: unreachable — ${r.base_error || 'connection failed'}`;
+    }
+    const eps = r.endpoints || {};
+    for (const [ep, info] of Object.entries(eps)) {
+      const urlNote = info.normalized_url && info.normalized_url !== info.url
+        ? ` → normalized: ${info.normalized_url}`
+        : '';
+      if (info.ok) {
+        msg += `\n  ✅ ${ep}: ${info.url} (${info.status})${urlNote}`;
+      } else {
+        msg += `\n  ❌ ${ep}: ${info.url} (${info.status || info.error || 'failed'})${urlNote}`;
+      }
+    }
+    if (r.warnings?.length) {
+      msg += '\n⚠️ ' + r.warnings.join('\n⚠️ ');
+    }
+    showToast(msg, r.reachable ? 'success' : 'error');
+  } catch (e) {
+    showToast(`Test failed: ${e.message || e}`, 'error');
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = t('btn.test'); }
+  }
+}

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -93,6 +93,7 @@ from .profiling import (
     get_profiling_results,
     get_profiling_status,
 )
+from .connectivity import test_provider_connectivity
 from .testing import (
     cancel_test,
     get_test_result,
@@ -212,6 +213,10 @@ def register_admin_routes(app: Any) -> None:
     app.route("/admin/api/test/<task_id>", methods=["GET"])(get_test_result)
     app.route("/admin/api/test/<task_id>/poll", methods=["POST"])(get_test_result)
     app.route("/admin/api/test/<task_id>", methods=["DELETE"])(cancel_test)
+    # Provider connectivity test
+    app.route("/admin/api/config/providers/<name>/test-connectivity", methods=["POST"])(
+        test_provider_connectivity
+    )
     # Content capture (dashboard tab)
     app.route("/admin/api/capture/status", methods=["GET"])(
         _guard("dashboard", get_capture_status)

--- a/src/llm_rosetta/gateway/admin/routes/connectivity.py
+++ b/src/llm_rosetta/gateway/admin/routes/connectivity.py
@@ -1,0 +1,144 @@
+"""Provider connectivity test handler."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from llm_rosetta._vendor.httpserver import JSONResponse, Response
+
+_VERSION_PREFIX = re.compile(r"/v\d+(?:beta\d?)?(?=/|$)", re.IGNORECASE)
+
+
+async def test_provider_connectivity(request: Any, name: str) -> Response:
+    """Probe a provider's base_url and endpoint paths for reachability.
+
+    Checks:
+    1. Base URL reachability (GET with short timeout)
+    2. Each configured endpoint (models list, embedding, rerank)
+    3. Double version prefix detection
+    """
+    config = getattr(request.app, "config", None) or getattr(
+        request.app, "gateway_config", None
+    )
+    if config is None:
+        return JSONResponse({"error": "No config loaded"}, status_code=500)
+
+    raw_providers = getattr(config, "_raw_providers", {})
+    provider_cfg = raw_providers.get(name)
+    if provider_cfg is None:
+        return JSONResponse({"error": f"Provider '{name}' not found"}, status_code=404)
+
+    base_url = provider_cfg.get("base_url", "").rstrip("/")
+    if not base_url:
+        return JSONResponse(
+            {"error": "Provider has no base_url configured"}, status_code=400
+        )
+
+    from llm_rosetta._vendor.httpclient import AsyncClient
+
+    proxy = provider_cfg.get("proxy") or getattr(config, "proxy", None)
+    timeout = float(provider_cfg.get("timeout", 10))
+    client = AsyncClient(timeout=min(timeout, 10), proxy=proxy)
+
+    results: dict[str, Any] = {
+        "provider": name,
+        "base_url": base_url,
+        "endpoints": {},
+        "warnings": [],
+    }
+
+    # 1. Probe base URL
+    try:
+        resp = await client.get(base_url)
+        results["reachable"] = True
+        results["base_status"] = resp.status_code
+    except Exception as exc:
+        results["reachable"] = False
+        results["base_status"] = None
+        results["base_error"] = str(exc)
+
+    # 2. Check for models endpoint (OpenAI convention)
+    models_url = f"{base_url}/models"
+    try:
+        resp = await client.get(models_url)
+        results["endpoints"]["models"] = {
+            "url": models_url,
+            "status": resp.status_code,
+            "ok": resp.status_code < 400,
+        }
+    except Exception as exc:
+        results["endpoints"]["models"] = {
+            "url": models_url,
+            "status": None,
+            "ok": False,
+            "error": str(exc),
+        }
+
+    # 3. Check embedding endpoint if configured
+    embedding_path = provider_cfg.get("embedding_path", "/v1/embeddings")
+    if provider_cfg.get("embedding_format"):
+        embed_url = f"{base_url}{embedding_path}"
+        from llm_rosetta.gateway.transport.provider_info import _normalize_base_url
+
+        normalized_base = _normalize_base_url(base_url, "{base_url}" + embedding_path)
+        normalized_url = f"{normalized_base}{embedding_path}"
+        _check_double_prefix(base_url, embedding_path, "embedding", results)
+        try:
+            resp = await client.get(embed_url)
+            results["endpoints"]["embedding"] = {
+                "url": embed_url,
+                "normalized_url": normalized_url,
+                "status": resp.status_code,
+                "ok": resp.status_code != 404,
+            }
+        except Exception as exc:
+            results["endpoints"]["embedding"] = {
+                "url": embed_url,
+                "normalized_url": normalized_url,
+                "status": None,
+                "ok": False,
+                "error": str(exc),
+            }
+
+    # 4. Check rerank endpoint if configured
+    rerank_path = provider_cfg.get("rerank_path", "/v1/rerank")
+    if provider_cfg.get("rerank_format"):
+        rerank_url = f"{base_url}{rerank_path}"
+        from llm_rosetta.gateway.transport.provider_info import _normalize_base_url
+
+        normalized_base = _normalize_base_url(base_url, "{base_url}" + rerank_path)
+        normalized_rerank_url = f"{normalized_base}{rerank_path}"
+        _check_double_prefix(base_url, rerank_path, "rerank", results)
+        try:
+            resp = await client.get(rerank_url)
+            results["endpoints"]["rerank"] = {
+                "url": rerank_url,
+                "normalized_url": normalized_rerank_url,
+                "status": resp.status_code,
+                "ok": resp.status_code != 404,
+            }
+        except Exception as exc:
+            results["endpoints"]["rerank"] = {
+                "url": rerank_url,
+                "normalized_url": normalized_rerank_url,
+                "status": None,
+                "ok": False,
+                "error": str(exc),
+            }
+
+    return JSONResponse(results)
+
+
+def _check_double_prefix(
+    base_url: str, path: str, endpoint_name: str, results: dict
+) -> None:
+    """Warn if base_url and path share a version prefix."""
+    m = _VERSION_PREFIX.search(base_url)
+    if m and path.startswith(m.group()):
+        results["warnings"].append(
+            f"{endpoint_name}: base_url ends with '{m.group()}' and "
+            f"{endpoint_name}_path starts with '{m.group()}' — "
+            f"this would cause a double prefix but is auto-corrected by "
+            f"the gateway's base_url normalization."
+        )

--- a/src/llm_rosetta/gateway/admin/routes/connectivity.py
+++ b/src/llm_rosetta/gateway/admin/routes/connectivity.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
-
-_VERSION_PREFIX = re.compile(r"/v\d+(?:beta\d?)?(?=/|$)", re.IGNORECASE)
+from llm_rosetta.gateway.transport.provider_info import _VERSION_SUFFIXES
 
 
 async def test_provider_connectivity(request: Any, name: str) -> Response:
@@ -79,9 +77,9 @@ async def test_provider_connectivity(request: Any, name: str) -> Response:
     embedding_path = provider_cfg.get("embedding_path", "/v1/embeddings")
     if provider_cfg.get("embedding_format"):
         embed_url = f"{base_url}{embedding_path}"
-        from llm_rosetta.gateway.transport.provider_info import _normalize_base_url
+        from llm_rosetta.gateway.transport.provider_info import normalize_base_url
 
-        normalized_base = _normalize_base_url(base_url, "{base_url}" + embedding_path)
+        normalized_base = normalize_base_url(base_url, "{base_url}" + embedding_path)
         normalized_url = f"{normalized_base}{embedding_path}"
         _check_double_prefix(base_url, embedding_path, "embedding", results)
         try:
@@ -105,9 +103,9 @@ async def test_provider_connectivity(request: Any, name: str) -> Response:
     rerank_path = provider_cfg.get("rerank_path", "/v1/rerank")
     if provider_cfg.get("rerank_format"):
         rerank_url = f"{base_url}{rerank_path}"
-        from llm_rosetta.gateway.transport.provider_info import _normalize_base_url
+        from llm_rosetta.gateway.transport.provider_info import normalize_base_url
 
-        normalized_base = _normalize_base_url(base_url, "{base_url}" + rerank_path)
+        normalized_base = normalize_base_url(base_url, "{base_url}" + rerank_path)
         normalized_rerank_url = f"{normalized_base}{rerank_path}"
         _check_double_prefix(base_url, rerank_path, "rerank", results)
         try:
@@ -134,7 +132,7 @@ def _check_double_prefix(
     base_url: str, path: str, endpoint_name: str, results: dict
 ) -> None:
     """Warn if base_url and path share a version prefix."""
-    m = _VERSION_PREFIX.search(base_url)
+    m = _VERSION_SUFFIXES.search(base_url)
     if m and path.startswith(m.group()):
         results["warnings"].append(
             f"{endpoint_name}: base_url ends with '{m.group()}' and "

--- a/src/llm_rosetta/gateway/embeddings.py
+++ b/src/llm_rosetta/gateway/embeddings.py
@@ -78,7 +78,7 @@ def _resolve_embedding_provider(
             body["model"] = upstream_model
         return _ResolvedEmbedding(
             provider_info=route.provider_info,
-            upstream_url=f"{route.provider_info.base_url}{route.embedding_path}",
+            upstream_url=route.provider_info.upstream_url(""),
             provider_name=route.provider_name,
             target_format=route.format,
             source_format=source_format,
@@ -98,7 +98,7 @@ def _resolve_embedding_provider(
 
     return _ResolvedEmbedding(
         provider_info=provider_info,
-        upstream_url=f"{provider_info.base_url}/embeddings",
+        upstream_url=f"{provider_info.base_url}/embeddings",  # chat fallback: no url_template
         provider_name=chat_route.provider_name,
     )
 

--- a/src/llm_rosetta/gateway/rerank.py
+++ b/src/llm_rosetta/gateway/rerank.py
@@ -123,7 +123,7 @@ async def handle_rerank(
         )
 
     # --- Forward via transport ---
-    upstream_url = f"{route.provider_info.base_url}{route.rerank_path}"
+    upstream_url = route.provider_info.upstream_url("")
     transport: UpstreamTransport = request.app.transport
     extra_headers = build_upstream_extra_headers(request, request_id)
 

--- a/src/llm_rosetta/gateway/transport/provider_info.py
+++ b/src/llm_rosetta/gateway/transport/provider_info.py
@@ -14,6 +14,7 @@ Higher-level factory logic (shim resolution, config parsing) stays in
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 
 # Type alias for auth-header builder callables
@@ -53,6 +54,36 @@ class KeyRing:
 # ---------------------------------------------------------------------------
 
 
+# Version-prefix segments that may appear at the end of base_url AND
+# at the start of a url_template path, causing duplication.
+_VERSION_SUFFIXES = re.compile(r"/v\d+(?:beta\d?)?$", re.IGNORECASE)
+
+
+def _normalize_base_url(base_url: str, url_template: str) -> str:
+    """Strip trailing version prefix from *base_url* when it would
+    duplicate the start of *url_template*.
+
+    Example: ``base_url="https://api.openai.com/v1"`` with
+    ``url_template="{base_url}/v1/embeddings"`` → strips ``/v1`` from
+    base_url to avoid ``/v1/v1/embeddings``.
+
+    Templates like ``"{base_url}/chat/completions"`` (no version prefix
+    after ``{base_url}``) are left alone — the ``/v1`` in base_url is
+    needed.
+    """
+    m = _VERSION_SUFFIXES.search(base_url)
+    if not m:
+        return base_url
+    suffix = m.group()  # e.g. "/v1", "/v1beta", "/v3"
+    # Check if the template path (after {base_url}) starts with the same segment
+    tpl_path = (
+        url_template.split("{base_url}", 1)[-1] if "{base_url}" in url_template else ""
+    )
+    if tpl_path.startswith(suffix + "/") or tpl_path == suffix:
+        return base_url[: m.start()]
+    return base_url
+
+
 class ProviderInfo:
     """Runtime representation of a single configured provider.
 
@@ -78,7 +109,7 @@ class ProviderInfo:
                 f"got '{base_url}'"
             )
         self.name = name
-        self.base_url = base_url.rstrip("/")
+        self.base_url = _normalize_base_url(base_url.rstrip("/"), url_template)
         self.key_ring = KeyRing(api_key)
         self._auth_header_fn = auth_header_fn
         self._url_template = url_template

--- a/src/llm_rosetta/gateway/transport/provider_info.py
+++ b/src/llm_rosetta/gateway/transport/provider_info.py
@@ -59,7 +59,7 @@ class KeyRing:
 _VERSION_SUFFIXES = re.compile(r"/v\d+(?:beta\d?)?$", re.IGNORECASE)
 
 
-def _normalize_base_url(base_url: str, url_template: str) -> str:
+def normalize_base_url(base_url: str, url_template: str) -> str:
     """Strip trailing version prefix from *base_url* when it would
     duplicate the start of *url_template*.
 
@@ -109,7 +109,7 @@ class ProviderInfo:
                 f"got '{base_url}'"
             )
         self.name = name
-        self.base_url = _normalize_base_url(base_url.rstrip("/"), url_template)
+        self.base_url = normalize_base_url(base_url.rstrip("/"), url_template)
         self.key_ring = KeyRing(api_key)
         self._auth_header_fn = auth_header_fn
         self._url_template = url_template

--- a/tests/gateway/test_url_construction.py
+++ b/tests/gateway/test_url_construction.py
@@ -135,7 +135,7 @@ class TestEmbeddingUrlConstruction:
 class TestRerankUrlConstruction:
     def _rerank_upstream_url(self, cfg: GatewayConfig, model: str) -> str:
         route = cfg.resolve_rerank(model)
-        return f"{route.provider_info.base_url}{route.rerank_path}"
+        return route.provider_info.upstream_url("")
 
     def test_base_url_no_v1_default_path(self):
         cfg = _config_with_provider(

--- a/tests/gateway/test_url_construction.py
+++ b/tests/gateway/test_url_construction.py
@@ -1,0 +1,173 @@
+"""Tests for URL construction across all endpoint types.
+
+Validates that base_url + path produces correct upstream URLs for
+chat, embedding, and rerank endpoints.
+"""
+
+from __future__ import annotations
+
+from llm_rosetta.gateway.config import GatewayConfig
+from llm_rosetta.gateway.embeddings import _resolve_embedding_provider
+
+
+def _config_with_provider(
+    base_url: str,
+    *,
+    embedding_format: str | None = None,
+    embedding_path: str | None = None,
+    rerank_format: str | None = None,
+    rerank_path: str | None = None,
+    extra_models: dict | None = None,
+) -> GatewayConfig:
+    provider: dict = {
+        "api_key": "sk-test",
+        "base_url": base_url,
+        "type": "openai_chat",
+    }
+    if embedding_format:
+        provider["embedding_format"] = embedding_format
+    if embedding_path:
+        provider["embedding_path"] = embedding_path
+    if rerank_format:
+        provider["rerank_format"] = rerank_format
+    if rerank_path:
+        provider["rerank_path"] = rerank_path
+
+    models: dict = {
+        "gpt-4": "test-provider",
+        "embed-model": {
+            "provider": "test-provider",
+            "type": "embedding" if embedding_format else "llm",
+        },
+    }
+    if extra_models:
+        models.update(extra_models)
+
+    raw: dict = {
+        "providers": {"test-provider": provider},
+        "models": models,
+        "server": {"open_on_no_keys": True},
+    }
+    return GatewayConfig(raw)
+
+
+# ── Chat URL construction ────────────────────────────────────────────
+
+
+class TestChatUrlConstruction:
+    def test_base_url_with_v1(self):
+        cfg = _config_with_provider("https://api.openai.com/v1")
+        _, pinfo = cfg.resolve("openai_chat", "gpt-4")
+        url = pinfo.upstream_url("gpt-4")
+        assert url == "https://api.openai.com/v1/chat/completions"
+
+    def test_base_url_without_v1(self):
+        cfg = _config_with_provider("https://api.deepseek.com")
+        _, pinfo = cfg.resolve("openai_chat", "gpt-4")
+        url = pinfo.upstream_url("gpt-4")
+        assert url == "https://api.deepseek.com/chat/completions"
+
+    def test_base_url_trailing_slash_stripped(self):
+        cfg = _config_with_provider("https://api.openai.com/v1/")
+        _, pinfo = cfg.resolve("openai_chat", "gpt-4")
+        url = pinfo.upstream_url("gpt-4")
+        assert url == "https://api.openai.com/v1/chat/completions"
+
+
+# ── Embedding URL construction ───────────────────────────────────────
+
+
+class TestEmbeddingUrlConstruction:
+    def test_base_url_no_v1_default_path(self):
+        cfg = _config_with_provider(
+            "https://api.example.com",
+            embedding_format="openai",
+        )
+        body: dict = {"model": "embed-model", "input": "test"}
+        resolved = _resolve_embedding_provider(cfg, "embed-model", body)
+        assert resolved is not None
+        assert resolved.upstream_url == "https://api.example.com/v1/embeddings"
+
+    def test_base_url_with_v1_default_path(self):
+        """base_url with /v1 + default /v1/embeddings — normalized, no double /v1."""
+        cfg = _config_with_provider(
+            "https://api.openai.com/v1",
+            embedding_format="openai",
+        )
+        body: dict = {"model": "embed-model", "input": "test"}
+        resolved = _resolve_embedding_provider(cfg, "embed-model", body)
+        assert resolved is not None
+        assert resolved.upstream_url == "https://api.openai.com/v1/embeddings"
+
+    def test_base_url_with_v1_custom_path_no_v1(self):
+        cfg = _config_with_provider(
+            "https://api.openai.com/v1",
+            embedding_format="openai",
+            embedding_path="/embeddings",
+        )
+        body: dict = {"model": "embed-model", "input": "test"}
+        resolved = _resolve_embedding_provider(cfg, "embed-model", body)
+        assert resolved is not None
+        assert resolved.upstream_url == "https://api.openai.com/v1/embeddings"
+
+    def test_custom_path_v4_embed(self):
+        cfg = _config_with_provider(
+            "https://api.custom.com",
+            embedding_format="openai",
+            embedding_path="/v4/embed",
+        )
+        body: dict = {"model": "embed-model", "input": "test"}
+        resolved = _resolve_embedding_provider(cfg, "embed-model", body)
+        assert resolved is not None
+        assert resolved.upstream_url == "https://api.custom.com/v4/embed"
+
+    def test_chat_fallback_no_embedding_format(self):
+        cfg = _config_with_provider("https://api.openai.com/v1")
+        body: dict = {"model": "gpt-4", "input": "test"}
+        resolved = _resolve_embedding_provider(cfg, "gpt-4", body)
+        assert resolved is not None
+        assert resolved.upstream_url == "https://api.openai.com/v1/embeddings"
+
+
+# ── Rerank URL construction ──────────────────────────────────────────
+
+
+class TestRerankUrlConstruction:
+    def _rerank_upstream_url(self, cfg: GatewayConfig, model: str) -> str:
+        route = cfg.resolve_rerank(model)
+        return f"{route.provider_info.base_url}{route.rerank_path}"
+
+    def test_base_url_no_v1_default_path(self):
+        cfg = _config_with_provider(
+            "https://api.jina.ai",
+            rerank_format="jina",
+            extra_models={
+                "rerank-model": {"provider": "test-provider", "type": "rerank"},
+            },
+        )
+        url = self._rerank_upstream_url(cfg, "rerank-model")
+        assert url == "https://api.jina.ai/v1/rerank"
+
+    def test_base_url_with_v1_default_path(self):
+        """base_url with /v1 + default /v1/rerank — normalized, no double /v1."""
+        cfg = _config_with_provider(
+            "https://api.example.com/v1",
+            rerank_format="jina",
+            extra_models={
+                "rerank-model": {"provider": "test-provider", "type": "rerank"},
+            },
+        )
+        url = self._rerank_upstream_url(cfg, "rerank-model")
+        assert url == "https://api.example.com/v1/rerank"
+
+    def test_custom_rerank_path(self):
+        cfg = _config_with_provider(
+            "https://api.cohere.com",
+            rerank_format="cohere",
+            rerank_path="/v2/rerank",
+            extra_models={
+                "rerank-model": {"provider": "test-provider", "type": "rerank"},
+            },
+        )
+        url = self._rerank_upstream_url(cfg, "rerank-model")
+        assert url == "https://api.cohere.com/v2/rerank"


### PR DESCRIPTION
## Summary

### Phase 0-2: base_url normalization

- Add `_normalize_base_url()` in `ProviderInfo.__init__` that detects and strips trailing version segments from `base_url` when the `url_template` would cause duplication (e.g. `/v1/v1/embeddings`)
- Unify embedding/rerank URL construction to use `ProviderInfo.upstream_url()` instead of ad hoc f-string concatenation
- Add 11 URL construction tests covering chat, embedding, and rerank with various base_url patterns

### Phase 3: Provider connectivity test

- Add `POST /admin/api/config/providers/<name>/test-connectivity` endpoint that probes base_url and each configured endpoint (models, embedding, rerank)
- Shows both raw and normalized URLs so users can spot double-prefix issues
- Detects and warns about `/v1/v1/...` patterns with auto-correction note
- Add "Test" button to provider cards in admin UI

### How normalization works

Only strips when the **exact same** version segment appears at end of `base_url` AND start of `url_template` path:

| base_url | url_template | Result |
|----------|-------------|--------|
| `api.openai.com/v1` | `{base_url}/chat/completions` | **Keep** `/v1` |
| `api.openai.com/v1` | `{base_url}/v1/embeddings` | **Strip** `/v1` |
| `ark.volces.com/api/v3` | `{base_url}/chat/completions` | **Keep** `/v3` |
| `ark.volces.com/api/v3` | `{base_url}/v1/embeddings` | **Keep** `/v3` |

No changes to templates, shim defaults, or config schema. Fully backward compatible.

Closes #587 (Phases 0-3).

## Test plan

- [ ] 11 new URL construction tests pass
- [ ] 2967 total tests pass (0 failures)
- [ ] Lint clean
- [ ] Manual: connectivity test endpoint returns correct probe results
- [ ] Manual: admin UI "Test" button works on provider cards