### PR TITLE
feat(gateway): enforce reasoning capability flag in pipeline

### DIFF
--- a/src/llm_rosetta/capabilities.py
+++ b/src/llm_rosetta/capabilities.py
@@ -11,6 +11,7 @@ adaptation) and from **converter logic** (API-standard translation).
 Functions follow the ``enforce_*`` naming convention:
 
 - :func:`enforce_reasoning` — configure reasoning output mode (pre-IR)
+- :func:`strip_reasoning_for_non_reasoning` — strip reasoning for non-reasoning models (post-IR)
 - :func:`enforce_vision` — strip images for non-vision models (post-IR)
 - :func:`enforce_custom_tools` — downgrade custom tools for non-supporting providers (post-IR)
 
@@ -121,6 +122,48 @@ def enforce_reasoning(
         cap = _apply_config_reasoning_override(cap, config_override)
     if cap is not None:
         ctx.options["reasoning_cap"] = cap
+
+
+def strip_reasoning_for_non_reasoning(
+    ir_request: dict[str, Any],
+    *,
+    model_capabilities: list[str] | None = None,
+    model: str = "",
+    request_id: str = "-",
+) -> dict[str, Any]:
+    """Strip reasoning config from the IR request if the model lacks reasoning capability.
+
+    Must be called **after** source → IR conversion (operates on the IR
+    dict, not the raw provider body).
+
+    No-op when *model_capabilities* is ``None`` (unknown) or includes
+    ``"reasoning"``.
+
+    Args:
+        ir_request: The IR request dict — **always use the return value**.
+        model_capabilities: Declared capabilities of the model.
+        model: Upstream model identifier (for logging).
+        request_id: Request identifier (for logging).
+
+    Returns:
+        The IR request with reasoning config removed, or the original
+        request if the model has reasoning capability.
+    """
+    if model_capabilities is None or "reasoning" in model_capabilities:
+        return ir_request
+
+    reasoning = ir_request.pop("reasoning", None)
+    if reasoning:
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.info(
+            "[%s] model=%s: stripped reasoning config (model lacks 'reasoning' capability)",
+            request_id,
+            model,
+        )
+
+    return ir_request
 
 
 def enforce_vision(

--- a/src/llm_rosetta/capabilities.py
+++ b/src/llm_rosetta/capabilities.py
@@ -21,6 +21,7 @@ appropriate pipeline stages.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from llm_rosetta.converters.base.context import ConversionContext
@@ -29,6 +30,8 @@ from llm_rosetta.shims.provider_shim import (
     ReasoningCapability,
     resolve_shim,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _apply_config_reasoning_override(
@@ -154,9 +157,6 @@ def strip_reasoning_for_non_reasoning(
 
     reasoning = ir_request.pop("reasoning", None)
     if reasoning:
-        import logging
-
-        logger = logging.getLogger(__name__)
         logger.info(
             "[%s] model=%s: stripped reasoning config (model lacks 'reasoning' capability)",
             request_id,

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -33,6 +33,7 @@ from llm_rosetta.capabilities import (
     enforce_vision,
     get_custom_tool_names,
     restore_custom_tool_calls,
+    strip_reasoning_for_non_reasoning,
     unwrap_custom_tool_input,
 )
 from llm_rosetta.converters.base.context import ConversionContext
@@ -511,6 +512,14 @@ class ConversionPipeline:
         # Capability enforcement: vision (post-IR) + shim IR transforms
         t0 = time.perf_counter()
         ir_request = enforce_vision(
+            ir_request,
+            model_capabilities=self._model_capabilities,
+            model=self._upstream_model or body.get("model") or "",
+            request_id=request_id,
+        )
+
+        # Capability enforcement: reasoning (post-IR)
+        ir_request = strip_reasoning_for_non_reasoning(
             ir_request,
             model_capabilities=self._model_capabilities,
             model=self._upstream_model or body.get("model") or "",

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,6 +12,7 @@ import pytest
 from llm_rosetta.capabilities import (
     _apply_config_reasoning_override,
     enforce_reasoning,
+    strip_reasoning_for_non_reasoning,
 )
 from llm_rosetta.converters.base.context import ConversionContext
 from llm_rosetta.pipeline import apply_ir_transforms
@@ -181,6 +182,43 @@ class TestEnforceReasoning:
         ctx = ConversionContext()
         enforce_reasoning(ctx, "nonexistent")
         assert "reasoning_cap" not in ctx.options
+
+
+# ---------------------------------------------------------------------------
+# strip_reasoning_for_non_reasoning
+# ---------------------------------------------------------------------------
+
+
+class TestStripReasoningForNonReasoning:
+    def test_strips_when_no_reasoning_cap(self):
+        """Reasoning config stripped when model lacks 'reasoning' capability."""
+        ir = _simple_ir_request()
+        ir["reasoning"] = {"mode": "auto", "effort": "high"}
+        result = strip_reasoning_for_non_reasoning(ir, model_capabilities=["text"])
+        assert "reasoning" not in result
+
+    def test_keeps_when_reasoning_cap_present(self):
+        """Reasoning config kept when model has 'reasoning' capability."""
+        ir = _simple_ir_request()
+        ir["reasoning"] = {"mode": "auto", "effort": "high"}
+        result = strip_reasoning_for_non_reasoning(
+            ir, model_capabilities=["text", "reasoning"]
+        )
+        assert result["reasoning"]["mode"] == "auto"
+        assert result["reasoning"]["effort"] == "high"
+
+    def test_noop_when_caps_none(self):
+        """No-op when model_capabilities is None (unknown)."""
+        ir = _simple_ir_request()
+        ir["reasoning"] = {"mode": "enabled"}
+        result = strip_reasoning_for_non_reasoning(ir, model_capabilities=None)
+        assert result["reasoning"]["mode"] == "enabled"
+
+    def test_noop_when_no_reasoning_in_request(self):
+        """No-op when request has no reasoning config."""
+        ir = _simple_ir_request()
+        result = strip_reasoning_for_non_reasoning(ir, model_capabilities=["text"])
+        assert "reasoning" not in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Wire the admin UI's existing `reasoning` capability checkbox into the actual conversion pipeline
- Add `strip_reasoning_for_non_reasoning()` that strips IR reasoning config when `"reasoning" not in model_capabilities`, matching the `enforce_vision` pattern
- No-op when `model_capabilities` is `None` (unknown) — backward compat for configs without explicit capabilities

## Context

The admin UI already has a `capReasoning` checkbox, but it was purely cosmetic — the pipeline never checked it. Now when a model lacks the `"reasoning"` capability, reasoning config is stripped from the IR request before conversion, preventing reasoning parameters from reaching providers that don't support them.

Closes #613

## Test plan

- [x] `make test` — 3033 passed
- [x] New tests: `TestStripReasoningForNonReasoning` (4 cases: strips when absent, keeps when present, no-op when None, no-op when no reasoning in request)