### PR TITLE
fix(converters): sanitize tool_call_id at provider output boundary

### DIFF
--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -42,7 +42,11 @@ from ...types.ir.stream import (
 )
 from ..base import BaseConverter
 from ..base.context import ConversionContext, StreamContext
-from ..base.helpers import fix_orphaned_tool_calls_ir, strip_orphaned_tool_config
+from ..base.helpers import (
+    fix_orphaned_tool_calls_ir,
+    sanitize_tool_call_id,
+    strip_orphaned_tool_config,
+)
 from ._constants import (
     ANTHROPIC_REASON_FROM_PROVIDER,
     ANTHROPIC_REASON_TO_PROVIDER,
@@ -1047,7 +1051,7 @@ class AnthropicConverter(BaseConverter):
             "type": AnthropicEventType.CONTENT_BLOCK_START,
             "content_block": {
                 "type": "tool_use",
-                "id": event["tool_call_id"],
+                "id": sanitize_tool_call_id(event["tool_call_id"]),
                 "name": event["tool_name"],
                 "input": {},
             },

--- a/src/llm_rosetta/converters/anthropic/tool_ops.py
+++ b/src/llm_rosetta/converters/anthropic/tool_ops.py
@@ -33,6 +33,7 @@ from ..base.helpers import (
     extract_part_ids,
     log_orphan_warnings,
     sanitize_schema,
+    sanitize_tool_call_id,
 )
 
 logger = logging.getLogger(__name__)
@@ -315,14 +316,14 @@ class AnthropicToolOps(BaseToolOps):
         if tool_type == "web_search":
             result = {
                 "type": "server_tool_use",
-                "id": ir_tool_call["tool_call_id"],
+                "id": sanitize_tool_call_id(ir_tool_call["tool_call_id"]),
                 "name": "web_search",
                 "input": tool_input,
             }
         else:
             result = {
                 "type": "tool_use",
-                "id": ir_tool_call["tool_call_id"],
+                "id": sanitize_tool_call_id(ir_tool_call["tool_call_id"]),
                 "name": ir_tool_call["tool_name"],
                 "input": tool_input,
             }
@@ -404,7 +405,7 @@ class AnthropicToolOps(BaseToolOps):
         """
         result: dict[str, Any] = {
             "type": "tool_result",
-            "tool_use_id": ir_tool_result["tool_call_id"],
+            "tool_use_id": sanitize_tool_call_id(ir_tool_result["tool_call_id"]),
         }
 
         content = ir_tool_result.get("result", "")

--- a/src/llm_rosetta/converters/base/helpers/__init__.py
+++ b/src/llm_rosetta/converters/base/helpers/__init__.py
@@ -11,6 +11,7 @@ Modules:
     reasoning       — Shim-driven reasoning configuration helpers.
     schema          — JSON Schema sanitization for provider compatibility.
     tool_call_unwind — Unwind parallel tool calls into sequential pairs.
+    tool_call_id    — Tool call ID sanitization for provider compatibility.
     tool_content    — Multimodal content block conversion inside tool results.
 """
 
@@ -25,6 +26,7 @@ from .tool_orphan_fix import (
     strip_orphaned_tool_config,
 )
 from .schema import convert_nullable_to_type_array, sanitize_schema
+from .tool_call_id import sanitize_tool_call_id
 from .reasoning import DEFAULT_REASONING_CAPS, apply_reasoning_config
 from .tool_call_unwind import unwind_parallel_tool_calls_ir
 from .tool_content import convert_content_blocks_to_ir, convert_ir_content_blocks_to_p
@@ -38,6 +40,7 @@ __all__ = [
     # schema
     "convert_nullable_to_type_array",
     "sanitize_schema",
+    "sanitize_tool_call_id",
     # reasoning
     "DEFAULT_REASONING_CAPS",
     "apply_reasoning_config",

--- a/src/llm_rosetta/converters/base/helpers/tool_call_id.py
+++ b/src/llm_rosetta/converters/base/helpers/tool_call_id.py
@@ -48,7 +48,7 @@ def sanitize_tool_call_id(
         conforms.
     """
     if not raw_id:
-        return raw_id
+        return raw_id or ""
 
     sanitized = _INVALID_CHARS.sub("_", raw_id)
 

--- a/src/llm_rosetta/converters/base/helpers/tool_call_id.py
+++ b/src/llm_rosetta/converters/base/helpers/tool_call_id.py
@@ -55,6 +55,8 @@ def sanitize_tool_call_id(
     if len(sanitized) <= max_length:
         return sanitized
 
+    # Hash the sanitized form (not raw) — two raw IDs differing only in
+    # which invalid chars they use will collide, but this is acceptable.
     digest = hashlib.sha256(sanitized.encode()).hexdigest()[:_HASH_SUFFIX_LEN]
     truncated_len = max_length - _HASH_SUFFIX_LEN - 1  # 1 for separator
     return f"{sanitized[:truncated_len]}_{digest}"

--- a/src/llm_rosetta/converters/base/helpers/tool_call_id.py
+++ b/src/llm_rosetta/converters/base/helpers/tool_call_id.py
@@ -1,0 +1,60 @@
+"""Tool call ID sanitization for provider compatibility.
+
+Ensures ``tool_call_id`` values conform to provider-specific constraints
+before they are written into outgoing requests or streaming events.
+
+Provider constraints:
+    - OpenAI Chat / Responses: max 64 characters
+    - Anthropic Messages: must match ``^[a-zA-Z0-9_-]+$``
+    - Google GenAI: generates its own IDs (not affected)
+
+The sanitization is applied at the IR → provider boundary so that the IR
+itself preserves the original ID for internal correlation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+_INVALID_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+
+MAX_TOOL_CALL_ID_LENGTH = 64
+_HASH_SUFFIX_LEN = 8
+
+
+def sanitize_tool_call_id(
+    raw_id: str, max_length: int = MAX_TOOL_CALL_ID_LENGTH
+) -> str:
+    """Sanitize a tool call ID for provider compatibility.
+
+    1. Replace characters outside ``[a-zA-Z0-9_-]`` with ``_``.
+    2. If the result exceeds *max_length*, truncate and append a
+       deterministic hash suffix to preserve uniqueness.
+
+    The function is pure and deterministic — the same input always
+    produces the same output, so tool_call and tool_result pairs
+    remain correlated without a lookup table.
+
+    Args:
+        raw_id: The original tool call ID (may contain invalid chars
+            or exceed length limits).
+        max_length: Maximum allowed length (default 64, matching
+            OpenAI's constraint).
+
+    Returns:
+        A sanitized ID that satisfies both character-set and length
+        constraints.  Returns the input unchanged if it already
+        conforms.
+    """
+    if not raw_id:
+        return raw_id
+
+    sanitized = _INVALID_CHARS.sub("_", raw_id)
+
+    if len(sanitized) <= max_length:
+        return sanitized
+
+    digest = hashlib.sha256(sanitized.encode()).hexdigest()[:_HASH_SUFFIX_LEN]
+    truncated_len = max_length - _HASH_SUFFIX_LEN - 1  # 1 for separator
+    return f"{sanitized[:truncated_len]}_{digest}"

--- a/src/llm_rosetta/converters/google_genai/converter.py
+++ b/src/llm_rosetta/converters/google_genai/converter.py
@@ -44,7 +44,11 @@ from ...types.ir.stream import (
 )
 from ..base import BaseConverter
 from ..base.context import ConversionContext, StreamContext
-from ..base.helpers import fix_orphaned_tool_calls_ir, strip_orphaned_tool_config
+from ..base.helpers import (
+    fix_orphaned_tool_calls_ir,
+    sanitize_tool_call_id,
+    strip_orphaned_tool_config,
+)
 from ._constants import (
     GOOGLE_REASON_FROM_PROVIDER,
     GOOGLE_REASON_TO_PROVIDER,
@@ -1098,7 +1102,7 @@ class GoogleGenAIConverter(BaseConverter):
                     args = {}
                 fc: dict[str, Any] = {"name": tool_name, "args": args}
                 if call_id:
-                    fc["id"] = call_id
+                    fc["id"] = sanitize_tool_call_id(call_id)
                 parts.append({"functionCall": fc})
 
         finish_chunk: dict[str, Any] = {

--- a/src/llm_rosetta/converters/google_genai/tool_ops.py
+++ b/src/llm_rosetta/converters/google_genai/tool_ops.py
@@ -25,7 +25,7 @@ from ...types.ir import (
 )
 from ...types.ir.tools import ToolCallConfig
 from ..base import BaseToolOps
-from ..base.helpers import sanitize_schema
+from ..base.helpers import sanitize_schema, sanitize_tool_call_id
 from ._constants import generate_tool_call_id
 
 
@@ -323,7 +323,7 @@ class GoogleGenAIToolOps(BaseToolOps):
         }
         tool_call_id = ir_tool_call.get("tool_call_id")
         if tool_call_id:
-            func_call["id"] = tool_call_id
+            func_call["id"] = sanitize_tool_call_id(tool_call_id)
 
         part: dict[str, Any] = {"functionCall": func_call}
 
@@ -412,7 +412,7 @@ class GoogleGenAIToolOps(BaseToolOps):
         }
         tool_call_id = ir_tool_result.get("tool_call_id")
         if tool_call_id:
-            func_response["id"] = tool_call_id
+            func_response["id"] = sanitize_tool_call_id(tool_call_id)
 
         return {"functionResponse": func_response}
 
@@ -468,7 +468,7 @@ class GoogleGenAIToolOps(BaseToolOps):
         }
         tool_call_id = ir_tool_result.get("tool_call_id")
         if tool_call_id:
-            func_response["id"] = tool_call_id
+            func_response["id"] = sanitize_tool_call_id(tool_call_id)
 
         return {"functionResponse": func_response}
 

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -35,7 +35,11 @@ from ...types.ir.stream import (
 )
 from ..base import BaseConverter
 from ..base.context import ConversionContext, StreamContext
-from ..base.helpers import fix_orphaned_tool_calls_ir, strip_orphaned_tool_config
+from ..base.helpers import (
+    fix_orphaned_tool_calls_ir,
+    sanitize_tool_call_id,
+    strip_orphaned_tool_config,
+)
 from ._constants import OPENAI_CHAT_REASON_FROM_PROVIDER, OPENAI_CHAT_REASON_TO_PROVIDER
 from .config_ops import OpenAIChatConfigOps
 from .content_ops import OpenAIChatContentOps
@@ -999,11 +1003,12 @@ class OpenAIChatConverter(BaseConverter):
         choice_index = event.get("choice_index", 0)
         tc_index = event.get("tool_call_index", 0)
         tool_type = event.get("tool_type", "function")
+        call_id = sanitize_tool_call_id(event["tool_call_id"])
 
         if tool_type == "custom":
             tc_entry: dict[str, Any] = {
                 "index": tc_index,
-                "id": event["tool_call_id"],
+                "id": call_id,
                 "type": "custom",
                 "custom": {
                     "name": event["tool_name"],
@@ -1013,7 +1018,7 @@ class OpenAIChatConverter(BaseConverter):
         else:
             tc_entry = {
                 "index": tc_index,
-                "id": event["tool_call_id"],
+                "id": call_id,
                 "type": "function",
                 "function": {
                     "name": event["tool_name"],
@@ -1022,9 +1027,7 @@ class OpenAIChatConverter(BaseConverter):
             }
 
         if context is not None:
-            context.register_tool_call(
-                event["tool_call_id"], event["tool_name"], tool_type
-            )
+            context.register_tool_call(call_id, event["tool_name"], tool_type)
 
         chunk = {
             "choices": [

--- a/src/llm_rosetta/converters/openai_chat/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/tool_ops.py
@@ -24,7 +24,7 @@ from ...types.ir import (
 )
 from ...types.ir.tools import ToolCallConfig
 from ..base import BaseToolOps
-from ..base.helpers import log_orphan_warnings, sanitize_schema
+from ..base.helpers import log_orphan_warnings, sanitize_schema, sanitize_tool_call_id
 
 logger = logging.getLogger(__name__)
 
@@ -382,7 +382,7 @@ class OpenAIChatToolOps(BaseToolOps):
                     else str(tool_input)
                 )
             result: dict[str, Any] = {
-                "id": ir_tool_call["tool_call_id"],
+                "id": sanitize_tool_call_id(ir_tool_call["tool_call_id"]),
                 "type": "custom",
                 "custom": {
                     "name": ir_tool_call["tool_name"],
@@ -397,7 +397,7 @@ class OpenAIChatToolOps(BaseToolOps):
             json.dumps(tool_input) if isinstance(tool_input, dict) else str(tool_input)
         )
         result = {
-            "id": ir_tool_call["tool_call_id"],
+            "id": sanitize_tool_call_id(ir_tool_call["tool_call_id"]),
             "type": "function",
             "function": {
                 "name": ir_tool_call["tool_name"],
@@ -488,7 +488,7 @@ class OpenAIChatToolOps(BaseToolOps):
 
         return {
             "role": "tool",
-            "tool_call_id": ir_tool_result["tool_call_id"],
+            "tool_call_id": sanitize_tool_call_id(ir_tool_result["tool_call_id"]),
             "content": content,
         }
 

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -39,7 +39,11 @@ from ...types.ir.stream import (
 )
 from ..base import BaseConverter
 from ..base.context import ConversionContext, StreamContext
-from ..base.helpers import fix_orphaned_tool_calls_ir, strip_orphaned_tool_config
+from ..base.helpers import (
+    fix_orphaned_tool_calls_ir,
+    sanitize_tool_call_id,
+    strip_orphaned_tool_config,
+)
 from .stream_context import OpenAIResponsesStreamContext
 from ._constants import (
     RESPONSES_INCOMPLETE_REASON_TO_IR,
@@ -1464,7 +1468,7 @@ class OpenAIResponsesConverter(BaseConverter):
         event: ToolCallStartEvent,
         context: StreamContext | None,
     ) -> dict[str, Any]:
-        call_id = event["tool_call_id"]
+        call_id = sanitize_tool_call_id(event["tool_call_id"])
         tool_name = event["tool_name"]
         tool_type = event.get("tool_type", "function")
         pm = event.get("provider_metadata") or {}
@@ -1513,7 +1517,7 @@ class OpenAIResponsesConverter(BaseConverter):
         event: ToolCallDeltaEvent,
         context: StreamContext | None,
     ) -> dict[str, Any]:
-        call_id = event["tool_call_id"]
+        call_id = sanitize_tool_call_id(event["tool_call_id"])
         delta = event["arguments_delta"]
         tc_index = event.get("tool_call_index")
 

--- a/src/llm_rosetta/converters/openai_responses/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/tool_ops.py
@@ -642,6 +642,8 @@ class OpenAIResponsesToolOps(BaseToolOps):
         else:
             output = str(result_content)
 
+        # Sanitize here to match the ID registered by ir_tool_call_to_p / streaming start.
+        # Non-streaming ctx may be None (falls back to "function"), which is correct.
         call_id = sanitize_tool_call_id(ir_tool_result["tool_call_id"])
         ctx = kwargs.get("context")
         tool_type = ctx.get_tool_type(call_id) if ctx is not None else "function"

--- a/src/llm_rosetta/converters/openai_responses/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/tool_ops.py
@@ -28,7 +28,12 @@ from ...types.ir import (
 )
 from ...types.ir.tools import ToolCallConfig
 from ..base import BaseToolOps
-from ..base.helpers import extract_part_ids, log_orphan_warnings, sanitize_schema
+from ..base.helpers import (
+    extract_part_ids,
+    log_orphan_warnings,
+    sanitize_schema,
+    sanitize_tool_call_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -426,7 +431,9 @@ class OpenAIResponsesToolOps(BaseToolOps):
             OpenAI Responses tool call item dict.
         """
         tool_type = ir_tool_call.get("tool_type", "function")
-        tool_call_id = ir_tool_call.get("tool_call_id", ir_tool_call.get("id", ""))
+        tool_call_id = sanitize_tool_call_id(
+            ir_tool_call.get("tool_call_id", ir_tool_call.get("id", ""))
+        )
         tool_name = ir_tool_call.get("tool_name", ir_tool_call.get("name", ""))
         tool_input = ir_tool_call.get("tool_input", ir_tool_call.get("arguments", {}))
 
@@ -635,7 +642,7 @@ class OpenAIResponsesToolOps(BaseToolOps):
         else:
             output = str(result_content)
 
-        call_id = ir_tool_result["tool_call_id"]
+        call_id = sanitize_tool_call_id(ir_tool_result["tool_call_id"])
         ctx = kwargs.get("context")
         tool_type = ctx.get_tool_type(call_id) if ctx is not None else "function"
 

--- a/tests/test_tool_call_id_sanitize.py
+++ b/tests/test_tool_call_id_sanitize.py
@@ -1,0 +1,174 @@
+"""Tests for tool_call_id sanitization."""
+
+import re
+
+
+from llm_rosetta.converters.base.helpers.tool_call_id import (
+    MAX_TOOL_CALL_ID_LENGTH,
+    sanitize_tool_call_id,
+)
+
+
+class TestSanitizeToolCallId:
+    """Unit tests for the sanitize_tool_call_id function."""
+
+    def test_clean_id_unchanged(self):
+        assert sanitize_tool_call_id("call_abc123") == "call_abc123"
+
+    def test_anthropic_id_unchanged(self):
+        assert (
+            sanitize_tool_call_id("toolu_vrtx_017Gnb9udfcY5kqjdAUkence")
+            == "toolu_vrtx_017Gnb9udfcY5kqjdAUkence"
+        )
+
+    def test_openai_id_unchanged(self):
+        assert (
+            sanitize_tool_call_id("call_NTEBXqjyLLvYusbiGf1fXZv2")
+            == "call_NTEBXqjyLLvYusbiGf1fXZv2"
+        )
+
+    def test_dashes_preserved(self):
+        assert sanitize_tool_call_id("call-abc-123") == "call-abc-123"
+
+    def test_newline_replaced(self):
+        result = sanitize_tool_call_id("abc\ndef")
+        assert "\n" not in result
+        assert result == "abc_def"
+
+    def test_spaces_replaced(self):
+        assert sanitize_tool_call_id("abc def") == "abc_def"
+
+    def test_dots_replaced(self):
+        assert sanitize_tool_call_id("abc.def") == "abc_def"
+
+    def test_empty_string(self):
+        assert sanitize_tool_call_id("") == ""
+
+    def test_all_invalid_chars(self):
+        result = sanitize_tool_call_id("!@#$%")
+        assert re.match(r"^[a-zA-Z0-9_-]+$", result)
+        assert result == "_____"
+
+    def test_exactly_64_chars(self):
+        raw = "a" * 64
+        assert sanitize_tool_call_id(raw) == raw
+
+    def test_65_chars_truncated(self):
+        raw = "a" * 65
+        result = sanitize_tool_call_id(raw)
+        assert len(result) == 64
+        assert re.match(r"^[a-zA-Z0-9_-]+$", result)
+
+    def test_long_id_truncated_with_hash(self):
+        raw = "a" * 100
+        result = sanitize_tool_call_id(raw)
+        assert len(result) == MAX_TOOL_CALL_ID_LENGTH
+        assert result.startswith("a" * 55)
+        assert "_" in result[55:]
+
+    def test_deterministic(self):
+        raw = "call-3898c698-4c99-4803-87b7-217020159648-0\nfc_d9dc660e-7d55-9b7f-af1e-f62010e084f7_0"
+        assert sanitize_tool_call_id(raw) == sanitize_tool_call_id(raw)
+
+    def test_brettin_id_valid(self):
+        """The real-world broken ID from the bug report."""
+        raw = "call-3898c698-4c99-4803-87b7-217020159648-0\nfc_d9dc660e-7d55-9b7f-af1e-f62010e084f7_0"
+        result = sanitize_tool_call_id(raw)
+        assert len(result) <= 64
+        assert re.match(r"^[a-zA-Z0-9_-]+$", result)
+
+    def test_different_long_ids_produce_different_results(self):
+        a = "a" * 100
+        b = "b" * 100
+        assert sanitize_tool_call_id(a) != sanitize_tool_call_id(b)
+
+    def test_custom_max_length(self):
+        raw = "a" * 50
+        result = sanitize_tool_call_id(raw, max_length=30)
+        assert len(result) == 30
+
+    def test_tool_call_and_result_match(self):
+        """Tool call and tool result with the same raw ID produce the same sanitized ID."""
+        raw = "call-x\nfc_y"
+        assert sanitize_tool_call_id(raw) == sanitize_tool_call_id(raw)
+
+
+class TestSanitizationInConverters:
+    """Integration tests: verify sanitized IDs flow through converter output."""
+
+    def test_openai_chat_tool_call_sanitized(self):
+        from llm_rosetta.converters.openai_chat.tool_ops import OpenAIChatToolOps
+
+        ir_tool_call = {
+            "type": "tool_call",
+            "tool_call_id": "bad\nid_with_newline",
+            "tool_name": "test_fn",
+            "tool_input": {"x": 1},
+            "tool_type": "function",
+        }
+        result = OpenAIChatToolOps.ir_tool_call_to_p(ir_tool_call)
+        assert "\n" not in result["id"]
+        assert re.match(r"^[a-zA-Z0-9_-]+$", result["id"])
+
+    def test_openai_chat_tool_result_sanitized(self):
+        from llm_rosetta.converters.openai_chat.tool_ops import OpenAIChatToolOps
+
+        ir_tool_result = {
+            "type": "tool_result",
+            "tool_call_id": "bad\nid",
+            "tool_name": "test_fn",
+            "content": "ok",
+        }
+        result = OpenAIChatToolOps.ir_tool_result_to_p(ir_tool_result)
+        assert "\n" not in result["tool_call_id"]
+
+    def test_anthropic_tool_call_sanitized(self):
+        from llm_rosetta.converters.anthropic.tool_ops import AnthropicToolOps
+
+        ir_tool_call = {
+            "type": "tool_call",
+            "tool_call_id": "too-long-" * 10,
+            "tool_name": "test_fn",
+            "tool_input": {"x": 1},
+            "tool_type": "function",
+        }
+        result = AnthropicToolOps.ir_tool_call_to_p(ir_tool_call)
+        assert len(result["id"]) <= 64
+        assert re.match(r"^[a-zA-Z0-9_-]+$", result["id"])
+
+    def test_anthropic_tool_result_sanitized(self):
+        from llm_rosetta.converters.anthropic.tool_ops import AnthropicToolOps
+
+        ir_tool_result = {
+            "type": "tool_result",
+            "tool_call_id": "has spaces and.dots",
+            "tool_name": "test_fn",
+            "content": [{"type": "text", "text": "ok"}],
+        }
+        result = AnthropicToolOps.ir_tool_result_to_p(ir_tool_result)
+        assert result["tool_use_id"] == "has_spaces_and_dots"
+
+    def test_openai_chat_tool_call_result_ids_match(self):
+        """Tool call and result must produce matching sanitized IDs."""
+        from llm_rosetta.converters.openai_chat.tool_ops import OpenAIChatToolOps
+
+        raw_id = "call-bad\nid-0\nfc_other_0"
+
+        call_result = OpenAIChatToolOps.ir_tool_call_to_p(
+            {
+                "type": "tool_call",
+                "tool_call_id": raw_id,
+                "tool_name": "fn",
+                "tool_input": {},
+                "tool_type": "function",
+            }
+        )
+        result_result = OpenAIChatToolOps.ir_tool_result_to_p(
+            {
+                "type": "tool_result",
+                "tool_call_id": raw_id,
+                "tool_name": "fn",
+                "content": "ok",
+            }
+        )
+        assert call_result["id"] == result_result["tool_call_id"]

--- a/tests/test_tool_call_id_sanitize.py
+++ b/tests/test_tool_call_id_sanitize.py
@@ -170,3 +170,34 @@ class TestSanitizationInConverters:
             }
         )
         assert call_result["id"] == result_result["tool_call_id"]
+
+    def test_google_genai_tool_call_sanitized(self):
+        from llm_rosetta.converters.google_genai.tool_ops import GoogleGenAIToolOps
+
+        ir_tool_call = {
+            "type": "tool_call",
+            "tool_call_id": "bad\nid_with_newline",
+            "tool_name": "test_fn",
+            "tool_input": {"x": 1},
+            "tool_type": "function",
+        }
+        result = GoogleGenAIToolOps.ir_tool_call_to_p(ir_tool_call)
+        fc = result.get("functionCall", {})
+        assert "\n" not in fc.get("id", "")
+        assert re.match(r"^[a-zA-Z0-9_-]+$", fc["id"])
+
+    def test_openai_responses_tool_call_sanitized(self):
+        from llm_rosetta.converters.openai_responses.tool_ops import (
+            OpenAIResponsesToolOps,
+        )
+
+        ir_tool_call = {
+            "type": "tool_call",
+            "tool_call_id": "bad\nid_with_newline",
+            "tool_name": "test_fn",
+            "tool_input": {"x": 1},
+            "tool_type": "function",
+        }
+        result = OpenAIResponsesToolOps.ir_tool_call_to_p(ir_tool_call)
+        assert "\n" not in result.get("call_id", "")
+        assert re.match(r"^[a-zA-Z0-9_-]+$", result["call_id"])

--- a/tests/test_tool_call_id_sanitize.py
+++ b/tests/test_tool_call_id_sanitize.py
@@ -130,7 +130,7 @@ class TestSanitizationInConverters:
             "tool_name": "test_fn",
             "tool_input": {"x": 1},
             "tool_type": "function",
-        }  # type: ignore[typeddict-item]  # ty: ignore[invalid-argument-type]
+        }
         result = AnthropicToolOps.ir_tool_call_to_p(ir_tool_call)  # ty: ignore[invalid-argument-type]
         assert len(result["id"]) <= 64
         assert re.match(r"^[a-zA-Z0-9_-]+$", result["id"])
@@ -152,7 +152,7 @@ class TestSanitizationInConverters:
 
         raw_id = "call-bad\nid-0\nfc_other_0"
 
-        call_result = OpenAIChatToolOps.ir_tool_call_to_p(  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        call_result = OpenAIChatToolOps.ir_tool_call_to_p(
             {
                 "type": "tool_call",
                 "tool_call_id": raw_id,
@@ -161,7 +161,7 @@ class TestSanitizationInConverters:
                 "tool_type": "function",
             }
         )
-        result_result = OpenAIChatToolOps.ir_tool_result_to_p(  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        result_result = OpenAIChatToolOps.ir_tool_result_to_p(
             {
                 "type": "tool_result",
                 "tool_call_id": raw_id,

--- a/tests/test_tool_call_id_sanitize.py
+++ b/tests/test_tool_call_id_sanitize.py
@@ -106,7 +106,7 @@ class TestSanitizationInConverters:
             "tool_input": {"x": 1},
             "tool_type": "function",
         }
-        result = OpenAIChatToolOps.ir_tool_call_to_p(ir_tool_call)
+        result = OpenAIChatToolOps.ir_tool_call_to_p(ir_tool_call)  # ty: ignore[invalid-argument-type]
         assert "\n" not in result["id"]
         assert re.match(r"^[a-zA-Z0-9_-]+$", result["id"])
 
@@ -118,7 +118,7 @@ class TestSanitizationInConverters:
             "tool_call_id": "bad\nid",
             "result": "ok",
         }
-        result = OpenAIChatToolOps.ir_tool_result_to_p(ir_tool_result)
+        result = OpenAIChatToolOps.ir_tool_result_to_p(ir_tool_result)  # ty: ignore[invalid-argument-type]
         assert "\n" not in result["tool_call_id"]
 
     def test_anthropic_tool_call_sanitized(self):
@@ -130,8 +130,8 @@ class TestSanitizationInConverters:
             "tool_name": "test_fn",
             "tool_input": {"x": 1},
             "tool_type": "function",
-        }  # type: ignore[typeddict-item]
-        result = AnthropicToolOps.ir_tool_call_to_p(ir_tool_call)
+        }  # type: ignore[typeddict-item]  # ty: ignore[invalid-argument-type]
+        result = AnthropicToolOps.ir_tool_call_to_p(ir_tool_call)  # ty: ignore[invalid-argument-type]
         assert len(result["id"]) <= 64
         assert re.match(r"^[a-zA-Z0-9_-]+$", result["id"])
 
@@ -143,7 +143,7 @@ class TestSanitizationInConverters:
             "tool_call_id": "has spaces and.dots",
             "result": [{"type": "text", "text": "ok"}],
         }
-        result = AnthropicToolOps.ir_tool_result_to_p(ir_tool_result)
+        result = AnthropicToolOps.ir_tool_result_to_p(ir_tool_result)  # ty: ignore[invalid-argument-type]
         assert result["tool_use_id"] == "has_spaces_and_dots"
 
     def test_openai_chat_tool_call_result_ids_match(self):
@@ -152,7 +152,7 @@ class TestSanitizationInConverters:
 
         raw_id = "call-bad\nid-0\nfc_other_0"
 
-        call_result = OpenAIChatToolOps.ir_tool_call_to_p(  # type: ignore[arg-type]
+        call_result = OpenAIChatToolOps.ir_tool_call_to_p(  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
             {
                 "type": "tool_call",
                 "tool_call_id": raw_id,
@@ -161,12 +161,11 @@ class TestSanitizationInConverters:
                 "tool_type": "function",
             }
         )
-        result_result = OpenAIChatToolOps.ir_tool_result_to_p(  # type: ignore[arg-type]
+        result_result = OpenAIChatToolOps.ir_tool_result_to_p(  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
             {
                 "type": "tool_result",
                 "tool_call_id": raw_id,
-                "tool_name": "fn",
-                "content": "ok",
+                "result": "ok",
             }
         )
         assert call_result["id"] == result_result["tool_call_id"]
@@ -181,7 +180,7 @@ class TestSanitizationInConverters:
             "tool_input": {"x": 1},
             "tool_type": "function",
         }
-        result = GoogleGenAIToolOps.ir_tool_call_to_p(ir_tool_call)
+        result = GoogleGenAIToolOps.ir_tool_call_to_p(ir_tool_call)  # ty: ignore[invalid-argument-type]
         fc = result.get("functionCall", {})
         assert "\n" not in fc.get("id", "")
         assert re.match(r"^[a-zA-Z0-9_-]+$", fc["id"])
@@ -198,6 +197,6 @@ class TestSanitizationInConverters:
             "tool_input": {"x": 1},
             "tool_type": "function",
         }
-        result = OpenAIResponsesToolOps.ir_tool_call_to_p(ir_tool_call)
+        result = OpenAIResponsesToolOps.ir_tool_call_to_p(ir_tool_call)  # ty: ignore[invalid-argument-type]
         assert "\n" not in result.get("call_id", "")
         assert re.match(r"^[a-zA-Z0-9_-]+$", result["call_id"])

--- a/tests/test_tool_call_id_sanitize.py
+++ b/tests/test_tool_call_id_sanitize.py
@@ -116,8 +116,7 @@ class TestSanitizationInConverters:
         ir_tool_result = {
             "type": "tool_result",
             "tool_call_id": "bad\nid",
-            "tool_name": "test_fn",
-            "content": "ok",
+            "result": "ok",
         }
         result = OpenAIChatToolOps.ir_tool_result_to_p(ir_tool_result)
         assert "\n" not in result["tool_call_id"]
@@ -131,7 +130,7 @@ class TestSanitizationInConverters:
             "tool_name": "test_fn",
             "tool_input": {"x": 1},
             "tool_type": "function",
-        }
+        }  # type: ignore[typeddict-item]
         result = AnthropicToolOps.ir_tool_call_to_p(ir_tool_call)
         assert len(result["id"]) <= 64
         assert re.match(r"^[a-zA-Z0-9_-]+$", result["id"])
@@ -142,8 +141,7 @@ class TestSanitizationInConverters:
         ir_tool_result = {
             "type": "tool_result",
             "tool_call_id": "has spaces and.dots",
-            "tool_name": "test_fn",
-            "content": [{"type": "text", "text": "ok"}],
+            "result": [{"type": "text", "text": "ok"}],
         }
         result = AnthropicToolOps.ir_tool_result_to_p(ir_tool_result)
         assert result["tool_use_id"] == "has_spaces_and_dots"

--- a/tests/test_tool_call_id_sanitize.py
+++ b/tests/test_tool_call_id_sanitize.py
@@ -152,7 +152,7 @@ class TestSanitizationInConverters:
 
         raw_id = "call-bad\nid-0\nfc_other_0"
 
-        call_result = OpenAIChatToolOps.ir_tool_call_to_p(
+        call_result = OpenAIChatToolOps.ir_tool_call_to_p(  # type: ignore[arg-type]
             {
                 "type": "tool_call",
                 "tool_call_id": raw_id,
@@ -161,7 +161,7 @@ class TestSanitizationInConverters:
                 "tool_type": "function",
             }
         )
-        result_result = OpenAIChatToolOps.ir_tool_result_to_p(
+        result_result = OpenAIChatToolOps.ir_tool_result_to_p(  # type: ignore[arg-type]
             {
                 "type": "tool_result",
                 "tool_call_id": raw_id,


### PR DESCRIPTION
## Summary

- Add `sanitize_tool_call_id()` helper that normalizes tool call IDs at the IR → provider output boundary
- Replace characters outside `[a-zA-Z0-9_-]` with `_` (satisfies Anthropic's regex constraint)
- Truncate to 64 chars with deterministic hash suffix (satisfies OpenAI's length constraint)
- Applied at all write points across all 4 converters (openai_chat, anthropic, openai_responses, google_genai) in both non-streaming and streaming paths

Fixes #596 — a Cursor/Codex client was generating compound tool_call_ids with literal `\n` characters (85+ chars), causing upstream 400 errors and infinite retry loops on ts-lambda5.

## Test plan

- [ ] 22 new tests in `test_tool_call_id_sanitize.py` (unit + converter integration)
- [ ] Full test suite (2980 tests) passes with no regressions
- [ ] Clean IDs pass through unchanged (no-op for conformant clients)
- [ ] Verify with brettin's real-world ID: `call-...-0\nfc_..._0` → valid 64-char ID