### PR TITLE
fix(admin): address chart review nits from PR #600

### DIFF
--- a/src/llm_rosetta/gateway/admin/js/dashboard.js
+++ b/src/llm_rosetta/gateway/admin/js/dashboard.js
@@ -699,7 +699,7 @@ function drawLatencyChart(canvasId, series) {
     }
   }
 
-  const maxMs = points.length > 0 ? Math.max(...points.map(p => p.ms), 1) : 1;
+  const maxMs = points.reduce((m, p) => Math.max(m, p.ms), 1);
 
   _drawAxes(ctx, w, h, cs, maxMs, padL, padR, padT, padB);
 
@@ -716,15 +716,17 @@ function drawLatencyChart(canvasId, series) {
   const tMax = series[series.length - 1].t;
   const tRange = tMax - tMin || 1;
 
+  ctx.strokeStyle = blueColor;
+  ctx.lineWidth = 1;
   for (const p of points) {
     const x = padL + ((p.t - tMin) / tRange) * chartW;
     const y = padT + chartH - (p.ms / maxMs) * chartH;
     ctx.beginPath();
     ctx.arc(x, y, 4, 0, Math.PI * 2);
-    ctx.fillStyle = blueColor + '66';
+    ctx.globalAlpha = 0.4;
+    ctx.fillStyle = blueColor;
     ctx.fill();
-    ctx.strokeStyle = blueColor;
-    ctx.lineWidth = 1;
+    ctx.globalAlpha = 1.0;
     ctx.stroke();
   }
 }

--- a/src/llm_rosetta/observability/metrics.py
+++ b/src/llm_rosetta/observability/metrics.py
@@ -84,7 +84,7 @@ class _RollingWindow:
                         "count": bucket.count,
                         "avg_ms": round(avg_ms, 2),
                         "errors": bucket.error_count,
-                        "latencies": bucket.latencies,
+                        "latencies": bucket.latencies[:],
                     }
                 )
             else:


### PR DESCRIPTION
## Summary
- Fix hex-alpha fragility: use `ctx.globalAlpha` instead of `blueColor + '66'` for scatter dot transparency — works with any CSS color format (hex, rgb, hsl)
- Replace `Math.max(...spread)` with `reduce` to avoid call stack limits at scale
- Copy `bucket.latencies` via `[:]` slice in `get_series()` to prevent accidental mutation of internal state

Follow-up to #600, addressing nits from Elena, Clementine, and Milo.

## Test plan
- [x] `make test` passes
- [x] Visual behavior unchanged (same alpha effect via globalAlpha)