### PR TITLE
chore(vendor): update httpclient 0.4.5→0.4.6, sse 0.3.2→0.3.3

### DIFF
--- a/src/llm_rosetta/_vendor/httpclient.py
+++ b/src/llm_rosetta/_vendor/httpclient.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.4.5"
+# version = "0.4.6"
 # deps = []
 # tier = "subsystem"
 # category = "network"
@@ -814,7 +814,14 @@ class StreamingResponse:
             size_str = size_line.decode("latin-1").split(";")[0].strip()
             if not size_str:
                 break
-            chunk_size = int(size_str, 16)
+            try:
+                chunk_size = int(size_str, 16)
+            except ValueError:
+                preview = size_str[:100]
+                raise HttpConnectionError(
+                    f"Invalid chunked encoding: expected hex chunk size, "
+                    f"got {preview!r} (upstream may have injected an error mid-stream)"
+                ) from None
             if chunk_size == 0:
                 await asyncio.wait_for(
                     reader.readline(), timeout=timeout

--- a/src/llm_rosetta/_vendor/sse.py
+++ b/src/llm_rosetta/_vendor/sse.py
@@ -1,5 +1,5 @@
 # /// zerodep
-# version = "0.3.2"
+# version = "0.3.3"
 # deps = ["httpclient"]
 # tier = "subsystem"
 # category = "network"
@@ -78,17 +78,18 @@ __all__ = [
 
 
 def _ensure_sibling_path(name: str) -> str:
-    """Return the sibling module directory and prepend it to ``sys.path``."""
-    sibling_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", name)
-    if sibling_dir not in sys.path:
-        sys.path.insert(0, sibling_dir)
-    return sibling_dir
+    """Add sibling module paths to ``sys.path`` for flat and nested layouts."""
+    base = os.path.dirname(os.path.abspath(__file__))
+    for candidate in [base, os.path.normpath(os.path.join(base, "..", name))]:
+        if candidate not in sys.path:
+            sys.path.insert(0, candidate)
+    return base
 
 
 # ── Sibling httpclient import (guarded) ──
 
 try:
-    _httpclient_dir = _ensure_sibling_path("httpclient")
+    _ensure_sibling_path("httpclient")
     from httpclient import HttpConnectionError as _HttpConnectionError
     from httpclient import HttpTimeoutError as _HttpTimeoutError
     from httpclient import async_get as _http_async_get


### PR DESCRIPTION
## Summary

- Update vendored `httpclient` 0.4.5 → 0.4.6: fixes `ValueError` crash when upstream injects raw HTTP error (e.g. `HTTP/1.1 502 Bad Gateway`) into active chunked transfer stream — now raises `HttpConnectionError` with descriptive message (zerodep#129, zerodep#130)
- Update vendored `sse` 0.3.2 → 0.3.3: minor upstream improvements

## Test plan

- [x] `make test` — 2988 passed, 0 failed