### PR TITLE
fix(admin): close accessibility gaps from #561 audit

### DIFF
--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -397,7 +397,7 @@
 </div>
 
 <!-- Settings Popup (wide section-card layout) -->
-<div class="settings-popup" id="settingsPopup" role="dialog" aria-modal="true" onclick="this.classList.remove('open')">
+<div class="settings-popup" id="settingsPopup" role="dialog" aria-modal="true" onclick="closeModal('settingsPopup')">
   <div class="settings-popup-panel" onclick="event.stopPropagation()">
     <h3 data-i18n="modal.settings">Settings</h3>
 
@@ -451,14 +451,14 @@
         <div class="settings-popup-item">
           <label data-i18n="label.errorDumps">Error Detail Log</label>
           <label class="toggle-label">
-            <input type="checkbox" id="settingsErrorDumps" onchange="saveSettingsField('errorDumps',this.checked)">
+            <input type="checkbox" id="settingsErrorDumps" role="switch" onchange="this.setAttribute('aria-checked',this.checked);saveSettingsField('errorDumps',this.checked)">
             <span data-i18n="label.enabled">Enabled</span>
           </label>
         </div>
         <div class="settings-popup-item">
           <label data-i18n="label.credentialReveal">Credential Reveal</label>
           <label class="toggle-label">
-            <input type="checkbox" id="settingsCredentialVisible" onchange="saveSettingsField('credentialVisible',this.checked)">
+            <input type="checkbox" id="settingsCredentialVisible" role="switch" onchange="this.setAttribute('aria-checked',this.checked);saveSettingsField('credentialVisible',this.checked)">
             <span data-i18n="label.disabled">Disabled</span>
           </label>
         </div>
@@ -475,7 +475,7 @@
         <div class="settings-popup-item">
           <label data-i18n="label.rlEnabled">Enabled</label>
           <label class="toggle-label">
-            <input type="checkbox" id="rlEnabled" onchange="onRlToggle()">
+            <input type="checkbox" id="rlEnabled" role="switch" onchange="this.setAttribute('aria-checked',this.checked);onRlToggle()">
             <span id="rlEnabledLabel" data-i18n="label.disabled">Disabled</span>
           </label>
         </div>

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -451,14 +451,14 @@
         <div class="settings-popup-item">
           <label data-i18n="label.errorDumps">Error Detail Log</label>
           <label class="toggle-label">
-            <input type="checkbox" id="settingsErrorDumps" role="switch" onchange="this.setAttribute('aria-checked',this.checked);saveSettingsField('errorDumps',this.checked)">
+            <input type="checkbox" id="settingsErrorDumps" role="switch" aria-checked="false" onchange="this.setAttribute('aria-checked',this.checked);saveSettingsField('errorDumps',this.checked)">
             <span data-i18n="label.enabled">Enabled</span>
           </label>
         </div>
         <div class="settings-popup-item">
           <label data-i18n="label.credentialReveal">Credential Reveal</label>
           <label class="toggle-label">
-            <input type="checkbox" id="settingsCredentialVisible" role="switch" onchange="this.setAttribute('aria-checked',this.checked);saveSettingsField('credentialVisible',this.checked)">
+            <input type="checkbox" id="settingsCredentialVisible" role="switch" aria-checked="false" onchange="this.setAttribute('aria-checked',this.checked);saveSettingsField('credentialVisible',this.checked)">
             <span data-i18n="label.disabled">Disabled</span>
           </label>
         </div>
@@ -475,7 +475,7 @@
         <div class="settings-popup-item">
           <label data-i18n="label.rlEnabled">Enabled</label>
           <label class="toggle-label">
-            <input type="checkbox" id="rlEnabled" role="switch" onchange="this.setAttribute('aria-checked',this.checked);onRlToggle()">
+            <input type="checkbox" id="rlEnabled" role="switch" aria-checked="false" onchange="this.setAttribute('aria-checked',this.checked);onRlToggle()">
             <span id="rlEnabledLabel" data-i18n="label.disabled">Disabled</span>
           </label>
         </div>

--- a/src/llm_rosetta/gateway/admin/js/auth.js
+++ b/src/llm_rosetta/gateway/admin/js/auth.js
@@ -70,7 +70,8 @@ function openSettings() {
     const el = document.getElementById(id); if (el) el.value = '';
   });
   document.getElementById('settingsPwError').textContent = '';
-  popup.classList.toggle('open');
+  if (popup.classList.contains('open')) { closeModal('settingsPopup'); }
+  else { openModal('settingsPopup'); }
 }
 
 async function saveSettingsField(field, value) {
@@ -185,7 +186,7 @@ function openCleanupConfirm(target) {
   document.getElementById('cleanupConfirmBtn').disabled = true;
   const btn = document.getElementById('cleanupConfirmBtn');
   btn.style.background = '#ccc'; btn.style.color = '#888'; btn.style.cursor = 'not-allowed';
-  document.getElementById('cleanupConfirmModal').classList.add('open');
+  openModal('cleanupConfirmModal');
   document.getElementById('cleanupConfirmInput').focus();
 }
 
@@ -226,7 +227,7 @@ async function onCleanupConfirmClick() {
 function openExportDumpsModal() {
   document.getElementById('exportStartDate').value = '';
   document.getElementById('exportEndDate').value = '';
-  document.getElementById('exportDumpsModal').classList.add('open');
+  openModal('exportDumpsModal');
 }
 
 async function doExportDumps() {

--- a/src/llm_rosetta/gateway/admin/js/auth.js
+++ b/src/llm_rosetta/gateway/admin/js/auth.js
@@ -32,7 +32,7 @@ function openSettings() {
   const ar = document.getElementById('settingsAutoRefresh');
   if (ar) ar.value = localStorage.getItem('dashboardRefreshMs') || '3000';
   const ed = document.getElementById('settingsErrorDumps');
-  if (ed) ed.checked = S.configData?.debug?.error_dumps !== false;
+  if (ed) { ed.checked = S.configData?.debug?.error_dumps !== false; ed.setAttribute('aria-checked', ed.checked); }
   // Sync log retention
   if (S.configData?.server?.request_log) {
     const sm = document.getElementById('settingsSuccessMax');
@@ -45,7 +45,7 @@ function openSettings() {
   // Sync rate limiting
   const rl = S.configData?.server?.rate_limit || {};
   const rlEn = document.getElementById('rlEnabled');
-  if (rlEn) { rlEn.checked = !!rl.enabled; onRlToggle(); }
+  if (rlEn) { rlEn.checked = !!rl.enabled; rlEn.setAttribute('aria-checked', rlEn.checked); onRlToggle(); }
   const rlAlgo = document.getElementById('rlAlgorithm');
   if (rlAlgo && rl.algorithm) rlAlgo.value = rl.algorithm;
   const rlG = document.getElementById('rlGlobal');
@@ -59,7 +59,7 @@ function openSettings() {
   _validateRlQuotas();
   // Sync credential visibility
   const cv = document.getElementById('settingsCredentialVisible');
-  if (cv) cv.checked = S.configData?.server?.credential_visible !== false;
+  if (cv) { cv.checked = S.configData?.server?.credential_visible !== false; cv.setAttribute('aria-checked', cv.checked); }
   // Sync token
   _refreshTokenDisplay();
   // Sync rotate interval

--- a/src/llm_rosetta/gateway/admin/js/core.js
+++ b/src/llm_rosetta/gateway/admin/js/core.js
@@ -128,9 +128,19 @@ function showToast(msg, type='success') {
 }
 
 // ===================== Modal =====================
+const _modalTriggers = new Map();
+
+function openModal(id) {
+  _modalTriggers.set(id, document.activeElement);
+  document.getElementById(id).classList.add('open');
+}
+
 function closeModal(id) {
   document.getElementById(id).classList.remove('open');
   if (id === 'testModal') window._abortPendingTest?.();
+  const trigger = _modalTriggers.get(id);
+  _modalTriggers.delete(id);
+  if (trigger && typeof trigger.focus === 'function') trigger.focus();
 }
 
 // ===================== Inline Confirm =====================
@@ -189,13 +199,13 @@ function fmtBytesShort(n) {
 // ===================== Window globals =====================
 Object.assign(window, {
   setScheme, setMode, setTheme, api, doLogout, copyText, copyProviderEntry,
-  showToast, closeModal, inlineConfirm, esc, formatDuration,
+  showToast, openModal, closeModal, inlineConfirm, esc, formatDuration,
   fmtBytesShort, fmtBytesLong,
   _startInactivityTracking, _stopInactivityTracking,
 });
 
 export {
-  setScheme, setMode, setTheme, _adminHeaders, api, showToast, closeModal,
+  setScheme, setMode, setTheme, _adminHeaders, api, showToast, openModal, closeModal,
   copyText, copyProviderEntry, esc, formatDuration,
   fmtBytesShort, fmtBytesLong,
   inlineConfirm, doLogout,

--- a/src/llm_rosetta/gateway/admin/js/dashboard.js
+++ b/src/llm_rosetta/gateway/admin/js/dashboard.js
@@ -467,7 +467,7 @@ function openClearDumpsConfirm() {
   document.getElementById('clearDumpsInput').value = '';
   const btn = document.getElementById('clearDumpsBtn');
   btn.disabled = true; btn.style.opacity = '0.4'; btn.style.cursor = 'not-allowed';
-  document.getElementById('clearDumpsModal').classList.add('open');
+  openModal('clearDumpsModal');
   document.getElementById('clearDumpsInput').focus();
 }
 

--- a/src/llm_rosetta/gateway/admin/js/fetch-models.js
+++ b/src/llm_rosetta/gateway/admin/js/fetch-models.js
@@ -31,7 +31,7 @@ function openFetchModelsModal() {
   document.getElementById('fetchCapTools').checked = true;
   document.getElementById('fetchCapReasoning').checked = false;
   document.getElementById('fetchCapsRow').style.display = '';
-  document.getElementById('fetchModelsModal').classList.add('open');
+  openModal('fetchModelsModal');
 }
 
 function onFetchTypeChange() {

--- a/src/llm_rosetta/gateway/admin/js/init.js
+++ b/src/llm_rosetta/gateway/admin/js/init.js
@@ -92,7 +92,8 @@ document.querySelectorAll('.modal-overlay').forEach(m => {
 // Close popups/modals on Escape key
 document.addEventListener('keydown', e => {
   if (e.key === 'Escape') {
-    document.getElementById('settingsPopup').classList.remove('open');
+    const sp = document.getElementById('settingsPopup');
+    if (sp && sp.classList.contains('open')) closeModal('settingsPopup');
     const testModal = document.getElementById('testModal');
     if (testModal && testModal.classList.contains('open')) closeModal('testModal');
   }

--- a/src/llm_rosetta/gateway/admin/js/keys.js
+++ b/src/llm_rosetta/gateway/admin/js/keys.js
@@ -45,7 +45,7 @@ function renderKeys() {
 function openKeyModal() {
   document.getElementById('keyLabel').value = '';
   document.getElementById('keyManual').value = '';
-  document.getElementById('keyModal').classList.add('open');
+  openModal('keyModal');
 }
 
 async function generateKey() {
@@ -59,7 +59,7 @@ async function generateKey() {
     showToast(t('toast.keySaved'));
     // Show the created key for one-time copy
     document.getElementById('createdKeyValue').value = res.key.key;
-    document.getElementById('keyCreatedModal').classList.add('open');
+    openModal('keyCreatedModal');
     loadKeys();
   } else {
     showToast(res.error || 'Failed', 'error');
@@ -102,7 +102,7 @@ function rotateKey(id, label, btn) {
       showToast(t('toast.keyRotated', {label}));
       // Show the new key for one-time copy
       document.getElementById('createdKeyValue').value = res.key;
-      document.getElementById('keyCreatedModal').classList.add('open');
+      openModal('keyCreatedModal');
       loadKeys();
     } else {
       showToast(res.error || 'Failed', 'error');

--- a/src/llm_rosetta/gateway/admin/js/models.js
+++ b/src/llm_rosetta/gateway/admin/js/models.js
@@ -345,10 +345,10 @@ function renderModels() {
         </div>
         <button class="btn btn-sm" aria-label="${t('btn.edit')} ${esc(name)}" onclick="editModel('${esc(name)}','${esc(prov)}')">${t('btn.edit')}</button>
         <button class="btn btn-sm" onclick="toggleMoreMenu(this)" style="padding:3px 6px">⋯</button>
-        <div class="more-menu" style="display:none;position:absolute;right:0;top:calc(100% + 4px);min-width:110px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.12);z-index:10;overflow:hidden">
-          <div style="padding:7px 14px;font-size:13px;cursor:pointer" onmouseenter="this.style.background='var(--bg)'" onmouseleave="this.style.background=''" aria-label="${t('btn.clone')} ${esc(name)}" onclick="this.closest('.more-menu').style.display='none';cloneModel('${esc(name)}')">${t('btn.clone')}</div>
-          <div style="border-top:1px solid var(--border);margin:2px 0"></div>
-          <div style="padding:7px 14px;font-size:13px;cursor:pointer;color:var(--danger, #cf222e)" onmouseenter="this.style.background='#fff1f0'" onmouseleave="this.style.background=''" aria-label="${t('btn.delete')} ${esc(name)}" onclick="this.closest('.more-menu').style.display='none';deleteModel('${esc(name)}', this)">${t('btn.delete')}</div>
+        <div class="more-menu" role="menu" style="display:none;position:absolute;right:0;top:calc(100% + 4px);min-width:110px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.12);z-index:10;overflow:hidden">
+          <div role="menuitem" style="padding:7px 14px;font-size:13px;cursor:pointer" onmouseenter="this.style.background='var(--bg)'" onmouseleave="this.style.background=''" aria-label="${t('btn.clone')} ${esc(name)}" onclick="this.closest('.more-menu').style.display='none';cloneModel('${esc(name)}')">${t('btn.clone')}</div>
+          <div role="separator" style="border-top:1px solid var(--border);margin:2px 0"></div>
+          <div role="menuitem" style="padding:7px 14px;font-size:13px;cursor:pointer;color:var(--danger, #cf222e)" onmouseenter="this.style.background='#fff1f0'" onmouseleave="this.style.background=''" aria-label="${t('btn.delete')} ${esc(name)}" onclick="this.closest('.more-menu').style.display='none';deleteModel('${esc(name)}', this)">${t('btn.delete')}</div>
         </div>
       </td>
     </tr>`;

--- a/src/llm_rosetta/gateway/admin/js/models.js
+++ b/src/llm_rosetta/gateway/admin/js/models.js
@@ -144,7 +144,7 @@ function openModelModal(model, provider, capabilities, upstreamModel, sourceMode
   document.getElementById('reasoningBudgetRatio').value = configOverride.budget_tokens_default_ratio != null ? configOverride.budget_tokens_default_ratio : '';
   document.getElementById('reasoningDisabled').value = configOverride.disabled || '';
 
-  document.getElementById('modelModal').classList.add('open');
+  openModal('modelModal');
 }
 
 function onModelTypeChange() {
@@ -321,7 +321,7 @@ function renderModels() {
       <td style="text-align:center">${capBadges || '<span style="color:var(--text-dim);font-size:11px">—</span>'}</td>
       <td><span class="provider-link" onclick="goToProviderFromModel('${esc(prov)}')">${esc(prov)}</span>${provDisabled ? ` <span style="color:var(--text-dim);font-size:11px">(${t('provider.disabled')})</span>` : ''}</td>
       <td style="text-align:right;white-space:nowrap;position:relative">
-        <div class="pill-toggle ${modelEnabled ? 'is-on' : 'is-off'}" onclick="toggleModel('${esc(name)}')" title="${modelEnabled ? t('model.enabled') : t('model.disabled')}" style="vertical-align:middle;margin-right:4px"><span class="pill-on">${t('label.on')}</span><span class="pill-off">${t('label.off')}</span></div>
+        <div class="pill-toggle ${modelEnabled ? 'is-on' : 'is-off'}" role="switch" aria-checked="${modelEnabled}" aria-label="${esc(name)}" onclick="toggleModel('${esc(name)}')" title="${modelEnabled ? t('model.enabled') : t('model.disabled')}" style="vertical-align:middle;margin-right:4px"><span class="pill-on">${t('label.on')}</span><span class="pill-off">${t('label.off')}</span></div>
         <div class="test-group" style="display:inline-block">
           <button class="btn btn-sm btn-test${modelType !== 'llm' ? ' btn-test-embed' : ''}" onclick="runTest('${esc(name)}','${modelType === 'embedding' ? 'embedding' : modelType === 'rerank' ? 'rerank' : 'text'}')">${t('btn.test')}</button>
           <button class="btn btn-sm btn-caret" onclick="toggleTestMenu(this)">&#9662;</button>
@@ -343,12 +343,12 @@ function renderModels() {
             `}
           </div>
         </div>
-        <button class="btn btn-sm" onclick="editModel('${esc(name)}','${esc(prov)}')">${t('btn.edit')}</button>
+        <button class="btn btn-sm" aria-label="${t('btn.edit')} ${esc(name)}" onclick="editModel('${esc(name)}','${esc(prov)}')">${t('btn.edit')}</button>
         <button class="btn btn-sm" onclick="toggleMoreMenu(this)" style="padding:3px 6px">⋯</button>
         <div class="more-menu" style="display:none;position:absolute;right:0;top:calc(100% + 4px);min-width:110px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.12);z-index:10;overflow:hidden">
-          <div style="padding:7px 14px;font-size:13px;cursor:pointer" onmouseenter="this.style.background='var(--bg)'" onmouseleave="this.style.background=''" onclick="this.closest('.more-menu').style.display='none';cloneModel('${esc(name)}')">${t('btn.clone')}</div>
+          <div style="padding:7px 14px;font-size:13px;cursor:pointer" onmouseenter="this.style.background='var(--bg)'" onmouseleave="this.style.background=''" aria-label="${t('btn.clone')} ${esc(name)}" onclick="this.closest('.more-menu').style.display='none';cloneModel('${esc(name)}')">${t('btn.clone')}</div>
           <div style="border-top:1px solid var(--border);margin:2px 0"></div>
-          <div style="padding:7px 14px;font-size:13px;cursor:pointer;color:var(--danger, #cf222e)" onmouseenter="this.style.background='#fff1f0'" onmouseleave="this.style.background=''" onclick="this.closest('.more-menu').style.display='none';deleteModel('${esc(name)}', this)">${t('btn.delete')}</div>
+          <div style="padding:7px 14px;font-size:13px;cursor:pointer;color:var(--danger, #cf222e)" onmouseenter="this.style.background='#fff1f0'" onmouseleave="this.style.background=''" aria-label="${t('btn.delete')} ${esc(name)}" onclick="this.closest('.more-menu').style.display='none';deleteModel('${esc(name)}', this)">${t('btn.delete')}</div>
         </div>
       </td>
     </tr>`;

--- a/src/llm_rosetta/gateway/admin/js/models.js
+++ b/src/llm_rosetta/gateway/admin/js/models.js
@@ -321,7 +321,7 @@ function renderModels() {
       <td style="text-align:center">${capBadges || '<span style="color:var(--text-dim);font-size:11px">—</span>'}</td>
       <td><span class="provider-link" onclick="goToProviderFromModel('${esc(prov)}')">${esc(prov)}</span>${provDisabled ? ` <span style="color:var(--text-dim);font-size:11px">(${t('provider.disabled')})</span>` : ''}</td>
       <td style="text-align:right;white-space:nowrap;position:relative">
-        <div class="pill-toggle ${modelEnabled ? 'is-on' : 'is-off'}" role="switch" aria-checked="${modelEnabled}" aria-label="${esc(name)}" onclick="toggleModel('${esc(name)}')" title="${modelEnabled ? t('model.enabled') : t('model.disabled')}" style="vertical-align:middle;margin-right:4px"><span class="pill-on">${t('label.on')}</span><span class="pill-off">${t('label.off')}</span></div>
+        <div class="pill-toggle ${modelEnabled ? 'is-on' : 'is-off'}" role="switch" tabindex="0" aria-checked="${modelEnabled}" aria-label="${esc(name)}" onclick="toggleModel('${esc(name)}')" onkeydown="if(event.key===' '||event.key==='Enter'){event.preventDefault();toggleModel('${esc(name)}')}" title="${modelEnabled ? t('model.enabled') : t('model.disabled')}" style="vertical-align:middle;margin-right:4px"><span class="pill-on">${t('label.on')}</span><span class="pill-off">${t('label.off')}</span></div>
         <div class="test-group" style="display:inline-block">
           <button class="btn btn-sm btn-test${modelType !== 'llm' ? ' btn-test-embed' : ''}" onclick="runTest('${esc(name)}','${modelType === 'embedding' ? 'embedding' : modelType === 'rerank' ? 'rerank' : 'text'}')">${t('btn.test')}</button>
           <button class="btn btn-sm btn-caret" onclick="toggleTestMenu(this)">&#9662;</button>

--- a/src/llm_rosetta/gateway/admin/js/providers.js
+++ b/src/llm_rosetta/gateway/admin/js/providers.js
@@ -143,7 +143,7 @@ function openProviderModal(name, baseUrl, apiKey, proxy, provType) {
     document.getElementById('provRerankPath').value = '';
   }
   toggleProvCapSection();
-  document.getElementById('providerModal').classList.add('open');
+  openModal('providerModal');
   // When editing, fetch the real (unmasked) key
   if (name && S._credentialVisible) {
     api.get(`/admin/api/config/providers/${encodeURIComponent(name)}/key`).then(res => {
@@ -478,16 +478,16 @@ function renderProviders() {
       <div class="card-header">
         <div class="name" style="display:flex;align-items:center;gap:6px">${logoHtml}${esc(name)} ${capBadges}</div>
         <label class="toggle" title="${enabled ? t('provider.enabled') : t('provider.disabled')}">
-          <input type="checkbox" ${enabled ? 'checked' : ''} onchange="toggleProvider('${esc(name)}')">
+          <input type="checkbox" ${enabled ? 'checked' : ''} role="switch" aria-checked="${enabled}" aria-label="${esc(name)}" onchange="this.setAttribute('aria-checked',this.checked);toggleProvider('${esc(name)}')">
           <span class="slider"></span>
         </label>
       </div>
       ${fieldsHtml}
       <div class="actions" style="margin-top:auto;padding-top:12px">
-        <button class="btn btn-sm" onclick="copyProviderEntry('${esc(name)}')">${t('btn.clone')}</button>
-        <button class="btn btn-sm" onclick="editProvider('${esc(name)}')">${t('btn.edit')}</button>
-        <button class="btn btn-sm btn-test-conn" onclick="testProviderConnectivity('${esc(name)}')">${t('btn.test')}</button>
-        <button class="btn btn-sm btn-danger" onclick="deleteProvider('${esc(name)}')">${t('btn.delete')}</button>
+        <button class="btn btn-sm" aria-label="${t('btn.clone')} ${esc(name)}" onclick="copyProviderEntry('${esc(name)}')">${t('btn.clone')}</button>
+        <button class="btn btn-sm" aria-label="${t('btn.edit')} ${esc(name)}" onclick="editProvider('${esc(name)}')">${t('btn.edit')}</button>
+        <button class="btn btn-sm btn-test-conn" aria-label="${t('btn.test')} ${esc(name)}" onclick="testProviderConnectivity('${esc(name)}')">${t('btn.test')}</button>
+        <button class="btn btn-sm btn-danger" aria-label="${t('btn.delete')} ${esc(name)}" onclick="deleteProvider('${esc(name)}')">${t('btn.delete')}</button>
         ${modelLink}
       </div>
     </div>`;
@@ -561,7 +561,7 @@ function deleteProvider(name) {
   } else {
     el.style.display = 'none';
   }
-  document.getElementById('deleteConfirmModal').classList.add('open');
+  openModal('deleteConfirmModal');
   document.getElementById('deleteConfirmInput').focus();
 }
 

--- a/src/llm_rosetta/gateway/admin/js/test.js
+++ b/src/llm_rosetta/gateway/admin/js/test.js
@@ -99,7 +99,7 @@ function _newTestSignal() {
 function promptMatryoshka(model) {
   S._matryoshkaModel = model;
   document.getElementById('matryoshkaDim').value = '256';
-  document.getElementById('matryoshkaModal').classList.add('open');
+  openModal('matryoshkaModal');
   document.getElementById('matryoshkaDim').focus();
 }
 function confirmMatryoshka() {
@@ -138,7 +138,7 @@ async function runTest(model, type, extraParam) {
     imgDetails.style.display = 'none';
     imgBody.innerHTML = '';
   }
-  document.getElementById('testModal').classList.add('open');
+  openModal('testModal');
 
   const payload = buildTestPayload(model, type, extraParam);
   reqBody.textContent = truncatePayloadForDisplay(payload);


### PR DESCRIPTION
## Summary
- **Modal focus restore**: centralized `openModal()`/`closeModal()` in core.js — closing any modal returns focus to the triggering element. All 12 modal open sites across 7 files now use `openModal()`.
- **Toggle switches**: added `role="switch"` + `aria-checked` to settings toggles (error dumps, credential reveal, rate limiting) and provider/model enable pills
- **Context aria-labels**: provider action buttons (Clone, Edit, Test, Delete) and model action buttons include the entity name (e.g., "Edit Test Provider", "Delete gpt-4o")

Closes #602

## Test plan
- [x] `make test` — 3018 passed, 0 failed
- [x] Console zero errors
- [x] Playwright: provider toggle shows `switch "Test Provider" [checked]` in accessibility tree
- [x] Playwright: action buttons show `button "Edit Test Provider"` etc.
- [x] Playwright: Settings open → Escape → focus returns to Settings button