### PR TITLE
fix(admin): redesign provider list view as compact rows

### DIFF
--- a/src/llm_rosetta/gateway/admin/css/components.css
+++ b/src/llm_rosetta/gateway/admin/css/components.css
@@ -109,14 +109,15 @@ tr:hover td { background: var(--bg-hover); }
 .pill-toggle.is-off .pill-off { background:var(--border);color:var(--text); }
 .pill-toggle.is-off .pill-on { background:var(--bg-card);color:var(--text-dim); }
 .btn-test-embed { color:var(--orange) !important;font-weight:600; }
+.provider-card { display: flex; flex-direction: column; }
 .provider-card .card-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
-.provider-card .actions { margin-top: 12px; display: flex; gap: 8px; }
-/* List view — CSS grid for column alignment across rows */
+.provider-card .actions { margin-top: auto; padding-top: 12px; display: flex; gap: 8px; }
+/* List view — compact single-line rows */
 .provider-grid.list-view { grid-template-columns: 1fr; gap: 4px; }
 .provider-grid.list-view .provider-card {
   display: grid;
-  grid-template-columns: minmax(140px, 1.2fr) minmax(80px, 0.8fr) minmax(100px, 1.2fr) minmax(80px, 1fr) auto;
-  align-items: center; gap: 4px 12px; padding: 8px 16px;
+  grid-template-columns: minmax(140px, 1.5fr) minmax(80px, 0.8fr) minmax(120px, 2fr) auto;
+  align-items: center; gap: 0 16px; padding: 6px 16px;
 }
 .provider-grid.list-view .provider-card .card-header { margin-bottom: 0; overflow: hidden; }
 .provider-grid.list-view .provider-card .card-header .name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -126,12 +127,13 @@ tr:hover td { background: var(--bg-hover); }
 .provider-grid.list-view .provider-card .field code {
   max-width: none; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.provider-grid.list-view .provider-card .actions { margin-top: 0; justify-self: end; white-space: nowrap; }
+.provider-grid.list-view .provider-card .actions { margin-top: 0; padding-top: 0; justify-self: end; white-space: nowrap; }
 /* View toggle buttons */
 .view-toggle { display:inline-flex;gap:2px;margin-left:8px; }
 .view-toggle .btn { padding:4px 6px; }
 .view-toggle .btn.active { color:var(--accent);border-color:var(--accent); }
-.provider-card .provider-logo { width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; }
+.provider-card .provider-logo { width: 16px; height: 16px; vertical-align: middle; margin-right: 4px; flex-shrink: 0; }
+.provider-card .provider-logo-placeholder { display: inline-block; width: 16px; height: 16px; flex-shrink: 0; margin-right: 4px; }
 .type-logo-wrapper { display: flex; align-items: center; gap: 8px; }
 .type-logo-wrapper select { flex: 1; }
 .type-logo-wrapper .type-logo-preview { width: 20px; height: 20px; flex-shrink: 0; }

--- a/src/llm_rosetta/gateway/admin/js/providers.js
+++ b/src/llm_rosetta/gateway/admin/js/providers.js
@@ -321,9 +321,8 @@ function switchProviderFilter(el, filter) {
 function setProviderView(mode) {
   _providerViewMode = mode;
   localStorage.setItem('provider-view', mode);
-  const grid = document.getElementById('providerGrid');
-  grid.classList.toggle('list-view', mode === 'list');
   _updateViewToggle();
+  renderProviders();
 }
 
 function _updateViewToggle() {
@@ -458,11 +457,12 @@ function renderProviders() {
     const enabled = cfg.enabled !== false;
     const typeName = cfg.type || name;
     const logo = shimLogo[typeName];
-    const logoHtml = logo ? `<img class="provider-logo" src="${esc(logo)}" alt="">` : '';
+    const logoHtml = logo
+      ? `<img class="provider-logo" src="${esc(logo)}" alt="">`
+      : (isList ? '<span class="provider-logo-placeholder"></span>' : '');
     const fieldsHtml = isList
       ? `<div class="field" title="Type: ${esc(typeName)}"><code>${esc(typeName)}</code></div>
-         <div class="field" title="${esc(cfg.base_url || '')}"><code>${esc(cfg.base_url || '')}</code></div>
-         ${S._credentialVisible ? `<div class="field" title="${esc(cfg.api_key || '')}"><code>${esc(cfg.api_key || '')}</code></div>` : '<div class="field"></div>'}`
+         <div class="field" title="${esc(cfg.base_url || '')}"><code>${esc(cfg.base_url || '')}</code></div>`
       : `<div class="field">Type: <code>${esc(typeName)}</code></div>
          <div class="field">Base URL: <code>${esc(cfg.base_url || '')}</code></div>
          ${S._credentialVisible ? `<div class="field">API Key: <code>${esc(cfg.api_key || '')}</code></div>` : ''}`;
@@ -473,23 +473,32 @@ function renderProviders() {
       ? `<span class="model-link" onclick="goToModelsForProvider('${esc(name)}')">${modelCount} model${modelCount !== 1 ? 's' : ''} →</span>`
       : '';
     // Endpoint details are in Edit modal — badges on card are sufficient
-    return `
-    <div class="provider-card${enabled ? '' : ' disabled'}" data-provider="${esc(name)}" style="display:flex;flex-direction:column">
-      <div class="card-header">
-        <div class="name" style="display:flex;align-items:center;gap:6px">${logoHtml}${esc(name)} ${capBadges}</div>
+    const toggleHtml = isList ? '' : `
         <label class="toggle" title="${enabled ? t('provider.enabled') : t('provider.disabled')}">
           <input type="checkbox" ${enabled ? 'checked' : ''} role="switch" aria-checked="${enabled}" aria-label="${esc(name)}" onchange="this.setAttribute('aria-checked',this.checked);toggleProvider('${esc(name)}')">
           <span class="slider"></span>
-        </label>
+        </label>`;
+    const actionsHtml = isList
+      ? `<div class="actions">
+          <button class="btn btn-sm" aria-label="${t('btn.edit')} ${esc(name)}" onclick="editProvider('${esc(name)}')">${t('btn.edit')}</button>
+          <button class="btn btn-sm btn-test-conn" aria-label="${t('btn.test')} ${esc(name)}" onclick="testProviderConnectivity('${esc(name)}')">${t('btn.test')}</button>
+          ${modelLink}
+        </div>`
+      : `<div class="actions">
+          <button class="btn btn-sm" aria-label="${t('btn.clone')} ${esc(name)}" onclick="copyProviderEntry('${esc(name)}')">${t('btn.clone')}</button>
+          <button class="btn btn-sm" aria-label="${t('btn.edit')} ${esc(name)}" onclick="editProvider('${esc(name)}')">${t('btn.edit')}</button>
+          <button class="btn btn-sm btn-test-conn" aria-label="${t('btn.test')} ${esc(name)}" onclick="testProviderConnectivity('${esc(name)}')">${t('btn.test')}</button>
+          <button class="btn btn-sm btn-danger" aria-label="${t('btn.delete')} ${esc(name)}" onclick="deleteProvider('${esc(name)}')">${t('btn.delete')}</button>
+          ${modelLink}
+        </div>`;
+    return `
+    <div class="provider-card${enabled ? '' : ' disabled'}" data-provider="${esc(name)}">
+      <div class="card-header">
+        <div class="name" style="display:flex;align-items:center;gap:6px">${logoHtml}${esc(name)} ${capBadges}</div>
+        ${toggleHtml}
       </div>
       ${fieldsHtml}
-      <div class="actions" style="margin-top:auto;padding-top:12px">
-        <button class="btn btn-sm" aria-label="${t('btn.clone')} ${esc(name)}" onclick="copyProviderEntry('${esc(name)}')">${t('btn.clone')}</button>
-        <button class="btn btn-sm" aria-label="${t('btn.edit')} ${esc(name)}" onclick="editProvider('${esc(name)}')">${t('btn.edit')}</button>
-        <button class="btn btn-sm btn-test-conn" aria-label="${t('btn.test')} ${esc(name)}" onclick="testProviderConnectivity('${esc(name)}')">${t('btn.test')}</button>
-        <button class="btn btn-sm btn-danger" aria-label="${t('btn.delete')} ${esc(name)}" onclick="deleteProvider('${esc(name)}')">${t('btn.delete')}</button>
-        ${modelLink}
-      </div>
+      ${actionsHtml}
     </div>`;
   }).join('');
 }


### PR DESCRIPTION
## Summary
- Fix list view layout: inline `style="display:flex;flex-direction:column"` on provider cards was overriding the CSS grid rules, making list view look like centered blog posts
- Move layout styles from inline to CSS base rules (`.provider-card { display: flex; flex-direction: column }`)
- List view now renders as compact single-line rows: name+badges | type | base_url | Edit+Test+models
- Add logo placeholder span for consistent name alignment when some providers have logos and some don't
- `setProviderView()` now re-renders providers so `isList` conditionals take effect immediately

Closes #604

## Test plan
- [x] `make test` — 3018 passed
- [x] Grid view unchanged
- [x] List view: compact rows with aligned columns
- [x] Toggle between grid/list works without page reload
- [x] Console zero errors