### PR TITLE
fix(admin): support rerank type + Jina/Cohere model fetching

### DIFF
--- a/examples/gateway/config.jsonc
+++ b/examples/gateway/config.jsonc
@@ -32,6 +32,7 @@
     "jina": {
       "api_key": "${JINA_API_KEY}",
       "base_url": "https://api.jina.ai",
+      "models_path": "/v1/models",
       "embedding_format": "jina",
       "embedding_path": "/v1/embeddings",
       "rerank_format": "jina",
@@ -40,6 +41,7 @@
     "cohere": {
       "api_key": "${COHERE_API_KEY}",
       "base_url": "https://api.cohere.com",
+      "models_path": "/v1/models",
       "embedding_format": "cohere",
       "embedding_path": "/v2/embed",
       "rerank_format": "cohere",

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -885,6 +885,7 @@ Rules:..."</code><br><br>Some upstream providers don't support content arrays in
         <div class="fetch-type-radios">
           <label><input type="radio" name="fetchModelType" value="llm" checked onchange="onFetchTypeChange()"> <span data-i18n="label.llm">LLM</span></label>
           <label><input type="radio" name="fetchModelType" value="embedding" onchange="onFetchTypeChange()"> <span data-i18n="label.embedding">Embedding</span></label>
+          <label><input type="radio" name="fetchModelType" value="rerank" onchange="onFetchTypeChange()"> <span data-i18n="label.rerank">Rerank</span></label>
         </div>
       </div>
       <div class="fetch-caps-row" id="fetchCapsRow">

--- a/src/llm_rosetta/gateway/admin/js/fetch-models.js
+++ b/src/llm_rosetta/gateway/admin/js/fetch-models.js
@@ -43,12 +43,17 @@ function onFetchTypeChange() {
 function _getFetchCapabilities() {
   const type = document.querySelector('input[name="fetchModelType"]:checked').value;
   if (type === 'embedding') return ['embedding'];
+  if (type === 'rerank') return ['rerank'];
   const caps = [];
   if (document.getElementById('fetchCapText').checked) caps.push('text');
   if (document.getElementById('fetchCapVision').checked) caps.push('vision');
   if (document.getElementById('fetchCapTools').checked) caps.push('tools');
   if (document.getElementById('fetchCapReasoning').checked) caps.push('reasoning');
   return caps.length > 0 ? caps : ['text'];
+}
+
+function _getFetchModelType() {
+  return document.querySelector('input[name="fetchModelType"]:checked').value;
 }
 
 async function doFetchModels() {
@@ -151,10 +156,12 @@ async function bulkAddFetchedModels() {
 
     // Add new models
     if (toAdd.length > 0) {
+      const modelType = _getFetchModelType();
       const res = await api.post('/admin/api/config/models', {
         provider: S._fetchProvider,
         models: toAdd,
         prefix: prefix,
+        type: modelType,
         capabilities: _getFetchCapabilities(),
         upstream_map: S._fetchUpstreamMap,
       });

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -864,7 +864,9 @@ def _extract_model_ids(
     model_ids: list[str] = []
 
     if mlt is not None:
-        raw_entries = body.get("data", []) or body.get("models", [])
+        raw_entries: list[dict[str, Any]] = (
+            body.get("data", []) if "data" in body else body.get("models", [])
+        )
         model_ids, upstream_map = mlt(raw_entries)
     elif ptype == "google":
         for m in body.get("models", []):

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -864,9 +864,7 @@ def _extract_model_ids(
     model_ids: list[str] = []
 
     if mlt is not None:
-        raw_entries = (
-            body.get("models", []) if ptype == "google" else body.get("data", [])
-        )
+        raw_entries = body.get("data", []) or body.get("models", [])
         model_ids, upstream_map = mlt(raw_entries)
     elif ptype == "google":
         for m in body.get("models", []):
@@ -902,13 +900,17 @@ async def fetch_upstream_models(request: Any, **kwargs: Any) -> Response:
     pinfo = config.providers[provider_name]
     ptype = config.provider_types.get(provider_name, "unknown")
 
-    # Build the models listing URL based on provider type
-    if ptype == "google":
+    # Build the models listing URL.  Explicit ``models_path`` in the
+    # provider config takes precedence (e.g. ``/v1/models`` for Jina).
+    raw_cfg = getattr(config, "_raw_providers", {}).get(provider_name, {})
+    explicit_path = raw_cfg.get("models_path")
+    if explicit_path:
+        models_url = f"{pinfo.base_url}{explicit_path}"
+    elif ptype == "google":
         models_url = f"{pinfo.base_url}/v1beta/models"
     elif ptype == "anthropic":
         models_url = f"{pinfo.base_url}/v1/models"
     else:
-        # OpenAI-compatible (openai_chat, openai_responses, etc.)
         models_url = f"{pinfo.base_url}/models"
 
     headers = pinfo.auth_headers()
@@ -1004,10 +1006,13 @@ async def bulk_add_models(request: Any) -> Response:
             if display_name in models_section:
                 skipped.append(display_name)
                 continue
+            model_type = body.get("type", "llm")
             entry: dict[str, Any] = {
                 "provider": provider,
                 "capabilities": body.get("capabilities", ["text", "vision", "tools"]),
             }
+            if model_type != "llm":
+                entry["type"] = model_type
             # Set upstream_model when the gateway-facing name differs from
             # what the upstream provider expects.  The upstream_map (from a
             # shim's model_list_transform) takes precedence, then prefix.

--- a/src/llm_rosetta/gateway/admin/routes/connectivity.py
+++ b/src/llm_rosetta/gateway/admin/routes/connectivity.py
@@ -68,7 +68,10 @@ async def test_provider_connectivity(request: Any, name: str) -> Response:
         if hasattr(config, "provider_types")
         else "unknown"
     )
-    if ptype == "google":
+    explicit_path = provider_cfg.get("models_path")
+    if explicit_path:
+        models_url = f"{base_url}{explicit_path}"
+    elif ptype == "google":
         models_url = f"{base_url}/v1beta/models"
     elif ptype == "anthropic":
         models_url = f"{base_url}/v1/models"

--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -81,6 +81,47 @@ def get_model_list_transform(
     return _model_list_transforms.get(shim_name)
 
 
+def register_model_list_transform(name: str, transform: ModelListTransform) -> None:
+    """Register a model_list_transform for providers without a shim directory."""
+    _model_list_transforms[name] = transform
+
+
+# --------------- Built-in model list transforms ---------------
+
+
+def _jina_model_list_transform(
+    entries: list[dict[str, Any]],
+) -> tuple[list[str], dict[str, str]]:
+    """Strip the ``jina-ai/`` org prefix from Jina model IDs."""
+    ids: list[str] = []
+    upstream_map: dict[str, str] = {}
+    for m in entries:
+        raw_id = m.get("id", "")
+        if not raw_id:
+            continue
+        display = raw_id.removeprefix("jina-ai/")
+        ids.append(display)
+        if display != raw_id:
+            upstream_map[display] = raw_id
+    return ids, upstream_map
+
+
+def _cohere_model_list_transform(
+    entries: list[dict[str, Any]],
+) -> tuple[list[str], dict[str, str]]:
+    """Parse Cohere's ``models[].name`` format."""
+    ids: list[str] = []
+    for m in entries:
+        name = m.get("name", "")
+        if name:
+            ids.append(name)
+    return ids, {}
+
+
+register_model_list_transform("jina", _jina_model_list_transform)
+register_model_list_transform("cohere", _cohere_model_list_transform)
+
+
 def _parse_reasoning_cap(
     cfg: dict,
     *,

--- a/tests/test_model_list_transforms.py
+++ b/tests/test_model_list_transforms.py
@@ -1,0 +1,80 @@
+"""Tests for built-in model_list_transform hooks (Jina, Cohere)."""
+
+from __future__ import annotations
+
+from llm_rosetta.shims.providers import (
+    _jina_model_list_transform,
+    _cohere_model_list_transform,
+    get_model_list_transform,
+)
+
+
+class TestJinaModelListTransform:
+    """Unit tests for the Jina model_list_transform."""
+
+    def test_strips_prefix(self):
+        raw = [{"id": "jina-ai/jina-embeddings-v3"}]
+        ids, upstream = _jina_model_list_transform(raw)
+        assert ids == ["jina-embeddings-v3"]
+        assert upstream == {"jina-embeddings-v3": "jina-ai/jina-embeddings-v3"}
+
+    def test_multiple_models(self):
+        raw = [
+            {"id": "jina-ai/jina-reranker-v3"},
+            {"id": "jina-ai/jina-embeddings-v3"},
+            {"id": "jina-ai/jina-clip-v2"},
+        ]
+        ids, upstream = _jina_model_list_transform(raw)
+        assert ids == ["jina-reranker-v3", "jina-embeddings-v3", "jina-clip-v2"]
+        assert all(v.startswith("jina-ai/") for v in upstream.values())
+
+    def test_no_prefix(self):
+        raw = [{"id": "some-model-without-prefix"}]
+        ids, upstream = _jina_model_list_transform(raw)
+        assert ids == ["some-model-without-prefix"]
+        assert upstream == {}
+
+    def test_empty_id_skipped(self):
+        raw = [{"id": ""}, {"id": "jina-ai/valid"}]
+        ids, upstream = _jina_model_list_transform(raw)
+        assert ids == ["valid"]
+
+    def test_empty_input(self):
+        ids, upstream = _jina_model_list_transform([])
+        assert ids == []
+        assert upstream == {}
+
+    def test_registered(self):
+        assert get_model_list_transform("jina") is _jina_model_list_transform
+
+
+class TestCohereModelListTransform:
+    """Unit tests for the Cohere model_list_transform."""
+
+    def test_parses_name_field(self):
+        raw = [{"name": "rerank-v3.5", "endpoints": ["rerank"]}]
+        ids, upstream = _cohere_model_list_transform(raw)
+        assert ids == ["rerank-v3.5"]
+        assert upstream == {}
+
+    def test_multiple_models(self):
+        raw = [
+            {"name": "command-a-03-2025", "endpoints": ["chat"]},
+            {"name": "embed-english-v3.0", "endpoints": ["embed"]},
+            {"name": "rerank-v3.5", "endpoints": ["rerank"]},
+        ]
+        ids, upstream = _cohere_model_list_transform(raw)
+        assert ids == ["command-a-03-2025", "embed-english-v3.0", "rerank-v3.5"]
+
+    def test_empty_name_skipped(self):
+        raw = [{"name": ""}, {"name": "valid-model"}]
+        ids, upstream = _cohere_model_list_transform(raw)
+        assert ids == ["valid-model"]
+
+    def test_empty_input(self):
+        ids, upstream = _cohere_model_list_transform([])
+        assert ids == []
+        assert upstream == {}
+
+    def test_registered(self):
+        assert get_model_list_transform("cohere") is _cohere_model_list_transform


### PR DESCRIPTION
Closes #617

## Summary

- Add **rerank** radio button to Fetch Models modal (was only llm/embedding)
- Add `models_path` provider config field for custom model listing URLs, consistent with existing `embedding_path`/`rerank_path` pattern
- Register `model_list_transform` for **Jina** (strip `jina-ai/` org prefix) and **Cohere** (parse `models[].name` format instead of `data[].id`)
- Fix `_extract_model_ids` to try both `data[]` and `models[]` response keys when a transform is present
- Wire selected model type (llm/embedding/rerank) through `bulk_add_models` so fetched models get the correct `type` field in config

## Test plan

- [x] `make test` — 3029 passed, 0 failed
- [x] `ruff check` + `ruff format` clean
- [x] `ty check` passes
- [x] Verified Jina transform strips `jina-ai/` prefix and builds upstream_map
- [x] Verified Cohere transform parses `models[].name` format
- [ ] Manual: open admin panel, Fetch Models from Jina provider → should list models
- [ ] Manual: open admin panel, Fetch Models from Cohere provider → should list models
- [ ] Manual: select rerank type, add fetched rerank models → config should have `type: rerank`