### PR TITLE
fix: defensive model_list_transform when internal_id is absent

### DIFF
--- a/src/llm_rosetta/shims/providers/argo/model_utils.py
+++ b/src/llm_rosetta/shims/providers/argo/model_utils.py
@@ -15,6 +15,11 @@ def model_list_transform(
     compact upstream ID ("claudeopus5").  This converts to slug-style
     display names suitable for gateway routing.
 
+    When ``internal_id`` is absent (e.g. when the upstream is an
+    argo-proxy instance that already returns ``argo:...`` style IDs),
+    the entry is passed through as-is — no slug transformation or
+    prefix is applied.
+
     Args:
         raw_entries: List of model dicts from the upstream ``/models``
             response, each containing at least an ``id`` key and
@@ -22,20 +27,24 @@ def model_list_transform(
 
     Returns:
         A ``(model_ids, upstream_map)`` tuple where *model_ids* is a
-        list of slug-style display names and *upstream_map* maps each
-        display name to its upstream internal ID (only for entries
-        where the two differ).
+        list of display names and *upstream_map* maps each display
+        name to its upstream internal ID (only for entries where the
+        two differ).
     """
     model_ids: list[str] = []
     upstream_map: dict[str, str] = {}
     for m in raw_entries:
         raw_id = m.get("id", "")
-        slug = re.sub(r"[^a-z0-9]+", "-", raw_id.lower()).strip("-")
-        if not slug:
+        if not raw_id:
             continue
-        display = f"argo:{slug}"
-        upstream = m.get("internal_id", raw_id)
+        internal_id = m.get("internal_id")
+        if internal_id:
+            slug = re.sub(r"[^a-z0-9]+", "-", raw_id.lower()).strip("-")
+            if not slug:
+                continue
+            display = f"argo:{slug}"
+            upstream_map[display] = internal_id
+        else:
+            display = raw_id
         model_ids.append(display)
-        if display != upstream:
-            upstream_map[display] = upstream
     return model_ids, upstream_map

--- a/tests/test_argo_model_list_transform.py
+++ b/tests/test_argo_model_list_transform.py
@@ -39,13 +39,19 @@ class TestModelListTransform:
         assert ids == ["argo:claude-opus-5"]
         assert upstream == {"argo:claude-opus-5": "claudeopus5"}
 
-    def test_missing_internal_id_falls_back_to_id(self):
-        """When internal_id is absent, the raw id is used as upstream value."""
-        raw = [{"id": "Some Model"}]
+    def test_no_internal_id_passthrough(self):
+        """When internal_id is absent, the raw id is passed through as-is."""
+        raw = [{"id": "argo:claude-opus-5"}]
         ids, upstream = model_list_transform(raw)
-        assert ids == ["argo:some-model"]
-        # Display "argo:some-model" differs from raw id "Some Model" → mapped.
-        assert upstream == {"argo:some-model": "Some Model"}
+        assert ids == ["argo:claude-opus-5"]
+        assert upstream == {}
+
+    def test_no_internal_id_plain_name(self):
+        """A plain model name without internal_id passes through unchanged."""
+        raw = [{"id": "gpt-4o"}]
+        ids, upstream = model_list_transform(raw)
+        assert ids == ["gpt-4o"]
+        assert upstream == {}
 
     def test_display_always_has_prefix(self):
         """Even when slug matches internal_id, argo: prefix causes a mapping."""
@@ -72,10 +78,6 @@ class TestModelListTransform:
         raw = [{"id": "  Claude Opus 5  ", "internal_id": "claudeopus5"}]
         ids, upstream = model_list_transform(raw)
         assert ids == ["argo:claude-opus-5"]
-        assert "argo:claude-opus-5" not in [
-            "argo:-claude-opus-5-",
-            "argo:-claude-opus-5",
-        ]
 
     def test_empty_list(self):
         """Empty input returns empty results."""
@@ -89,3 +91,13 @@ class TestModelListTransform:
         ids, upstream = model_list_transform(raw)
         assert ids == []
         assert upstream == {}
+
+    def test_mixed_with_and_without_internal_id(self):
+        """Entries with internal_id get transformed; without get passed through."""
+        raw = [
+            {"id": "Claude Opus 5", "internal_id": "claudeopus5"},
+            {"id": "argo:claude-opus-4.7"},
+        ]
+        ids, upstream = model_list_transform(raw)
+        assert ids == ["argo:claude-opus-5", "argo:claude-opus-4.7"]
+        assert upstream == {"argo:claude-opus-5": "claudeopus5"}


### PR DESCRIPTION
## Problem

When the argo provider points at an argo-proxy instance (not the raw ARGO API), the `/models` response contains already-formatted `argo:claude-opus-5` style IDs with no `internal_id` field. The transform would re-slug and double-prefix these into `argo:argo-claude-opus-5`.

## Fix

If `internal_id` is absent, pass the raw `id` through unchanged — no slug transformation, no `argo:` prefix. Only apply the display-name transform when `internal_id` is present (raw ARGO API).

## Tests

- Added `test_no_internal_id_passthrough` — argo-proxy style IDs pass through as-is
- Added `test_no_internal_id_plain_name` — plain model names pass through unchanged  
- Added `test_mixed_with_and_without_internal_id` — mixed entries handled correctly
- 12/12 targeted tests pass, 3029 full suite pass