### PR TITLE
feat(gateway): configurable data_dir for persistence storage

### DIFF
--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -71,6 +71,7 @@ def setup_admin(
     disabled_tabs: list[str] | None = None,
     custom_head: str | None = None,
     branding: dict[str, Any] | None = None,
+    data_dir: str | None = None,
 ) -> None:
     """Initialize admin panel state on the app.
 
@@ -121,13 +122,17 @@ def setup_admin(
         config_io = JsoncConfigIO()
     metrics = MetricsCollector()
 
-    # Set up SQLite persistence alongside the config file
+    # Set up SQLite persistence — explicit data_dir > config field > config-path default
     persistence: PersistenceManager | None = None
-    if config_path:
-        data_dir = os.path.join(os.path.dirname(config_path), "data")
+    resolved_data_dir = (
+        data_dir
+        or getattr(config, "data_dir", None)
+        or (os.path.join(os.path.dirname(config_path), "data") if config_path else None)
+    )
+    if resolved_data_dir:
         success_max, error_max = _resolve_log_caps(config)
         persistence = PersistenceManager(
-            data_dir, success_max=success_max, error_max=error_max
+            resolved_data_dir, success_max=success_max, error_max=error_max
         )
 
         # Restore persisted metrics counters

--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -124,11 +124,18 @@ def setup_admin(
 
     # Set up SQLite persistence — explicit data_dir > config field > config-path default
     persistence: PersistenceManager | None = None
-    resolved_data_dir = (
-        data_dir
-        or getattr(config, "data_dir", None)
-        or (os.path.join(os.path.dirname(config_path), "data") if config_path else None)
-    )
+    resolved_data_dir: str | None = data_dir
+    if not resolved_data_dir:
+        configured = getattr(config, "data_dir", None)
+        if configured:
+            if config_path and not os.path.isabs(configured):
+                resolved_data_dir = os.path.join(
+                    os.path.dirname(config_path), configured
+                )
+            else:
+                resolved_data_dir = configured
+        elif config_path:
+            resolved_data_dir = os.path.join(os.path.dirname(config_path), "data")
     if resolved_data_dir:
         success_max, error_max = _resolve_log_caps(config)
         persistence = PersistenceManager(

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -873,7 +873,13 @@ def create_app(
             disabled_tabs=ext.disabled_tabs,
             custom_head=ext.custom_head,
             branding=ext.branding,
-            data_dir=config.data_dir,
+            data_dir=(
+                os.path.join(os.path.dirname(config_path), config.data_dir)
+                if config.data_dir
+                and config_path
+                and not os.path.isabs(config.data_dir)
+                else config.data_dir
+            ),
         )
 
     return app

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -579,8 +579,25 @@ def _flush_now(app: App) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _setup_auth(
+def _resolve_data_dir_for_app(
     config: GatewayConfig, config_path: str | None
+) -> str | None:
+    """Resolve data directory from config, anchoring relative paths to config dir."""
+    import os
+
+    if config.data_dir:
+        if config_path and not os.path.isabs(config.data_dir):
+            return os.path.join(os.path.dirname(config_path), config.data_dir)
+        return config.data_dir
+    if config_path:
+        return os.path.join(os.path.dirname(config_path), "data")
+    return None
+
+
+def _setup_auth(
+    config: GatewayConfig,
+    config_path: str | None,
+    data_dir: str | None = None,
 ) -> tuple[str, KeyStore, AuthState]:
     """Create KeyStore, import config keys, build AuthState."""
     import os
@@ -590,6 +607,25 @@ def _setup_auth(
 
     if config.api_keys_db:
         keys_db_path = config.api_keys_db
+    elif data_dir:
+        new_path = os.path.join(data_dir, "keys.db")
+        old_path = (
+            os.path.join(os.path.dirname(os.path.abspath(config_path)), "keys.db")
+            if config_path
+            else None
+        )
+        if os.path.exists(new_path):
+            keys_db_path = new_path
+        elif old_path and os.path.exists(old_path):
+            keys_db_path = old_path
+            logger.warning(
+                "Using keys.db from legacy location %s — "
+                "move it to %s to silence this warning.",
+                old_path,
+                new_path,
+            )
+        else:
+            keys_db_path = new_path
     elif config_path:
         keys_db_path = os.path.join(
             os.path.dirname(os.path.abspath(config_path)), "keys.db"
@@ -808,8 +844,13 @@ def create_app(
 
     _install_root_redirect(app, config.root_redirect)
 
+    # --- Resolve data directory (shared by keystore + persistence) ---
+    resolved_data_dir = _resolve_data_dir_for_app(config, config_path)
+
     # --- Auth (SQLite keystore + config fallback) ---
-    internal_token, keystore, auth_state = _setup_auth(config, config_path)
+    internal_token, keystore, auth_state = _setup_auth(
+        config, config_path, data_dir=resolved_data_dir
+    )
     if not ext.skip_builtin_auth:
         app.before_request(create_auth_hook(auth_state))
 
@@ -873,13 +914,7 @@ def create_app(
             disabled_tabs=ext.disabled_tabs,
             custom_head=ext.custom_head,
             branding=ext.branding,
-            data_dir=(
-                os.path.join(os.path.dirname(config_path), config.data_dir)
-                if config.data_dir
-                and config_path
-                and not os.path.isabs(config.data_dir)
-                else config.data_dir
-            ),
+            data_dir=resolved_data_dir,
         )
 
     return app

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -873,6 +873,7 @@ def create_app(
             disabled_tabs=ext.disabled_tabs,
             custom_head=ext.custom_head,
             branding=ext.branding,
+            data_dir=config.data_dir,
         )
 
     return app

--- a/src/llm_rosetta/gateway/cli.py
+++ b/src/llm_rosetta/gateway/cli.py
@@ -250,6 +250,17 @@ def _cmd_set_password(args: argparse.Namespace) -> None:
 _KNOWN_PROVIDERS = known_provider_types()
 
 
+def _resolve_data_dir(config_path: str, args: argparse.Namespace) -> str:
+    """Resolve the data directory from CLI flag, config file, or default."""
+    if getattr(args, "data_dir", None):
+        return args.data_dir
+    raw = load_config(config_path)
+    configured = raw.get("server", {}).get("data_dir")
+    if configured:
+        return configured
+    return os.path.join(os.path.dirname(config_path), "data")
+
+
 def _cmd_db_cleanup(args: argparse.Namespace) -> None:
     """Run age-based database cleanup."""
     from llm_rosetta.observability import PersistenceManager
@@ -259,7 +270,7 @@ def _cmd_db_cleanup(args: argparse.Namespace) -> None:
         print("No config file found. Use --config to specify one.", file=sys.stderr)
         sys.exit(1)
 
-    data_dir = os.path.join(os.path.dirname(config_path), "data")
+    data_dir = _resolve_data_dir(config_path, args)
     db_path = os.path.join(data_dir, "gateway.db")
     if not os.path.exists(db_path):
         print(f"Database not found: {db_path}", file=sys.stderr)
@@ -298,7 +309,7 @@ def _cmd_db_cleanup_logs(args: argparse.Namespace) -> None:
         print("No config file found. Use --config to specify one.", file=sys.stderr)
         sys.exit(1)
 
-    data_dir = os.path.join(os.path.dirname(config_path), "data")
+    data_dir = _resolve_data_dir(config_path, args)
     db_path = os.path.join(data_dir, "gateway.db")
     if not os.path.exists(db_path):
         print(f"Database not found: {db_path}", file=sys.stderr)
@@ -331,7 +342,7 @@ def _cmd_db_cleanup_errors(args: argparse.Namespace) -> None:
         print("No config file found. Use --config to specify one.", file=sys.stderr)
         sys.exit(1)
 
-    data_dir = os.path.join(os.path.dirname(config_path), "data")
+    data_dir = _resolve_data_dir(config_path, args)
     db_path = os.path.join(data_dir, "gateway.db")
     if not os.path.exists(db_path):
         print(f"Database not found: {db_path}", file=sys.stderr)
@@ -368,7 +379,7 @@ def _cmd_db_export_errors(args: argparse.Namespace) -> None:
         print("No config file found. Use --config to specify one.", file=sys.stderr)
         sys.exit(1)
 
-    data_dir = os.path.join(os.path.dirname(config_path), "data")
+    data_dir = _resolve_data_dir(config_path, args)
     db_path = os.path.join(data_dir, "gateway.db")
     if not os.path.exists(db_path):
         print(f"Database not found: {db_path}", file=sys.stderr)
@@ -462,6 +473,11 @@ def main() -> None:
         help="HTTP/SOCKS proxy URL for upstream requests (overrides config)",
     )
     parser.add_argument(
+        "--data-dir",
+        default=None,
+        help="Directory for gateway.db and other persistent data (overrides config)",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
@@ -510,6 +526,11 @@ def main() -> None:
 
     # ``db`` subcommands
     db_parser = sub.add_parser("db", help="Database maintenance commands")
+    db_parser.add_argument(
+        "--data-dir",
+        default=None,
+        help="Directory containing gateway.db (overrides config)",
+    )
     db_sub = db_parser.add_subparsers(dest="db_type")
     cleanup_parser = db_sub.add_parser(
         "cleanup", help="Delete all records older than max-age-days and vacuum"
@@ -583,6 +604,8 @@ def main() -> None:
     # CLI --proxy overrides config-level server.proxy
     if args.proxy:
         raw_config.setdefault("server", {})["proxy"] = args.proxy
+    if args.data_dir:
+        raw_config.setdefault("server", {})["data_dir"] = args.data_dir
 
     config = GatewayConfig(raw_config)
 

--- a/src/llm_rosetta/gateway/cli.py
+++ b/src/llm_rosetta/gateway/cli.py
@@ -257,6 +257,8 @@ def _resolve_data_dir(config_path: str, args: argparse.Namespace) -> str:
     raw = load_config(config_path)
     configured = raw.get("server", {}).get("data_dir")
     if configured:
+        if not os.path.isabs(configured):
+            return os.path.join(os.path.dirname(config_path), configured)
         return configured
     return os.path.join(os.path.dirname(config_path), "data")
 
@@ -528,7 +530,7 @@ def main() -> None:
     db_parser = sub.add_parser("db", help="Database maintenance commands")
     db_parser.add_argument(
         "--data-dir",
-        default=None,
+        default=argparse.SUPPRESS,
         help="Directory containing gateway.db (overrides config)",
     )
     db_sub = db_parser.add_subparsers(dest="db_type")

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -532,6 +532,7 @@ class GatewayConfig:
 
         # Request-log retention knobs (consumed by setup_admin).
         self.request_log: dict[str, Any] = _server.get("request_log", {}) or {}
+        self.data_dir: str | None = _server.get("data_dir")
 
     def _apply_auth_settings(self, _server: dict[str, Any]) -> None:
         """Parse API key auth settings from the server section.

--- a/tests/gateway/test_data_dir.py
+++ b/tests/gateway/test_data_dir.py
@@ -155,3 +155,133 @@ class TestArgparseSubparserClobber:
 
         args = parser.parse_args(["db", "cleanup"])
         assert args.data_dir is None
+
+
+class TestKeysDbDataDir:
+    """keys.db should default to data_dir when available."""
+
+    def _make_config(self, tmp_path, server_extra=None):
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        config_path = str(tmp_path / "config.jsonc")
+        server = {}
+        if server_extra:
+            server.update(server_extra)
+        raw = {
+            "providers": {"t": {"api_key": "k", "base_url": "http://x"}},
+            "models": {"m": "t"},
+            "server": server,
+        }
+        _write_config(config_path, server)
+        config = GatewayConfig(raw)
+        return config, config_path
+
+    def test_keys_db_defaults_to_data_dir(self, tmp_path):
+        """Fresh start, no existing keys.db → created in data_dir."""
+        from llm_rosetta.gateway.app import _setup_auth
+
+        config, config_path = self._make_config(tmp_path)
+        data_dir = str(tmp_path / "data")
+        os.makedirs(data_dir, exist_ok=True)
+
+        _, keystore, _ = _setup_auth(config, config_path, data_dir=data_dir)
+        try:
+            assert str(keystore._db_path) == os.path.join(data_dir, "keys.db")
+        finally:
+            keystore.close()
+
+    def test_keys_db_legacy_fallback(self, tmp_path):
+        """keys.db exists at old config-sibling location → uses old path."""
+        import sqlite3
+
+        from llm_rosetta.gateway.app import _setup_auth
+
+        config, config_path = self._make_config(tmp_path)
+        data_dir = str(tmp_path / "data")
+        os.makedirs(data_dir, exist_ok=True)
+
+        # Create a legacy keys.db next to config
+        old_path = str(tmp_path / "keys.db")
+        conn = sqlite3.connect(old_path)
+        conn.execute("CREATE TABLE test (id INTEGER)")
+        conn.close()
+
+        _, keystore, _ = _setup_auth(config, config_path, data_dir=data_dir)
+        try:
+            assert str(keystore._db_path) == old_path
+        finally:
+            keystore.close()
+
+    def test_keys_db_explicit_api_keys_db_wins(self, tmp_path):
+        """config.api_keys_db set → uses that, ignores data_dir."""
+        from llm_rosetta.gateway.app import _setup_auth
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        explicit = str(tmp_path / "custom" / "my-keys.db")
+        raw = {
+            "providers": {"t": {"api_key": "k", "base_url": "http://x"}},
+            "models": {"m": "t"},
+            "server": {"api_keys_db": explicit},
+        }
+        config = GatewayConfig(raw)
+        config_path = str(tmp_path / "config.jsonc")
+        _write_config(config_path)
+
+        data_dir = str(tmp_path / "data")
+        _, keystore, _ = _setup_auth(config, config_path, data_dir=data_dir)
+        try:
+            assert str(keystore._db_path) == explicit
+        finally:
+            keystore.close()
+
+    def test_keys_db_new_location_preferred(self, tmp_path):
+        """keys.db exists in both old and data_dir → uses data_dir."""
+        import sqlite3
+
+        from llm_rosetta.gateway.app import _setup_auth
+
+        config, config_path = self._make_config(tmp_path)
+        data_dir = str(tmp_path / "data")
+        os.makedirs(data_dir, exist_ok=True)
+
+        # Create keys.db in both locations
+        for path in [str(tmp_path / "keys.db"), os.path.join(data_dir, "keys.db")]:
+            conn = sqlite3.connect(path)
+            conn.execute("CREATE TABLE test (id INTEGER)")
+            conn.close()
+
+        _, keystore, _ = _setup_auth(config, config_path, data_dir=data_dir)
+        try:
+            assert str(keystore._db_path) == os.path.join(data_dir, "keys.db")
+        finally:
+            keystore.close()
+
+    def test_resolve_data_dir_for_app(self, tmp_path):
+        """_resolve_data_dir_for_app mirrors _resolve_data_dir behavior."""
+        from llm_rosetta.gateway.app import _resolve_data_dir_for_app
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        config_path = str(tmp_path / "config.jsonc")
+        _write_config(config_path)
+
+        # No data_dir in config → default
+        raw = {
+            "providers": {"t": {"api_key": "k", "base_url": "http://x"}},
+            "models": {"m": "t"},
+            "server": {},
+        }
+        config = GatewayConfig(raw)
+        result = _resolve_data_dir_for_app(config, config_path)
+        assert result == str(tmp_path / "data")
+
+        # Relative data_dir → resolved against config dir
+        raw["server"]["data_dir"] = "my-data"
+        config = GatewayConfig(raw)
+        result = _resolve_data_dir_for_app(config, config_path)
+        assert result == str(tmp_path / "my-data")
+
+        # Absolute data_dir → used as-is
+        raw["server"]["data_dir"] = "/absolute/path"
+        config = GatewayConfig(raw)
+        result = _resolve_data_dir_for_app(config, config_path)
+        assert result == "/absolute/path"

--- a/tests/gateway/test_data_dir.py
+++ b/tests/gateway/test_data_dir.py
@@ -1,0 +1,157 @@
+"""Tests for data_dir resolution order: CLI > config > default."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from llm_rosetta.gateway.cli import _resolve_data_dir
+
+
+from typing import Any
+
+
+class _MockApp:
+    persistence: Any = None
+
+
+def _write_config(path: str, server: dict | None = None) -> None:
+    cfg = {
+        "providers": {"test": {"api_key": "k", "base_url": "http://x"}},
+        "models": {"m": "test"},
+        "server": server or {},
+    }
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(cfg, f)
+
+
+class TestResolveDataDir:
+    """_resolve_data_dir: CLI --data-dir > config server.data_dir > default."""
+
+    def test_cli_flag_wins(self, tmp_path):
+        config_path = str(tmp_path / "config.jsonc")
+        _write_config(config_path, {"data_dir": "/from-config"})
+        args = argparse.Namespace(data_dir="/from-cli")
+        assert _resolve_data_dir(config_path, args) == "/from-cli"
+
+    def test_config_absolute(self, tmp_path):
+        config_path = str(tmp_path / "config.jsonc")
+        _write_config(config_path, {"data_dir": "/absolute/data"})
+        args = argparse.Namespace(data_dir=None)
+        assert _resolve_data_dir(config_path, args) == "/absolute/data"
+
+    def test_config_relative_resolved_against_config_dir(self, tmp_path):
+        config_path = str(tmp_path / "config.jsonc")
+        _write_config(config_path, {"data_dir": "my-data"})
+        args = argparse.Namespace(data_dir=None)
+        expected = str(tmp_path / "my-data")
+        assert _resolve_data_dir(config_path, args) == expected
+
+    def test_config_relative_dot_prefix(self, tmp_path):
+        config_path = str(tmp_path / "config.jsonc")
+        _write_config(config_path, {"data_dir": "./subdir"})
+        args = argparse.Namespace(data_dir=None)
+        expected = str(tmp_path / "./subdir")
+        assert os.path.normpath(
+            _resolve_data_dir(config_path, args)
+        ) == os.path.normpath(expected)
+
+    def test_default_fallback(self, tmp_path):
+        config_path = str(tmp_path / "config.jsonc")
+        _write_config(config_path)
+        args = argparse.Namespace(data_dir=None)
+        expected = str(tmp_path / "data")
+        assert _resolve_data_dir(config_path, args) == expected
+
+    def test_no_data_dir_attr_on_args(self, tmp_path):
+        config_path = str(tmp_path / "config.jsonc")
+        _write_config(config_path)
+        args = argparse.Namespace()  # no data_dir attr at all (SUPPRESS)
+        expected = str(tmp_path / "data")
+        assert _resolve_data_dir(config_path, args) == expected
+
+
+class TestSetupAdminDataDir:
+    """setup_admin data_dir resolution mirrors _resolve_data_dir."""
+
+    def test_explicit_data_dir_wins(self, tmp_path):
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        explicit_dir = str(tmp_path / "explicit")
+        raw = {
+            "providers": {"t": {"api_key": "k", "base_url": "http://x"}},
+            "models": {"m": "t"},
+            "server": {"data_dir": str(tmp_path / "from-config")},
+        }
+        config = GatewayConfig(raw)
+        config_path = str(tmp_path / "config.jsonc")
+        _write_config(config_path)
+
+        app = _MockApp()
+        from llm_rosetta.gateway.admin import setup_admin
+
+        setup_admin(app, config, config_path, data_dir=explicit_dir)
+        assert app.persistence is not None
+        assert "explicit" in str(app.persistence._data_dir)
+
+    def test_config_relative_resolved(self, tmp_path):
+        from llm_rosetta.gateway.config import GatewayConfig
+
+        raw = {
+            "providers": {"t": {"api_key": "k", "base_url": "http://x"}},
+            "models": {"m": "t"},
+            "server": {"data_dir": "my-data"},
+        }
+        config = GatewayConfig(raw)
+        config_path = str(tmp_path / "config.jsonc")
+        _write_config(config_path)
+
+        app = _MockApp()
+        from llm_rosetta.gateway.admin import setup_admin
+
+        setup_admin(app, config, config_path)
+        assert app.persistence is not None
+        assert os.path.normpath(app.persistence._data_dir) == os.path.normpath(
+            str(tmp_path / "my-data")
+        )
+
+
+class TestArgparseSubparserClobber:
+    """Verify --data-dir on parent isn't clobbered by db subparser."""
+
+    def test_parent_data_dir_survives_subcommand(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--data-dir", default=None)
+        sub = parser.add_subparsers(dest="command")
+        db_parser = sub.add_parser("db")
+        db_parser.add_argument("--data-dir", default=argparse.SUPPRESS)
+        db_sub = db_parser.add_subparsers(dest="db_type")
+        db_sub.add_parser("cleanup")
+
+        args = parser.parse_args(["--data-dir", "/foo", "db", "cleanup"])
+        assert args.data_dir == "/foo"
+
+    def test_subparser_data_dir_explicit(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--data-dir", default=None)
+        sub = parser.add_subparsers(dest="command")
+        db_parser = sub.add_parser("db")
+        db_parser.add_argument("--data-dir", default=argparse.SUPPRESS)
+        db_sub = db_parser.add_subparsers(dest="db_type")
+        db_sub.add_parser("cleanup")
+
+        args = parser.parse_args(["db", "--data-dir", "/bar", "cleanup"])
+        assert args.data_dir == "/bar"
+
+    def test_neither_level_sets_data_dir(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--data-dir", default=None)
+        sub = parser.add_subparsers(dest="command")
+        db_parser = sub.add_parser("db")
+        db_parser.add_argument("--data-dir", default=argparse.SUPPRESS)
+        db_sub = db_parser.add_subparsers(dest="db_type")
+        db_sub.add_parser("cleanup")
+
+        args = parser.parse_args(["db", "cleanup"])
+        assert args.data_dir is None


### PR DESCRIPTION
## Summary

- Add `server.data_dir` config field to `GatewayConfig` for specifying where `gateway.db` and other persistent data lives
- Add `--data-dir` CLI flag (top-level and on `db` subcommands) that overrides config
- Add `data_dir` parameter to `setup_admin()` for downstream projects (e.g. argo-proxy) to pass through
- Extract `_resolve_data_dir()` helper, replacing 4 duplicate `os.path.dirname(config_path)/data` derivations in CLI
- Move `keys.db` default location into `data_dir` alongside `gateway.db`, with deprecation fallback for existing deployments
- Extract `_resolve_data_dir_for_app()` helper shared by keystore and persistence setup

Resolution order: CLI `--data-dir` > config `server.data_dir` > `<config_dir>/data` (existing default). Fully backward compatible — no changes needed for existing deployments.

Fixes the "database is locked" error when two gateway instances share a config directory (via symlink or same folder).

Fixes #622

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (3004 passed)
- [x] 16 unit tests covering data_dir resolution order, relative path handling, argparse clobber fix, keys.db placement, and legacy fallback
- [x] Manual: relative `data_dir` in config resolves against config dir, not CWD
- [x] Manual: `--data-dir` CLI flag correctly overrides config
- [ ] Manual: start two instances with same config but different `--data-dir`, verify no lock conflict