### PR TITLE
fix: make supports_custom_tools a tri-state so an explicit False is honoured

### DIFF
--- a/src/llm_rosetta/capabilities.py
+++ b/src/llm_rosetta/capabilities.py
@@ -221,7 +221,7 @@ def enforce_custom_tools(
     ir_request: dict[str, Any],
     *,
     shim: ProviderShim | str | None = None,
-    config_override: bool = False,
+    config_override: bool | None = None,
 ) -> dict[str, Any]:
     """Downgrade custom tools to functions for providers that lack support.
 
@@ -233,23 +233,29 @@ def enforce_custom_tools(
     restore it.
 
     Resolution: ``config_override`` carries the pre-resolved value from
-    ``config.resolve()`` (config override > shim default > False).
-    Direct callers may omit it and pass ``shim`` instead.
+    ``config.resolve()`` (config override > shim default > False) and is
+    authoritative when not ``None``.  Direct callers may omit it and pass
+    ``shim`` instead, in which case the shim's default is used.
+
+    ``None`` and ``False`` are distinct: ``None`` means "unset, fall back to
+    the shim", while ``False`` means "this provider does not support custom
+    tools" and must not be overridden by a shim that claims otherwise.
 
     No-op when the effective value is True.
 
     Args:
         ir_request: The IR request dict — **always use the return value**.
-        shim: Provider shim (name or object).  Used as fallback when
-            ``config_override`` is False and no gateway config is set.
-        config_override: Pre-resolved supports_custom_tools value.
+        shim: Provider shim (name or object).  Used as fallback only when
+            ``config_override`` is ``None``.
+        config_override: Pre-resolved supports_custom_tools value, or
+            ``None`` to defer to ``shim``.
 
     Returns:
         The IR request with custom tools downgraded, or the original
         request unchanged.
     """
     supports = config_override
-    if not supports and shim is not None:
+    if supports is None and shim is not None:
         resolved = resolve_shim(shim) if isinstance(shim, str) else shim
         supports = resolved.supports_custom_tools if resolved is not None else False
     if supports:

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -237,7 +237,7 @@ class ConversionPipeline:
         upstream_model: str | None = None,
         model_capabilities: list[str] | None = None,
         reasoning_config_override: dict[str, Any] | None = None,
-        supports_custom_tools: bool = False,
+        supports_custom_tools: bool | None = None,
         hoist_system_messages: bool = True,
         force_conversion: bool = True,
         fidelity_mode: Literal["critical", "full"] | None = None,

--- a/tests/test_custom_tool_downgrade.py
+++ b/tests/test_custom_tool_downgrade.py
@@ -158,6 +158,30 @@ class TestEnforceCustomTools:
         assert result["tools"][0]["type"] == "function"
         assert result["tools"][0]["metadata"]["_downgraded_from"] == "custom"
 
+    def test_config_override_false_overrides_shim_true(self):
+        """A gateway config saying False must beat a shim saying True.
+
+        Regression: ``config_override`` was compared with ``not supports``,
+        so an explicit False was indistinguishable from unset and fell back
+        to the shim — making ``supports_custom_tools: false`` inert for any
+        provider whose shim declared support.
+        """
+        shim = _make_shim(supports=True)
+        tool = dict(CUSTOM_TOOL_IR)
+        tool["metadata"] = copy.deepcopy(CUSTOM_TOOL_IR.get("metadata", {}))
+        ir = {"tools": [tool]}
+        result = enforce_custom_tools(ir, shim=shim, config_override=False)
+        assert result["tools"][0]["type"] == "function"
+        assert result["tools"][0]["metadata"]["_downgraded_from"] == "custom"
+
+    def test_config_override_none_defers_to_shim_true(self):
+        shim = _make_shim(supports=True)
+        tool = dict(CUSTOM_TOOL_IR)
+        tool["metadata"] = copy.deepcopy(CUSTOM_TOOL_IR.get("metadata", {}))
+        ir = {"tools": [tool]}
+        result = enforce_custom_tools(ir, shim=shim, config_override=None)
+        assert result["tools"][0]["type"] == "custom"
+
     def test_config_override_default_defers_to_shim(self):
         shim = _make_shim(supports=False)
         tool = dict(CUSTOM_TOOL_IR)


### PR DESCRIPTION
## Problem

`enforce_custom_tools()` resolved its capability with `not supports`, where `config_override` was typed `bool = False`. That makes an explicit `False` — "this provider does not support custom tools" — indistinguishable from the unset default. Both fall through to the shim, and every built-in shim reports `supports_custom_tools: True`.

Net effect: configuring `supports_custom_tools: False` on a provider was **silently inert**. Custom tools were never downgraded, and there was no diagnostic to suggest the setting had been ignored.

This is not hypothetical. ARGO's OpenAI upstream caps `tools[].custom.description` at 4096 characters; Codex Code Mode's `exec` tool carries a 10.5k–13.5k character description, so every such request is rejected with `string_above_max_length`. The documented remedy is exactly this config flag, and it did nothing.

## Change

Type `config_override` and the pipeline's `supports_custom_tools` as `bool | None`, defaulting to `None`, and resolve with `supports is None`.

- `None` — unset, defer to the shim (matches the old default's behaviour)
- `False` — not supported, authoritative, shim cannot override
- `True` — supported

## Compatibility

A caller that previously passed `False` expecting shim fallback now gets the downgrade it asked for. That is the point of the change, but it is a behaviour change worth naming explicitly. Callers relying on the old default are unaffected, since `None` and the old `False` both defer to the shim.

## Verification

Full suite green on this branch: **3031 passed, 21 skipped**, `ruff check` and `ruff format --check` clean. `tests/test_custom_tool_downgrade.py` covers the three-way resolution and the `_downgraded_from` metadata round-trip.

Confirmed end to end against the live ARGO upstream: the cap applies only to `custom` tools (a 13457-char `function` description is accepted; the same string as `custom` is rejected; 4096 as `custom` is accepted), and with this fix the downgrade fires and the request succeeds. Truncating the description instead is not viable — with the instructions cut off, the model emits garbage into the tool input rather than a shell command.

## Not included

Changelog entries. `docs_en`/`docs_zh` are not mounted as worktrees in my checkout, so the EN+ZH `[Unreleased]` entries the contributing guide requires are missing. Happy to add them if you mount them or tell me the preferred flow.

Minor adjacent nit, not fixed here to keep the diff scoped: the `enforce_custom_tools` docstring says the original type is preserved in `metadata["provider_type"]`, but the implementation and tests use `metadata["_downgraded_from"]`.

---

*Developed with assistance from Claude Code; all changes reviewed and tested by me.*