### PR TITLE
feat(argo): auto-generate human-readable model names from upstream display names

### DIFF
--- a/src/llm_rosetta/gateway/admin/js/fetch-models.js
+++ b/src/llm_rosetta/gateway/admin/js/fetch-models.js
@@ -17,6 +17,7 @@ function openFetchModelsModal() {
   }
   // Reset state
   S._fetchedModels = [];
+  S._fetchUpstreamMap = {};
   S._fetchProvider = '';
   document.getElementById('fetchModelsContent').style.display = 'none';
   document.getElementById('fetchModelsLoading').style.display = 'none';
@@ -70,6 +71,7 @@ async function doFetchModels() {
       return;
     }
     S._fetchedModels = data.models || [];
+    S._fetchUpstreamMap = data.upstream_map || {};
     if (S._fetchedModels.length === 0) {
       document.getElementById('fetchModelsError').textContent = t('fetch.noModels');
       document.getElementById('fetchModelsError').style.display = 'block';
@@ -154,6 +156,7 @@ async function bulkAddFetchedModels() {
         models: toAdd,
         prefix: prefix,
         capabilities: _getFetchCapabilities(),
+        upstream_map: S._fetchUpstreamMap,
       });
       if (res.ok) {
         addedCount = (res.added || []).length;

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -844,6 +844,47 @@ def _format_connection_error(exc: Exception, url: str) -> str:
     return f"Failed to connect to upstream: {err_str}"
 
 
+def _extract_model_ids(
+    body: dict[str, Any],
+    ptype: str,
+    shim_name: str | None,
+    id_field: str | None,
+) -> tuple[list[str], dict[str, str]]:
+    """Extract model IDs from an upstream ``/models`` response body.
+
+    Returns ``(model_ids, upstream_map)``.  When a shim provides a
+    ``model_list_transform`` hook, it is used to derive human-readable
+    slugs and the mapping back to internal upstream IDs.
+    """
+    from llm_rosetta.shims.providers import get_model_list_transform
+
+    mlt = get_model_list_transform(shim_name) if shim_name else None
+
+    upstream_map: dict[str, str] = {}
+    model_ids: list[str] = []
+
+    if mlt is not None:
+        raw_entries = (
+            body.get("models", []) if ptype == "google" else body.get("data", [])
+        )
+        model_ids, upstream_map = mlt(raw_entries)
+    elif ptype == "google":
+        for m in body.get("models", []):
+            name = m.get("name", "")
+            if name.startswith("models/"):
+                name = name[len("models/") :]
+            model_ids.append(m.get(id_field, name) if id_field else name)
+    else:
+        for m in body.get("data", []):
+            model_ids.append(
+                m.get(id_field, m.get("id", "")) if id_field else m.get("id", "")
+            )
+
+    model_ids = [m for m in model_ids if m]
+    model_ids.sort()
+    return model_ids, upstream_map
+
+
 async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
     """Fetch the model list from an upstream provider's /v1/models endpoint."""
     from llm_rosetta.shims import get_shim
@@ -908,32 +949,16 @@ async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
     shim = get_shim(shim_name) if shim_name else None
     id_field = shim.model_id_field if shim and shim.model_id_field else None
 
-    # Normalize response — different providers return different formats
-    model_ids: list[str] = []
-    if ptype == "google":
-        # Google: {"models": [{"name": "models/gemini-...", ...}]}
-        for m in body.get("models", []):
-            name = m.get("name", "")
-            if name.startswith("models/"):
-                name = name[len("models/") :]
-            model_ids.append(m.get(id_field, name) if id_field else name)
-    else:
-        # Anthropic & OpenAI-compatible: {"data": [{"id": "...", ...}]}
-        for m in body.get("data", []):
-            model_ids.append(
-                m.get(id_field, m.get("id", "")) if id_field else m.get("id", "")
-            )
+    model_ids, upstream_map = _extract_model_ids(body, ptype, shim_name, id_field)
 
-    model_ids = [m for m in model_ids if m]
-    model_ids.sort()
-
-    return JSONResponse(
-        {
-            "provider": provider_name,
-            "api_standard": ptype,
-            "models": model_ids,
-        }
-    )
+    result: dict[str, Any] = {
+        "provider": provider_name,
+        "api_standard": ptype,
+        "models": model_ids,
+    }
+    if upstream_map:
+        result["upstream_map"] = upstream_map
+    return JSONResponse(result)
 
 
 async def bulk_add_models(request: Any) -> Response:
@@ -948,6 +973,7 @@ async def bulk_add_models(request: Any) -> Response:
     provider = body.get("provider")
     models_to_add: list[str] = body.get("models", [])
     prefix = body.get("prefix", "")
+    upstream_map: dict[str, str] = body.get("upstream_map", {})
 
     if not provider or not models_to_add:
         return JSONResponse(
@@ -982,10 +1008,13 @@ async def bulk_add_models(request: Any) -> Response:
                 "provider": provider,
                 "capabilities": body.get("capabilities", ["text", "vision", "tools"]),
             }
-            # When a prefix is used, the gateway name differs from the
-            # upstream model id — store the original as upstream_model so the
-            # proxy handler can substitute it before forwarding.
-            if prefix:
+            # Set upstream_model when the gateway-facing name differs from
+            # what the upstream provider expects.  The upstream_map (from a
+            # shim's model_list_transform) takes precedence, then prefix.
+            mapped_upstream = upstream_map.get(model_id)
+            if mapped_upstream:
+                entry["upstream_model"] = mapped_upstream
+            elif prefix:
                 entry["upstream_model"] = model_id
             models_section[display_name] = entry
             added.append(display_name)

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -326,3 +326,8 @@ def _reset_registry() -> None:
     from llm_rosetta.auto_detect import _converter_cache
 
     _converter_cache.clear()
+
+    # Clear convention-based model list transforms.
+    from llm_rosetta.shims.providers import _model_list_transforms
+
+    _model_list_transforms.clear()

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -55,6 +55,8 @@ import importlib.util
 import logging
 from importlib.metadata import entry_points
 from pathlib import Path
+from typing import Any
+from collections.abc import Callable
 
 from llm_rosetta._vendor.yaml import load as yaml_load
 
@@ -63,6 +65,18 @@ from ..provider_shim import ProviderShim, ReasoningCapability, register_shim
 logger = logging.getLogger(__name__)
 
 _PROVIDERS_DIR = Path(__file__).parent
+
+# Convention-based model list transforms registered by shim transforms modules.
+# Each entry maps a shim name to a callable with signature:
+#   (raw_entries: list[dict]) -> tuple[list[str], dict[str, str]]
+_model_list_transforms: dict[str, Callable[..., Any]] = {}
+
+
+def get_model_list_transform(
+    shim_name: str,
+) -> Callable[..., Any] | None:
+    """Return the model_list_transform for *shim_name*, or ``None``."""
+    return _model_list_transforms.get(shim_name)
 
 
 def _parse_reasoning_cap(
@@ -101,12 +115,16 @@ def _parse_reasoning_cap(
 
 def _load_transforms(
     provider_dir: Path, *, group: str | None = None, _builtin: bool = True
-) -> tuple[tuple, tuple, tuple]:
-    """Import transforms.py if present, return (pre_ir_transforms, post_ir_transforms, ir_transforms).
+) -> tuple[tuple, tuple, tuple, Any]:
+    """Import transforms.py if present, return (pre, post, ir, module).
 
     Accepts both new names (``pre_ir_transforms``, ``post_ir_transforms``)
     and legacy names (``from_transforms``, ``to_transforms``) from the
     transforms module.  New names take precedence if both are present.
+
+    The fourth element is the loaded module object (or ``None`` when no
+    ``transforms.py`` exists).  Callers can inspect it for convention-based
+    hooks such as ``model_list_transform``.
 
     Args:
         provider_dir: Path to the leaf provider directory.
@@ -117,7 +135,7 @@ def _load_transforms(
     """
     tf_path = provider_dir / "transforms.py"
     if not tf_path.exists():
-        return (), (), ()
+        return (), (), (), None
     prefix = "llm_rosetta.shims.providers" if _builtin else "_llm_rosetta_plugin_shims"
     if group is not None:
         module_name = f"{prefix}.{group}.{provider_dir.name}.transforms"
@@ -126,7 +144,7 @@ def _load_transforms(
     spec = importlib.util.spec_from_file_location(module_name, tf_path)
     if spec is None or spec.loader is None:
         logger.warning("Could not load %s", tf_path)
-        return (), (), ()
+        return (), (), (), None
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     # New names take precedence; fall back to legacy names.
@@ -151,6 +169,7 @@ def _load_transforms(
         pre,
         post,
         getattr(mod, "ir_transforms", ()),
+        mod,
     )
 
 
@@ -174,7 +193,9 @@ def _load_single_provider(
         logger.warning("Skipping %s: missing 'name' or 'base'", yaml_path)
         return None
 
-    pre_t, post_t, ir_t = _load_transforms(provider_dir, group=group, _builtin=_builtin)
+    pre_t, post_t, ir_t, transforms_mod = _load_transforms(
+        provider_dir, group=group, _builtin=_builtin
+    )
 
     # Parse optional reasoning capability config from YAML.
     reasoning_cfg = cfg.get("reasoning")
@@ -214,6 +235,14 @@ def _load_single_provider(
         tool_search_mode=cfg.get("tool_search_mode", "disabled"),
     )
     register_shim(shim)
+
+    # Register convention-based model_list_transform if the transforms
+    # module exports one (e.g. Argo shims that slug-ify display names).
+    if transforms_mod is not None:
+        mlt = getattr(transforms_mod, "model_list_transform", None)
+        if mlt is not None:
+            _model_list_transforms[shim.name] = mlt
+
     logger.debug("Registered provider shim: %s (base=%s)", shim.name, shim.base)
     return shim
 

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -55,8 +55,8 @@ import importlib.util
 import logging
 from importlib.metadata import entry_points
 from pathlib import Path
-from typing import Any
 from collections.abc import Callable
+from typing import Any
 
 from llm_rosetta._vendor.yaml import load as yaml_load
 
@@ -67,14 +67,16 @@ logger = logging.getLogger(__name__)
 _PROVIDERS_DIR = Path(__file__).parent
 
 # Convention-based model list transforms registered by shim transforms modules.
-# Each entry maps a shim name to a callable with signature:
-#   (raw_entries: list[dict]) -> tuple[list[str], dict[str, str]]
-_model_list_transforms: dict[str, Callable[..., Any]] = {}
+# Each entry maps a shim name to a callable that converts upstream model
+# entries into (display_ids, upstream_map).
+ModelListTransform = Callable[[list[dict[str, Any]]], tuple[list[str], dict[str, str]]]
+
+_model_list_transforms: dict[str, ModelListTransform] = {}
 
 
 def get_model_list_transform(
     shim_name: str,
-) -> Callable[..., Any] | None:
+) -> ModelListTransform | None:
     """Return the model_list_transform for *shim_name*, or ``None``."""
     return _model_list_transforms.get(shim_name)
 

--- a/src/llm_rosetta/shims/providers/argo/anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/anthropic/transforms.py
@@ -24,6 +24,10 @@ from llm_rosetta.shims.transforms import (
     hoist_late_system_messages,
 )
 
+# Re-export shared Argo model list transform for convention-based hook
+# discovery by the shim loader.
+from ..model_utils import model_list_transform  # noqa: F401
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -132,23 +136,3 @@ pre_ir_transforms = (
     _NamedTransform(_normalize_openai_response, "normalize_openai_response()"),
 )
 ir_transforms = (hoist_late_system_messages(), auto_cache_breakpoints())
-
-
-def model_list_transform(raw_entries: list[dict]) -> tuple[list[str], dict[str, str]]:
-    """Transform raw ARGO model entries into (display_names, upstream_map).
-
-    ARGO's /models endpoint returns entries where ``id`` is a human-readable
-    name ("Claude Opus 5") and ``internal_id`` is the compact upstream ID
-    ("claudeopus5"). This converts to slug-style display names suitable
-    for gateway routing.
-    """
-    model_ids: list[str] = []
-    upstream_map: dict[str, str] = {}
-    for m in raw_entries:
-        display = m.get("id", "").replace(" ", "-").lower()
-        upstream = m.get("internal_id", m.get("id", ""))
-        if display:
-            model_ids.append(display)
-            if display != upstream:
-                upstream_map[display] = upstream
-    return model_ids, upstream_map

--- a/src/llm_rosetta/shims/providers/argo/anthropic/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/anthropic/transforms.py
@@ -132,3 +132,23 @@ pre_ir_transforms = (
     _NamedTransform(_normalize_openai_response, "normalize_openai_response()"),
 )
 ir_transforms = (hoist_late_system_messages(), auto_cache_breakpoints())
+
+
+def model_list_transform(raw_entries: list[dict]) -> tuple[list[str], dict[str, str]]:
+    """Transform raw ARGO model entries into (display_names, upstream_map).
+
+    ARGO's /models endpoint returns entries where ``id`` is a human-readable
+    name ("Claude Opus 5") and ``internal_id`` is the compact upstream ID
+    ("claudeopus5"). This converts to slug-style display names suitable
+    for gateway routing.
+    """
+    model_ids: list[str] = []
+    upstream_map: dict[str, str] = {}
+    for m in raw_entries:
+        display = m.get("id", "").replace(" ", "-").lower()
+        upstream = m.get("internal_id", m.get("id", ""))
+        if display:
+            model_ids.append(display)
+            if display != upstream:
+                upstream_map[display] = upstream
+    return model_ids, upstream_map

--- a/src/llm_rosetta/shims/providers/argo/model_utils.py
+++ b/src/llm_rosetta/shims/providers/argo/model_utils.py
@@ -1,0 +1,39 @@
+"""Shared model-list utilities for Argo provider shims."""
+
+from __future__ import annotations
+
+import re
+
+
+def model_list_transform(
+    raw_entries: list[dict],
+) -> tuple[list[str], dict[str, str]]:
+    """Transform raw Argo model entries into (display_names, upstream_map).
+
+    Argo's ``/models`` endpoint returns entries where ``id`` is a
+    human-readable name ("Claude Opus 5") and ``internal_id`` is the
+    compact upstream ID ("claudeopus5").  This converts to slug-style
+    display names suitable for gateway routing.
+
+    Args:
+        raw_entries: List of model dicts from the upstream ``/models``
+            response, each containing at least an ``id`` key and
+            optionally ``internal_id``.
+
+    Returns:
+        A ``(model_ids, upstream_map)`` tuple where *model_ids* is a
+        list of slug-style display names and *upstream_map* maps each
+        display name to its upstream internal ID (only for entries
+        where the two differ).
+    """
+    model_ids: list[str] = []
+    upstream_map: dict[str, str] = {}
+    for m in raw_entries:
+        raw_id = m.get("id", "")
+        display = re.sub(r"[^a-z0-9]+", "-", raw_id.lower()).strip("-")
+        upstream = m.get("internal_id", raw_id)
+        if display:
+            model_ids.append(display)
+            if display != upstream:
+                upstream_map[display] = upstream
+    return model_ids, upstream_map

--- a/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
@@ -37,6 +37,10 @@ from llm_rosetta.shims.transforms import (
     unwind_parallel_tool_calls,
 )
 
+# Re-export shared Argo model list transform for convention-based hook
+# discovery by the shim loader.
+from ..model_utils import model_list_transform  # noqa: F401
+
 post_ir_transforms = (
     rename_field("max_tokens", "max_completion_tokens"),
     replace_message_field("role", "developer", "system"),
@@ -50,23 +54,3 @@ ir_transforms = (
     truncate_images(50, pattern=r"^(gpt|o\d)"),
     unwind_parallel_tool_calls(pattern=r"^gemini"),
 )
-
-
-def model_list_transform(raw_entries: list[dict]) -> tuple[list[str], dict[str, str]]:
-    """Transform raw ARGO model entries into (display_names, upstream_map).
-
-    ARGO's /models endpoint returns entries where ``id`` is a human-readable
-    name ("Claude Opus 5") and ``internal_id`` is the compact upstream ID
-    ("claudeopus5"). This converts to slug-style display names suitable
-    for gateway routing.
-    """
-    model_ids: list[str] = []
-    upstream_map: dict[str, str] = {}
-    for m in raw_entries:
-        display = m.get("id", "").replace(" ", "-").lower()
-        upstream = m.get("internal_id", m.get("id", ""))
-        if display:
-            model_ids.append(display)
-            if display != upstream:
-                upstream_map[display] = upstream
-    return model_ids, upstream_map

--- a/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
+++ b/src/llm_rosetta/shims/providers/argo/openai_chat/transforms.py
@@ -50,3 +50,23 @@ ir_transforms = (
     truncate_images(50, pattern=r"^(gpt|o\d)"),
     unwind_parallel_tool_calls(pattern=r"^gemini"),
 )
+
+
+def model_list_transform(raw_entries: list[dict]) -> tuple[list[str], dict[str, str]]:
+    """Transform raw ARGO model entries into (display_names, upstream_map).
+
+    ARGO's /models endpoint returns entries where ``id`` is a human-readable
+    name ("Claude Opus 5") and ``internal_id`` is the compact upstream ID
+    ("claudeopus5"). This converts to slug-style display names suitable
+    for gateway routing.
+    """
+    model_ids: list[str] = []
+    upstream_map: dict[str, str] = {}
+    for m in raw_entries:
+        display = m.get("id", "").replace(" ", "-").lower()
+        upstream = m.get("internal_id", m.get("id", ""))
+        if display:
+            model_ids.append(display)
+            if display != upstream:
+                upstream_map[display] = upstream
+    return model_ids, upstream_map

--- a/tests/test_argo_model_list_transform.py
+++ b/tests/test_argo_model_list_transform.py
@@ -1,0 +1,88 @@
+"""Tests for the shared Argo model_list_transform hook."""
+
+from __future__ import annotations
+
+
+from llm_rosetta.shims.providers.argo.model_utils import model_list_transform
+
+
+class TestModelListTransform:
+    """Unit tests for model_list_transform slug generation and upstream mapping."""
+
+    def test_normal_input(self):
+        """Human-readable id is slugified; internal_id is mapped."""
+        raw = [{"id": "Claude Opus 5", "internal_id": "claudeopus5"}]
+        ids, upstream = model_list_transform(raw)
+        assert ids == ["claude-opus-5"]
+        assert upstream == {"claude-opus-5": "claudeopus5"}
+
+    def test_multiple_models(self):
+        """Multiple entries are all processed."""
+        raw = [
+            {"id": "Claude Opus 5", "internal_id": "claudeopus5"},
+            {"id": "GPT 4o Mini", "internal_id": "gpt4omini"},
+        ]
+        ids, upstream = model_list_transform(raw)
+        assert ids == ["claude-opus-5", "gpt-4o-mini"]
+        assert upstream == {
+            "claude-opus-5": "claudeopus5",
+            "gpt-4o-mini": "gpt4omini",
+        }
+
+    def test_empty_id_skipped(self):
+        """Entries with empty id are excluded from the result."""
+        raw = [
+            {"id": "", "internal_id": "ghost"},
+            {"id": "Claude Opus 5", "internal_id": "claudeopus5"},
+        ]
+        ids, upstream = model_list_transform(raw)
+        assert ids == ["claude-opus-5"]
+        assert upstream == {"claude-opus-5": "claudeopus5"}
+
+    def test_missing_internal_id_falls_back_to_id(self):
+        """When internal_id is absent, the raw id is used as upstream value."""
+        raw = [{"id": "Some Model"}]
+        ids, upstream = model_list_transform(raw)
+        assert ids == ["some-model"]
+        # Slug "some-model" differs from raw id "Some Model" → mapped.
+        assert upstream == {"some-model": "Some Model"}
+
+    def test_display_equals_upstream_no_map_entry(self):
+        """When slug matches the upstream value, no mapping is needed."""
+        raw = [{"id": "gpt-4o", "internal_id": "gpt-4o"}]
+        ids, upstream = model_list_transform(raw)
+        assert ids == ["gpt-4o"]
+        assert upstream == {}
+
+    def test_double_spaces(self):
+        """Double spaces produce a single hyphen, not double hyphens."""
+        raw = [{"id": "Claude  Opus  5", "internal_id": "claudeopus5"}]
+        ids, upstream = model_list_transform(raw)
+        assert ids == ["claude-opus-5"]
+
+    def test_special_characters(self):
+        """Parentheses, dots, slashes, and other special chars are collapsed."""
+        raw = [{"id": "Model (v2.1/beta)", "internal_id": "modelv21beta"}]
+        ids, upstream = model_list_transform(raw)
+        assert ids == ["model-v2-1-beta"]
+        assert upstream == {"model-v2-1-beta": "modelv21beta"}
+
+    def test_leading_trailing_whitespace(self):
+        """Leading/trailing whitespace does not produce leading/trailing hyphens."""
+        raw = [{"id": "  Claude Opus 5  ", "internal_id": "claudeopus5"}]
+        ids, upstream = model_list_transform(raw)
+        assert ids == ["claude-opus-5"]
+        assert "claude-opus-5" not in ["-claude-opus-5-", "-claude-opus-5"]
+
+    def test_empty_list(self):
+        """Empty input returns empty results."""
+        ids, upstream = model_list_transform([])
+        assert ids == []
+        assert upstream == {}
+
+    def test_missing_id_key(self):
+        """Entry without id key at all is skipped."""
+        raw = [{"internal_id": "orphan"}]
+        ids, upstream = model_list_transform(raw)
+        assert ids == []
+        assert upstream == {}

--- a/tests/test_shim_loader.py
+++ b/tests/test_shim_loader.py
@@ -32,9 +32,10 @@ class TestLoadTransforms:
 
     def test_no_transforms_file(self, tmp_path: Path):
         """Returns empty tuples when transforms.py does not exist."""
-        from_t, to_t, ir_t = _load_transforms(tmp_path)
+        from_t, to_t, ir_t, mod = _load_transforms(tmp_path)
         assert from_t == ()
         assert to_t == ()
+        assert mod is None
 
     def test_transforms_with_to_only(self, tmp_path: Path):
         """Loads post_ir_transforms from transforms.py."""
@@ -45,9 +46,10 @@ class TestLoadTransforms:
             post_ir_transforms = (strip_fields("foo"),)
         """)
         )
-        from_t, to_t, ir_t = _load_transforms(tmp_path)
+        from_t, to_t, ir_t, mod = _load_transforms(tmp_path)
         assert from_t == ()
         assert len(to_t) == 1
+        assert mod is not None
         # Verify the transform works
         body = {"foo": 1, "bar": 2}
         result = to_t[0](body)
@@ -64,9 +66,10 @@ class TestLoadTransforms:
             pre_ir_transforms = (rename_field("a", "b"),)
         """)
         )
-        from_t, to_t, ir_t = _load_transforms(tmp_path)
+        from_t, to_t, ir_t, mod = _load_transforms(tmp_path)
         assert len(from_t) == 1
         assert len(to_t) == 1
+        assert mod is not None
 
 
 class TestLoadProviders:


### PR DESCRIPTION
## Summary

- Adds a convention-based `model_list_transform` hook to the shim loader, allowing shim transforms modules to customize how upstream model lists are processed
- Argo shims (both `openai_chat` and `anthropic`) now export a `model_list_transform` that converts human-readable display names ("Claude Opus 5") into URL-friendly slugs ("claude-opus-5") and maps them back to compact internal IDs ("claudeopus5") via `upstream_model`
- The admin UI fetch-models flow passes the `upstream_map` through to `bulk_add_models`, so models added from Argo providers automatically get the correct `upstream_model` set

## Changes

- `src/llm_rosetta/shims/providers/argo/{openai_chat,anthropic}/transforms.py` -- add `model_list_transform`
- `src/llm_rosetta/shims/providers/__init__.py` -- add `_model_list_transforms` registry, `get_model_list_transform()`, register hook in `_load_single_provider`, return transforms module from `_load_transforms`
- `src/llm_rosetta/shims/provider_shim.py` -- clear `_model_list_transforms` in `_reset_registry()`
- `src/llm_rosetta/gateway/admin/routes/config.py` -- extract `_extract_model_ids` helper, use transform hook in `fetch_upstream_models`, accept `upstream_map` in `bulk_add_models`
- `src/llm_rosetta/gateway/admin/js/fetch-models.js` -- store and pass `upstream_map` through fetch -> bulk-add flow
- `tests/test_shim_loader.py` -- update for 4-tuple return from `_load_transforms`

## Test plan

- [x] All 3018 existing tests pass (no regressions)
- [ ] Manual test with an Argo provider: verify fetched models show slug-style names and bulk-add sets `upstream_model` correctly

Closes #608