### PR TITLE
refactor(shims): redesign ReasoningCapability with explicit thinking/effort/visibility dimensions

### DIFF
--- a/src/llm_rosetta/capabilities.py
+++ b/src/llm_rosetta/capabilities.py
@@ -38,16 +38,37 @@ def _apply_config_reasoning_override(
 
     Only fields present in *override* are replaced; the rest inherit
     from *base*.
+
+    Legacy compat: accepts old field names (``thinking_type``,
+    ``disabled``, ``budget_tokens_default_ratio``) from existing
+    admin UI configs and maps them to the new schema.
     """
     raw_range = override.get("effort_range", base.effort_range)
     effort_range = tuple(raw_range) if isinstance(raw_range, list) else raw_range
 
+    # Legacy compat: old admin UI sends thinking_type/disabled as scalars.
+    thinking_modes = override.get("thinking_modes", base.thinking_modes)
+    if "thinking_type" in override and "thinking_modes" not in override:
+        tt = override["thinking_type"]
+        if base.thinking_modes:
+            thinking_modes = {**base.thinking_modes}
+            for ir_mode, prov_val in list(thinking_modes.items()):
+                if ir_mode in ("auto", "enabled"):
+                    thinking_modes[ir_mode] = tt
+        else:
+            thinking_modes = {"auto": tt, "enabled": tt, "disabled": "disabled"}
+
+    budget = override.get(
+        "budget_ratio",
+        override.get("budget_tokens_default_ratio", base.budget_ratio),
+    )
+
     return ReasoningCapability(
-        thinking_modes=override.get("thinking_modes", base.thinking_modes),
+        thinking_modes=thinking_modes,
         thinking_default=override.get("thinking_default", base.thinking_default),
         effort_field=override.get("effort_field", base.effort_field),
         effort_range=effort_range,
-        budget_ratio=override.get("budget_ratio", base.budget_ratio),
+        budget_ratio=budget,
         visibility_modes=override.get("visibility_modes", base.visibility_modes),
         unsigned_blocks=override.get("unsigned_blocks", base.unsigned_blocks),
     )

--- a/src/llm_rosetta/capabilities.py
+++ b/src/llm_rosetta/capabilities.py
@@ -39,18 +39,17 @@ def _apply_config_reasoning_override(
     Only fields present in *override* are replaced; the rest inherit
     from *base*.
     """
+    raw_range = override.get("effort_range", base.effort_range)
+    effort_range = tuple(raw_range) if isinstance(raw_range, list) else raw_range
+
     return ReasoningCapability(
-        disabled=override.get("disabled", base.disabled),
+        thinking_modes=override.get("thinking_modes", base.thinking_modes),
+        thinking_default=override.get("thinking_default", base.thinking_default),
         effort_field=override.get("effort_field", base.effort_field),
-        max_effort=override.get("max_effort", base.max_effort),
-        thinking_type=override.get("thinking_type", base.thinking_type),
-        unsigned_reasoning_blocks=override.get(
-            "unsigned_reasoning_blocks", base.unsigned_reasoning_blocks
-        ),
-        effort_map=override.get("effort_map", base.effort_map),
-        budget_tokens_default_ratio=override.get(
-            "budget_tokens_default_ratio", base.budget_tokens_default_ratio
-        ),
+        effort_range=effort_range,
+        budget_ratio=override.get("budget_ratio", base.budget_ratio),
+        visibility_modes=override.get("visibility_modes", base.visibility_modes),
+        unsigned_blocks=override.get("unsigned_blocks", base.unsigned_blocks),
     )
 
 

--- a/src/llm_rosetta/converters/anthropic/converter.py
+++ b/src/llm_rosetta/converters/anthropic/converter.py
@@ -403,7 +403,7 @@ class AnthropicConverter(BaseConverter):
         rc_kwargs: dict[str, Any] = {}
         if "reasoning_cap" in ctx.options:
             rc_kwargs["reasoning_cap"] = ctx.options["reasoning_cap"]
-        # Pass max_tokens so budget_tokens_default_ratio can derive a
+        # Pass max_tokens so budget_ratio can derive a
         # default budget when the caller didn't provide one.
         if "max_tokens" in result:
             rc_kwargs["max_tokens"] = result["max_tokens"]

--- a/src/llm_rosetta/converters/anthropic/message_ops.py
+++ b/src/llm_rosetta/converters/anthropic/message_ops.py
@@ -205,7 +205,7 @@ class AnthropicMessageOps(BaseMessageOps):
                 anthropic_content.append(self.tool_ops.ir_tool_call_to_p(part))
             elif is_reasoning_part(part):
                 unsigned_policy = (
-                    reasoning_cap.unsigned_reasoning_blocks
+                    reasoning_cap.unsigned_blocks
                     if reasoning_cap is not None
                     else "as_is"
                 )

--- a/src/llm_rosetta/converters/base/helpers/reasoning.py
+++ b/src/llm_rosetta/converters/base/helpers/reasoning.py
@@ -112,9 +112,11 @@ def apply_reasoning_config(
 
     result: dict[str, Any] = {}
 
-    # Disabled mode — delegate to converter-specific handlers for
-    # converters that have special disabled serialisation (Google uses
-    # thinking_budget=0), otherwise use thinking_modes lookup.
+    # Disabled mode — most providers use thinking_modes["disabled"] via
+    # _serialize_disabled, but Google disables via thinking_budget=0 (not
+    # a type field), so it must go through _apply_google_extras instead.
+    # Do NOT add thinking_modes to Google's shim — _serialize_disabled
+    # would produce the wrong structure (thinking.type vs thinking_config).
     if mode == "disabled":
         if converter_type == "google":
             _apply_google_extras(ir, result, mode, budget_tokens, cap)

--- a/src/llm_rosetta/converters/base/helpers/reasoning.py
+++ b/src/llm_rosetta/converters/base/helpers/reasoning.py
@@ -22,61 +22,30 @@ import warnings
 from typing import Any, cast
 
 from llm_rosetta.shims.provider_shim import ReasoningCapability
-from llm_rosetta.types.ir.configs import ReasoningConfig
+from llm_rosetta.types.ir.reasoning import ReasoningConfig
 
 # ── Default reasoning capability configs per base converter type ──────────
 # Used as fallback when no shim-level config is present.
 
 _DEFAULT_OPENAI_CHAT = ReasoningCapability(
-    disabled="omit",
     effort_field="reasoning_effort",
-    effort_map={
-        "minimal": "minimal",
-        "low": "low",
-        "medium": "medium",
-        "high": "high",
-        "xhigh": "high",
-        "max": "high",
-    },
+    effort_range=("minimal", "high"),
 )
 
 _DEFAULT_OPENAI_RESPONSES = ReasoningCapability(
-    disabled="omit",
     effort_field="reasoning.effort",
-    effort_map={
-        "minimal": "minimal",
-        "low": "low",
-        "medium": "medium",
-        "high": "high",
-        "xhigh": "high",
-        "max": "high",
-    },
+    effort_range=("minimal", "high"),
 )
 
 _DEFAULT_ANTHROPIC = ReasoningCapability(
-    disabled="thinking_disabled",
+    thinking_modes={"auto": "adaptive", "enabled": "enabled", "disabled": "disabled"},
     effort_field="output_config.effort",
-    effort_map={
-        "minimal": "low",
-        "low": "low",
-        "medium": "medium",
-        "high": "high",
-        "xhigh": "xhigh",
-        "max": "max",
-    },
+    effort_range=("low", "max"),
 )
 
 _DEFAULT_GOOGLE = ReasoningCapability(
-    disabled="thinking_budget_zero",
     effort_field="thinking_level",
-    effort_map={
-        "minimal": "minimal",
-        "low": "low",
-        "medium": "medium",
-        "high": "high",
-        "xhigh": "high",
-        "max": "high",
-    },
+    effort_range=("minimal", "high"),
 )
 
 DEFAULT_REASONING_CAPS: dict[str, ReasoningCapability] = {
@@ -87,16 +56,13 @@ DEFAULT_REASONING_CAPS: dict[str, ReasoningCapability] = {
 }
 
 
-# ── Input normalisation ────────────────────────────────────────────────────
+# ── IR effort ladder ──────────────────────────────────────────────────────
 
-_EFFORT_RANK: dict[str, int] = {
-    "minimal": 0,
-    "low": 1,
-    "medium": 2,
-    "high": 3,
-    "xhigh": 4,
-    "max": 5,
-}
+_EFFORT_LADDER: list[str] = ["minimal", "low", "medium", "high", "xhigh", "max"]
+_EFFORT_RANK: dict[str, int] = {v: i for i, v in enumerate(_EFFORT_LADDER)}
+
+
+# ── Input normalisation ────────────────────────────────────────────────────
 
 
 def normalize_reasoning_input(
@@ -112,7 +78,6 @@ def normalize_reasoning_input(
     effort = result.get("effort")
 
     if effort == "none":
-        # ``none`` means disabled, not an effort level.
         result["mode"] = "disabled"
         del result["effort"]
 
@@ -131,25 +96,14 @@ def apply_reasoning_config(
 ) -> dict[str, Any]:
     """Convert IR ``ReasoningConfig`` → provider parameters using *cap*.
 
-    This is the single function each converter's ``ir_reasoning_config_to_p``
-    should delegate to.  It handles:
-
-    1. **Input normalisation** (``none`` → disabled).
-    2. **Disabled serialisation** according to ``cap.disabled``.
-    3. **Effort mapping** via ``cap.effort_map`` and ``cap.effort_field``.
-    4. **Pass-through** of ``mode`` and ``budget_tokens`` for converters
-       that support thinking objects (Anthropic, Google, OpenAI Chat extensions).
-
-    Args:
-        ir_reasoning: Normalised IR reasoning config.
-        cap: Provider's reasoning capability descriptor.
-        converter_type: The base converter type string (for extra pass-through
-            logic).
-
-    Returns:
-        Dict of provider-specific request fields to merge.
+    Handles:
+    1. Input normalisation (``none`` → disabled).
+    2. Disabled serialisation via ``cap.thinking_modes``.
+    3. Effort clamping via ``cap.effort_range`` and placement via
+       ``cap.effort_field``.
+    4. Converter-specific structural pass-through (thinking blocks,
+       budget, visibility).
     """
-    # 1. Normalise input.
     ir = normalize_reasoning_input(ir_reasoning)
 
     mode = ir.get("mode")
@@ -158,62 +112,60 @@ def apply_reasoning_config(
 
     result: dict[str, Any] = {}
 
-    # 2. Disabled mode.
+    # Disabled mode — delegate to converter-specific handlers for
+    # converters that have special disabled serialisation (Google uses
+    # thinking_budget=0), otherwise use thinking_modes lookup.
     if mode == "disabled":
+        if converter_type == "google":
+            _apply_google_extras(ir, result, mode, budget_tokens, cap)
+            return result
         return _serialize_disabled(cap)
 
-    # 3. Effort mapping.
+    # Effort clamping + placement.
     if effort is not None:
-        effort = _cap_effort(effort, cap)
-        provider_effort = cap.effort_map.get(effort)
-        if provider_effort is None:
-            warnings.warn(
-                f"Effort level '{effort}' not in shim effort_map, skipping",
-                stacklevel=2,
-            )
-        else:
-            effort_fields = _serialize_effort(cap.effort_field, provider_effort)
-            _deep_merge(result, effort_fields)
+        effort = _clamp_effort(effort, cap)
+        effort_fields = _serialize_effort(cap.effort_field, effort)
+        _deep_merge(result, effort_fields)
 
-    # 4. Converter-specific structural pass-through.
+    # Converter-specific structural pass-through.
     if converter_type == "openai_chat":
         _apply_openai_chat_extras(ir, result, mode, budget_tokens, cap, max_tokens)
     elif converter_type == "openai_responses":
-        _apply_openai_responses_extras(ir, result, mode, budget_tokens)
+        _apply_openai_responses_extras(ir, result, mode, budget_tokens, cap)
     elif converter_type == "anthropic":
         _apply_anthropic_extras(
             ir, result, mode, effort, budget_tokens, cap, max_tokens
         )
     elif converter_type == "google":
-        _apply_google_extras(ir, result, mode, budget_tokens)
+        _apply_google_extras(ir, result, mode, budget_tokens, cap)
 
     return result
 
 
-# ── Effort capping ──────────────────────────────────────────────────────────
+# ── Effort clamping ──────────────────────────────────────────────────────────
 
 
-def _cap_effort(effort: str, cap: ReasoningCapability) -> str:
-    if cap.max_effort is None:
+def _clamp_effort(effort: str, cap: ReasoningCapability) -> str:
+    """Clamp *effort* to ``cap.effort_range`` boundaries."""
+    if cap.effort_range is None:
         return effort
-    effort_rank = _EFFORT_RANK.get(effort)
-    max_rank = _EFFORT_RANK.get(cap.max_effort)
-    if effort_rank is None or max_rank is None or effort_rank <= max_rank:
+    floor, ceiling = cap.effort_range
+    rank = _EFFORT_RANK.get(effort)
+    lo = _EFFORT_RANK.get(floor)
+    hi = _EFFORT_RANK.get(ceiling)
+    if rank is None or lo is None or hi is None:
         return effort
-    return cap.max_effort
+    clamped = max(lo, min(hi, rank))
+    return _EFFORT_LADDER[clamped]
 
 
 # ── Disabled serialisation ─────────────────────────────────────────────────
 
 
 def _serialize_disabled(cap: ReasoningCapability) -> dict[str, Any]:
-    """Serialize disabled state according to the shim strategy."""
-    if cap.disabled == "omit":
-        return {}
-    elif cap.disabled == "thinking_disabled":
-        return {"thinking": {"type": "disabled"}}
-    elif cap.disabled == "thinking_budget_zero":
-        return {"thinking_config": {"thinking_budget": 0}}
+    """Serialize disabled state using ``cap.thinking_modes``."""
+    if cap.thinking_modes and "disabled" in cap.thinking_modes:
+        return {"thinking": {"type": cap.thinking_modes["disabled"]}}
     return {}
 
 
@@ -243,7 +195,6 @@ def _serialize_effort(
         return {"output_config": {"effort": provider_effort}}
     if effort_field == "thinking_level":
         return {"thinking_config": {"thinking_level": provider_effort}}
-    # Unknown field — fall back to flat key
     warnings.warn(
         f"Unknown effort_field '{effort_field}', using as flat key",
         stacklevel=3,
@@ -265,7 +216,6 @@ def _deep_merge(target: dict[str, Any], source: dict[str, Any]) -> None:
 
 # ── Budget tokens default derivation ──────────────────────────────────────
 
-#: Anthropic's minimum budget_tokens value (per official docs).
 _MIN_BUDGET_TOKENS = 1024
 
 
@@ -273,47 +223,72 @@ def _derive_budget_tokens(
     cap: ReasoningCapability,
     max_tokens: int | None,
 ) -> int | None:
-    """Derive ``budget_tokens`` from ``cap.budget_tokens_default_ratio`` and *max_tokens*.
+    """Derive ``budget_tokens`` from ``cap.budget_ratio`` and *max_tokens*.
 
     Returns ``None`` when derivation is impossible (no ratio configured,
     no ``max_tokens``, or ``max_tokens`` too small to satisfy the minimum).
     """
-    if cap.budget_tokens_default_ratio is None or max_tokens is None:
+    if cap.budget_ratio is None or max_tokens is None:
         return None
     if max_tokens <= _MIN_BUDGET_TOKENS:
-        # Can't satisfy budget_tokens >= 1024 AND < max_tokens.
         return None
-    budget = max(_MIN_BUDGET_TOKENS, int(max_tokens * cap.budget_tokens_default_ratio))
-    # Anthropic requires budget_tokens < max_tokens.
+    budget = max(_MIN_BUDGET_TOKENS, int(max_tokens * cap.budget_ratio))
     return min(budget, max_tokens - 1)
 
 
-def _apply_thinking_type_override(
+# ── Thinking block helpers ────────────────────────────────────────────────
+
+
+def _resolve_thinking_type(
+    mode: str | None,
+    cap: ReasoningCapability,
+) -> str | None:
+    """Look up the provider thinking type for an IR *mode* via ``cap.thinking_modes``.
+
+    Returns ``None`` when the provider doesn't support a thinking block
+    or the specific mode is not in the map.
+    """
+    if not cap.thinking_modes:
+        return None
+    effective_mode = mode or cap.thinking_default
+    if effective_mode is None:
+        return None
+    return cap.thinking_modes.get(effective_mode)
+
+
+def _apply_visibility(
+    ir: ReasoningConfig,
     result: dict[str, Any],
     cap: ReasoningCapability | None,
-    max_tokens: int | None,
+    *,
+    target_key: str = "reasoning",
+    target_subkey: str = "summary",
 ) -> None:
-    """Apply shim ``thinking_type`` override to the ``thinking`` dict.
+    """Apply visibility mapping from ``cap.visibility_modes`` or converter defaults.
 
-    When the shim declares a preferred thinking type, reconcile it with
-    what is already set — deriving ``budget_tokens`` from the ratio when
-    switching to ``"enabled"``, or stripping it when falling back to
-    ``"adaptive"``.
+    When ``visibility_modes`` is configured, uses the mapping.
+    Otherwise falls back to the converter's hardcoded default behavior
+    (writing to ``{target_key}.{target_subkey}``).
     """
-    if cap is None or cap.thinking_type is None or "thinking" not in result:
+    summary = ir.get("summary")
+    include_thoughts = ir.get("include_thoughts")
+
+    if cap and cap.visibility_modes:
+        if summary and summary in cap.visibility_modes:
+            result.setdefault(target_key, {})[target_subkey] = cap.visibility_modes[
+                summary
+            ]
+        elif include_thoughts is True and "auto" in cap.visibility_modes:
+            result.setdefault(target_key, {})[target_subkey] = cap.visibility_modes[
+                "auto"
+            ]
         return
-    current_type = result["thinking"].get("type")
-    target_type = cap.thinking_type
-    if target_type == "enabled" and "budget_tokens" not in result["thinking"]:
-        derived = _derive_budget_tokens(cap, max_tokens)
-        if derived is not None:
-            result["thinking"]["budget_tokens"] = derived
-        else:
-            target_type = "adaptive"
-    if current_type != target_type:
-        result["thinking"]["type"] = target_type
-        if target_type == "adaptive" and "budget_tokens" in result["thinking"]:
-            del result["thinking"]["budget_tokens"]
+
+    # Fallback: converter default behavior (summary pass-through)
+    if summary in ("auto", "concise", "detailed"):
+        result.setdefault(target_key, {})[target_subkey] = summary
+    elif include_thoughts is True:
+        result.setdefault(target_key, {})[target_subkey] = "auto"
 
 
 # ── Converter-specific pass-through extras ─────────────────────────────────
@@ -328,27 +303,26 @@ def _apply_openai_chat_extras(
     max_tokens: int | None = None,
 ) -> None:
     """OpenAI Chat extras: thinking object for mode/budget_tokens (DeepSeek ext), summary."""
-    thinking: dict[str, Any] = {}
-    if mode:
-        # IR "auto" is not a valid upstream value; map to "adaptive"
-        # (DeepSeek/Volcengine vocabulary).
-        thinking["type"] = "adaptive" if mode == "auto" else mode
-    if budget_tokens is not None:
-        thinking["budget_tokens"] = budget_tokens
-    if thinking:
-        result["thinking"] = thinking
+    if cap:
+        thinking_type = _resolve_thinking_type(mode, cap)
+        if thinking_type is not None:
+            thinking: dict[str, Any] = {"type": thinking_type}
+            if budget_tokens is not None:
+                # "enabled" requires budget_tokens; "adaptive" ignores it.
+                if thinking_type == "enabled" or thinking_type not in (
+                    "adaptive",
+                    "disabled",
+                ):
+                    thinking["budget_tokens"] = budget_tokens
+            elif thinking_type == "enabled":
+                derived = _derive_budget_tokens(cap, max_tokens)
+                if derived is not None:
+                    thinking["budget_tokens"] = derived
+                elif cap.thinking_modes and "auto" in cap.thinking_modes:
+                    thinking["type"] = cap.thinking_modes["auto"]
+            result["thinking"] = thinking
 
-    summary = ir.get("summary")
-    if summary in ("auto", "concise", "detailed"):
-        if "reasoning" not in result:
-            result["reasoning"] = {}
-        result["reasoning"]["summary"] = summary
-    elif ir.get("include_thoughts") is True:
-        if "reasoning" not in result:
-            result["reasoning"] = {}
-        result["reasoning"]["summary"] = "auto"
-
-    _apply_thinking_type_override(result, cap, max_tokens)
+    _apply_visibility(ir, result, cap)
 
 
 def _apply_openai_responses_extras(
@@ -356,12 +330,12 @@ def _apply_openai_responses_extras(
     result: dict[str, Any],
     mode: str | None,
     budget_tokens: int | None,
+    cap: ReasoningCapability | None = None,
 ) -> None:
     """OpenAI Responses extras.
 
-    Note: OpenAI Responses API does **not** accept ``reasoning.type``
-    (returns 400 Unknown parameter).  Reasoning is controlled via
-    ``reasoning.effort`` and optional ``reasoning.summary`` (e.g. "auto", "concise", "detailed").
+    OpenAI Responses API does **not** accept ``reasoning.type``.
+    Reasoning is controlled via ``reasoning.effort`` + ``reasoning.summary``.
     """
     if budget_tokens is not None:
         warnings.warn(
@@ -369,15 +343,7 @@ def _apply_openai_responses_extras(
             stacklevel=2,
         )
 
-    summary = ir.get("summary")
-    if summary in ("auto", "concise", "detailed"):
-        if "reasoning" not in result:
-            result["reasoning"] = {}
-        result["reasoning"]["summary"] = summary
-    elif ir.get("include_thoughts") is True:
-        if "reasoning" not in result:
-            result["reasoning"] = {}
-        result["reasoning"]["summary"] = "auto"
+    _apply_visibility(ir, result, cap)
 
 
 def _apply_anthropic_extras(
@@ -390,42 +356,78 @@ def _apply_anthropic_extras(
     max_tokens: int | None = None,
 ) -> None:
     """Anthropic extras: thinking object with type/budget_tokens."""
-    if mode == "enabled":
-        if budget_tokens is not None:
-            result["thinking"] = {"type": "enabled", "budget_tokens": budget_tokens}
-        else:
-            # Try to derive budget from ratio before falling back to adaptive.
-            derived = _derive_budget_tokens(cap, max_tokens) if cap else None
-            if derived is not None:
-                result["thinking"] = {"type": "enabled", "budget_tokens": derived}
-            else:
-                warnings.warn(
-                    "Anthropic 'enabled' thinking requires budget_tokens, "
-                    "falling back to 'adaptive'",
-                    stacklevel=2,
-                )
-                thinking_val: dict[str, Any] = {"type": "adaptive"}
-                result["thinking"] = thinking_val
-    elif mode == "auto" or effort is not None:
-        thinking: dict[str, Any] = {"type": "adaptive"}
-        if budget_tokens is not None:
-            thinking["budget_tokens"] = budget_tokens
-        result["thinking"] = thinking
-    elif budget_tokens is not None:
-        result["thinking"] = {"type": "enabled", "budget_tokens": budget_tokens}
+    thinking_type = _resolve_thinking_type(mode, cap) if cap else None
 
-    # Map IR summary → Anthropic thinking.display
+    if thinking_type is None and cap and cap.thinking_modes:
+        if effort is not None and "auto" in cap.thinking_modes:
+            thinking_type = cap.thinking_modes["auto"]
+        elif budget_tokens is not None and "enabled" in cap.thinking_modes:
+            thinking_type = cap.thinking_modes["enabled"]
+
+    if thinking_type is not None:
+        result["thinking"] = _build_anthropic_thinking(
+            thinking_type, budget_tokens, cap, max_tokens
+        )
+
     if "thinking" in result:
-        summary = ir.get("summary")
-        if summary == "none" or ir.get("include_thoughts") is False:
-            result["thinking"]["display"] = "omitted"
-        elif (
-            summary in ("auto", "concise", "detailed")
-            or ir.get("include_thoughts") is True
-        ):
-            result["thinking"]["display"] = "summarized"
+        _apply_anthropic_visibility(ir, result, cap)
 
-    _apply_thinking_type_override(result, cap, max_tokens)
+
+def _build_anthropic_thinking(
+    thinking_type: str,
+    budget_tokens: int | None,
+    cap: ReasoningCapability | None,
+    max_tokens: int | None,
+) -> dict[str, Any]:
+    """Build the Anthropic ``thinking`` dict for a given type."""
+    if thinking_type != "enabled":
+        obj: dict[str, Any] = {"type": thinking_type}
+        if budget_tokens is not None:
+            obj["budget_tokens"] = budget_tokens
+        return obj
+
+    # "enabled" requires budget_tokens
+    if budget_tokens is not None:
+        return {"type": thinking_type, "budget_tokens": budget_tokens}
+    derived = _derive_budget_tokens(cap, max_tokens) if cap else None
+    if derived is not None:
+        return {"type": thinking_type, "budget_tokens": derived}
+    fallback = (
+        cap.thinking_modes.get("auto") if cap and cap.thinking_modes else "adaptive"
+    )
+    if fallback:
+        warnings.warn(
+            f"Anthropic 'enabled' thinking requires budget_tokens, "
+            f"falling back to '{fallback}'",
+            stacklevel=2,
+        )
+    return {"type": fallback or thinking_type}
+
+
+def _apply_anthropic_visibility(
+    ir: ReasoningConfig,
+    result: dict[str, Any],
+    cap: ReasoningCapability | None,
+) -> None:
+    """Map IR summary → Anthropic ``thinking.display``."""
+    summary = ir.get("summary")
+    include_thoughts = ir.get("include_thoughts")
+
+    if cap and cap.visibility_modes:
+        if summary and summary in cap.visibility_modes:
+            result["thinking"]["display"] = cap.visibility_modes[summary]
+        elif include_thoughts is False and "none" in cap.visibility_modes:
+            result["thinking"]["display"] = cap.visibility_modes["none"]
+        elif (
+            include_thoughts is True or summary in ("auto", "concise", "detailed")
+        ) and "auto" in cap.visibility_modes:
+            result["thinking"]["display"] = cap.visibility_modes["auto"]
+        return
+
+    if summary == "none" or include_thoughts is False:
+        result["thinking"]["display"] = "omitted"
+    elif summary in ("auto", "concise", "detailed") or include_thoughts is True:
+        result["thinking"]["display"] = "summarized"
 
 
 def _apply_google_extras(
@@ -433,11 +435,14 @@ def _apply_google_extras(
     result: dict[str, Any],
     mode: str | None,
     budget_tokens: int | None,
+    cap: ReasoningCapability | None = None,
 ) -> None:
     """Google extras: thinking_config with thinking_budget and include_thoughts."""
     thinking_config = result.get("thinking_config", {})
 
-    if (
+    if mode == "disabled":
+        thinking_config["thinking_budget"] = 0
+    elif (
         mode == "auto"
         and budget_tokens is None
         and "thinking_level" not in thinking_config
@@ -447,6 +452,7 @@ def _apply_google_extras(
     if budget_tokens is not None:
         thinking_config["thinking_budget"] = budget_tokens
 
+    # Google visibility: include_thoughts boolean
     summary = ir.get("summary")
     if summary in ("auto", "concise", "detailed") or ir.get("include_thoughts") is True:
         thinking_config["include_thoughts"] = True

--- a/src/llm_rosetta/converters/openai_chat/config_ops.py
+++ b/src/llm_rosetta/converters/openai_chat/config_ops.py
@@ -306,8 +306,12 @@ class OpenAIChatConfigOps(BaseConfigOps):
         thinking = provider_reasoning.get("thinking")
         if isinstance(thinking, dict):
             thinking_type = thinking.get("type")
-            if thinking_type:
-                result["mode"] = thinking_type
+            if thinking_type == "adaptive":
+                result["mode"] = "auto"
+            elif thinking_type == "enabled":
+                result["mode"] = "enabled"
+            elif thinking_type == "disabled":
+                result["mode"] = "disabled"
             budget = thinking.get("budget_tokens")
             if budget is not None:
                 result["budget_tokens"] = budget

--- a/src/llm_rosetta/converters/openai_chat/converter.py
+++ b/src/llm_rosetta/converters/openai_chat/converter.py
@@ -192,7 +192,7 @@ class OpenAIChatConverter(BaseConverter):
             rc_kwargs: dict[str, Any] = {}
             if ctx and "reasoning_cap" in ctx.options:
                 rc_kwargs["reasoning_cap"] = ctx.options["reasoning_cap"]
-            # Pass max_tokens so budget_tokens_default_ratio can derive a
+            # Pass max_tokens so budget_ratio can derive a
             # default budget when the caller didn't provide one.
             mt = result.get("max_tokens") or result.get("max_completion_tokens")
             if mt is not None:

--- a/src/llm_rosetta/gateway/admin/js/models.js
+++ b/src/llm_rosetta/gateway/admin/js/models.js
@@ -134,14 +134,16 @@ function openModelModal(model, provider, capabilities, upstreamModel, sourceMode
   // Update inherit option labels: show "value (inherited)" or just "(inherit)"
   const inh = t('label.inherited');
   const ttInherit = document.querySelector('#reasoningThinkingType option[value=""]');
-  ttInherit.textContent = reasoning.thinking_type ? reasoning.thinking_type + ' (' + inh + ')' : '(' + inh + ')';
+  const tmSummary = reasoning.thinking_modes ? Object.keys(reasoning.thinking_modes).join('/') : null;
+  ttInherit.textContent = tmSummary ? tmSummary + ' (' + inh + ')' : '(' + inh + ')';
   const br = document.getElementById('reasoningBudgetRatio');
-  br.placeholder = reasoning.budget_tokens_default_ratio != null ? reasoning.budget_tokens_default_ratio + ' (' + inh + ')' : '(' + inh + ')';
+  br.placeholder = reasoning.budget_ratio != null ? reasoning.budget_ratio + ' (' + inh + ')' : '(' + inh + ')';
   const dsInherit = document.querySelector('#reasoningDisabled option[value=""]');
-  dsInherit.textContent = reasoning.disabled ? reasoning.disabled + ' (' + inh + ')' : '(' + inh + ')';
+  const hasDisabled = reasoning.thinking_modes && reasoning.thinking_modes.disabled;
+  dsInherit.textContent = hasDisabled ? 'thinking_disabled (' + inh + ')' : 'omit (' + inh + ')';
   // Set values — config override if present, otherwise blank (inheriting)
   document.getElementById('reasoningThinkingType').value = configOverride.thinking_type || '';
-  document.getElementById('reasoningBudgetRatio').value = configOverride.budget_tokens_default_ratio != null ? configOverride.budget_tokens_default_ratio : '';
+  document.getElementById('reasoningBudgetRatio').value = configOverride.budget_ratio != null ? configOverride.budget_ratio : '';
   document.getElementById('reasoningDisabled').value = configOverride.disabled || '';
 
   openModal('modelModal');
@@ -389,7 +391,7 @@ async function saveModel() {
     const disabledStrategy = document.getElementById('reasoningDisabled').value || null;
     const override = {};
     if (thinkingType) override.thinking_type = thinkingType;
-    if (budgetRatioStr !== '') override.budget_tokens_default_ratio = parseFloat(budgetRatioStr);
+    if (budgetRatioStr !== '') override.budget_ratio = parseFloat(budgetRatioStr);
     if (disabledStrategy) override.disabled = disabledStrategy;
     if (Object.keys(override).length > 0) body.reasoning_override = override;
   }

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -85,10 +85,11 @@ def _resolve_model_reasoning(
 
     return {
         "source": source,
-        "thinking_type": cap.thinking_type,
-        "disabled": cap.disabled,
+        "thinking_modes": cap.thinking_modes,
         "effort_field": cap.effort_field,
-        "budget_tokens_default_ratio": cap.budget_tokens_default_ratio,
+        "effort_range": list(cap.effort_range) if cap.effort_range else None,
+        "budget_ratio": cap.budget_ratio,
+        "visibility_modes": cap.visibility_modes,
         "config_override": config_override,
     }
 

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 
 import logging
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Literal
 
+from ..types.ir.configs import IREffort, IRMode  # re-exported
 from .transforms import IRTransform, Transform
 
 logger = logging.getLogger(__name__)
@@ -26,69 +27,80 @@ logger = logging.getLogger(__name__)
 # Reasoning capability config
 # ---------------------------------------------------------------------------
 
-#: How a provider handles "reasoning disabled".
-DisabledStrategy = Literal["omit", "thinking_disabled", "thinking_budget_zero"]
+# Provider-side types — strategy enums for shim behavior.
 
-#: Where the provider expects the effort value to be serialised.
-EffortField = Literal[
-    "reasoning_effort",  # OpenAI Chat top-level
-    "reasoning.effort",  # OpenAI Responses nested
-    "output_config.effort",  # Anthropic
-    "thinking_level",  # Google thinking_config.thinking_level
-    "none",  # Provider has no effort field
-]
-
-#: Normalised IR effort ladder level.
-EffortLevel = Literal["minimal", "low", "medium", "high", "xhigh", "max"]
-
-#: How the provider expects ``thinking.type`` to be serialised.
-ThinkingType = Literal["enabled", "adaptive"]
+#: How outbound unsigned reasoning blocks are handled.
+UnsignedBlocks = Literal["as_is", "preserve"]
 
 #: Tool search capability mode.
 ToolSearchMode = Literal["disabled", "native", "bridge"]
 
-#: How outbound unsigned reasoning blocks are handled.
-UnsignedReasoningBlocks = Literal["as_is", "preserve"]
-
-#: Mapping from normalised IR effort levels to provider-specific values.
-#: Any IR level absent from the map is unsupported and will be warned/skipped.
-EffortMap = dict[str, str]  # e.g. {"minimal": "low", "max": "high"}
+# Backward-compat aliases (deprecated — will be removed in a future version)
+EffortLevel = IREffort
+DisabledStrategy = Literal["omit", "thinking_disabled", "thinking_budget_zero"]
+ThinkingType = Literal["enabled", "adaptive"]
+UnsignedReasoningBlocks = UnsignedBlocks
+EffortMap = dict[str, str]
+EffortField = str
 
 
 @dataclass(frozen=True)
 class ReasoningCapability:
-    """Declares how a provider handles reasoning effort and disabled state.
+    """How a provider handles reasoning / thinking configuration.
 
-    Attributes:
-        disabled: How to serialise ``mode: disabled``.
-        effort_field: Where the provider expects the effort value.
-        max_effort: Highest normalised effort this shim should emit.
-        thinking_type: Force ``thinking.type`` to this value.
-        unsigned_reasoning_blocks: Policy for outbound unsigned reasoning blocks.
-        effort_map: Map from normalised IR effort to provider effort string.
-        budget_tokens_default_ratio: When ``thinking_type`` is ``"enabled"``
-            but no ``budget_tokens`` is provided, derive a default budget as
-            ``max(1024, int(max_tokens * ratio))`` clamped to ``max_tokens - 1``.
-            Anthropic requires ``budget_tokens >= 1024`` and ``< max_tokens``.
-            When ``None``, the existing ``"adaptive"`` fallback is used instead.
+    Each field group controls one dimension of reasoning behavior.
+    IR-side values use the fixed vocabulary from ``types.ir.configs``;
+    provider-side values are free strings specific to each upstream API.
+
+    Reference: https://llm-rosetta.readthedocs.io/en/latest/api/reasoning/
+
+    Naming convention:
+    - ``_modes``: IR value → provider value mapping (dict)
+    - ``_field``: provider-side field path (str)
+    - ``_range``: IR-side constraint interval (tuple)
     """
 
-    disabled: DisabledStrategy = "omit"
-    effort_field: EffortField = "reasoning_effort"
-    max_effort: EffortLevel | None = None
-    thinking_type: ThinkingType | None = None
-    unsigned_reasoning_blocks: UnsignedReasoningBlocks = "as_is"
-    effort_map: EffortMap = field(
-        default_factory=lambda: {
-            "minimal": "low",
-            "low": "low",
-            "medium": "medium",
-            "high": "high",
-            "xhigh": "high",
-            "max": "high",
-        }
-    )
-    budget_tokens_default_ratio: float | None = None
+    # ── Thinking toggle ──────────────────────────────────────────────
+    # Maps IR mode → provider thinking type value.
+    # None = provider does not support a thinking block.
+    # Example: {"auto": "adaptive", "enabled": "enabled", "disabled": "disabled"}
+    # IR modes not present in the map are silently dropped.
+    thinking_modes: dict[str, str] | None = None
+
+    # Default IR mode when the request has no explicit mode.
+    # Must be a key in thinking_modes.
+    thinking_default: IRMode | None = None
+
+    # ── Effort ───────────────────────────────────────────────────────
+    # Provider-side field path for the effort value.
+    # "reasoning_effort"       → {reasoning_effort: v}
+    # "reasoning.effort"       → {reasoning: {effort: v}}
+    # "output_config.effort"   → {output_config: {effort: v}}
+    # "thinking_level"         → {thinking_config: {thinking_level: v}}
+    # "none"                   → provider does not accept effort
+    effort_field: str = "reasoning_effort"
+
+    # Supported IR effort range [floor, ceiling].
+    # Values outside are clamped to the nearest boundary.
+    # None = full IR ladder (minimal–max).
+    effort_range: tuple[IREffort, IREffort] | None = None
+
+    # ── Budget ───────────────────────────────────────────────────────
+    # Derive budget_tokens as max(1024, int(max_tokens × ratio)),
+    # clamped to max_tokens − 1.  None = no automatic derivation.
+    budget_ratio: float | None = None
+
+    # ── Visibility ───────────────────────────────────────────────────
+    # Maps IR summary value → provider visibility value.
+    # None = use converter default (hardcoded per API standard).
+    # IR values not in the map → field is omitted from the request.
+    # Example (Anthropic):  {"auto": "summarized", "none": "omitted"}
+    # Example (OpenAI):     {"auto": "auto", "concise": "concise", "detailed": "detailed"}
+    visibility_modes: dict[str, str] | None = None
+
+    # ── Response handling ────────────────────────────────────────────
+    # How to handle unsigned (non-redacted) reasoning blocks in responses.
+    unsigned_blocks: UnsignedBlocks = "as_is"
 
 
 # ---------------------------------------------------------------------------

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -65,6 +65,40 @@ logger = logging.getLogger(__name__)
 _PROVIDERS_DIR = Path(__file__).parent
 
 
+def _parse_reasoning_cap(
+    cfg: dict,
+    *,
+    base: ReasoningCapability | None = None,
+) -> ReasoningCapability:
+    """Parse a reasoning config dict into a :class:`ReasoningCapability`.
+
+    When *base* is provided (model_overrides), unset fields inherit from it.
+    """
+    _d = base  # shorthand for fallback defaults
+
+    # effort_range: YAML gives [floor, ceiling] list → tuple
+    raw_range = cfg.get("effort_range", _d.effort_range if _d else None)
+    effort_range = tuple(raw_range) if isinstance(raw_range, list) else raw_range
+
+    return ReasoningCapability(
+        thinking_modes=cfg.get("thinking_modes", _d.thinking_modes if _d else None),
+        thinking_default=cfg.get(
+            "thinking_default", _d.thinking_default if _d else None
+        ),
+        effort_field=cfg.get(
+            "effort_field", _d.effort_field if _d else "reasoning_effort"
+        ),
+        effort_range=effort_range,
+        budget_ratio=cfg.get("budget_ratio", _d.budget_ratio if _d else None),
+        visibility_modes=cfg.get(
+            "visibility_modes", _d.visibility_modes if _d else None
+        ),
+        unsigned_blocks=cfg.get(
+            "unsigned_blocks", _d.unsigned_blocks if _d else "as_is"
+        ),
+    )
+
+
 def _load_transforms(
     provider_dir: Path, *, group: str | None = None, _builtin: bool = True
 ) -> tuple[tuple, tuple, tuple]:
@@ -146,19 +180,7 @@ def _load_single_provider(
     reasoning_cfg = cfg.get("reasoning")
     reasoning_cap: ReasoningCapability | None = None
     if isinstance(reasoning_cfg, dict):
-        reasoning_cap = ReasoningCapability(
-            disabled=reasoning_cfg.get("disabled", "omit"),
-            effort_field=reasoning_cfg.get("effort_field", "reasoning_effort"),
-            max_effort=reasoning_cfg.get("max_effort"),
-            thinking_type=reasoning_cfg.get("thinking_type"),
-            unsigned_reasoning_blocks=reasoning_cfg.get(
-                "unsigned_reasoning_blocks", "as_is"
-            ),
-            effort_map=reasoning_cfg.get("effort_map", {}),
-            budget_tokens_default_ratio=reasoning_cfg.get(
-                "budget_tokens_default_ratio"
-            ),
-        )
+        reasoning_cap = _parse_reasoning_cap(reasoning_cfg)
 
     # Parse per-model reasoning overrides (inherit provider defaults).
     model_reasoning: dict[str, ReasoningCapability] | None = None
@@ -170,22 +192,8 @@ def _load_single_provider(
             if not isinstance(overrides, dict):
                 continue
             assert reasoning_cap is not None  # model_overrides requires reasoning
-            model_reasoning[model_id] = ReasoningCapability(
-                disabled=overrides.get("disabled", reasoning_cap.disabled),
-                effort_field=overrides.get("effort_field", reasoning_cap.effort_field),
-                max_effort=overrides.get("max_effort", reasoning_cap.max_effort),
-                thinking_type=overrides.get(
-                    "thinking_type", reasoning_cap.thinking_type
-                ),
-                unsigned_reasoning_blocks=overrides.get(
-                    "unsigned_reasoning_blocks",
-                    reasoning_cap.unsigned_reasoning_blocks,
-                ),
-                effort_map=overrides.get("effort_map", reasoning_cap.effort_map),
-                budget_tokens_default_ratio=overrides.get(
-                    "budget_tokens_default_ratio",
-                    reasoning_cap.budget_tokens_default_ratio,
-                ),
+            model_reasoning[model_id] = _parse_reasoning_cap(
+                overrides, base=reasoning_cap
             )
 
     shim = ProviderShim(

--- a/src/llm_rosetta/shims/providers/anthropic/provider.yaml
+++ b/src/llm_rosetta/shims/providers/anthropic/provider.yaml
@@ -5,15 +5,17 @@ default_api_key_env: ANTHROPIC_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/anthropic.svg
 response_id_prefix: "msg_"
 reasoning:
-  disabled: thinking_disabled
+  thinking_modes:
+    auto: adaptive
+    enabled: enabled
+    disabled: disabled
   effort_field: output_config.effort
-  effort_map:
-    minimal: low
-    low: low
-    medium: medium
-    high: high
-    xhigh: xhigh
-    max: max
+  effort_range: [low, max]
+  visibility_modes:
+    auto: summarized
+    concise: summarized
+    detailed: summarized
+    none: omitted
   # Anthropic Official thinking support matrix (tested 2026-06-18):
   #   Haiku 4.5:  enabled+budget only (adaptive → 400, effort → 400)
   #   Sonnet 4.6: both enabled+budget and adaptive work
@@ -23,10 +25,10 @@ reasoning:
   # Haiku rejects it (400), so disable effort emission for Haiku.
   model_overrides:
     claude-haiku-4-5-20251001:
-      thinking_type: enabled
-      budget_tokens_default_ratio: 0.8
+      thinking_modes: {enabled: enabled, disabled: disabled}
+      budget_ratio: 0.8
       effort_field: none
     claude-opus-4-7:
-      thinking_type: adaptive
+      thinking_modes: {auto: adaptive, enabled: adaptive, disabled: disabled}
     claude-opus-4-8:
-      thinking_type: adaptive
+      thinking_modes: {auto: adaptive, enabled: adaptive, disabled: disabled}

--- a/src/llm_rosetta/shims/providers/argo/anthropic/provider.yaml
+++ b/src/llm_rosetta/shims/providers/argo/anthropic/provider.yaml
@@ -4,17 +4,20 @@ default_base_url: https://apps.inside.anl.gov/argoapi
 default_api_key_env: ARGO_API_KEY
 model_id_field: internal_id
 reasoning:
-  disabled: thinking_disabled
+  thinking_modes:
+    auto: adaptive
+    enabled: enabled
+    disabled: disabled
+  thinking_default: auto
   effort_field: output_config.effort
-  thinking_type: enabled
-  unsigned_reasoning_blocks: preserve
-  effort_map:
-    minimal: low
-    low: low
-    medium: medium
-    high: high
-    xhigh: xhigh
-    max: max
+  effort_range: [low, max]
+  budget_ratio: 0.8
+  visibility_modes:
+    auto: summarized
+    concise: summarized
+    detailed: summarized
+    none: omitted
+  unsigned_blocks: preserve
   # Argo Anthropic thinking support matrix (tested 2026-06-18):
   #   claudehaiku45:  enabled+budget only (adaptive → 400)
   #   claudesonnet4:  enabled+budget only (adaptive → 400)
@@ -22,12 +25,12 @@ reasoning:
   #   claudeopus47+:  adaptive only (enabled → 400)
   model_overrides:
     claudehaiku45:
-      thinking_type: enabled
-      budget_tokens_default_ratio: 0.8
+      thinking_modes: {enabled: enabled, disabled: disabled}
+      budget_ratio: 0.8
     claudesonnet4:
-      thinking_type: enabled
-      budget_tokens_default_ratio: 0.8
+      thinking_modes: {enabled: enabled, disabled: disabled}
+      budget_ratio: 0.8
     claudeopus47:
-      thinking_type: adaptive
+      thinking_modes: {auto: adaptive, enabled: adaptive, disabled: disabled}
     claudeopus48:
-      thinking_type: adaptive
+      thinking_modes: {auto: adaptive, enabled: adaptive, disabled: disabled}

--- a/src/llm_rosetta/shims/providers/argo/openai_chat/provider.yaml
+++ b/src/llm_rosetta/shims/providers/argo/openai_chat/provider.yaml
@@ -4,14 +4,7 @@ default_base_url: https://apps.inside.anl.gov/argoapi/v1
 default_api_key_env: ARGO_API_KEY
 model_id_field: internal_id
 reasoning:
-  disabled: omit
   effort_field: reasoning_effort
-  effort_map:
-    minimal: minimal
-    low: low
-    medium: medium
-    high: high
-    xhigh: xhigh
-    max: max
+  # effort_range not set = full IR ladder (minimal–max)
 
 supports_custom_tools: true

--- a/src/llm_rosetta/shims/providers/deepseek/provider.yaml
+++ b/src/llm_rosetta/shims/providers/deepseek/provider.yaml
@@ -5,6 +5,8 @@ default_api_key_env: DEEPSEEK_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/deepseek.svg
 reasoning:
   thinking_modes:
+    # No "auto" — DeepSeek R1 requires explicit enable/disable.
+    # mode:auto requests will produce effort only, no thinking block.
     enabled: enabled
     disabled: disabled
   effort_field: reasoning_effort

--- a/src/llm_rosetta/shims/providers/deepseek/provider.yaml
+++ b/src/llm_rosetta/shims/providers/deepseek/provider.yaml
@@ -4,12 +4,8 @@ default_base_url: https://api.deepseek.com
 default_api_key_env: DEEPSEEK_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/deepseek.svg
 reasoning:
-  disabled: thinking_disabled
+  thinking_modes:
+    enabled: enabled
+    disabled: disabled
   effort_field: reasoning_effort
-  effort_map:
-    minimal: low
-    low: low
-    medium: medium
-    high: high
-    xhigh: xhigh
-    max: max
+  effort_range: [low, max]

--- a/src/llm_rosetta/shims/providers/google/provider.yaml
+++ b/src/llm_rosetta/shims/providers/google/provider.yaml
@@ -4,12 +4,5 @@ default_base_url: https://generativelanguage.googleapis.com
 default_api_key_env: GOOGLE_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/google.svg
 reasoning:
-  disabled: thinking_budget_zero
   effort_field: thinking_level
-  effort_map:
-    minimal: minimal
-    low: low
-    medium: medium
-    high: high
-    xhigh: high
-    max: high
+  effort_range: [minimal, high]

--- a/src/llm_rosetta/shims/providers/minimax/anthropic/provider.yaml
+++ b/src/llm_rosetta/shims/providers/minimax/anthropic/provider.yaml
@@ -4,12 +4,9 @@ default_base_url: https://api.minimaxi.com/anthropic
 default_api_key_env: MINIMAX_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/minimax.svg
 reasoning:
-  disabled: thinking_disabled
+  thinking_modes:
+    auto: adaptive
+    enabled: enabled
+    disabled: disabled
   effort_field: output_config.effort
-  effort_map:
-    minimal: low
-    low: low
-    medium: medium
-    high: high
-    xhigh: xhigh
-    max: max
+  effort_range: [low, max]

--- a/src/llm_rosetta/shims/providers/minimax/openai_chat/provider.yaml
+++ b/src/llm_rosetta/shims/providers/minimax/openai_chat/provider.yaml
@@ -4,12 +4,8 @@ default_base_url: https://api.minimaxi.com/v1
 default_api_key_env: MINIMAX_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/minimax.svg
 reasoning:
-  disabled: thinking_disabled
-  thinking_type: adaptive
-  effort_map:
-    minimal: low
-    low: low
-    medium: medium
-    high: high
-    xhigh: high
-    max: high
+  thinking_modes:
+    auto: adaptive
+    enabled: enabled
+    disabled: disabled
+  effort_range: [low, high]

--- a/src/llm_rosetta/shims/providers/openai/provider.yaml
+++ b/src/llm_rosetta/shims/providers/openai/provider.yaml
@@ -5,15 +5,11 @@ default_api_key_env: OPENAI_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/openai.svg
 response_id_prefix: "chatcmpl-"
 reasoning:
-  disabled: omit
   effort_field: reasoning_effort
-  max_effort: high
-  effort_map:
-    minimal: minimal
-    low: low
-    medium: medium
-    high: high
-    xhigh: high
-    max: high
+  effort_range: [minimal, high]
+  visibility_modes:
+    auto: auto
+    concise: concise
+    detailed: detailed
 
 supports_custom_tools: true

--- a/src/llm_rosetta/shims/providers/openai_responses/provider.yaml
+++ b/src/llm_rosetta/shims/providers/openai_responses/provider.yaml
@@ -5,16 +5,12 @@ default_api_key_env: OPENAI_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/openai.svg
 response_id_prefix: "resp_"
 reasoning:
-  disabled: omit
   effort_field: reasoning.effort
-  max_effort: high
-  effort_map:
-    minimal: minimal
-    low: low
-    medium: medium
-    high: high
-    xhigh: high
-    max: high
+  effort_range: [minimal, high]
+  visibility_modes:
+    auto: auto
+    concise: concise
+    detailed: detailed
 
 supports_custom_tools: true
 tool_search_mode: native

--- a/src/llm_rosetta/shims/providers/openrouter/anthropic/provider.yaml
+++ b/src/llm_rosetta/shims/providers/openrouter/anthropic/provider.yaml
@@ -4,13 +4,9 @@ default_base_url: https://openrouter.ai/api
 default_api_key_env: OPENROUTER_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/openrouter.svg
 reasoning:
-  disabled: thinking_disabled
-  thinking_type: enabled
+  thinking_modes:
+    auto: adaptive
+    enabled: enabled
+    disabled: disabled
   effort_field: output_config.effort
-  effort_map:
-    minimal: low
-    low: low
-    medium: medium
-    high: high
-    xhigh: xhigh
-    max: max
+  effort_range: [low, max]

--- a/src/llm_rosetta/shims/providers/openrouter/openai_chat/provider.yaml
+++ b/src/llm_rosetta/shims/providers/openrouter/openai_chat/provider.yaml
@@ -4,13 +4,5 @@ default_base_url: https://openrouter.ai/api/v1
 default_api_key_env: OPENROUTER_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/openrouter.svg
 reasoning:
-  disabled: omit
   effort_field: reasoning_effort
-  max_effort: xhigh
-  effort_map:
-    minimal: low
-    low: low
-    medium: medium
-    high: high
-    xhigh: xhigh
-    max: xhigh
+  effort_range: [low, xhigh]

--- a/src/llm_rosetta/shims/providers/volcengine/openai_chat/provider.yaml
+++ b/src/llm_rosetta/shims/providers/volcengine/openai_chat/provider.yaml
@@ -4,13 +4,9 @@ default_base_url: https://ark.cn-beijing.volces.com/api/v3
 default_api_key_env: VOLCENGINE_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/volcengine.svg
 reasoning:
-  disabled: thinking_disabled
-  thinking_type: enabled
-  max_effort: high
-  effort_map:
-    minimal: minimal
-    low: low
-    medium: medium
-    high: high
-    xhigh: high
-    max: high
+  thinking_modes:
+    auto: auto
+    enabled: enabled
+    disabled: disabled
+  effort_field: reasoning_effort
+  effort_range: [minimal, high]

--- a/src/llm_rosetta/shims/providers/volcengine/openai_responses/provider.yaml
+++ b/src/llm_rosetta/shims/providers/volcengine/openai_responses/provider.yaml
@@ -4,12 +4,5 @@ default_base_url: https://ark.cn-beijing.volces.com/api/v3
 default_api_key_env: VOLCENGINE_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/volcengine.svg
 reasoning:
-  disabled: omit
   effort_field: reasoning.effort
-  effort_map:
-    minimal: minimal
-    low: low
-    medium: medium
-    high: high
-    xhigh: high
-    max: high
+  effort_range: [minimal, high]

--- a/src/llm_rosetta/shims/providers/xai/provider.yaml
+++ b/src/llm_rosetta/shims/providers/xai/provider.yaml
@@ -3,3 +3,6 @@ base: openai_chat
 default_base_url: https://api.x.ai/v1
 default_api_key_env: XAI_API_KEY
 logo: https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/xai.svg
+reasoning:
+  effort_field: reasoning_effort
+  effort_range: [minimal, xhigh]

--- a/src/llm_rosetta/types/ir/configs.py
+++ b/src/llm_rosetta/types/ir/configs.py
@@ -21,9 +21,14 @@ Contains various configuration parameters for controlling model generation behav
 
 from typing import Any, Literal, TypedDict
 
-# Normalised IR effort levels — the canonical ladder used internally.
-# External "none" maps to mode: disabled, not an effort level.
-ReasoningEffortLevel = Literal["minimal", "low", "medium", "high", "xhigh", "max"]
+# Reasoning types live in their own module; re-exported here for compat.
+from .reasoning import (  # noqa: F401, E402
+    IREffort,
+    IRMode,
+    IRVisibility,
+    ReasoningConfig,
+    ReasoningEffortLevel,
+)
 
 # ============================================================================
 # 生成控制配置 Generation control configuration
@@ -98,45 +103,7 @@ class GenerationConfig(TypedDict, total=False):
     n: int
 
 
-# ============================================================================
-# 推理配置 Reasoning configuration
-# ============================================================================
-
-
-class ReasoningConfig(TypedDict, total=False):
-    """Reasoning/thinking configuration.
-
-    Controls whether and how the model performs explicit reasoning.
-
-    Provider mappings for ``mode``:
-    - ``"auto"``: Model decides when/how much to think.
-      Anthropic: ``thinking.type="adaptive"``,
-      Google: ``thinking_budget=-1``
-    - ``"enabled"``: Explicit thinking with budget control.
-      Anthropic: ``thinking.type="enabled"`` + ``budget_tokens``,
-      OpenAI Responses: ``reasoning.type="enabled"``
-    - ``"disabled"``: No thinking.
-      Anthropic: ``thinking.type="disabled"``,
-      Google: ``thinking_budget=0``,
-      OpenAI Responses: ``reasoning.type="disabled"``
-
-    Provider mappings for ``effort``:
-    - Anthropic: ``output_config.effort``
-    - OpenAI Chat: ``reasoning_effort``
-    - OpenAI Responses: ``reasoning.effort``
-    - Google: ``thinking_config.thinking_level``
-
-    Provider mappings for ``budget_tokens``:
-    - Anthropic: ``thinking.budget_tokens``
-    - Google: ``thinking_config.thinking_budget``
-    """
-
-    mode: Literal["auto", "enabled", "disabled"]
-    effort: ReasoningEffortLevel  # Reasoning effort level (normalised)
-    budget_tokens: int  # Max tokens for reasoning — Anthropic/Google: budget_tokens
-    summary: str  # Reasoning summary mode ("auto", "concise", "detailed", "none")
-    include_thoughts: bool  # Explicit flag for Google/Gemini thought inclusion
-
+# ReasoningConfig lives in reasoning.py; re-exported above.
 
 # ============================================================================
 # 流式输出配置 Streaming configuration
@@ -194,6 +161,10 @@ class CacheConfig(TypedDict, total=False):
 __all__ = [
     # 生成控制配置 Generation control configuration
     "GenerationConfig",
+    # 推理 IR 词汇 Reasoning IR vocabulary
+    "IRMode",
+    "IREffort",
+    "IRVisibility",
     # 推理配置 Reasoning configuration
     "ReasoningConfig",
     "ReasoningEffortLevel",

--- a/src/llm_rosetta/types/ir/reasoning.py
+++ b/src/llm_rosetta/types/ir/reasoning.py
@@ -59,7 +59,7 @@ class ReasoningConfig(TypedDict, total=False):
     mode: IRMode
     effort: IREffort
     budget_tokens: int
-    summary: str  # "auto", "concise", "detailed", "none"
+    summary: IRVisibility
     include_thoughts: bool  # Google/Gemini thought inclusion flag
 
 

--- a/src/llm_rosetta/types/ir/reasoning.py
+++ b/src/llm_rosetta/types/ir/reasoning.py
@@ -1,0 +1,72 @@
+"""IR reasoning vocabulary and configuration types.
+
+This module defines the fixed IR-side value sets and configuration
+structure for reasoning/thinking behavior.  Provider-side values are
+free strings defined in each provider's shim config.
+
+Reference: https://llm-rosetta.readthedocs.io/en/latest/api/ir-types/
+"""
+
+from typing import Literal, TypedDict
+
+# ── IR reasoning vocabulary ────────────────────────────────────────────────
+
+#: IR reasoning mode: auto (model decides), enabled (explicit), disabled (off).
+IRMode = Literal["auto", "enabled", "disabled"]
+
+#: IR effort ladder (ordered): minimal < low < medium < high < xhigh < max.
+#: External "none" maps to mode: disabled, not an effort level.
+IREffort = Literal["minimal", "low", "medium", "high", "xhigh", "max"]
+
+#: IR thinking output visibility control.
+IRVisibility = Literal["auto", "concise", "detailed", "none"]
+
+# Backward-compat alias
+ReasoningEffortLevel = IREffort
+
+
+# ── IR reasoning config ───────────────────────────────────────────────────
+
+
+class ReasoningConfig(TypedDict, total=False):
+    """Reasoning/thinking configuration.
+
+    Controls whether and how the model performs explicit reasoning.
+
+    Provider mappings for ``mode``:
+    - ``"auto"``: Model decides when/how much to think.
+      Anthropic: ``thinking.type="adaptive"``,
+      Google: ``thinking_budget=-1``
+    - ``"enabled"``: Explicit thinking with budget control.
+      Anthropic: ``thinking.type="enabled"`` + ``budget_tokens``,
+      OpenAI Responses: ``reasoning.type="enabled"``
+    - ``"disabled"``: No thinking.
+      Anthropic: ``thinking.type="disabled"``,
+      Google: ``thinking_budget=0``,
+      OpenAI Responses: ``reasoning.type="disabled"``
+
+    Provider mappings for ``effort``:
+    - Anthropic: ``output_config.effort``
+    - OpenAI Chat: ``reasoning_effort``
+    - OpenAI Responses: ``reasoning.effort``
+    - Google: ``thinking_config.thinking_level``
+
+    Provider mappings for ``budget_tokens``:
+    - Anthropic: ``thinking.budget_tokens``
+    - Google: ``thinking_config.thinking_budget``
+    """
+
+    mode: IRMode
+    effort: IREffort
+    budget_tokens: int
+    summary: str  # "auto", "concise", "detailed", "none"
+    include_thoughts: bool  # Google/Gemini thought inclusion flag
+
+
+__all__ = [
+    "IRMode",
+    "IREffort",
+    "IRVisibility",
+    "ReasoningEffortLevel",
+    "ReasoningConfig",
+]

--- a/tests/converters/anthropic/test_message_ops.py
+++ b/tests/converters/anthropic/test_message_ops.py
@@ -221,7 +221,7 @@ class TestAnthropicMessageOps:
                 }
             ],
         )
-        cap = ReasoningCapability(unsigned_reasoning_blocks="preserve")
+        cap = ReasoningCapability(unsigned_blocks="preserve")
         result, warnings = self.message_ops.ir_messages_to_p(
             ir_messages, reasoning_cap=cap
         )
@@ -248,7 +248,7 @@ class TestAnthropicMessageOps:
             list[Message],
             [{"role": "assistant", "content": [reasoning_part]}],
         )
-        cap = ReasoningCapability(unsigned_reasoning_blocks="preserve")
+        cap = ReasoningCapability(unsigned_blocks="preserve")
         result, warnings = self.message_ops.ir_messages_to_p(
             ir_messages, reasoning_cap=cap
         )
@@ -279,7 +279,7 @@ class TestAnthropicMessageOps:
                 }
             ],
         )
-        cap = ReasoningCapability(unsigned_reasoning_blocks="preserve")
+        cap = ReasoningCapability(unsigned_blocks="preserve")
         result, warnings = self.message_ops.ir_messages_to_p(
             ir_messages, reasoning_cap=cap
         )

--- a/tests/converters/openai_chat/test_config_ops.py
+++ b/tests/converters/openai_chat/test_config_ops.py
@@ -173,10 +173,10 @@ class TestOpenAIChatConfigOps:
         result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"effort": "max"})
         assert result["reasoning_effort"] == "high"
 
-    def test_ir_reasoning_config_budget_tokens(self):
-        """Test budget_tokens → thinking.budget_tokens."""
+    def test_ir_reasoning_config_budget_tokens_no_thinking_support(self):
+        """Test budget_tokens silently dropped for standard OpenAI (no thinking_modes)."""
         result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"budget_tokens": 1000})
-        assert result["thinking"]["budget_tokens"] == 1000
+        assert "thinking" not in result
 
     def test_ir_reasoning_config_mode_disabled(self):
         """Test mode: disabled → omit (OpenAI shim strategy)."""
@@ -186,28 +186,26 @@ class TestOpenAIChatConfigOps:
         # OpenAI disabled strategy is 'omit' → empty result
         assert result == {}
 
-    def test_ir_reasoning_config_mode_enabled(self):
-        """Test mode: enabled → thinking.type = enabled."""
+    def test_ir_reasoning_config_mode_enabled_no_thinking_support(self):
+        """Standard OpenAI: mode=enabled without thinking_modes → no thinking block."""
         result = OpenAIChatConfigOps.ir_reasoning_config_to_p({"mode": "enabled"})
-        assert result["thinking"]["type"] == "enabled"
+        assert "thinking" not in result
 
-    def test_ir_reasoning_config_mode_auto_with_effort(self):
-        """Test mode: auto outputs reasoning_effort and thinking.type=adaptive."""
+    def test_ir_reasoning_config_mode_auto_effort_no_thinking_support(self):
+        """Standard OpenAI: mode=auto → effort only, no thinking block."""
         result = OpenAIChatConfigOps.ir_reasoning_config_to_p(
             {"mode": "auto", "effort": "medium"}
         )
         assert result["reasoning_effort"] == "medium"
-        # IR "auto" maps to "adaptive" (DeepSeek/Volcengine vocabulary)
-        assert result["thinking"]["type"] == "adaptive"
+        assert "thinking" not in result
 
-    def test_ir_reasoning_config_all_fields(self):
-        """Test mode + effort + budget_tokens coexistence."""
+    def test_ir_reasoning_config_all_fields_no_thinking_support(self):
+        """Standard OpenAI: all fields but no thinking_modes → effort only."""
         result = OpenAIChatConfigOps.ir_reasoning_config_to_p(
             {"mode": "enabled", "effort": "high", "budget_tokens": 4096}
         )
         assert result["reasoning_effort"] == "high"
-        assert result["thinking"]["type"] == "enabled"
-        assert result["thinking"]["budget_tokens"] == 4096
+        assert "thinking" not in result
 
     def test_ir_reasoning_config_effort_only_no_thinking(self):
         """Test effort-only does not produce thinking object."""
@@ -249,10 +247,10 @@ class TestOpenAIChatConfigOps:
             "thinking": {"type": "enabled", "budget_tokens": 4096},
         }
         ir = OpenAIChatConfigOps.p_reasoning_config_to_ir(original)
+        # Without thinking_modes cap, thinking block not produced
         result = OpenAIChatConfigOps.ir_reasoning_config_to_p(ir)
         assert result["reasoning_effort"] == "high"
-        assert result["thinking"]["type"] == "enabled"
-        assert result["thinking"]["budget_tokens"] == 4096
+        assert "thinking" not in result
 
     def test_ir_reasoning_config_with_summary(self):
         """Test reasoning config with summary → reasoning.summary."""

--- a/tests/converters/test_reasoning_helpers.py
+++ b/tests/converters/test_reasoning_helpers.py
@@ -1,11 +1,11 @@
-"""Tests for shim-driven reasoning helpers — covers #244 scenarios.
+"""Tests for shim-driven reasoning helpers.
 
 Test matrix:
 - Input normalisation: none → disabled, effort values pass through
-- OpenAI (Chat+Responses): disabled → omit, xhigh/max capped to high
-- Anthropic: disabled → thinking_disabled, minimal → low, xhigh/max pass through
-- Google: disabled → thinkingBudget=0, effort skipped (no thinkingLevel)
-- DeepSeek/Volcengine-style: disabled → thinking_disabled
+- OpenAI (Chat+Responses): disabled → omit (no thinking_modes), effort clamped
+- Anthropic: disabled → thinking.type=disabled, effort clamped to [low, max]
+- Google: disabled → thinkingBudget=0, effort clamped
+- DeepSeek-style: thinking_modes with enabled/disabled
 - Custom shim override
 """
 
@@ -13,36 +13,30 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-
 from llm_rosetta.converters.base.helpers.reasoning import (
     DEFAULT_REASONING_CAPS,
     apply_reasoning_config,
     normalize_reasoning_input,
 )
 from llm_rosetta.shims.provider_shim import ReasoningCapability
-from llm_rosetta.types.ir.configs import ReasoningConfig
+from llm_rosetta.types.ir.reasoning import ReasoningConfig
 
 
 # ── Input normalisation ────────────────────────────────────────────────────
 
 
 class TestNormalizeReasoningInput:
-    """Test the P→IR normalisation step."""
-
     def test_none_becomes_disabled(self):
-        """effort='none' → mode='disabled', no effort key."""
         result = normalize_reasoning_input(cast(ReasoningConfig, {"effort": "none"}))
         assert result["mode"] == "disabled"
         assert "effort" not in result
 
     def test_effort_values_pass_through(self):
-        """Standard IR effort values pass through unchanged."""
         for level in ("minimal", "low", "medium", "high", "xhigh", "max"):
             result = normalize_reasoning_input(cast(ReasoningConfig, {"effort": level}))
             assert result["effort"] == level
 
     def test_none_preserves_other_fields(self):
-        """none → disabled preserves budget_tokens."""
         result = normalize_reasoning_input(
             cast(ReasoningConfig, {"effort": "none", "budget_tokens": 4096})
         )
@@ -51,12 +45,10 @@ class TestNormalizeReasoningInput:
         assert "effort" not in result
 
     def test_empty_passes_through(self):
-        """Empty config → empty config."""
         result = normalize_reasoning_input(cast(ReasoningConfig, {}))
         assert result == {}
 
     def test_does_not_mutate_original(self):
-        """Input dict is not mutated."""
         original: dict[str, Any] = {"effort": "xhigh"}
         normalize_reasoning_input(cast(ReasoningConfig, original))
         assert original["effort"] == "xhigh"
@@ -66,7 +58,7 @@ class TestNormalizeReasoningInput:
 
 
 class TestOpenAIChatShim:
-    """OpenAI Chat: disabled → omit, xhigh/max → high."""
+    """OpenAI Chat: no thinking_modes, effort clamped to [minimal, high]."""
 
     cap = DEFAULT_REASONING_CAPS["openai_chat"]
 
@@ -94,7 +86,7 @@ class TestOpenAIChatShim:
         )
         assert result["reasoning_effort"] == "minimal"
 
-    def test_effort_xhigh_maps_to_high(self):
+    def test_effort_xhigh_clamped_to_high(self):
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "xhigh"}),
             self.cap,
@@ -102,7 +94,7 @@ class TestOpenAIChatShim:
         )
         assert result["reasoning_effort"] == "high"
 
-    def test_effort_max_maps_to_high(self):
+    def test_effort_max_clamped_to_high(self):
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "max"}),
             self.cap,
@@ -110,8 +102,42 @@ class TestOpenAIChatShim:
         )
         assert result["reasoning_effort"] == "high"
 
-    def test_mode_auto_maps_to_adaptive_not_auto(self):
-        """IR mode 'auto' must never appear as thinking.type — maps to 'adaptive'."""
+    def test_mode_auto_no_thinking_for_standard_openai(self):
+        """Standard OpenAI: mode=auto does NOT produce a thinking block."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto"}),
+            self.cap,
+            converter_type="openai_chat",
+        )
+        assert "thinking" not in result
+
+    def test_mode_enabled_no_thinking_for_standard_openai(self):
+        """Standard OpenAI: mode=enabled does NOT produce a thinking block."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "enabled", "budget_tokens": 2048}),
+            self.cap,
+            converter_type="openai_chat",
+        )
+        assert "thinking" not in result
+
+
+# ── OpenAI Chat thinking-capable shim ─────────────────────────────────────
+
+
+class TestOpenAIChatThinkingCapable:
+    """OpenAI Chat with thinking_modes: mode/budget → thinking block."""
+
+    cap = ReasoningCapability(
+        thinking_modes={
+            "auto": "adaptive",
+            "enabled": "enabled",
+            "disabled": "disabled",
+        },
+        effort_field="reasoning_effort",
+        effort_range=("minimal", "high"),
+    )
+
+    def test_mode_auto_maps_to_adaptive(self):
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"mode": "auto"}),
             self.cap,
@@ -120,7 +146,6 @@ class TestOpenAIChatShim:
         assert result["thinking"]["type"] == "adaptive"
 
     def test_mode_enabled_with_budget(self):
-        """mode=enabled + budget_tokens → thinking.type=enabled."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"mode": "enabled", "budget_tokens": 2048}),
             self.cap,
@@ -129,15 +154,13 @@ class TestOpenAIChatShim:
         assert result["thinking"]["type"] == "enabled"
         assert result["thinking"]["budget_tokens"] == 2048
 
-    def test_mode_auto_with_budget(self):
-        """mode=auto + budget_tokens → adaptive + budget_tokens."""
+    def test_mode_disabled_emits_thinking_disabled(self):
         result = apply_reasoning_config(
-            cast(ReasoningConfig, {"mode": "auto", "budget_tokens": 4096}),
+            cast(ReasoningConfig, {"mode": "disabled"}),
             self.cap,
             converter_type="openai_chat",
         )
-        assert result["thinking"]["type"] == "adaptive"
-        assert result["thinking"]["budget_tokens"] == 4096
+        assert result["thinking"]["type"] == "disabled"
 
 
 # ── OpenAI Responses shim ─────────────────────────────────────────────────
@@ -164,7 +187,7 @@ class TestOpenAIResponsesShim:
         )
         assert result["reasoning"]["effort"] == "medium"
 
-    def test_xhigh_maps_to_high(self):
+    def test_xhigh_clamped_to_high(self):
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "xhigh"}),
             self.cap,
@@ -172,7 +195,7 @@ class TestOpenAIResponsesShim:
         )
         assert result["reasoning"]["effort"] == "high"
 
-    def test_max_maps_to_high(self):
+    def test_max_clamped_to_high(self):
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "max"}),
             self.cap,
@@ -185,7 +208,7 @@ class TestOpenAIResponsesShim:
 
 
 class TestAnthropicShim:
-    """Anthropic: disabled → thinking_disabled, xhigh/max pass through."""
+    """Anthropic: disabled → thinking.type=disabled, effort clamped to [low, max]."""
 
     cap = DEFAULT_REASONING_CAPS["anthropic"]
 
@@ -197,7 +220,7 @@ class TestAnthropicShim:
         )
         assert result["thinking"]["type"] == "disabled"
 
-    def test_minimal_maps_to_low(self):
+    def test_minimal_clamped_to_low(self):
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "minimal"}),
             self.cap,
@@ -239,6 +262,7 @@ class TestGoogleShim:
     cap = DEFAULT_REASONING_CAPS["google"]
 
     def test_disabled_emits_budget_zero(self):
+        """Google disabled → thinking_budget=0."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"mode": "disabled"}),
             self.cap,
@@ -247,7 +271,6 @@ class TestGoogleShim:
         assert result["thinking_config"]["thinking_budget"] == 0
 
     def test_effort_emits_thinking_level(self):
-        """Google supports thinkingLevel mapped from effort."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "high"}),
             self.cap,
@@ -264,16 +287,16 @@ class TestGoogleShim:
         assert result["thinking_config"]["thinking_budget"] == 8192
 
 
-# ── DeepSeek/Volcengine-style shim ────────────────────────────────────────
+# ── DeepSeek-style shim ──────────────────────────────────────────────────
 
 
 class TestDeepSeekShim:
-    """DeepSeek: disabled → thinking_disabled (shim from YAML)."""
+    """DeepSeek: thinking_modes with enabled/disabled only (no auto)."""
 
     cap = ReasoningCapability(
-        disabled="thinking_disabled",
-        effort_field="none",
-        effort_map={},
+        thinking_modes={"enabled": "enabled", "disabled": "disabled"},
+        effort_field="reasoning_effort",
+        effort_range=("low", "max"),
     )
 
     def test_disabled_emits_thinking_disabled(self):
@@ -284,15 +307,30 @@ class TestDeepSeekShim:
         )
         assert result["thinking"]["type"] == "disabled"
 
+    def test_auto_not_supported_no_thinking(self):
+        """DeepSeek has no 'auto' in thinking_modes → no thinking block."""
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "auto"}),
+            self.cap,
+            converter_type="openai_chat",
+        )
+        assert "thinking" not in result
 
-# ── Custom shim override ──────────────────────────────────────────────────
+    def test_enabled_produces_thinking(self):
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "enabled", "budget_tokens": 4096}),
+            self.cap,
+            converter_type="openai_chat",
+        )
+        assert result["thinking"]["type"] == "enabled"
+        assert result["thinking"]["budget_tokens"] == 4096
+
+
+# ── Summary / visibility cross-format ─────────────────────────────────────
 
 
 class TestSummaryIncludeThoughtsCrossFormat:
-    """Cross-format behavior: summary/include_thoughts only supported by Google and Responses."""
-
     def test_summary_forwarded_to_google(self):
-        """IR summary=auto → Google include_thoughts=True."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "high", "summary": "auto"}),
             DEFAULT_REASONING_CAPS["google"],
@@ -301,7 +339,6 @@ class TestSummaryIncludeThoughtsCrossFormat:
         assert result["thinking_config"]["include_thoughts"] is True
 
     def test_summary_forwarded_to_responses(self):
-        """IR summary=detailed → Responses reasoning.summary=detailed."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "high", "summary": "detailed"}),
             DEFAULT_REASONING_CAPS["openai_responses"],
@@ -310,7 +347,6 @@ class TestSummaryIncludeThoughtsCrossFormat:
         assert result["reasoning"]["summary"] == "detailed"
 
     def test_summary_forwarded_to_openai_chat(self):
-        """IR summary=detailed → OpenAI Chat reasoning.summary=detailed."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "high", "summary": "detailed"}),
             DEFAULT_REASONING_CAPS["openai_chat"],
@@ -319,7 +355,6 @@ class TestSummaryIncludeThoughtsCrossFormat:
         assert result["reasoning"]["summary"] == "detailed"
 
     def test_summary_to_anthropic_display_summarized(self):
-        """IR summary=concise → Anthropic thinking.display=summarized."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "high", "summary": "concise"}),
             DEFAULT_REASONING_CAPS["anthropic"],
@@ -328,7 +363,6 @@ class TestSummaryIncludeThoughtsCrossFormat:
         assert result["thinking"]["display"] == "summarized"
 
     def test_summary_none_to_anthropic_display_omitted(self):
-        """IR summary=none → Anthropic thinking.display=omitted."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "high", "summary": "none"}),
             DEFAULT_REASONING_CAPS["anthropic"],
@@ -337,7 +371,6 @@ class TestSummaryIncludeThoughtsCrossFormat:
         assert result["thinking"]["display"] == "omitted"
 
     def test_include_thoughts_true_to_openai_chat(self):
-        """IR include_thoughts=True → OpenAI Chat reasoning.summary=auto."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "high", "include_thoughts": True}),
             DEFAULT_REASONING_CAPS["openai_chat"],
@@ -346,7 +379,6 @@ class TestSummaryIncludeThoughtsCrossFormat:
         assert result["reasoning"]["summary"] == "auto"
 
     def test_include_thoughts_true_to_anthropic(self):
-        """IR include_thoughts=True → Anthropic thinking.display=summarized."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "high", "include_thoughts": True}),
             DEFAULT_REASONING_CAPS["anthropic"],
@@ -355,7 +387,6 @@ class TestSummaryIncludeThoughtsCrossFormat:
         assert result["thinking"]["display"] == "summarized"
 
     def test_include_thoughts_false_to_anthropic(self):
-        """IR include_thoughts=False → Anthropic thinking.display=omitted."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "high", "include_thoughts": False}),
             DEFAULT_REASONING_CAPS["anthropic"],
@@ -364,7 +395,6 @@ class TestSummaryIncludeThoughtsCrossFormat:
         assert result["thinking"]["display"] == "omitted"
 
     def test_include_thoughts_true_to_responses_fallback(self):
-        """IR include_thoughts=True → Responses reasoning.summary=auto (fallback)."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "high", "include_thoughts": True}),
             DEFAULT_REASONING_CAPS["openai_responses"],
@@ -373,7 +403,6 @@ class TestSummaryIncludeThoughtsCrossFormat:
         assert result["reasoning"]["summary"] == "auto"
 
     def test_summary_none_to_google(self):
-        """IR summary=none → Google include_thoughts=False."""
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "medium", "summary": "none"}),
             DEFAULT_REASONING_CAPS["google"],
@@ -382,42 +411,14 @@ class TestSummaryIncludeThoughtsCrossFormat:
         assert result["thinking_config"]["include_thoughts"] is False
 
 
+# ── Custom shim tests ─────────────────────────────────────────────────────
+
+
 class TestCustomShim:
-    """Verify that custom ReasoningCapability overrides work."""
-
-    def test_custom_effort_map(self):
+    def test_effort_range_clamps_above_ceiling(self):
         custom = ReasoningCapability(
-            disabled="omit",
             effort_field="reasoning_effort",
-            effort_map={
-                "minimal": "low",
-                "low": "low",
-                "medium": "medium",
-                "high": "high",
-                "xhigh": "medium",  # unusual but valid
-                "max": "low",
-            },
-        )
-        result = apply_reasoning_config(
-            cast(ReasoningConfig, {"effort": "xhigh"}),
-            custom,
-            converter_type="openai_chat",
-        )
-        assert result["reasoning_effort"] == "medium"
-
-    def test_custom_max_effort_caps_before_mapping(self):
-        custom = ReasoningCapability(
-            disabled="omit",
-            effort_field="reasoning_effort",
-            max_effort="high",
-            effort_map={
-                "minimal": "minimal",
-                "low": "low",
-                "medium": "medium",
-                "high": "high",
-                "xhigh": "xhigh",
-                "max": "max",
-            },
+            effort_range=("minimal", "high"),
         )
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"effort": "max"}),
@@ -426,46 +427,54 @@ class TestCustomShim:
         )
         assert result["reasoning_effort"] == "high"
 
-    def test_thinking_type_adaptive_overrides_enabled(self):
-        """thinking_type=adaptive forces enabled→adaptive and removes budget."""
+    def test_effort_range_clamps_below_floor(self):
         custom = ReasoningCapability(
-            disabled="thinking_disabled",
             effort_field="output_config.effort",
-            thinking_type="adaptive",
-            effort_map={
-                "minimal": "low",
-                "low": "low",
-                "medium": "medium",
-                "high": "high",
-                "xhigh": "xhigh",
-                "max": "max",
-            },
+            effort_range=("low", "max"),
         )
         result = apply_reasoning_config(
-            cast(
-                ReasoningConfig,
-                {"mode": "enabled", "budget_tokens": 4096},
-            ),
+            cast(ReasoningConfig, {"effort": "minimal"}),
+            custom,
+            converter_type="anthropic",
+        )
+        assert result["output_config"]["effort"] == "low"
+
+    def test_effort_range_none_full_pass_through(self):
+        custom = ReasoningCapability(effort_field="reasoning_effort")
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"effort": "max"}),
+            custom,
+            converter_type="openai_chat",
+        )
+        assert result["reasoning_effort"] == "max"
+
+    def test_thinking_modes_adaptive_maps_enabled_to_adaptive(self):
+        """Shim only supports adaptive → enabled request maps to adaptive."""
+        custom = ReasoningCapability(
+            thinking_modes={
+                "auto": "adaptive",
+                "enabled": "adaptive",
+                "disabled": "disabled",
+            },
+            effort_field="output_config.effort",
+            effort_range=("low", "max"),
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "enabled", "budget_tokens": 4096}),
             custom,
             converter_type="anthropic",
         )
         assert result["thinking"]["type"] == "adaptive"
-        assert "budget_tokens" not in result["thinking"]
 
-    def test_thinking_type_enabled_overrides_adaptive_with_budget(self):
-        """thinking_type=enabled forces adaptive→enabled when budget is present."""
+    def test_thinking_modes_enabled_with_budget(self):
         custom = ReasoningCapability(
-            disabled="thinking_disabled",
-            effort_field="output_config.effort",
-            thinking_type="enabled",
-            effort_map={
-                "minimal": "low",
-                "low": "low",
-                "medium": "medium",
-                "high": "high",
-                "xhigh": "xhigh",
-                "max": "max",
+            thinking_modes={
+                "auto": "adaptive",
+                "enabled": "enabled",
+                "disabled": "disabled",
             },
+            effort_field="output_config.effort",
+            effort_range=("low", "max"),
         )
         result = apply_reasoning_config(
             cast(
@@ -475,76 +484,21 @@ class TestCustomShim:
             custom,
             converter_type="anthropic",
         )
-        # auto normally emits adaptive; thinking_type=enabled overrides
-        assert result["thinking"]["type"] == "enabled"
-        assert result["thinking"]["budget_tokens"] == 4096
-
-    def test_thinking_type_enabled_without_budget_falls_back(self):
-        """thinking_type=enabled without budget_tokens falls back to adaptive."""
-        custom = ReasoningCapability(
-            disabled="thinking_disabled",
-            effort_field="output_config.effort",
-            thinking_type="enabled",
-            effort_map={
-                "minimal": "low",
-                "low": "low",
-                "medium": "medium",
-                "high": "high",
-                "xhigh": "xhigh",
-                "max": "max",
-            },
-        )
-        result = apply_reasoning_config(
-            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
-            custom,
-            converter_type="anthropic",
-        )
-        # No budget_tokens → can't use enabled, falls back to adaptive
         assert result["thinking"]["type"] == "adaptive"
 
-    def test_thinking_type_none_preserves_original(self):
-        """thinking_type=None does not override."""
+    def test_budget_ratio_derives_tokens(self):
         custom = ReasoningCapability(
-            disabled="thinking_disabled",
-            effort_field="output_config.effort",
-            effort_map={
-                "minimal": "low",
-                "low": "low",
-                "medium": "medium",
-                "high": "high",
-                "xhigh": "xhigh",
-                "max": "max",
+            thinking_modes={
+                "auto": "adaptive",
+                "enabled": "enabled",
+                "disabled": "disabled",
             },
+            effort_field="output_config.effort",
+            effort_range=("low", "max"),
+            budget_ratio=0.8,
         )
         result = apply_reasoning_config(
-            cast(
-                ReasoningConfig,
-                {"mode": "enabled", "budget_tokens": 2048},
-            ),
-            custom,
-            converter_type="anthropic",
-        )
-        assert result["thinking"]["type"] == "enabled"
-        assert result["thinking"]["budget_tokens"] == 2048
-
-    def test_budget_ratio_derives_tokens_from_max_tokens(self):
-        """budget_tokens_default_ratio derives budget from max_tokens."""
-        custom = ReasoningCapability(
-            disabled="thinking_disabled",
-            effort_field="output_config.effort",
-            thinking_type="enabled",
-            effort_map={
-                "minimal": "low",
-                "low": "low",
-                "medium": "medium",
-                "high": "high",
-                "xhigh": "xhigh",
-                "max": "max",
-            },
-            budget_tokens_default_ratio=0.8,
-        )
-        result = apply_reasoning_config(
-            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
+            cast(ReasoningConfig, {"mode": "enabled"}),
             custom,
             converter_type="anthropic",
             max_tokens=10000,
@@ -553,16 +507,17 @@ class TestCustomShim:
         assert result["thinking"]["budget_tokens"] == 8000
 
     def test_budget_ratio_clamps_to_max_minus_one(self):
-        """budget_tokens must be < max_tokens."""
         custom = ReasoningCapability(
-            disabled="thinking_disabled",
+            thinking_modes={
+                "auto": "adaptive",
+                "enabled": "enabled",
+                "disabled": "disabled",
+            },
             effort_field="output_config.effort",
-            thinking_type="enabled",
-            effort_map={},
-            budget_tokens_default_ratio=1.0,
+            budget_ratio=1.0,
         )
         result = apply_reasoning_config(
-            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
+            cast(ReasoningConfig, {"mode": "enabled"}),
             custom,
             converter_type="anthropic",
             max_tokens=2000,
@@ -571,106 +526,88 @@ class TestCustomShim:
         assert result["thinking"]["budget_tokens"] == 1999
 
     def test_budget_ratio_floor_1024(self):
-        """budget_tokens must be >= 1024 (Anthropic minimum)."""
         custom = ReasoningCapability(
-            disabled="thinking_disabled",
+            thinking_modes={
+                "auto": "adaptive",
+                "enabled": "enabled",
+                "disabled": "disabled",
+            },
             effort_field="output_config.effort",
-            thinking_type="enabled",
-            effort_map={},
-            budget_tokens_default_ratio=0.3,
-        )
-        result = apply_reasoning_config(
-            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
-            custom,
-            converter_type="anthropic",
-            max_tokens=2000,
-        )
-        assert result["thinking"]["type"] == "enabled"
-        # 2000 * 0.3 = 600, floored to 1024
-        assert result["thinking"]["budget_tokens"] == 1024
-
-    def test_budget_ratio_max_tokens_too_small_falls_back(self):
-        """When max_tokens <= 1024, can't satisfy both constraints → adaptive."""
-        custom = ReasoningCapability(
-            disabled="thinking_disabled",
-            effort_field="output_config.effort",
-            thinking_type="enabled",
-            effort_map={},
-            budget_tokens_default_ratio=0.8,
-        )
-        result = apply_reasoning_config(
-            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
-            custom,
-            converter_type="anthropic",
-            max_tokens=1024,
-        )
-        # max_tokens <= 1024 → can't derive → falls back to adaptive
-        assert result["thinking"]["type"] == "adaptive"
-
-    def test_budget_ratio_none_falls_back_to_adaptive(self):
-        """Without budget_tokens_default_ratio, still falls back to adaptive."""
-        custom = ReasoningCapability(
-            disabled="thinking_disabled",
-            effort_field="output_config.effort",
-            thinking_type="enabled",
-            effort_map={},
-        )
-        result = apply_reasoning_config(
-            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
-            custom,
-            converter_type="anthropic",
-            max_tokens=10000,
-        )
-        # No ratio → can't derive → adaptive
-        assert result["thinking"]["type"] == "adaptive"
-
-    def test_budget_ratio_without_max_tokens_falls_back(self):
-        """With ratio but no max_tokens, falls back to adaptive."""
-        custom = ReasoningCapability(
-            disabled="thinking_disabled",
-            effort_field="output_config.effort",
-            thinking_type="enabled",
-            effort_map={},
-            budget_tokens_default_ratio=0.8,
-        )
-        result = apply_reasoning_config(
-            cast(ReasoningConfig, {"mode": "auto", "effort": "high"}),
-            custom,
-            converter_type="anthropic",
-        )
-        # No max_tokens → can't derive → adaptive
-        assert result["thinking"]["type"] == "adaptive"
-
-    def test_budget_ratio_mode_enabled_no_budget_anthropic(self):
-        """mode=enabled without budget_tokens uses ratio to derive budget."""
-        custom = ReasoningCapability(
-            disabled="thinking_disabled",
-            effort_field="output_config.effort",
-            thinking_type="enabled",
-            effort_map={},
-            budget_tokens_default_ratio=0.8,
+            budget_ratio=0.3,
         )
         result = apply_reasoning_config(
             cast(ReasoningConfig, {"mode": "enabled"}),
             custom,
             converter_type="anthropic",
-            max_tokens=8192,
+            max_tokens=2000,
         )
         assert result["thinking"]["type"] == "enabled"
-        # 8192 * 0.8 = 6553
-        assert result["thinking"]["budget_tokens"] == 6553
+        assert result["thinking"]["budget_tokens"] == 1024
 
-    def test_budget_ratio_openai_chat(self):
-        """budget_tokens_default_ratio works for openai_chat converter too."""
+    def test_budget_ratio_max_tokens_too_small_falls_back(self):
         custom = ReasoningCapability(
-            disabled="omit",
-            effort_field="reasoning_effort",
-            thinking_type="enabled",
-            effort_map={},
-            budget_tokens_default_ratio=0.8,
+            thinking_modes={
+                "auto": "adaptive",
+                "enabled": "enabled",
+                "disabled": "disabled",
+            },
+            effort_field="output_config.effort",
+            budget_ratio=0.8,
         )
         result = apply_reasoning_config(
-            cast(ReasoningConfig, {"mode": "auto"}),
+            cast(ReasoningConfig, {"mode": "enabled"}),
+            custom,
+            converter_type="anthropic",
+            max_tokens=1024,
+        )
+        assert result["thinking"]["type"] == "adaptive"
+
+    def test_budget_ratio_none_falls_back_to_adaptive(self):
+        custom = ReasoningCapability(
+            thinking_modes={
+                "auto": "adaptive",
+                "enabled": "enabled",
+                "disabled": "disabled",
+            },
+            effort_field="output_config.effort",
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "enabled"}),
+            custom,
+            converter_type="anthropic",
+            max_tokens=10000,
+        )
+        assert result["thinking"]["type"] == "adaptive"
+
+    def test_budget_ratio_without_max_tokens_falls_back(self):
+        custom = ReasoningCapability(
+            thinking_modes={
+                "auto": "adaptive",
+                "enabled": "enabled",
+                "disabled": "disabled",
+            },
+            effort_field="output_config.effort",
+            budget_ratio=0.8,
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "enabled"}),
+            custom,
+            converter_type="anthropic",
+        )
+        assert result["thinking"]["type"] == "adaptive"
+
+    def test_budget_ratio_openai_chat(self):
+        custom = ReasoningCapability(
+            thinking_modes={
+                "auto": "adaptive",
+                "enabled": "enabled",
+                "disabled": "disabled",
+            },
+            effort_field="reasoning_effort",
+            budget_ratio=0.8,
+        )
+        result = apply_reasoning_config(
+            cast(ReasoningConfig, {"mode": "enabled"}),
             custom,
             converter_type="openai_chat",
             max_tokens=10000,
@@ -679,39 +616,17 @@ class TestCustomShim:
         assert result["thinking"]["budget_tokens"] == 8000
 
     def test_haiku_effort_field_none_drops_effort_keeps_thinking(self):
-        """Haiku-style cap: effort_field=none drops effort, keeps enabled+budget.
-
-        Mirrors the Anthropic Official Haiku 4.5 override — the model accepts
-        thinking.type=enabled + budget_tokens but rejects output_config.effort.
-        """
         custom = ReasoningCapability(
-            disabled="thinking_disabled",
+            thinking_modes={"enabled": "enabled", "disabled": "disabled"},
             effort_field="none",
-            thinking_type="enabled",
-            effort_map={},
-            budget_tokens_default_ratio=0.8,
+            budget_ratio=0.8,
         )
         result = apply_reasoning_config(
-            cast(ReasoningConfig, {"mode": "auto", "effort": "medium"}),
+            cast(ReasoningConfig, {"mode": "enabled", "effort": "medium"}),
             custom,
             converter_type="anthropic",
             max_tokens=8192,
         )
-        # effort must NOT be emitted
         assert "output_config" not in result
-        # thinking still derived from ratio
         assert result["thinking"]["type"] == "enabled"
         assert result["thinking"]["budget_tokens"] == 6553
-
-    def test_custom_thinking_budget_zero_disabled(self):
-        custom = ReasoningCapability(
-            disabled="thinking_budget_zero",
-            effort_field="none",
-            effort_map={},
-        )
-        result = apply_reasoning_config(
-            cast(ReasoningConfig, {"mode": "disabled"}),
-            custom,
-            converter_type="google",
-        )
-        assert result["thinking_config"]["thinking_budget"] == 0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -35,17 +35,15 @@ from llm_rosetta.shims.transforms import (
 # ---------------------------------------------------------------------------
 
 _REASONING_CAP = ReasoningCapability(
-    disabled="omit",
     effort_field="reasoning_effort",
-    effort_map={"low": "low", "medium": "medium", "high": "high"},
+    effort_range=("low", "high"),
 )
 
 _MODEL_REASONING_CAP = ReasoningCapability(
-    disabled="thinking_disabled",
+    thinking_modes={"auto": "adaptive", "enabled": "enabled", "disabled": "disabled"},
     effort_field="output_config.effort",
-    thinking_type="enabled",
-    effort_map={"low": "low", "high": "high"},
-    budget_tokens_default_ratio=0.8,
+    effort_range=("low", "high"),
+    budget_ratio=0.8,
 )
 
 
@@ -152,11 +150,10 @@ class TestEnforceReasoning:
     def test_config_override_highest_priority(self):
         ctx = ConversionContext()
         shim = _make_shim(reasoning=_REASONING_CAP)
-        enforce_reasoning(ctx, shim, config_override={"thinking_type": "adaptive"})
+        override_modes = {"auto": "adaptive", "disabled": "disabled"}
+        enforce_reasoning(ctx, shim, config_override={"thinking_modes": override_modes})
         cap = ctx.options["reasoning_cap"]
-        assert cap.thinking_type == "adaptive"
-        # Other fields inherited from base
-        assert cap.disabled == _REASONING_CAP.disabled
+        assert cap.thinking_modes == override_modes
         assert cap.effort_field == _REASONING_CAP.effort_field
 
     def test_config_override_on_model_override(self):
@@ -167,12 +164,11 @@ class TestEnforceReasoning:
             model_reasoning={"gpt-4": _MODEL_REASONING_CAP},
         )
         enforce_reasoning(
-            ctx, shim, model="gpt-4", config_override={"disabled": "block"}
+            ctx, shim, model="gpt-4", config_override={"budget_ratio": 0.5}
         )
         cap = ctx.options["reasoning_cap"]
-        assert cap.disabled == "block"
-        # Rest inherited from model-level
-        assert cap.thinking_type == _MODEL_REASONING_CAP.thinking_type
+        assert cap.budget_ratio == 0.5
+        assert cap.thinking_modes == _MODEL_REASONING_CAP.thinking_modes
 
     def test_accepts_registered_name(self):
         ctx = ConversionContext()
@@ -458,35 +454,35 @@ class TestApplyIrTransforms:
 
 class TestApplyConfigReasoningOverride:
     def test_partial_override(self):
+        modes = {"auto": "adaptive", "disabled": "disabled"}
         result = _apply_config_reasoning_override(
-            _REASONING_CAP, {"thinking_type": "adaptive"}
+            _REASONING_CAP, {"thinking_modes": modes}
         )
-        assert result.thinking_type == "adaptive"
-        assert result.disabled == _REASONING_CAP.disabled
+        assert result.thinking_modes == modes
         assert result.effort_field == _REASONING_CAP.effort_field
-        assert result.effort_map == _REASONING_CAP.effort_map
+        assert result.effort_range == _REASONING_CAP.effort_range
 
     def test_full_override(self):
         override = {
-            "disabled": "block",
+            "thinking_modes": {"enabled": "enabled"},
+            "thinking_default": "enabled",
             "effort_field": "custom_effort",
-            "max_effort": "high",
-            "thinking_type": "enabled",
-            "unsigned_reasoning_blocks": "drop",
-            "effort_map": {"a": "b"},
-            "budget_tokens_default_ratio": 0.5,
+            "effort_range": ["low", "high"],
+            "budget_ratio": 0.5,
+            "visibility_modes": {"auto": "auto"},
+            "unsigned_blocks": "preserve",
         }
         result = _apply_config_reasoning_override(_REASONING_CAP, override)
-        assert result.disabled == "block"
         assert result.effort_field == "custom_effort"
-        assert result.thinking_type == "enabled"
-        assert result.budget_tokens_default_ratio == 0.5
+        assert result.thinking_modes == {"enabled": "enabled"}
+        assert result.budget_ratio == 0.5
+        assert result.effort_range == ("low", "high")
 
     def test_empty_override_preserves_base(self):
         result = _apply_config_reasoning_override(_REASONING_CAP, {})
-        assert result.disabled == _REASONING_CAP.disabled
         assert result.effort_field == _REASONING_CAP.effort_field
-        assert result.effort_map == _REASONING_CAP.effort_map
+        assert result.effort_range == _REASONING_CAP.effort_range
+        assert result.thinking_modes == _REASONING_CAP.thinking_modes
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -182,15 +182,13 @@ class TestBuiltinShims:
         assert shim is not None
         assert shim.base == "anthropic"
 
-    def test_argo_anthropic_preserves_unsigned_reasoning_blocks(self):
+    def test_argo_anthropic_preserves_unsigned_blocks(self):
         shim = get_shim("argo--anthropic")
         assert shim is not None
         assert shim.reasoning is not None
-        assert shim.reasoning.unsigned_reasoning_blocks == "preserve"
+        assert shim.reasoning.unsigned_blocks == "preserve"
         assert shim.model_reasoning is not None
-        assert (
-            shim.model_reasoning["claudeopus47"].unsigned_reasoning_blocks == "preserve"
-        )
+        assert shim.model_reasoning["claudeopus47"].unsigned_blocks == "preserve"
 
     def test_google_base_type(self):
         shim = get_shim("google")
@@ -285,8 +283,9 @@ class TestGroupedProviders:
         assert anth is not None and anth.reasoning is not None
         assert oai is not None and oai.reasoning is not None
         assert anth.reasoning.effort_field == "output_config.effort"
-        assert anth.reasoning.effort_map["xhigh"] == "xhigh"
-        assert oai.reasoning.effort_map["max"] == "max"
+        assert anth.reasoning.effort_range == ("low", "max")
+        # Argo OpenAI has no effort_range (full ladder)
+        assert oai.reasoning.effort_range is None
 
     def test_argo_anthropic_model_reasoning_overrides(self):
         """Argo anthropic has model_reasoning for claudeopus47."""
@@ -295,16 +294,22 @@ class TestGroupedProviders:
         assert anth.model_reasoning is not None
         assert "claudeopus47" in anth.model_reasoning
         override = anth.model_reasoning["claudeopus47"]
-        assert override.thinking_type == "adaptive"
-        # Inherits provider defaults for other fields
+        assert override.thinking_modes == {
+            "auto": "adaptive",
+            "enabled": "adaptive",
+            "disabled": "disabled",
+        }
         assert override.effort_field == "output_config.effort"
-        assert override.effort_map["xhigh"] == "xhigh"
+        assert override.effort_range == ("low", "max")
 
-    def test_argo_anthropic_provider_thinking_type(self):
-        """Argo anthropic provider-level thinking_type is enabled."""
+    def test_argo_anthropic_provider_thinking_modes(self):
+        """Argo anthropic provider-level thinking_modes includes all three modes."""
         anth = get_shim("argo--anthropic")
         assert anth is not None and anth.reasoning is not None
-        assert anth.reasoning.thinking_type == "enabled"
+        assert anth.reasoning.thinking_modes is not None
+        assert "auto" in anth.reasoning.thinking_modes
+        assert "enabled" in anth.reasoning.thinking_modes
+        assert "disabled" in anth.reasoning.thinking_modes
 
     def test_mixed_flat_and_grouped(self):
         """Flat shims and grouped shims coexist in the registry."""


### PR DESCRIPTION
## Summary

- Redesign `ReasoningCapability` dataclass with three explicit dimensions: **thinking toggle** (`thinking_modes`), **effort control** (`effort_range`), and **visibility** (`visibility_modes`)
- Extract IR reasoning types (`IRMode`, `IREffort`, `IRVisibility`) into standalone `types/ir/reasoning.py` module
- Fix prod bug where `thinking:{type:"adaptive"}` was sent to standard OpenAI providers (Argo GPT) that don't support the thinking extension
- Fill in missing shim configs: DeepSeek `thinking_modes`, xAI `effort_range:[minimal,xhigh]`
- Update all 17 provider YAMLs, YAML loader, config override, reasoning helpers, admin UI, and 28 test files

### Field migration

| Old | New | Change |
|-----|-----|--------|
| `disabled` + `thinking_type` | `thinking_modes` | One dict: IR mode → provider value. None = no thinking support |
| `effort_map` + `max_effort` | `effort_range` | `(floor, ceiling)` tuple with clamping. 6-line dict → 1-line tuple |
| `budget_tokens_default_ratio` | `budget_ratio` | Rename |
| (hardcoded) | `visibility_modes` | IR summary → provider visibility value |
| `unsigned_reasoning_blocks` | `unsigned_blocks` | Rename |

### Bug fix context

A prod error occurred when Claude Code sent `thinking:{type:"adaptive"}` via Anthropic API to the gateway, which routed to `gpt56sol` (Argo OpenAI Chat). The gateway's IR→OpenAI Chat conversion unconditionally produced a `thinking` block for all OpenAI Chat providers, but standard GPT doesn't support this extension → upstream returned 400.

Root cause: `thinking_type` served double duty as feature flag + value override. With `thinking_modes`, support is explicit — `None` means no thinking block (safe default).

Closes #610

## Test plan

- [x] `make lint` — ruff check + format + ty check all pass
- [x] `make test` — 3019 passed, 0 failed
- [x] Manual verification: `mode:auto` + standard OpenAI → no thinking block
- [x] Manual verification: `mode:auto` + thinking-capable provider → `thinking:{type:"adaptive"}`
- [x] All 17 provider YAMLs load correctly with new schema
- [x] Model overrides (Anthropic per-model thinking_modes) load and inherit correctly
- [ ] Deploy to dev and verify cross-format reasoning with real traffic