### PR TITLE
feat(openai_responses): flatten namespace tool containers into individual IR tools

### DIFF
--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -11,6 +11,7 @@ nested messages. The converter handles this structural difference.
 
 import logging
 import time
+from collections import defaultdict
 from collections.abc import Mapping
 from typing import Any, cast
 
@@ -98,10 +99,16 @@ def _qualify_tool_name(namespace: str, name: str, used_names: set[str]) -> str |
     qualified = f"{namespace}_{name}"
     if len(qualified) > _MAX_TOOL_NAME_LEN:
         max_ns = _MAX_TOOL_NAME_LEN - len(name) - 1
-        qualified = (
-            f"{namespace[:max_ns]}_{name}" if max_ns > 0 else name[:_MAX_TOOL_NAME_LEN]
-        )
-    if qualified in used_names and qualified != name:
+        if max_ns > 0:
+            qualified = f"{namespace[:max_ns]}_{name}"
+        else:
+            logger.warning(
+                "Tool name %r too long to qualify with namespace %r",
+                name,
+                namespace,
+            )
+            return None
+    if qualified in used_names:
         logger.warning("Qualified name %r still collides; keeping %r", qualified, name)
         return None
     return qualified
@@ -542,8 +549,6 @@ class OpenAIResponsesConverter(BaseConverter):
         Returns a new list; renamed entries are shallow-copied to avoid
         mutating cached references.
         """
-        from collections import defaultdict
-
         name_indices: dict[str, list[int]] = defaultdict(list)
         for i, tool in enumerate(ir_tools):
             name_indices[tool["name"]].append(i)

--- a/src/llm_rosetta/converters/openai_responses/converter.py
+++ b/src/llm_rosetta/converters/openai_responses/converter.py
@@ -9,6 +9,7 @@ Note: Responses API uses a flat list of items (input/output) instead of
 nested messages. The converter handles this structural difference.
 """
 
+import logging
 import time
 from collections.abc import Mapping
 from typing import Any, cast
@@ -85,6 +86,25 @@ def _capture_item_metadata(item: dict[str, Any]) -> dict[str, Any]:
         if parts_meta:
             meta["content_meta"] = parts_meta
     return meta
+
+
+logger = logging.getLogger(__name__)
+
+_MAX_TOOL_NAME_LEN = 64
+
+
+def _qualify_tool_name(namespace: str, name: str, used_names: set[str]) -> str | None:
+    """Build a qualified ``{namespace}_{name}`` that fits in 64 chars."""
+    qualified = f"{namespace}_{name}"
+    if len(qualified) > _MAX_TOOL_NAME_LEN:
+        max_ns = _MAX_TOOL_NAME_LEN - len(name) - 1
+        qualified = (
+            f"{namespace[:max_ns]}_{name}" if max_ns > 0 else name[:_MAX_TOOL_NAME_LEN]
+        )
+    if qualified in used_names and qualified != name:
+        logger.warning("Qualified name %r still collides; keeping %r", qualified, name)
+        return None
+    return qualified
 
 
 class OpenAIResponsesConverter(BaseConverter):
@@ -263,6 +283,7 @@ class OpenAIResponsesConverter(BaseConverter):
             if active_tools:
                 ir_tools = self._get_cached_p_tools_to_ir(active_tools)
                 if ir_tools:
+                    ir_tools = self._dedup_ir_tool_names(ir_tools)
                     ir_request["tools"] = ir_tools
 
         # 4-5. Tool choice + tool config
@@ -508,6 +529,45 @@ class OpenAIResponsesConverter(BaseConverter):
     # ------------------------------------------------------------------
     # Cross-provider consistency helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _dedup_ir_tool_names(ir_tools: list[Any]) -> list[Any]:
+        """Rename namespaced IR tools whose names collide.
+
+        Tools originating from a namespace container may share names with
+        top-level tools or with tools from a different namespace.  This
+        method qualifies colliding names as ``{namespace}_{name}`` while
+        leaving non-namespaced (top-level) tools unchanged.
+
+        Returns a new list; renamed entries are shallow-copied to avoid
+        mutating cached references.
+        """
+        from collections import defaultdict
+
+        name_indices: dict[str, list[int]] = defaultdict(list)
+        for i, tool in enumerate(ir_tools):
+            name_indices[tool["name"]].append(i)
+
+        result = list(ir_tools)
+        used_names: set[str] = {t["name"] for t in ir_tools}
+
+        for name, indices in name_indices.items():
+            if len(indices) <= 1:
+                continue
+            for i in indices:
+                ns = (ir_tools[i].get("metadata") or {}).get("namespace")
+                if not ns:
+                    continue
+                qualified = _qualify_tool_name(ns, name, used_names)
+                if qualified is None:
+                    continue
+                copy = dict(ir_tools[i])
+                copy["name"] = qualified
+                copy["metadata"] = dict(copy.get("metadata", {}))
+                result[i] = copy
+                used_names.add(qualified)
+
+        return result
 
     @staticmethod
     def _build_p_usage_to_ir(p_usage: dict[str, Any]) -> UsageInfo:

--- a/src/llm_rosetta/converters/openai_responses/tool_ops.py
+++ b/src/llm_rosetta/converters/openai_responses/tool_ops.py
@@ -166,6 +166,76 @@ def _synthesize_passthrough_tool(
     )
 
 
+def _flatten_namespace_tool(
+    provider_tool: dict[str, Any],
+) -> list[ToolDefinition]:
+    """Expand a ``type: "namespace"`` container into individual IR tools.
+
+    Iterates child tools, converts each via ``p_tool_definition_to_ir``,
+    and tags every result with namespace metadata for future round-trip.
+
+    Nested namespaces (namespace inside namespace) are skipped with a
+    warning — no real-world use case exists, and the OpenAI function-name
+    constraint ``^[a-zA-Z0-9_-]+$`` prohibits hierarchical separators.
+    """
+    namespace_name = provider_tool.get("name", "")
+    namespace_desc = provider_tool.get("description", "")
+    children = provider_tool.get("tools", [])
+    if not children:
+        return []
+
+    results: list[ToolDefinition] = []
+    for i, child in enumerate(children):
+        if not isinstance(child, dict):
+            logger.warning(
+                "Skipping non-dict child at index %d in namespace %r",
+                i,
+                namespace_name,
+            )
+            continue
+
+        child_type = child.get("type", "function")
+        if child_type == "namespace":
+            logger.warning(
+                "Skipping nested namespace %r inside %r — "
+                "only one level of nesting is supported",
+                child.get("name", ""),
+                namespace_name,
+            )
+            continue
+
+        child_name = child.get("name") or (
+            child.get("function", {}).get("name")
+            if isinstance(child.get("function"), dict)
+            else None
+        )
+        if not child_name:
+            logger.warning(
+                "Skipping unnamed child at index %d in namespace %r",
+                i,
+                namespace_name,
+            )
+            continue
+
+        converted = OpenAIResponsesToolOps.p_tool_definition_to_ir(child)
+        if converted is None:
+            continue
+
+        items = converted if isinstance(converted, list) else [converted]
+        for item in items:
+            meta = dict(item.get("metadata", {}))
+            meta["namespace"] = namespace_name
+            if namespace_desc:
+                meta["namespace_description"] = namespace_desc
+            if child.get("defer_loading"):
+                meta["defer_loading"] = True
+            item_copy = dict(item)
+            item_copy["metadata"] = meta
+            results.append(cast(ToolDefinition, item_copy))
+
+    return results
+
+
 def _build_function_call_item(
     ir_tool_call: ToolCallPart,
     tool_call_id: str,
@@ -256,12 +326,16 @@ class OpenAIResponsesToolOps(BaseToolOps):
         return result
 
     @staticmethod
-    def p_tool_definition_to_ir(provider_tool: Any, **kwargs: Any) -> ToolDefinition:
+    def p_tool_definition_to_ir(
+        provider_tool: Any, **kwargs: Any
+    ) -> ToolDefinition | list[ToolDefinition]:
         """OpenAI Responses tool definition → IR ToolDefinition.
 
         Handles both flat format (Responses API native) and nested format
-        (with ``function`` key).  Non-function tool types without a ``name``
-        field (e.g. ``web_search``) are stored as passthrough so they can be
+        (with ``function`` key).  ``type: "namespace"`` containers are
+        expanded into individual child tools via ``_flatten_namespace_tool``.
+        Non-function tool types without a ``name`` field (e.g.
+        ``web_search``) are stored as passthrough so they can be
         round-tripped without modification.  Named non-function tools (e.g.
         Codex ``"custom"`` ``apply_patch``) are downgraded to IR
         ``type: "function"`` so the request passes IR validation; this
@@ -273,7 +347,8 @@ class OpenAIResponsesToolOps(BaseToolOps):
             provider_tool: OpenAI Responses tool definition dict.
 
         Returns:
-            IR ToolDefinition.
+            IR ToolDefinition, or list of ToolDefinitions for namespace
+            containers.
         """
         _IR_ALLOWED_TYPES = {"function", "mcp", "custom"}
 
@@ -288,6 +363,8 @@ class OpenAIResponsesToolOps(BaseToolOps):
             }
         else:
             tool_type = provider_tool.get("type", "function")
+            if tool_type == "namespace":
+                return _flatten_namespace_tool(provider_tool)
             # Non-function tools outside the IR type set (e.g. web_search or
             # Codex custom apply_patch) are stored as passthrough to avoid
             # lossy conversion. IR ``type`` is forced to "function" to

--- a/src/llm_rosetta/tool_ops.py
+++ b/src/llm_rosetta/tool_ops.py
@@ -164,7 +164,9 @@ def from_openai_chat(provider_tool: Any, **kwargs: Any) -> ToolDefinition | None
     return OpenAIChatToolOps.p_tool_definition_to_ir(provider_tool, **kwargs)
 
 
-def from_openai_responses(provider_tool: Any, **kwargs: Any) -> ToolDefinition | None:
+def from_openai_responses(
+    provider_tool: Any, **kwargs: Any
+) -> ToolDefinition | list[ToolDefinition] | None:
     """Convert OpenAI Responses tool definition to IR format."""
     from .converters.openai_responses import OpenAIResponsesToolOps
 

--- a/tests/converters/openai_chat/test_custom_tool_grammar.py
+++ b/tests/converters/openai_chat/test_custom_tool_grammar.py
@@ -47,6 +47,7 @@ class TestCustomToolGrammarShape:
     def test_responses_flat_format_becomes_nested_for_chat(self):
         """Responses → IR → Chat nests syntax/definition under ``grammar``."""
         ir_tool = OpenAIResponsesToolOps.p_tool_definition_to_ir(RESPONSES_CUSTOM_TOOL)
+        assert isinstance(ir_tool, dict)
         chat_tool = OpenAIChatToolOps.ir_tool_definition_to_p(ir_tool)
 
         fmt = chat_tool["custom"]["format"]
@@ -82,8 +83,10 @@ class TestCustomToolGrammarShape:
     def test_responses_round_trip_is_stable(self):
         """Responses → IR → Chat → IR → Responses preserves the flat shape."""
         ir_a = OpenAIResponsesToolOps.p_tool_definition_to_ir(RESPONSES_CUSTOM_TOOL)
+        assert isinstance(ir_a, dict)
         chat_tool = OpenAIChatToolOps.ir_tool_definition_to_p(ir_a)
         ir_b = OpenAIChatToolOps.p_tool_definition_to_ir(chat_tool)
+        assert isinstance(ir_b, dict)
         responses_tool = OpenAIResponsesToolOps.ir_tool_definition_to_p(ir_b)
 
         assert responses_tool["format"] == RESPONSES_CUSTOM_TOOL["format"]
@@ -92,6 +95,7 @@ class TestCustomToolGrammarShape:
         """Non-grammar formats pass through both directions unchanged."""
         tool = dict(RESPONSES_CUSTOM_TOOL, format={"type": "text"})
         ir_tool = OpenAIResponsesToolOps.p_tool_definition_to_ir(tool)
+        assert isinstance(ir_tool, dict)
         chat_tool = OpenAIChatToolOps.ir_tool_definition_to_p(ir_tool)
 
         assert chat_tool["custom"]["format"] == {"type": "text"}
@@ -100,6 +104,7 @@ class TestCustomToolGrammarShape:
         """A custom tool with no ``format`` gains none."""
         tool = {k: v for k, v in RESPONSES_CUSTOM_TOOL.items() if k != "format"}
         ir_tool = OpenAIResponsesToolOps.p_tool_definition_to_ir(tool)
+        assert isinstance(ir_tool, dict)
         chat_tool = OpenAIChatToolOps.ir_tool_definition_to_p(ir_tool)
 
         assert "format" not in chat_tool["custom"]

--- a/tests/converters/openai_responses/test_namespace_tools.py
+++ b/tests/converters/openai_responses/test_namespace_tools.py
@@ -304,6 +304,17 @@ class TestDedupIrToolNames:
         ]
         result = OpenAIResponsesConverter._dedup_ir_tool_names(tools)
         assert len(result[1]["name"]) <= 64
+        assert result[0]["name"] != result[1]["name"]
+
+    def test_very_long_name_skips_qualify(self):
+        long_name = "x" * 64
+        tools = [
+            self._ir_tool(long_name),
+            self._ir_tool(long_name, "ns"),
+        ]
+        result = OpenAIResponsesConverter._dedup_ir_tool_names(tools)
+        # Name too long to qualify — namespaced tool keeps original name
+        assert result[1]["name"] == long_name
 
     def test_single_tool_no_dedup(self):
         tools = [self._ir_tool("only_one", "ns")]

--- a/tests/converters/openai_responses/test_namespace_tools.py
+++ b/tests/converters/openai_responses/test_namespace_tools.py
@@ -1,0 +1,485 @@
+"""Tests for namespace tool flattening in OpenAI Responses converter."""
+
+from typing import Any
+
+from llm_rosetta.converters.openai_responses.converter import (
+    OpenAIResponsesConverter,
+)
+from llm_rosetta.converters.openai_responses.tool_ops import (
+    OpenAIResponsesToolOps,
+    _flatten_namespace_tool,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ns_tool(
+    name: str = "functions",
+    description: str = "",
+    children: list[Any] | None = None,
+) -> dict[str, Any]:
+    tool: dict[str, Any] = {"type": "namespace", "name": name}
+    if description:
+        tool["description"] = description
+    if children is not None:
+        tool["tools"] = children
+    else:
+        tool["tools"] = []
+    return tool
+
+
+def _func_tool(
+    name: str, description: str = "", params: dict | None = None, **extra: Any
+) -> dict[str, Any]:
+    tool: dict[str, Any] = {
+        "type": "function",
+        "name": name,
+        "description": description,
+        "parameters": params or {},
+    }
+    tool.update(extra)
+    return tool
+
+
+def _custom_tool(name: str, description: str = "") -> dict[str, Any]:
+    return {"type": "custom", "name": name, "description": description}
+
+
+# ===========================================================================
+# _flatten_namespace_tool unit tests
+# ===========================================================================
+
+
+class TestFlattenNamespaceTool:
+    """Unit tests for the _flatten_namespace_tool helper."""
+
+    def test_basic_flatten_two_functions(self):
+        ns = _ns_tool(
+            "functions",
+            children=[
+                _func_tool(
+                    "exec", "Run a command", {"type": "object", "properties": {}}
+                ),
+                _func_tool("wait", "Wait for a process"),
+            ],
+        )
+        result = _flatten_namespace_tool(ns)
+        assert len(result) == 2
+        assert result[0]["name"] == "exec"
+        assert result[1]["name"] == "wait"
+        assert result[0]["metadata"]["namespace"] == "functions"
+        assert result[1]["metadata"]["namespace"] == "functions"
+
+    def test_namespace_description_preserved(self):
+        ns = _ns_tool(
+            "crm",
+            description="CRM tools for customer lookup",
+            children=[
+                _func_tool("get_customer"),
+            ],
+        )
+        result = _flatten_namespace_tool(ns)
+        assert len(result) == 1
+        assert result[0]["metadata"]["namespace"] == "crm"
+        assert (
+            result[0]["metadata"]["namespace_description"]
+            == "CRM tools for customer lookup"
+        )
+
+    def test_no_namespace_description_omitted(self):
+        ns = _ns_tool("tools", children=[_func_tool("ping")])
+        result = _flatten_namespace_tool(ns)
+        assert "namespace_description" not in result[0]["metadata"]
+
+    def test_mixed_function_and_custom(self):
+        ns = _ns_tool(
+            "tools",
+            children=[
+                _func_tool("exec", "Run cmd"),
+                _custom_tool("apply_patch", "Apply a patch"),
+            ],
+        )
+        result = _flatten_namespace_tool(ns)
+        assert len(result) == 2
+        names = {r["name"] for r in result}
+        assert names == {"exec", "apply_patch"}
+
+    def test_empty_namespace(self):
+        ns = _ns_tool("empty", children=[])
+        result = _flatten_namespace_tool(ns)
+        assert result == []
+
+    def test_no_tools_key(self):
+        ns = {"type": "namespace", "name": "bare"}
+        result = _flatten_namespace_tool(ns)
+        assert result == []
+
+    def test_nested_namespace_skipped(self):
+        ns = _ns_tool(
+            "outer",
+            children=[
+                _func_tool("ok_tool"),
+                _ns_tool("inner", children=[_func_tool("hidden")]),
+            ],
+        )
+        result = _flatten_namespace_tool(ns)
+        assert len(result) == 1
+        assert result[0]["name"] == "ok_tool"
+
+    def test_non_dict_child_skipped(self):
+        ns = _ns_tool(
+            "ns",
+            children=[
+                _func_tool("real"),
+                "not a dict",
+                42,
+            ],
+        )
+        result = _flatten_namespace_tool(ns)
+        assert len(result) == 1
+        assert result[0]["name"] == "real"
+
+    def test_unnamed_child_skipped(self):
+        ns = _ns_tool(
+            "ns",
+            children=[
+                {"type": "function", "description": "no name"},
+                _func_tool("named"),
+            ],
+        )
+        result = _flatten_namespace_tool(ns)
+        assert len(result) == 1
+        assert result[0]["name"] == "named"
+
+    def test_defer_loading_preserved(self):
+        ns = _ns_tool(
+            "crm",
+            children=[
+                _func_tool("get_orders", defer_loading=True),
+                _func_tool("get_profile"),
+            ],
+        )
+        result = _flatten_namespace_tool(ns)
+        assert result[0]["metadata"].get("defer_loading") is True
+        assert "defer_loading" not in result[1]["metadata"]
+
+    def test_passthrough_child_type(self):
+        """Unknown child type goes through _synthesize_passthrough_tool."""
+        ns = _ns_tool(
+            "ns",
+            children=[
+                {"type": "web_search", "name": "search"},
+            ],
+        )
+        result = _flatten_namespace_tool(ns)
+        assert len(result) == 1
+        assert result[0]["metadata"]["namespace"] == "ns"
+        assert result[0]["metadata"].get("provider_type") == "web_search"
+
+    def test_nested_format_child(self):
+        """Child in nested format: {"type": "function", "function": {...}}."""
+        ns = _ns_tool(
+            "ns",
+            children=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "nested_func",
+                        "description": "A nested function",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                },
+            ],
+        )
+        result = _flatten_namespace_tool(ns)
+        assert len(result) == 1
+        assert result[0]["name"] == "nested_func"
+        assert result[0]["metadata"]["namespace"] == "ns"
+
+    def test_metadata_does_not_mutate_original(self):
+        child = _func_tool("tool1")
+        ns = _ns_tool("ns", children=[child])
+        _flatten_namespace_tool(ns)
+        # Original child should not have namespace metadata
+        ir_direct = OpenAIResponsesToolOps.p_tool_definition_to_ir(child)
+        assert isinstance(ir_direct, dict)
+        assert "namespace" not in (ir_direct.get("metadata") or {})
+
+
+# ===========================================================================
+# p_tool_definition_to_ir dispatch tests
+# ===========================================================================
+
+
+class TestNamespaceDispatch:
+    """Test that p_tool_definition_to_ir dispatches namespace correctly."""
+
+    def test_namespace_returns_list(self):
+        ns = _ns_tool(
+            "funcs",
+            children=[
+                _func_tool("a"),
+                _func_tool("b"),
+            ],
+        )
+        result = OpenAIResponsesToolOps.p_tool_definition_to_ir(ns)
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_regular_function_returns_single(self):
+        result = OpenAIResponsesToolOps.p_tool_definition_to_ir(_func_tool("regular"))
+        assert isinstance(result, dict)
+        assert result["name"] == "regular"
+
+    def test_empty_namespace_returns_empty_list(self):
+        result = OpenAIResponsesToolOps.p_tool_definition_to_ir(
+            _ns_tool("empty", children=[])
+        )
+        assert result == []
+
+
+# ===========================================================================
+# _dedup_ir_tool_names tests
+# ===========================================================================
+
+
+class TestDedupIrToolNames:
+    """Tests for the converter-level name dedup method."""
+
+    @staticmethod
+    def _ir_tool(name: str, ns: str = "") -> dict[str, Any]:
+        meta: dict[str, Any] = {}
+        if ns:
+            meta["namespace"] = ns
+        return {
+            "type": "function",
+            "name": name,
+            "description": "",
+            "parameters": {},
+            "metadata": meta,
+        }
+
+    def test_no_collision_unchanged(self):
+        tools = [self._ir_tool("a"), self._ir_tool("b", "ns")]
+        result = OpenAIResponsesConverter._dedup_ir_tool_names(tools)
+        assert [t["name"] for t in result] == ["a", "b"]
+
+    def test_namespaced_vs_toplevel_collision(self):
+        tools = [
+            self._ir_tool("exec"),  # top-level, no namespace
+            self._ir_tool("exec", "functions"),  # from namespace
+        ]
+        result = OpenAIResponsesConverter._dedup_ir_tool_names(tools)
+        assert result[0]["name"] == "exec"
+        assert result[1]["name"] == "functions_exec"
+
+    def test_cross_namespace_collision(self):
+        tools = [
+            self._ir_tool("exec", "ns_a"),
+            self._ir_tool("exec", "ns_b"),
+        ]
+        result = OpenAIResponsesConverter._dedup_ir_tool_names(tools)
+        names = {t["name"] for t in result}
+        assert "ns_a_exec" in names
+        assert "ns_b_exec" in names
+
+    def test_no_mutation_of_originals(self):
+        original = self._ir_tool("exec", "ns")
+        tools = [self._ir_tool("exec"), original]
+        result = OpenAIResponsesConverter._dedup_ir_tool_names(tools)
+        # Original dict should be unchanged
+        assert original["name"] == "exec"
+        # Result entry is a copy
+        assert result[1]["name"] == "ns_exec"
+        assert result[1] is not original
+
+    def test_long_qualified_name_truncated(self):
+        long_ns = "a" * 60
+        tools = [
+            self._ir_tool("tool"),
+            self._ir_tool("tool", long_ns),
+        ]
+        result = OpenAIResponsesConverter._dedup_ir_tool_names(tools)
+        assert len(result[1]["name"]) <= 64
+
+    def test_single_tool_no_dedup(self):
+        tools = [self._ir_tool("only_one", "ns")]
+        result = OpenAIResponsesConverter._dedup_ir_tool_names(tools)
+        assert result[0]["name"] == "only_one"
+
+
+# ===========================================================================
+# Full request conversion integration tests
+# ===========================================================================
+
+
+class TestNamespaceRequestConversion:
+    """Integration tests for namespace tools through the full converter."""
+
+    def setup_method(self):
+        self.converter = OpenAIResponsesConverter()
+
+    def test_namespace_in_tools_array(self):
+        request = {
+            "model": "gpt-5",
+            "tools": [
+                _func_tool("top_level", "A top-level function"),
+                _ns_tool(
+                    "functions",
+                    children=[
+                        _func_tool(
+                            "exec",
+                            "Run a command",
+                            {
+                                "type": "object",
+                                "properties": {"cmd": {"type": "string"}},
+                                "required": ["cmd"],
+                            },
+                        ),
+                        _func_tool("wait", "Wait for process"),
+                    ],
+                ),
+            ],
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "list files"}],
+                },
+            ],
+        }
+        ir = self.converter.request_from_provider(request)
+        tool_names = {t["name"] for t in ir["tools"]}
+        assert "top_level" in tool_names
+        assert "exec" in tool_names
+        assert "wait" in tool_names
+        assert len(ir["tools"]) == 3
+
+    def test_namespace_collision_with_toplevel(self):
+        request = {
+            "model": "gpt-5",
+            "tools": [
+                _func_tool("exec", "Top-level exec"),
+                _ns_tool(
+                    "functions",
+                    children=[
+                        _func_tool("exec", "Namespace exec"),
+                    ],
+                ),
+            ],
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hi"}],
+                },
+            ],
+        }
+        ir = self.converter.request_from_provider(request)
+        tool_names = [t["name"] for t in ir["tools"]]
+        assert "exec" in tool_names
+        assert "functions_exec" in tool_names
+        assert len(ir["tools"]) == 2
+
+    def test_namespace_tools_params_preserved(self):
+        params = {
+            "type": "object",
+            "properties": {"cmd": {"type": "string"}},
+            "required": ["cmd"],
+        }
+        request = {
+            "model": "gpt-5",
+            "tools": [
+                _ns_tool(
+                    "ns",
+                    children=[
+                        _func_tool("exec", "Run", params),
+                    ],
+                ),
+            ],
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "go"}],
+                },
+            ],
+        }
+        ir = self.converter.request_from_provider(request)
+        tool = ir["tools"][0]
+        assert tool["parameters"] == params
+        assert tool["required_parameters"] == ["cmd"]
+
+    def test_cross_format_responses_to_chat(self):
+        """Namespace tools survive Responses → Chat Completions conversion."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        pipeline = ConversionPipeline("openai_responses", "openai_chat")
+        request = {
+            "model": "gpt-5",
+            "tools": [
+                _ns_tool(
+                    "functions",
+                    children=[
+                        _func_tool(
+                            "exec",
+                            "Run a command",
+                            {
+                                "type": "object",
+                                "properties": {"cmd": {"type": "string"}},
+                            },
+                        ),
+                    ],
+                ),
+            ],
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "list files"}],
+                },
+            ],
+        }
+        result = pipeline.convert_request(request)
+        tool_names = [
+            t.get("function", {}).get("name") or t.get("name")
+            for t in result.get("tools", [])
+        ]
+        assert "exec" in tool_names
+
+    def test_cross_format_responses_to_anthropic(self):
+        """Namespace tools survive Responses → Anthropic conversion."""
+        from llm_rosetta.pipeline import ConversionPipeline
+
+        pipeline = ConversionPipeline("openai_responses", "anthropic")
+        request = {
+            "model": "gpt-5",
+            "tools": [
+                _ns_tool(
+                    "functions",
+                    children=[
+                        _func_tool(
+                            "exec",
+                            "Run a command",
+                            {
+                                "type": "object",
+                                "properties": {"cmd": {"type": "string"}},
+                            },
+                        ),
+                    ],
+                ),
+            ],
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "list files"}],
+                },
+            ],
+        }
+        result = pipeline.convert_request(request)
+        tool_names = [t["name"] for t in result.get("tools", [])]
+        assert "exec" in tool_names

--- a/tests/converters/openai_responses/test_tool_ops.py
+++ b/tests/converters/openai_responses/test_tool_ops.py
@@ -81,6 +81,7 @@ class TestOpenAIResponsesToolOps:
             },
         }
         result = OpenAIResponsesToolOps.p_tool_definition_to_ir(provider_tool)
+        assert isinstance(result, dict)
         assert result["type"] == "function"
         assert result["name"] == "get_weather"
         assert result["description"] == "Get weather"
@@ -102,6 +103,7 @@ class TestOpenAIResponsesToolOps:
             },
         }
         result = OpenAIResponsesToolOps.p_tool_definition_to_ir(provider_tool)
+        assert isinstance(result, dict)
         assert result["type"] == "function"
         assert result["name"] == "search"
         assert result["description"] == "Search"
@@ -125,6 +127,7 @@ class TestOpenAIResponsesToolOps:
             },
         }
         result = OpenAIResponsesToolOps.p_tool_definition_to_ir(provider_tool)
+        assert isinstance(result, dict)
         assert result["type"] == "custom"
         assert result["name"] == "apply_patch"
         assert result["description"] == "Apply a unified-diff style patch."
@@ -150,6 +153,7 @@ class TestOpenAIResponsesToolOps:
         )
         provider = OpenAIResponsesToolOps.ir_tool_definition_to_p(ir_tool)
         restored = OpenAIResponsesToolOps.p_tool_definition_to_ir(provider)
+        assert isinstance(restored, dict)
         assert restored["name"] == ir_tool["name"]
         assert restored["description"] == ir_tool["description"]
 

--- a/tests/test_tool_ops.py
+++ b/tests/test_tool_ops.py
@@ -66,6 +66,7 @@ class TestFromProvider:
         provider_tool = tool_ops.to_openai_responses(IR_TOOL)
         recovered = tool_ops.from_openai_responses(provider_tool)
         assert recovered is not None
+        assert isinstance(recovered, dict)
         assert recovered["name"] == "get_weather"
 
     def test_from_anthropic(self):


### PR DESCRIPTION
## Summary

- Add `_flatten_namespace_tool` helper that expands `type: "namespace"` containers in the top-level `tools[]` array into individual IR `ToolDefinition` entries
- Add `_dedup_ir_tool_names` post-processing to handle name collisions between namespaced and top-level tools, or across different namespaces
- Widen `p_tool_definition_to_ir` return type to `ToolDefinition | list[ToolDefinition]` (matching the base class contract already used by Google GenAI)
- Fix pre-existing ty type-narrowing issues in test files

Part of #590 — this PR handles namespace tools in the top-level `tools[]` array. The companion PR #623 will handle `additional_tools` input item extraction and close #590.

### Design decisions (discussed in Matrix with @clementine @elena @milo)

1. **Nested namespaces**: limited to one level, warn + skip on nesting (no real-world use case, OpenAI function-name constraint `^[a-zA-Z0-9_-]+$` prohibits hierarchical separators)
2. **Name collisions**: handled at converter level (not in per-tool function) — namespaced tools get `{ns}_{name}`, cross-namespace collisions also handled
3. **`defer_loading`**: transparently recorded in metadata
4. **No namespace reconstruction**: output is always flat — all target formats accept flat tools
5. **Metadata preserved**: `namespace`, `namespace_description` for future round-trip support

## Test plan

- [x] `_flatten_namespace_tool` unit tests (basic, mixed types, empty, nested skip, defer_loading, passthrough child, nested format)
- [x] `_dedup_ir_tool_names` unit tests (no collision, namespaced vs top-level, cross-namespace, no mutation, long name truncation)
- [x] Full request conversion integration tests (namespace in tools array, collision handling, params preserved)
- [x] Cross-format tests (Responses→Chat, Responses→Anthropic)
- [x] `make lint` passes (ruff, ty, complexipy)
- [x] `make test` passes (3089 passed, 0 failed)