### PR TITLE
feat: relocate oversized custom tool descriptions instead of failing the request

### DIFF
--- a/src/llm_rosetta/capabilities.py
+++ b/src/llm_rosetta/capabilities.py
@@ -21,6 +21,8 @@ appropriate pipeline stages.
 
 from __future__ import annotations
 
+import copy
+
 import logging
 from typing import Any
 
@@ -395,9 +397,7 @@ def unwrap_custom_tool_input(raw: str) -> str:
 # Oversized tool description relocation
 # ---------------------------------------------------------------------------
 
-MAX_TOOL_DESCRIPTION_LENGTH = 1024
-
-_POINTER_TEMPLATE = "[Full documentation provided in a system message below.]"
+_POINTER_TEMPLATE = "[Full documentation for '{}' provided separately.]"
 
 
 def relocate_oversized_tool_descriptions(
@@ -445,9 +445,6 @@ def relocate_oversized_tool_descriptions(
     if not oversized:
         return ir_request
 
-    import copy
-    import logging
-
     logger = logging.getLogger(__name__)
 
     tools = copy.deepcopy(tools)
@@ -455,7 +452,7 @@ def relocate_oversized_tool_descriptions(
 
     sections: list[str] = []
     for idx, name, full_desc in oversized:
-        tools[idx]["description"] = _POINTER_TEMPLATE
+        tools[idx]["description"] = _POINTER_TEMPLATE.format(name)
         meta = tools[idx].get("metadata") or {}
         meta["_description_relocated"] = True
         tools[idx]["metadata"] = meta

--- a/src/llm_rosetta/capabilities.py
+++ b/src/llm_rosetta/capabilities.py
@@ -389,3 +389,91 @@ def unwrap_custom_tool_input(raw: str) -> str:
         value = parsed["input"]
         return value if isinstance(value, str) else json.dumps(value)
     return raw
+
+
+# ---------------------------------------------------------------------------
+# Oversized tool description relocation
+# ---------------------------------------------------------------------------
+
+MAX_TOOL_DESCRIPTION_LENGTH = 1024
+
+_POINTER_TEMPLATE = "[Full documentation provided in a system message below.]"
+
+
+def relocate_oversized_tool_descriptions(
+    ir_request: dict[str, Any],
+    *,
+    max_description_length: int | None = None,
+    request_id: str = "-",
+) -> dict[str, Any]:
+    """Move oversized tool descriptions into a late system message.
+
+    When a tool's description exceeds *max_description_length*, the full
+    text is moved into an appended system message and the tool's
+    description is replaced with a short pointer.  The downstream
+    ``hoist_late_system_messages`` transform adapts the system message
+    for each provider automatically.
+
+    No-op when *max_description_length* is ``None`` (provider has no
+    limit) or no tools exceed the threshold.
+
+    Args:
+        ir_request: The IR request dict — **always use the return value**.
+        max_description_length: Maximum allowed description length, or
+            ``None`` to skip relocation entirely.
+        request_id: For logging.
+
+    Returns:
+        The IR request with oversized descriptions relocated, or the
+        original request unchanged.
+    """
+    if max_description_length is None:
+        return ir_request
+
+    tools = ir_request.get("tools")
+    if not tools:
+        return ir_request
+
+    oversized: list[tuple[int, str, str]] = []
+    for i, tool in enumerate(tools):
+        if not isinstance(tool, dict):
+            continue
+        desc = tool.get("description", "")
+        if len(desc) > max_description_length:
+            oversized.append((i, tool.get("name", f"tool_{i}"), desc))
+
+    if not oversized:
+        return ir_request
+
+    import copy
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    tools = copy.deepcopy(tools)
+    ir_request = {**ir_request, "tools": tools}
+
+    sections: list[str] = []
+    for idx, name, full_desc in oversized:
+        tools[idx]["description"] = _POINTER_TEMPLATE
+        meta = tools[idx].get("metadata") or {}
+        meta["_description_relocated"] = True
+        tools[idx]["metadata"] = meta
+        sections.append(f"## Tool: {name}\n\n{full_desc}")
+
+    relocated_text = "\n\n---\n\n".join(sections)
+    system_msg: dict[str, Any] = {
+        "role": "system",
+        "content": [{"type": "text", "text": relocated_text}],
+    }
+
+    messages = list(ir_request.get("messages", []))
+    messages.append(system_msg)
+    ir_request["messages"] = messages
+
+    logger.debug(
+        "[%s] relocated %d oversized tool description(s) to late system message",
+        request_id,
+        len(oversized),
+    )
+    return ir_request

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -691,6 +691,10 @@
         <label data-i18n="label.timeout">Timeout (s)</label>
         <input id="provTimeout" type="number" min="1" step="1" placeholder="">
       </div>
+      <div class="form-group" style="flex:0 0 31%">
+        <label data-i18n="label.maxToolDescLen">Max Tool Desc Length</label>
+        <input id="provMaxToolDescLen" type="number" min="0" step="1" placeholder="">
+      </div>
     </div>
 
     <!-- LLM Endpoint panel -->

--- a/src/llm_rosetta/gateway/admin/js/providers.js
+++ b/src/llm_rosetta/gateway/admin/js/providers.js
@@ -121,6 +121,9 @@ function openProviderModal(name, baseUrl, apiKey, proxy, provType) {
   preflightCb.checked = !!(provCfg && provCfg.preflight_token_count);
   document.getElementById('provTimeout').value = (provCfg && provCfg.timeout != null) ? provCfg.timeout : '';
   document.getElementById('provTimeout').placeholder = (S.configData.server && S.configData.server.upstream_timeout) || 300;
+  const maxToolDescEl = document.getElementById('provMaxToolDescLen');
+  maxToolDescEl.value = (provCfg && provCfg.max_tool_description_length != null) ? provCfg.max_tool_description_length : '';
+  maxToolDescEl.placeholder = (shimMap[provType] && shimMap[provType].max_tool_description_length) || '';
   document.getElementById('provModelsPath').value = (provCfg && provCfg.models_path) || '';
   setLogoPickerValue((provCfg && provCfg.logo) || '');
   if (window._detectedHostIp) document.getElementById('provProxy').placeholder = `e.g. http://${window._detectedHostIp}:7890`;
@@ -553,6 +556,8 @@ async function saveProvider() {
   }
   const provTimeoutVal = document.getElementById('provTimeout').value.trim();
   if (provTimeoutVal) body.timeout = parseFloat(provTimeoutVal);
+  const maxToolDescVal = document.getElementById('provMaxToolDescLen').value.trim();
+  body.max_tool_description_length = maxToolDescVal ? parseInt(maxToolDescVal, 10) : '';
   body.models_path = document.getElementById('provModelsPath').value.trim();
   body.logo = getLogoPickerValue();
   // When api_key is empty and we're editing, omit it so backend keeps the original

--- a/src/llm_rosetta/gateway/admin/js/providers.js
+++ b/src/llm_rosetta/gateway/admin/js/providers.js
@@ -557,7 +557,7 @@ async function saveProvider() {
   const provTimeoutVal = document.getElementById('provTimeout').value.trim();
   if (provTimeoutVal) body.timeout = parseFloat(provTimeoutVal);
   const maxToolDescVal = document.getElementById('provMaxToolDescLen').value.trim();
-  body.max_tool_description_length = maxToolDescVal ? parseInt(maxToolDescVal, 10) : '';
+  body.max_tool_description_length = maxToolDescVal !== '' ? parseInt(maxToolDescVal, 10) : '';
   body.models_path = document.getElementById('provModelsPath').value.trim();
   body.logo = getLogoPickerValue();
   // When api_key is empty and we're editing, omit it so backend keeps the original

--- a/src/llm_rosetta/gateway/admin/routes/_shared.py
+++ b/src/llm_rosetta/gateway/admin/routes/_shared.py
@@ -119,6 +119,16 @@ def _sync_auth_middleware(app: Any, config: GatewayConfig) -> None:
             auth_state.change_password(config.admin_password or "")
 
 
+def _apply_optional_int(entry: dict[str, Any], body: dict[str, Any], key: str) -> None:
+    """Set or clear an optional integer field on a provider entry."""
+    if key in body:
+        val = body[key]
+        if val not in (None, ""):
+            entry[key] = int(val)
+        else:
+            entry.pop(key, None)
+
+
 def _build_provider_entry(
     body: dict[str, Any],
     api_key: str,
@@ -160,6 +170,7 @@ def _build_provider_entry(
             entry[flag] = bool(body[flag])
     if "timeout" in body and body["timeout"] not in (None, ""):
         entry["timeout"] = float(body["timeout"])
+    _apply_optional_int(entry, body, "max_tool_description_length")
 
     # Optional provider-level fields: set when truthy, clear when
     # explicitly sent as empty (so the admin UI can remove them).

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -182,6 +182,7 @@ async def get_config(request: Any) -> Response:
                     "default_api_key_env": s.default_api_key_env,
                     "supports_custom_tools": s.supports_custom_tools,
                     "hoist_system_messages": s.hoist_system_messages,
+                    "max_tool_description_length": s.max_tool_description_length,
                 }
                 for s in list_shims()
             ],

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -781,10 +781,13 @@ class GatewayConfig:
         )
         preflight = self.provider_preflight_token_count.get(provider_name, False)
 
+        _mtdl_model = self.model_max_tool_description_length.get(model)
+        _mtdl_prov = self.provider_max_tool_description_length.get(provider_name)
+        _mtdl_shim = _shim.max_tool_description_length if _shim else None
         max_tool_desc = (
-            self.model_max_tool_description_length.get(model)
-            or self.provider_max_tool_description_length.get(provider_name)
-            or (_shim.max_tool_description_length if _shim else None)
+            _mtdl_model
+            if _mtdl_model is not None
+            else (_mtdl_prov if _mtdl_prov is not None else _mtdl_shim)
         )
 
         route = ResolvedRoute(

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -291,6 +291,10 @@ class GatewayConfig:
             self._parse_preflight_token_count_overrides(self._raw_providers)
         )
 
+        self.provider_max_tool_description_length = (
+            self._parse_max_tool_description_length_overrides(self._raw_providers)
+        )
+
         self.models, self.model_capabilities, self.model_upstream_names = (
             self._parse_models(raw.get("models", {}), self._raw_providers)
         )
@@ -302,6 +306,7 @@ class GatewayConfig:
             self.model_reasoning_overrides,
             self.model_flatten_system,
             self.model_timeouts,
+            self.model_max_tool_description_length,
         ) = self._parse_model_overrides(raw_models)
 
         _server = raw.get("server", {})
@@ -455,6 +460,19 @@ class GatewayConfig:
         return result
 
     @staticmethod
+    def _parse_max_tool_description_length_overrides(
+        raw_providers: dict[str, dict[str, str]],
+    ) -> dict[str, int]:
+        """Extract per-provider max_tool_description_length overrides."""
+        result: dict[str, int] = {}
+        for pname, pcfg in raw_providers.items():
+            if isinstance(pcfg, dict) and "max_tool_description_length" in pcfg:
+                val = pcfg["max_tool_description_length"]
+                if val is not None:
+                    result[pname] = int(val)
+        return result
+
+    @staticmethod
     def _parse_model_overrides(
         raw_models: dict[str, Any],
     ) -> tuple[
@@ -463,13 +481,15 @@ class GatewayConfig:
         dict[str, dict[str, Any]],
         dict[str, bool],
         dict[str, float],
+        dict[str, int],
     ]:
-        """Extract per-model URL templates, reasoning overrides, flatten_system, and timeouts."""
+        """Extract per-model URL templates, reasoning overrides, flatten_system, timeouts, and max_tool_description_length."""
         url_templates: dict[str, str] = {}
         stream_url_templates: dict[str, str] = {}
         reasoning_overrides: dict[str, dict[str, Any]] = {}
         flatten_system: dict[str, bool] = {}
         timeouts: dict[str, float] = {}
+        max_tool_desc_lengths: dict[str, int] = {}
         for model_name, value in raw_models.items():
             if isinstance(value, dict):
                 if "url_template" in value:
@@ -482,6 +502,13 @@ class GatewayConfig:
                     flatten_system[model_name] = bool(value["flatten_system"])
                 if "timeout" in value:
                     timeouts[model_name] = float(value["timeout"])
+                if (
+                    "max_tool_description_length" in value
+                    and value["max_tool_description_length"] is not None
+                ):
+                    max_tool_desc_lengths[model_name] = int(
+                        value["max_tool_description_length"]
+                    )
             if model_name not in flatten_system and re.search(
                 r"gemini", model_name, re.IGNORECASE
             ):
@@ -492,6 +519,7 @@ class GatewayConfig:
             reasoning_overrides,
             flatten_system,
             timeouts,
+            max_tool_desc_lengths,
         )
 
     def _apply_server_settings(self, _server: dict[str, Any]) -> None:
@@ -753,6 +781,12 @@ class GatewayConfig:
         )
         preflight = self.provider_preflight_token_count.get(provider_name, False)
 
+        max_tool_desc = (
+            self.model_max_tool_description_length.get(model)
+            or self.provider_max_tool_description_length.get(provider_name)
+            or (_shim.max_tool_description_length if _shim else None)
+        )
+
         route = ResolvedRoute(
             source_provider=source_provider,
             target_provider=cast(ProviderType, provider_type),
@@ -765,6 +799,7 @@ class GatewayConfig:
             supports_custom_tools=custom_tools,
             hoist_system_messages=hoist_system,
             preflight_token_count=preflight,
+            max_tool_description_length=max_tool_desc,
         )
 
         pinfo = self.providers[provider_name]

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -332,6 +332,7 @@ async def handle_non_streaming(
         model_capabilities=route.model_capabilities,
         reasoning_config_override=route.reasoning_override,
         supports_custom_tools=route.supports_custom_tools,
+        max_tool_description_length=route.max_tool_description_length,
         hoist_system_messages=route.hoist_system_messages,
     )
 
@@ -805,6 +806,7 @@ async def handle_streaming(
         model_capabilities=route.model_capabilities,
         reasoning_config_override=route.reasoning_override,
         supports_custom_tools=route.supports_custom_tools,
+        max_tool_description_length=route.max_tool_description_length,
         hoist_system_messages=route.hoist_system_messages,
     )
 

--- a/src/llm_rosetta/pipeline.py
+++ b/src/llm_rosetta/pipeline.py
@@ -29,6 +29,7 @@ from typing import Any, Literal, Protocol, runtime_checkable
 
 from llm_rosetta.capabilities import (
     enforce_custom_tools,
+    relocate_oversized_tool_descriptions,
     enforce_reasoning,
     enforce_vision,
     get_custom_tool_names,
@@ -238,6 +239,7 @@ class ConversionPipeline:
         model_capabilities: list[str] | None = None,
         reasoning_config_override: dict[str, Any] | None = None,
         supports_custom_tools: bool | None = None,
+        max_tool_description_length: int | None = None,
         hoist_system_messages: bool = True,
         force_conversion: bool = True,
         fidelity_mode: Literal["critical", "full"] | None = None,
@@ -267,6 +269,7 @@ class ConversionPipeline:
         self._model_capabilities = model_capabilities
         self._reasoning_config_override = reasoning_config_override
         self._supports_custom_tools = supports_custom_tools
+        self._max_tool_description_length = max_tool_description_length
         self._hoist_system_messages = hoist_system_messages
         self._metadata_mode = metadata_mode
         self._google_output_format = google_output_format
@@ -531,6 +534,13 @@ class ConversionPipeline:
             ir_request,
             shim=self._target_shim,
             config_override=self._supports_custom_tools,
+        )
+
+        # Capability enforcement: oversized tool descriptions (post-custom-tools)
+        ir_request = relocate_oversized_tool_descriptions(
+            ir_request,
+            max_description_length=self._max_tool_description_length,
+            request_id=request_id,
         )
 
         # Phase 2a: Shim-driven IR transforms

--- a/src/llm_rosetta/routing.py
+++ b/src/llm_rosetta/routing.py
@@ -56,6 +56,7 @@ class ResolvedRoute:
     supports_custom_tools: bool = False
     hoist_system_messages: bool = True
     preflight_token_count: bool = False
+    max_tool_description_length: int | None = None
 
 
 class Router(Protocol):

--- a/src/llm_rosetta/shims/provider_shim.py
+++ b/src/llm_rosetta/shims/provider_shim.py
@@ -171,6 +171,7 @@ class ProviderShim:
     response_id_prefix: str = ""
     supports_custom_tools: bool = False
     hoist_system_messages: bool = True
+    max_tool_description_length: int | None = None
     multimodal_tool_result: bool | None = None
     tool_search_mode: ToolSearchMode = "disabled"
 
@@ -220,6 +221,7 @@ class ProviderShim:
             "response_id_prefix": "",
             "supports_custom_tools": False,
             "hoist_system_messages": True,
+            "max_tool_description_length": None,
             "multimodal_tool_result": None,
             "tool_search_mode": "disabled",
         }

--- a/src/llm_rosetta/shims/providers/argo/openai_chat/provider.yaml
+++ b/src/llm_rosetta/shims/providers/argo/openai_chat/provider.yaml
@@ -8,3 +8,4 @@ reasoning:
   # effort_range not set = full IR ladder (minimal–max)
 
 supports_custom_tools: true
+max_tool_description_length: 1024

--- a/src/llm_rosetta/shims/providers/openai/provider.yaml
+++ b/src/llm_rosetta/shims/providers/openai/provider.yaml
@@ -13,3 +13,4 @@ reasoning:
     detailed: detailed
 
 supports_custom_tools: true
+max_tool_description_length: 1024

--- a/tests/test_tool_description_relocation.py
+++ b/tests/test_tool_description_relocation.py
@@ -1,0 +1,136 @@
+"""Tests for oversized tool description relocation."""
+
+from llm_rosetta.capabilities import (
+    MAX_TOOL_DESCRIPTION_LENGTH,
+    relocate_oversized_tool_descriptions,
+)
+
+
+class TestRelocateOversizedToolDescriptions:
+    def _make_ir(self, tools, messages=None):
+        return {
+            "tools": tools,
+            "messages": messages
+            or [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        }
+
+    def _make_tool(self, name="t", desc="short"):
+        return {"name": name, "description": desc, "type": "function", "parameters": {}}
+
+    def test_none_threshold_is_noop(self):
+        ir = self._make_ir([self._make_tool(desc="x" * 5000)])
+        result = relocate_oversized_tool_descriptions(ir, max_description_length=None)
+        assert result is ir
+
+    def test_no_tools_is_noop(self):
+        ir = {"messages": [{"role": "user", "content": "hi"}]}
+        result = relocate_oversized_tool_descriptions(ir, max_description_length=1024)
+        assert result is ir
+
+    def test_short_description_unchanged(self):
+        ir = self._make_ir([self._make_tool(desc="short")])
+        result = relocate_oversized_tool_descriptions(ir, max_description_length=1024)
+        assert result["tools"][0]["description"] == "short"
+        assert len(result["messages"]) == 1
+
+    def test_long_description_relocated(self):
+        long_desc = "A" * 2000
+        ir = self._make_ir([self._make_tool(name="my_tool", desc=long_desc)])
+        result = relocate_oversized_tool_descriptions(ir, max_description_length=1024)
+
+        assert (
+            result["tools"][0]["description"]
+            == "[Full documentation provided in a system message below.]"
+        )
+        assert result["tools"][0]["metadata"]["_description_relocated"] is True
+        assert len(result["messages"]) == 2
+        sys_msg = result["messages"][-1]
+        assert sys_msg["role"] == "system"
+        text = sys_msg["content"][0]["text"]
+        assert "## Tool: my_tool" in text
+        assert long_desc in text
+
+    def test_multiple_oversized_consolidated(self):
+        ir = self._make_ir(
+            [
+                self._make_tool(name="tool_a", desc="A" * 2000),
+                self._make_tool(name="tool_b", desc="short"),
+                self._make_tool(name="tool_c", desc="C" * 3000),
+            ]
+        )
+        result = relocate_oversized_tool_descriptions(ir, max_description_length=1024)
+
+        assert (
+            result["tools"][0]["description"]
+            == "[Full documentation provided in a system message below.]"
+        )
+        assert result["tools"][1]["description"] == "short"
+        assert (
+            result["tools"][2]["description"]
+            == "[Full documentation provided in a system message below.]"
+        )
+        assert len(result["messages"]) == 2
+        sys_text = result["messages"][-1]["content"][0]["text"]
+        assert "## Tool: tool_a" in sys_text
+        assert "## Tool: tool_c" in sys_text
+        assert "---" in sys_text
+
+    def test_original_not_mutated(self):
+        orig_desc = "X" * 2000
+        tool = self._make_tool(desc=orig_desc)
+        ir = self._make_ir([tool])
+        _ = relocate_oversized_tool_descriptions(ir, max_description_length=1024)
+        assert tool["description"] == orig_desc
+        assert "metadata" not in tool
+
+    def test_exactly_at_threshold_not_relocated(self):
+        ir = self._make_ir([self._make_tool(desc="A" * 1024)])
+        result = relocate_oversized_tool_descriptions(ir, max_description_length=1024)
+        assert result["tools"][0]["description"] == "A" * 1024
+        assert len(result["messages"]) == 1
+
+    def test_custom_threshold(self):
+        ir = self._make_ir([self._make_tool(desc="A" * 100)])
+        result = relocate_oversized_tool_descriptions(ir, max_description_length=50)
+        assert (
+            result["tools"][0]["description"]
+            == "[Full documentation provided in a system message below.]"
+        )
+
+    def test_default_constant(self):
+        assert MAX_TOOL_DESCRIPTION_LENGTH == 1024
+
+
+class TestRelocationWithPipeline:
+    def test_relocation_before_hoist(self):
+        from llm_rosetta.converters.base.helpers.system_message_hoist import (
+            hoist_late_system_messages_ir,
+        )
+
+        long_desc = "D" * 2000
+        ir = {
+            "tools": [
+                {
+                    "name": "big_tool",
+                    "description": long_desc,
+                    "type": "function",
+                    "parameters": {},
+                }
+            ],
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+                {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+                {"role": "user", "content": [{"type": "text", "text": "use tool"}]},
+            ],
+        }
+
+        relocated = relocate_oversized_tool_descriptions(
+            ir, max_description_length=1024
+        )
+        assert relocated["messages"][-1]["role"] == "system"
+
+        hoisted = hoist_late_system_messages_ir(relocated)
+        last_msg = hoisted["messages"][-1]
+        assert last_msg["role"] == "user"
+        assert "<system>" in last_msg["content"][0]["text"]
+        assert long_desc in last_msg["content"][0]["text"]

--- a/tests/test_tool_description_relocation.py
+++ b/tests/test_tool_description_relocation.py
@@ -1,7 +1,6 @@
 """Tests for oversized tool description relocation."""
 
 from llm_rosetta.capabilities import (
-    MAX_TOOL_DESCRIPTION_LENGTH,
     relocate_oversized_tool_descriptions,
 )
 
@@ -40,7 +39,7 @@ class TestRelocateOversizedToolDescriptions:
 
         assert (
             result["tools"][0]["description"]
-            == "[Full documentation provided in a system message below.]"
+            == "[Full documentation for 'my_tool' provided separately.]"
         )
         assert result["tools"][0]["metadata"]["_description_relocated"] is True
         assert len(result["messages"]) == 2
@@ -62,12 +61,12 @@ class TestRelocateOversizedToolDescriptions:
 
         assert (
             result["tools"][0]["description"]
-            == "[Full documentation provided in a system message below.]"
+            == "[Full documentation for 'tool_a' provided separately.]"
         )
         assert result["tools"][1]["description"] == "short"
         assert (
             result["tools"][2]["description"]
-            == "[Full documentation provided in a system message below.]"
+            == "[Full documentation for 'tool_c' provided separately.]"
         )
         assert len(result["messages"]) == 2
         sys_text = result["messages"][-1]["content"][0]["text"]
@@ -94,11 +93,8 @@ class TestRelocateOversizedToolDescriptions:
         result = relocate_oversized_tool_descriptions(ir, max_description_length=50)
         assert (
             result["tools"][0]["description"]
-            == "[Full documentation provided in a system message below.]"
+            == "[Full documentation for 't' provided separately.]"
         )
-
-    def test_default_constant(self):
-        assert MAX_TOOL_DESCRIPTION_LENGTH == 1024
 
 
 class TestRelocationWithPipeline:


### PR DESCRIPTION
## Summary

- When a tool's description exceeds a configurable threshold, the full text is moved into a late system message and replaced with a short pointer
- The existing `hoist_late_system_messages` pipeline automatically adapts the system message per-provider (OpenAI: native system msg, Anthropic: `<system>` user msg, Google: system_instruction)
- Threshold is configurable at three levels: model config > provider config > shim default
- OpenAI and Argo-OpenAI shims default to 1024 chars; other providers default to None (no relocation)
- Admin panel exposes a numeric "Max Tool Desc Length" field in provider settings

Fixes #625 — prevents upstream 400 errors from oversized custom tool descriptions when downgraded to function tools.

## Pipeline

```
enforce_custom_tools()          ← downgrades custom → function
    ↓
relocate_oversized_tool_descriptions()   ← NEW: moves long descriptions
    ↓
apply_ir_transforms()           ← includes hoist_late_system_messages()
```

## Test plan

- [ ] 10 new tests in `test_tool_description_relocation.py`
- [ ] Full test suite (3093 tests) passes with no regressions
- [ ] E2E: send 14k-char tool desc to OpenAI and Claude models through gateway
- [ ] Admin panel: set/clear `max_tool_description_length` on a provider