### PR TITLE
fix(argo): use argo: prefix in model display names

### DIFF
--- a/src/llm_rosetta/gateway/admin/js/fetch-models.js
+++ b/src/llm_rosetta/gateway/admin/js/fetch-models.js
@@ -100,9 +100,11 @@ function renderFetchedModels() {
   list.innerHTML = models.map(m => {
     const displayName = prefix ? prefix + m : m;
     const exists = displayName in existingModels;
+    const upstreamId = S._fetchUpstreamMap ? S._fetchUpstreamMap[m] : '';
+    const upstreamHint = upstreamId ? ` <span style="font-size:11px;color:var(--text-dim)">→ ${esc(upstreamId)}</span>` : '';
     return `<label${exists ? ' style="opacity:0.6"' : ''}>
       <input type="checkbox" value="${esc(m)}" onchange="updateFetchCount()"${exists ? ' checked data-exists="true"' : ''}>
-      <span>${esc(m)}</span>${exists ? ' <span class="exists-tag" style="font-size:11px;color:var(--text-dim)">(exists)</span>' : ''}
+      <span>${esc(m)}</span>${upstreamHint}${exists ? ' <span class="exists-tag" style="font-size:11px;color:var(--text-dim)">(exists)</span>' : ''}
     </label>`;
   }).join('');
 

--- a/src/llm_rosetta/shims/providers/argo/model_utils.py
+++ b/src/llm_rosetta/shims/providers/argo/model_utils.py
@@ -30,10 +30,12 @@ def model_list_transform(
     upstream_map: dict[str, str] = {}
     for m in raw_entries:
         raw_id = m.get("id", "")
-        display = re.sub(r"[^a-z0-9]+", "-", raw_id.lower()).strip("-")
+        slug = re.sub(r"[^a-z0-9]+", "-", raw_id.lower()).strip("-")
+        if not slug:
+            continue
+        display = f"argo:{slug}"
         upstream = m.get("internal_id", raw_id)
-        if display:
-            model_ids.append(display)
-            if display != upstream:
-                upstream_map[display] = upstream
+        model_ids.append(display)
+        if display != upstream:
+            upstream_map[display] = upstream
     return model_ids, upstream_map

--- a/tests/test_argo_model_list_transform.py
+++ b/tests/test_argo_model_list_transform.py
@@ -10,23 +10,23 @@ class TestModelListTransform:
     """Unit tests for model_list_transform slug generation and upstream mapping."""
 
     def test_normal_input(self):
-        """Human-readable id is slugified; internal_id is mapped."""
+        """Human-readable id is slugified with argo: prefix; internal_id is mapped."""
         raw = [{"id": "Claude Opus 5", "internal_id": "claudeopus5"}]
         ids, upstream = model_list_transform(raw)
-        assert ids == ["claude-opus-5"]
-        assert upstream == {"claude-opus-5": "claudeopus5"}
+        assert ids == ["argo:claude-opus-5"]
+        assert upstream == {"argo:claude-opus-5": "claudeopus5"}
 
     def test_multiple_models(self):
-        """Multiple entries are all processed."""
+        """Multiple entries are all processed with argo: prefix."""
         raw = [
             {"id": "Claude Opus 5", "internal_id": "claudeopus5"},
             {"id": "GPT 4o Mini", "internal_id": "gpt4omini"},
         ]
         ids, upstream = model_list_transform(raw)
-        assert ids == ["claude-opus-5", "gpt-4o-mini"]
+        assert ids == ["argo:claude-opus-5", "argo:gpt-4o-mini"]
         assert upstream == {
-            "claude-opus-5": "claudeopus5",
-            "gpt-4o-mini": "gpt4omini",
+            "argo:claude-opus-5": "claudeopus5",
+            "argo:gpt-4o-mini": "gpt4omini",
         }
 
     def test_empty_id_skipped(self):
@@ -36,43 +36,46 @@ class TestModelListTransform:
             {"id": "Claude Opus 5", "internal_id": "claudeopus5"},
         ]
         ids, upstream = model_list_transform(raw)
-        assert ids == ["claude-opus-5"]
-        assert upstream == {"claude-opus-5": "claudeopus5"}
+        assert ids == ["argo:claude-opus-5"]
+        assert upstream == {"argo:claude-opus-5": "claudeopus5"}
 
     def test_missing_internal_id_falls_back_to_id(self):
         """When internal_id is absent, the raw id is used as upstream value."""
         raw = [{"id": "Some Model"}]
         ids, upstream = model_list_transform(raw)
-        assert ids == ["some-model"]
-        # Slug "some-model" differs from raw id "Some Model" → mapped.
-        assert upstream == {"some-model": "Some Model"}
+        assert ids == ["argo:some-model"]
+        # Display "argo:some-model" differs from raw id "Some Model" → mapped.
+        assert upstream == {"argo:some-model": "Some Model"}
 
-    def test_display_equals_upstream_no_map_entry(self):
-        """When slug matches the upstream value, no mapping is needed."""
+    def test_display_always_has_prefix(self):
+        """Even when slug matches internal_id, argo: prefix causes a mapping."""
         raw = [{"id": "gpt-4o", "internal_id": "gpt-4o"}]
         ids, upstream = model_list_transform(raw)
-        assert ids == ["gpt-4o"]
-        assert upstream == {}
+        assert ids == ["argo:gpt-4o"]
+        assert upstream == {"argo:gpt-4o": "gpt-4o"}
 
     def test_double_spaces(self):
         """Double spaces produce a single hyphen, not double hyphens."""
         raw = [{"id": "Claude  Opus  5", "internal_id": "claudeopus5"}]
         ids, upstream = model_list_transform(raw)
-        assert ids == ["claude-opus-5"]
+        assert ids == ["argo:claude-opus-5"]
 
     def test_special_characters(self):
         """Parentheses, dots, slashes, and other special chars are collapsed."""
         raw = [{"id": "Model (v2.1/beta)", "internal_id": "modelv21beta"}]
         ids, upstream = model_list_transform(raw)
-        assert ids == ["model-v2-1-beta"]
-        assert upstream == {"model-v2-1-beta": "modelv21beta"}
+        assert ids == ["argo:model-v2-1-beta"]
+        assert upstream == {"argo:model-v2-1-beta": "modelv21beta"}
 
     def test_leading_trailing_whitespace(self):
         """Leading/trailing whitespace does not produce leading/trailing hyphens."""
         raw = [{"id": "  Claude Opus 5  ", "internal_id": "claudeopus5"}]
         ids, upstream = model_list_transform(raw)
-        assert ids == ["claude-opus-5"]
-        assert "claude-opus-5" not in ["-claude-opus-5-", "-claude-opus-5"]
+        assert ids == ["argo:claude-opus-5"]
+        assert "argo:claude-opus-5" not in [
+            "argo:-claude-opus-5-",
+            "argo:-claude-opus-5",
+        ]
 
     def test_empty_list(self):
         """Empty input returns empty results."""


### PR DESCRIPTION
## Summary

Follow-up fixes for the `model_list_transform` feature from PR #609:

- **Display name format**: `model_list_transform` now produces `argo:slug` format directly (e.g. `argo:claude-opus-5` instead of `claude-opus-5`), so the user doesn't need to add a prefix — the colon-separated namespace is built into the display name, and `upstream_map` maps it back to the internal ID (e.g. `claudeopus5`).
- **Upstream hint in fetch dialog**: The fetch models dialog now shows the upstream model ID next to each model name (e.g. `→ claudeopus5`), matching how the main models page displays upstream mappings.
- **Test updates**: All test expectations updated for the new `argo:` prefix format, including renaming `test_display_equals_upstream_no_map_entry` to `test_display_always_has_prefix` since the prefix now always creates a mapping.

## Test plan

- [x] `pytest tests/test_argo_model_list_transform.py -v` — 10/10 passed
- [x] `pytest --ignore=tests/integration -q` — 3029 passed, 0 failures
- [ ] Manual: open admin UI, fetch models from an Argo provider, verify `argo:` prefix and `→ upstream` hints appear in the fetch dialog