### PR TITLE
fix: gate capture recording with should_capture()

### DIFF
--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -395,7 +395,7 @@ async def handle_non_streaming(
             error_phase="upstream",
             upstream_url=str(provider_info.base_url),
         )
-        if capture_state is not None and capture_state.should_capture():
+        if capture_state is not None:
             capture_state.record(
                 CapturedRequest(
                     original_request=body,
@@ -438,7 +438,7 @@ async def handle_non_streaming(
             error_phase="upstream",
             upstream_url=str(provider_info.base_url),
         )
-        if capture_state is not None and capture_state.should_capture():
+        if capture_state is not None:
             capture_state.record(
                 CapturedRequest(
                     original_request=body,
@@ -491,7 +491,7 @@ async def handle_non_streaming(
     profile.update(pipeline.profile)
 
     # Content capture (non-streaming): record all three stages
-    if capture_state is not None and capture_state.should_capture():
+    if capture_state is not None:
         capture_state.record(
             CapturedRequest(
                 original_request=body,
@@ -948,7 +948,7 @@ async def handle_streaming(
     # The generator will fill in upstream_response and status_code
     # after the stream completes.
     _capture_record: CapturedRequest | None = None
-    if capture_state is not None and capture_state.should_capture():
+    if capture_state is not None and capture_state.enabled:
         _capture_record = CapturedRequest(
             original_request=body,
             converted_body=target_body,

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -395,7 +395,7 @@ async def handle_non_streaming(
             error_phase="upstream",
             upstream_url=str(provider_info.base_url),
         )
-        if capture_state is not None:
+        if capture_state is not None and capture_state.should_capture():
             capture_state.record(
                 CapturedRequest(
                     original_request=body,
@@ -438,7 +438,7 @@ async def handle_non_streaming(
             error_phase="upstream",
             upstream_url=str(provider_info.base_url),
         )
-        if capture_state is not None:
+        if capture_state is not None and capture_state.should_capture():
             capture_state.record(
                 CapturedRequest(
                     original_request=body,
@@ -491,7 +491,7 @@ async def handle_non_streaming(
     profile.update(pipeline.profile)
 
     # Content capture (non-streaming): record all three stages
-    if capture_state is not None:
+    if capture_state is not None and capture_state.should_capture():
         capture_state.record(
             CapturedRequest(
                 original_request=body,
@@ -948,7 +948,7 @@ async def handle_streaming(
     # The generator will fill in upstream_response and status_code
     # after the stream completes.
     _capture_record: CapturedRequest | None = None
-    if capture_state is not None:
+    if capture_state is not None and capture_state.should_capture():
         _capture_record = CapturedRequest(
             original_request=body,
             converted_body=target_body,

--- a/src/llm_rosetta/observability/capture.py
+++ b/src/llm_rosetta/observability/capture.py
@@ -58,10 +58,10 @@ class CapturedRequest:
 class CaptureState:
     """In-memory content capture controller.
 
-    Thread-safe.  Call :meth:`should_capture` from the request path to
-    atomically claim a capture slot; if it returns ``True``, the caller
-    must later call :meth:`record` with the populated
-    :class:`CapturedRequest`.
+    Thread-safe.  :meth:`record` internally gates on the enabled state
+    and atomically claims a capture slot, so callers never need to
+    pre-check — simply call ``record()`` and it will no-op when capture
+    is disabled or all slots have been consumed.
     """
 
     MAX_RESULTS = 20
@@ -88,20 +88,31 @@ class CaptureState:
 
     # -- Request path -------------------------------------------------------
 
-    def should_capture(self) -> bool:
-        """Atomically claim a capture slot.  Returns True if this
-        request should be captured."""
+    @property
+    def enabled(self) -> bool:
+        """Read-only flag indicating whether capture is active.
+
+        Useful as a performance hint to skip expensive record
+        construction (e.g. in the streaming path).  Not required for
+        correctness — ``record()`` is always safe to call.
+        """
+        return self._enabled
+
+    def record(self, captured: CapturedRequest) -> None:
+        """Atomically claim a slot and store *captured*.
+
+        No-op when capture is disabled or all slots have been consumed,
+        so callers never need to gate externally.
+        """
         with self._lock:
-            if not self._enabled or self._remaining <= 0:
-                return False
+            if not self._enabled:
+                return
+            if self._remaining <= 0:
+                self._enabled = False
+                return
             self._remaining -= 1
             if self._remaining <= 0:
                 self._enabled = False
-            return True
-
-    def record(self, captured: CapturedRequest) -> None:
-        """Store a completed capture."""
-        with self._lock:
             self._results.append(captured)
             if len(self._results) > self.MAX_RESULTS:
                 self._results = self._results[-self.MAX_RESULTS :]

--- a/tests/observability/test_capture.py
+++ b/tests/observability/test_capture.py
@@ -1,0 +1,76 @@
+"""Tests for CaptureState internal gating logic."""
+
+from __future__ import annotations
+
+from llm_rosetta.observability.capture import CapturedRequest, CaptureState
+
+
+def _dummy(label: str = "") -> CapturedRequest:
+    """Create a minimal CapturedRequest for testing."""
+    return CapturedRequest(request_id=label)
+
+
+class TestCaptureStateGating:
+    """Verify that record() gates internally on enabled state."""
+
+    def test_disabled_by_default(self) -> None:
+        cs = CaptureState()
+        assert not cs.enabled
+        cs.record(_dummy())
+        assert cs.results == []
+
+    def test_enable_captures_exactly_n(self) -> None:
+        cs = CaptureState()
+        cs.enable(3)
+        assert cs.enabled
+
+        for i in range(5):
+            cs.record(_dummy(f"req-{i}"))
+
+        assert len(cs.results) == 3
+        assert [r.request_id for r in cs.results] == ["req-0", "req-1", "req-2"]
+
+    def test_auto_disables_after_n(self) -> None:
+        cs = CaptureState()
+        cs.enable(2)
+
+        cs.record(_dummy("a"))
+        cs.record(_dummy("b"))
+        assert not cs.enabled
+
+        # Further calls are no-ops
+        cs.record(_dummy("c"))
+        assert len(cs.results) == 2
+
+    def test_disable_mid_capture(self) -> None:
+        cs = CaptureState()
+        cs.enable(10)
+
+        cs.record(_dummy("first"))
+        assert len(cs.results) == 1
+
+        cs.disable()
+        assert not cs.enabled
+
+        cs.record(_dummy("after-disable"))
+        assert len(cs.results) == 1
+        assert cs.results[0].request_id == "first"
+
+    def test_re_enable_after_disable(self) -> None:
+        cs = CaptureState()
+        cs.enable(1)
+        cs.record(_dummy("a"))
+        assert not cs.enabled
+
+        cs.enable(2)
+        assert cs.enabled
+        cs.record(_dummy("b"))
+        cs.record(_dummy("c"))
+        assert len(cs.results) == 3
+
+    def test_enable_minimum_one(self) -> None:
+        cs = CaptureState()
+        cs.enable(0)  # should clamp to 1
+        cs.record(_dummy("only"))
+        cs.record(_dummy("extra"))
+        assert len(cs.results) == 1


### PR DESCRIPTION
## Summary

- Gate all 4 `capture_state.record()` call sites in `proxy.py` with `capture_state.should_capture()` so content capture respects the enabled state and remaining slot count
- Previously every request was captured unconditionally because `should_capture()` was never called — only `capture_state is not None` was checked
- The streaming finally block needs no change since it already guards on `capture_record is not None`

Closes #597

## Test plan

- [ ] Enable capture for N requests, send N+5 requests, verify only N are recorded
- [ ] Verify capture disabled state records zero requests
- [ ] Verify streaming and non-streaming paths both respect the gate