### PR TITLE
feat(admin): drag-and-drop layout editor for provider modal

### DIFF
--- a/design/ui/layout-editor.html
+++ b/design/ui/layout-editor.html
@@ -1,0 +1,574 @@
+<!DOCTYPE html>
+<html lang="en" data-scheme="minimal" data-mode="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Provider Modal — Layout Editor</title>
+<link rel="stylesheet" href="../../src/llm_rosetta/gateway/admin/css/base.css">
+<link rel="stylesheet" href="../../src/llm_rosetta/gateway/admin/css/components.css">
+<style>
+.editor-layout {
+  display: flex; flex-direction: column; align-items: center;
+  padding: 24px; min-height: calc(100vh - 60px);
+}
+.editor-toolbar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 24px; border-bottom: 1px solid var(--border);
+  flex-wrap: wrap; gap: 8px;
+}
+.editor-toolbar h1 { font-size: 18px; font-weight: 600; }
+.editor-toolbar h1 span { color: var(--text-dim); font-weight: 400; }
+.toolbar-actions { display: flex; gap: 8px; align-items: center; }
+.panel-header {
+  font-size: 11px; font-weight: 700; color: var(--text-dim);
+  text-transform: uppercase; letter-spacing: 0.6px; margin-bottom: 12px;
+  display: flex; align-items: center; justify-content: space-between;
+  width: 620px; max-width: 95vw;
+}
+.panel-header .hint { font-weight: 400; text-transform: none; letter-spacing: 0; font-size: 11px; }
+.drop-zone {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: 12px; padding: 24px;
+  width: 620px; max-width: 95vw; min-height: 400px;
+}
+
+/* Single item */
+.drag-item {
+  position: relative;
+  background: var(--bg); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 12px 12px 12px 36px;
+  margin-bottom: 8px; cursor: grab; user-select: none;
+  transition: box-shadow 0.15s, border-color 0.15s, opacity 0.15s;
+  min-width: 0; overflow: hidden;
+}
+.drag-item:hover { border-color: var(--text-dim); }
+.drag-item.dragging { opacity: 0.4; }
+.drag-item.drag-over { box-shadow: 0 0 0 2px var(--accent); }
+.drag-item.drag-over-merge {
+  border-color: var(--green);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--green) 25%, transparent);
+}
+.drag-handle {
+  position: absolute; left: 8px; top: 50%; transform: translateY(-50%);
+  color: var(--text-muted); font-size: 16px; line-height: 1;
+  cursor: grab; padding: 4px 2px;
+}
+.drag-handle:hover { color: var(--text-dim); }
+.field-label-badge {
+  font-size: 10px; font-weight: 600; color: var(--text-dim);
+  text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px;
+}
+
+/* Row with multiple fields */
+.field-row {
+  display: flex; gap: 0; margin-bottom: 8px; position: relative;
+  background: var(--bg); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 6px;
+}
+.field-row .drag-item { margin-bottom: 0; border-style: dashed; }
+.field-row .drag-item:hover { border-style: solid; }
+.field-row-badge {
+  position: absolute; top: -8px; left: 12px;
+  font-size: 9px; font-weight: 700; color: var(--green);
+  background: var(--bg-card); padding: 0 6px;
+  text-transform: uppercase; letter-spacing: 0.5px;
+}
+.field-row-actions {
+  position: absolute; top: -8px; right: 12px; display: flex; gap: 8px;
+}
+.field-row-actions button {
+  font-size: 9px; font-weight: 700;
+  background: var(--bg-card); padding: 0 6px;
+  cursor: pointer; border: none;
+  text-transform: uppercase; letter-spacing: 0.5px;
+}
+.field-row-actions .split-btn { color: var(--red); }
+.field-row-actions .split-btn:hover { text-decoration: underline; }
+
+/* Resize handle between fields in a row */
+.resize-handle {
+  width: 8px; cursor: col-resize; position: relative;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0; z-index: 1;
+}
+.resize-handle::after {
+  content: ''; display: block;
+  width: 2px; height: 24px; border-radius: 1px;
+  background: var(--border); transition: background 0.15s;
+}
+.resize-handle:hover::after { background: var(--accent); width: 3px; }
+.resize-handle.resizing::after { background: var(--accent); width: 3px; }
+
+/* Flex width label */
+.flex-label {
+  position: absolute; bottom: 2px; right: 6px;
+  font-size: 9px; color: var(--text-muted); font-family: var(--mono);
+}
+
+/* Drop indicators */
+.drop-line-top { box-shadow: 0 -2px 0 0 var(--accent) !important; }
+.drop-line-bottom { box-shadow: 0 2px 0 0 var(--accent) !important; }
+
+/* Code panel */
+.code-panel {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: 12px; display: flex; flex-direction: column;
+  overflow: hidden; width: 620px; max-width: 95vw; margin-top: 16px;
+}
+.code-panel.collapsed .code-output { display: none; }
+.code-panel-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 16px; cursor: pointer;
+}
+.code-panel-header .title {
+  font-size: 11px; font-weight: 700; color: var(--text-dim);
+  text-transform: uppercase; letter-spacing: 0.6px;
+}
+.toggle-arrow { font-size: 10px; color: var(--text-dim); transition: transform 0.2s; }
+.code-panel.collapsed .toggle-arrow { transform: rotate(-90deg); }
+.code-output {
+  overflow: auto; padding: 12px 16px; max-height: 200px;
+  font-family: var(--mono); font-size: 11px; line-height: 1.5;
+  white-space: pre; color: var(--text); tab-size: 2;
+  border-top: 1px solid var(--border);
+}
+.code-output .tag { color: var(--red); }
+.code-output .attr { color: var(--orange); }
+.code-output .val { color: var(--green); }
+.code-output .comment { color: var(--text-muted); font-style: italic; }
+
+/* Theme toggle */
+.theme-toggle {
+  display: inline-flex; gap: 2px; border: 1px solid var(--border);
+  border-radius: var(--radius); overflow: hidden;
+}
+.theme-toggle button {
+  padding: 4px 10px; font-size: 11px; border: none;
+  background: var(--bg); color: var(--text-dim); cursor: pointer;
+}
+.theme-toggle button:hover { color: var(--text); }
+.theme-toggle button.active { background: var(--accent); color: #fff; }
+
+.editor-toast {
+  position: fixed; bottom: 30px; left: 50%; transform: translateX(-50%);
+  padding: 10px 20px; border-radius: var(--radius); font-size: 13px;
+  background: var(--bg-card); color: var(--text); border: 1px solid var(--border);
+  box-shadow: 0 4px 16px rgba(0,0,0,0.12); z-index: 200;
+  opacity: 0; transition: opacity 0.3s; pointer-events: none;
+}
+.editor-toast.show { opacity: 0.95; }
+
+.drag-item input, .drag-item select, .drag-item button { pointer-events: none; }
+
+/* Preview overlay */
+.preview-overlay {
+  position: fixed; inset: 0; z-index: 100;
+  background: rgba(0,0,0,0.6); display: none;
+  align-items: center; justify-content: center;
+}
+.preview-overlay.open { display: flex; }
+.preview-modal {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: 12px; padding: 24px;
+  width: 620px; max-width: 95vw; max-height: 90vh; overflow-y: auto;
+  position: relative;
+}
+.preview-modal .form-row { display: flex; gap: 1rem; }
+.preview-close {
+  position: absolute; top: 12px; right: 16px;
+  font-size: 18px; cursor: pointer; border: none;
+  background: none; color: var(--text-dim); line-height: 1;
+}
+.preview-close:hover { color: var(--text); }
+
+/* Compact logo picker trigger */
+.lp-compact { display:inline-flex;position:relative; }
+.lp-trigger {
+  width:36px;height:36px;border:1px solid var(--border);border-radius:var(--radius);
+  background:transparent;cursor:pointer;display:flex;align-items:center;justify-content:center;
+  padding:0;transition:border-color 0.15s;color:var(--text-dim);
+}
+.lp-trigger:hover { border-color:var(--text-dim); }
+</style>
+</head>
+<body>
+<div class="editor-toolbar">
+  <h1>Layout Editor <span>Provider Modal Fields</span></h1>
+  <div class="toolbar-actions">
+    <div class="theme-toggle">
+      <button onclick="setTheme('light')" id="themeLight">Light</button>
+      <button onclick="setTheme('dark')" id="themeDark" class="active">Dark</button>
+    </div>
+    <button class="btn btn-sm" onclick="resetLayout()">Reset</button>
+    <button class="btn btn-sm btn-primary" onclick="copyHTML()">Copy HTML</button>
+    <button class="btn btn-sm" onclick="showPreview()" style="background:var(--green);color:#fff">Preview</button>
+  </div>
+</div>
+<div class="editor-layout">
+  <div class="panel-header">
+    <span>Form Fields</span>
+    <span class="hint">Drag to reorder or merge. Drag resize handles to adjust width.</span>
+  </div>
+  <div class="drop-zone" id="dropZone"></div>
+  <div class="code-panel collapsed" id="codePanel">
+    <div class="code-panel-header" onclick="toggleCodePanel()">
+      <span class="title">Generated HTML</span>
+      <span style="display:flex;gap:8px;align-items:center">
+        <button class="btn btn-sm" onclick="event.stopPropagation();copyHTML()">Copy</button>
+        <span class="toggle-arrow">&#9660;</span>
+      </span>
+    </div>
+    <div class="code-output" id="codeOutput"></div>
+  </div>
+</div>
+<div class="preview-overlay" id="previewOverlay" onclick="if(event.target===this)closePreview()">
+  <div class="preview-modal" id="previewContent">
+    <button class="preview-close" onclick="closePreview()">&times;</button>
+  </div>
+</div>
+<div class="editor-toast" id="toast"></div>
+
+<script>
+const FIELDS = [
+  { id:'provName', label:'Provider Name',
+    html:`<label data-i18n="label.providerName">Provider Name <span style="color:var(--red)">*</span></label>\n<input id="provName" placeholder="e.g. my-openai, openrouter-claude">` },
+  { id:'provBaseUrl', label:'Base URL',
+    html:`<label data-i18n="label.baseUrl">Base URL<span class="hint-icon">?<span class="hint-popup" data-i18n="hint.docker">In Docker, &quot;localhost&quot; refers to the container itself. Use &quot;host.docker.internal&quot; (macOS/Windows) or &quot;172.17.0.1&quot; (Linux) to reach the host machine.</span></span></label>\n<input id="provBaseUrl" placeholder="https://api.openai.com/v1">` },
+  { id:'provApiKey', label:'API Key',
+    html:`<label data-i18n="label.apiKey">API Key <span style="color:var(--red)">*</span></label>\n<div style="display:flex;gap:4px;align-items:center" id="provApiKeyRow">\n  <input id="provApiKey" placeholder="\${OPENAI_API_KEY}" type="password" style="flex:1">\n</div>\n<div class="multi-key-footer" id="provApiKeySingleFooter">\n  <button type="button" class="btn btn-sm">+ <span data-i18n="label.addKey">Add key</span></button>\n  <button type="button" class="key-btn" title="Toggle visibility"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>\n  <button type="button" class="key-btn" title="Copy"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>\n</div>` },
+  { id:'provProxy', label:'Proxy URL',
+    html:`<label data-i18n="label.proxyUrl">Proxy URL<span class="hint-icon">?<span class="hint-popup" data-i18n="hint.docker">In Docker, &quot;localhost&quot; refers to the container itself.</span></span></label>\n<input id="provProxy" placeholder="e.g. http://127.0.0.1:7890">` },
+  { id:'provTimeout', label:'Timeout',
+    html:`<label data-i18n="label.timeout">Timeout (s)</label>\n<input id="provTimeout" type="number" min="1" step="1" placeholder="">` },
+  { id:'provModelsPath', label:'Models Path',
+    html:`<label data-i18n="label.modelsPath">Models Listing Path</label>\n<input id="provModelsPath" placeholder="/v1/models">` },
+  { id:'provLogo', label:'Logo',
+    html:`<label data-i18n="label.logo">Logo</label>\n<div class="lp-wrapper lp-compact">\n  <button type="button" class="lp-trigger" title="Choose logo">\n    <svg width="24" height="24" viewBox="0 0 600 600" fill="currentColor" opacity="0.4"><g transform="translate(50, 40) scale(0.95)"><path d="M517.5,415.4c.3-10.7-2.6-21.4-2.2-31.9c.1-2.4,2-4.5,2.1-6.9c.2-5.1-1.1-12.1-2.8-16.2c-2-4.9-1.4-11.1-1.1-16.9c.4-5.9-.3-11.6-.3-17.5c0-5.9-1.4-13.4-.3-18.4c.9-3.9-.3-8.7.2-12.7c.2-1.3,1.3-1.6,1.5-2.7c.6-2.8-1.7-2.8-1.7-4.7c0-1.6,1.7-3.2,1.9-5c1.5-3-2.3-8.2-1.4-10.6c4.9-14.2-8.2-27.4-12.9-37c-.1-.2-.2-.5-.2-.8c-3.8-15.2-8.4-27.1-13.8-41.1c-1.8-4.8-6-8.7-7.6-13.6c-1.6-4.9-5.1-9.4-7.9-13.4c-6.6-9.4-14.5-22.3-13.8-35.9c-6-6.5-6-18.5-9-28.5c-1.3-4.3-2-8.8-2.9-13.4c-.8-4.1-2.3-10.6-2.1-14.3c0-.6.8-1.1.7-1.7c-.1-.6-1.2-1-1.4-1.5c-1-2.7-1-6.6-2.2-10c-1.1-3.1-2.3-6.9-2.7-9.6c-.3-1.8-.1-3.2-1.1-4.2c-.9-.9-2.1-.9-2.3-1.9c-.5-1.8.8-2.5.8-3.8c0-2.6-2.7-6.6-3-9.7c-.1-.6.5-1.3.5-1.9c-.2-2.3-3.3-4.1-4.7-5.6c-1.8-1.8-4.3-7.6-4.9-10.1c-.6-2.2.3-6.1-1-7.2c-.7-.6-6-1-6.7-1.1c-11.2-.2-22.7-2.7-35.3-2.3c-8.5.2-17.3.5-25.6,1.4c-8.4.9-15.5,3.4-23.4,4.3c-4.5.5-7.4,1.9-11.1,2.8c-8,1.8-16.2,2.5-23,4.9c-2.8,1-8,2.4-9.6,4.4c-2,2.5-1.4,1.9-4.4,2c-1.1,0-2.4.9-3.7,1.1c-1.4.2-2.7-.5-4-.5c-1.9.1-5.9,2.2-7.9,3c-2.7,1-5.4,2.2-8.1,2.9c-14.2,3.8-26.2,10.3-38.8,16c-2.2,1-4.8,3.7-6.8,4.2c-6.6,1.8-9.7,6.2-15.4,8.7c-2.7,1.2-7.5,1.5-10,3.2c-3.7,2.6-7.4,5.9-11.7,8.4c-3,1.7-3.8.7-5,3.5c-.5,1.2-3.4.7-4.5,1.4c-5.5,3.7-9.7,9.5-15,14.1c-2.8,2.5-6,3.5-8.7,5.9c-2.9,2.5-5.8,3.9-8.9,5.7c-1.5.9-2.5,3.5-4.1,4.2c-4.1,1.9-7.7,4.2-11,7.2c-.3.2-.5.6-.6.8c-7.2,11.5-19.6,18.1-30.6,25.2c-4.6,1.7-6.6,9.6-7.1,15.3c-.2,2.1,1.1,3.6,1,5.7c-.1,1.8-1.4,2.6-1.3,4.4c.1,2.2.1,2.6-.5,4.4c-.9,2.7.8,6,.7,9.2c-.3,6.5-2.2,12.4-2.7,17.9c-.2,2.8,1.9,6.2,1,8.7c-3.3,9-1.6,21.4-.3,31.4c.7,5.2-.9,10.4-1,15.7c-.1,5.6.7,11.4.4,16.4c-.4,6.1-3.1,12.3-2.8,18.1c.3,6.1,2.2,11.8,3.5,17.2c2,7.7-.1,13.8-2.5,19.1c-2.5,5.5-.7,10.8-1.5,17.1c-.3,2.1-2.1,3.7-1.7,6.8c.3,2.5,1.2,5.1,1.3,7.5c.1,3.5-1.3,5.8-.3,9.5c1,3.8-.1,5.9-.8,9.3c-1.8,9.5-4.1,17.8-2.5,29.2c.6,4.1,1.7,7.4,2.1,11.4c.4,4.3-2.4,6.8-2.6,10.8c-.4,9.7.3,20.4-1.9,29c-1,3.8.7,5.6,1.2,8.7c.4,2.5-.4,6.2-1.3,9c-1,3.3.2,6,1.1,8.5c1.8,5.3.4,12.4-.1,18.2c-.5,6.4-.7,12.4-.5,19.1c.2,6.5-1.3,13-.4,19.7c.8,5.8,2,11.2,2,18.5c0,6.8,0,13.5-.3,19.9c-.3,7.4,3.7,9.9,11.2,9.5c3.3-.2,6.6-1.4,9.2-.2c2.4,1,4.6,2.7,7.7,2.9c1.3.1,2.6-.8,3.5-.8c2.6.2,5.4,2.4,8.7,2.1c4.7-.4,8.5.6,13,1.9c3.7,1.1,6.8,3,10.7,3.4c.7.1,1.2-.8,1.8-.8c2.9,0,5.5,1.6,8.7,1.1c3.1-.4,6.4-.4,9.3-.4c6.4.2,11.4-2.6,15.7-4.7c.3-.2.7-.3,1.1-.4c7.2-1.7,13.7-5.7,20.8-8c2.6-.8,6.4,0,9.3-.1c5-.3,11.2-1.2,16.4.8c5.9,2.2,10.9.6,16.6,1.4c2.8.4,4.9.7,7.8.8c9.8.4,19.8-4.8,29.1-5.5c.1,0,.1,0,.2-.1c5.3-1.9,13-1.6,17.9-1.3c8.2.6,18,2.6,25.4-1.1c3.2-1.6,7.4-3.3,11.1-3.7c4.5-.5,9.4,1.5,13.7.6c.8-.2.6-1.1,1.5-1.2c.6,0,1.2.5,1.9.5c12-.4,25.1-2.8,34.6-7c6.8-3,10.3-7.7,18.8-9.3c3.3-.6,6.6-3.3,9.2-4.9c5.1-3.2,15.8-4.4,18.4-9.8c5.6-11.5,22.2-12.4,28.9-22.5c.1-.1.2-.2.3-.3c4.8-4.1,9.7-8.1,13.8-12.8c2-2.3,5.1-3.6,7.1-6.2c2-2.6,4-5,6.3-7c4.6-4,8.2-9.4,12.6-14c6.8-7.1,12.3-15.3,18.6-22.2c1.6-1.7,7.5-4.8,8-7.1C521.1,437.1,517.2,426,517.5,415.4z"/></g></svg>\n  </button>\n</div>` },
+];
+
+// Layout: array of rows. Each row: { fields: [{id, flex}] }
+let layout = FIELDS.map(f => ({ fields: [{ id: f.id, flex: 1 }] }));
+const INITIAL = () => FIELDS.map(f => ({ fields: [{ id: f.id, flex: 1 }] }));
+
+let dragData = null;
+
+function render() {
+  const zone = document.getElementById('dropZone');
+  zone.innerHTML = '';
+  layout.forEach((row, ri) => {
+    if (row.fields.length === 1) {
+      const el = mkItem(row.fields[0], ri, 0);
+      setupRowDrop(el, ri);
+      zone.appendChild(el);
+    } else {
+      const rowEl = document.createElement('div');
+      rowEl.className = 'field-row';
+      rowEl.dataset.rowIndex = ri;
+      // badge
+      const badge = document.createElement('span');
+      badge.className = 'field-row-badge';
+      badge.textContent = row.fields.length + '-col';
+      rowEl.appendChild(badge);
+      // actions
+      const acts = document.createElement('div');
+      acts.className = 'field-row-actions';
+      const splitBtn = document.createElement('button');
+      splitBtn.className = 'split-btn';
+      splitBtn.textContent = 'Split';
+      splitBtn.onclick = e => { e.stopPropagation(); splitRow(ri); };
+      acts.appendChild(splitBtn);
+      rowEl.appendChild(acts);
+      // fields + resize handles
+      row.fields.forEach((f, fi) => {
+        if (fi > 0) {
+          const h = mkResizeHandle(ri, fi);
+          rowEl.appendChild(h);
+        }
+        const el = mkItem(f, ri, fi, true);
+        el.style.flex = f.flex;
+        rowEl.appendChild(el);
+      });
+      // row-level drag
+      rowEl.draggable = true;
+      rowEl.addEventListener('dragstart', e => {
+        if (dragData) return;
+        dragData = { type: 'row', ri };
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain','row');
+        requestAnimationFrame(() => rowEl.classList.add('dragging'));
+      });
+      rowEl.addEventListener('dragend', clearDrag);
+      setupRowDrop(rowEl, ri);
+      zone.appendChild(rowEl);
+    }
+  });
+  updateCode();
+}
+
+function mkItem(f, ri, fi, inRow) {
+  const field = FIELDS.find(x => x.id === f.id);
+  const el = document.createElement('div');
+  el.className = 'drag-item';
+  el.dataset.fieldId = f.id;
+  el.dataset.ri = ri;
+  el.dataset.fi = fi;
+  el.draggable = true;
+  // handle
+  const h = document.createElement('span');
+  h.className = 'drag-handle';
+  h.innerHTML = '&#8801;';
+  el.appendChild(h);
+  // label
+  const lb = document.createElement('div');
+  lb.className = 'field-label-badge';
+  lb.textContent = field.label;
+  el.appendChild(lb);
+  // content
+  const c = document.createElement('div');
+  c.className = 'form-group';
+  c.style.marginBottom = '0';
+  c.innerHTML = field.html;
+  el.appendChild(c);
+  // flex label in row
+  if (inRow) {
+    const fl = document.createElement('span');
+    fl.className = 'flex-label';
+    fl.textContent = Math.round(f.flex * 100) + '%';
+    el.appendChild(fl);
+  }
+  el.addEventListener('dragstart', e => {
+    e.stopPropagation();
+    dragData = { type: 'field', id: f.id, ri, fi };
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', f.id);
+    requestAnimationFrame(() => el.classList.add('dragging'));
+  });
+  el.addEventListener('dragend', clearDrag);
+  return el;
+}
+
+function setupRowDrop(el, ri) {
+  el.addEventListener('dragover', e => {
+    e.preventDefault(); e.stopPropagation();
+    if (!dragData) return;
+    clearHL(el);
+    const rect = el.getBoundingClientRect();
+    const y = (e.clientY - rect.top) / rect.height;
+    if (y < 0.25) el.classList.add('drop-line-top');
+    else if (y > 0.75) el.classList.add('drop-line-bottom');
+    else el.classList.add('drag-over-merge');
+  });
+  el.addEventListener('dragleave', () => clearHL(el));
+  el.addEventListener('drop', e => {
+    e.preventDefault(); e.stopPropagation();
+    if (!dragData) return;
+    const rect = el.getBoundingClientRect();
+    const y = (e.clientY - rect.top) / rect.height;
+    let action = y < 0.25 ? 'above' : y > 0.75 ? 'below' : 'merge';
+    doDrop(ri, action);
+    clearHL(el);
+    clearDrag();
+    render();
+  });
+}
+
+function doDrop(targetRi, action) {
+  if (!dragData) return;
+  if (dragData.type === 'field') {
+    const { id, ri: srcRi, fi: srcFi } = dragData;
+    // remove from source
+    const srcRow = layout[srcRi];
+    const [removed] = srcRow.fields.splice(srcFi, 1);
+    if (srcRow.fields.length === 0) layout.splice(srcRi, 1);
+    else normalizeFlexes(srcRow);
+    // recalc target
+    let tgt = targetRi;
+    if (srcRow.fields.length === 0 && srcRi < targetRi) tgt--;
+    if (action === 'merge') {
+      layout[tgt].fields.push({ id, flex: 1 });
+      normalizeFlexes(layout[tgt]);
+    } else if (action === 'above') {
+      layout.splice(tgt, 0, { fields: [{ id, flex: 1 }] });
+    } else {
+      layout.splice(tgt + 1, 0, { fields: [{ id, flex: 1 }] });
+    }
+  } else if (dragData.type === 'row') {
+    const srcRi = dragData.ri;
+    if (srcRi === targetRi) return;
+    const [row] = layout.splice(srcRi, 1);
+    let tgt = targetRi;
+    if (srcRi < targetRi) tgt--;
+    if (action === 'above') layout.splice(tgt, 0, row);
+    else if (action === 'below') layout.splice(tgt + 1, 0, row);
+    else {
+      // merge entire row into target
+      row.fields.forEach(f => layout[tgt].fields.push({ ...f }));
+      normalizeFlexes(layout[tgt]);
+    }
+  }
+}
+
+function normalizeFlexes(row) {
+  const total = row.fields.reduce((s, f) => s + f.flex, 0);
+  if (total > 0) row.fields.forEach(f => f.flex = f.flex / total);
+}
+
+function splitRow(ri) {
+  const row = layout[ri];
+  const newRows = row.fields.map(f => ({ fields: [{ id: f.id, flex: 1 }] }));
+  layout.splice(ri, 1, ...newRows);
+  render();
+}
+
+function clearDrag() {
+  dragData = null;
+  document.querySelectorAll('.dragging').forEach(el => el.classList.remove('dragging'));
+  document.querySelectorAll('.drop-line-top,.drop-line-bottom,.drag-over,.drag-over-merge').forEach(el =>
+    el.classList.remove('drop-line-top','drop-line-bottom','drag-over','drag-over-merge'));
+}
+function clearHL(el) {
+  el.classList.remove('drop-line-top','drop-line-bottom','drag-over','drag-over-merge');
+}
+
+// Resize handles
+function mkResizeHandle(ri, fi) {
+  const h = document.createElement('div');
+  h.className = 'resize-handle';
+  h.addEventListener('mousedown', e => {
+    e.preventDefault(); e.stopPropagation();
+    h.classList.add('resizing');
+    const row = layout[ri];
+    const leftField = row.fields[fi - 1];
+    const rightField = row.fields[fi];
+    const rowEl = h.closest('.field-row');
+    const leftEl = rowEl.querySelectorAll('.drag-item')[fi - 1];
+    const rightEl = rowEl.querySelectorAll('.drag-item')[fi];
+    const startX = e.clientX;
+    const totalW = leftEl.offsetWidth + rightEl.offsetWidth;
+    const startLeftFlex = leftField.flex;
+    const startRightFlex = rightField.flex;
+    const sumFlex = startLeftFlex + startRightFlex;
+
+    const onMove = e2 => {
+      const dx = e2.clientX - startX;
+      const ratio = dx / totalW;
+      let newLeft = startLeftFlex + ratio * sumFlex;
+      let newRight = startRightFlex - ratio * sumFlex;
+      const minFlex = 0.15 * sumFlex;
+      if (newLeft < minFlex) { newLeft = minFlex; newRight = sumFlex - minFlex; }
+      if (newRight < minFlex) { newRight = minFlex; newLeft = sumFlex - minFlex; }
+      leftField.flex = newLeft;
+      rightField.flex = newRight;
+      leftEl.style.flex = newLeft;
+      rightEl.style.flex = newRight;
+      // update % labels
+      const lfl = leftEl.querySelector('.flex-label');
+      const rfl = rightEl.querySelector('.flex-label');
+      const total = row.fields.reduce((s, f) => s + f.flex, 0);
+      if (lfl) lfl.textContent = Math.round(leftField.flex / total * 100) + '%';
+      if (rfl) rfl.textContent = Math.round(rightField.flex / total * 100) + '%';
+    };
+    const onUp = () => {
+      h.classList.remove('resizing');
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      updateCode();
+    };
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  });
+  return h;
+}
+
+// Code generation
+function generateHTML() {
+  const I = '    ';
+  const lines = [I + '<!-- Connection — always visible -->'];
+  layout.forEach(row => {
+    if (row.fields.length === 1) {
+      const f = FIELDS.find(x => x.id === row.fields[0].id);
+      lines.push(I + '<div class="form-group">');
+      f.html.split('\n').forEach(l => lines.push(I + '  ' + l));
+      lines.push(I + '</div>');
+    } else {
+      // compute percentage widths
+      const total = row.fields.reduce((s,f) => s + f.flex, 0);
+      const percs = row.fields.map(f => Math.round(f.flex / total * 100));
+      // adjust rounding to sum to 100
+      const diff = 100 - percs.reduce((a,b) => a+b, 0);
+      if (diff) percs[percs.length - 1] += diff;
+      lines.push(I + '<div class="form-row" style="display:flex;gap:8px;align-items:flex-end">');
+      row.fields.forEach((rf, i) => {
+        const f = FIELDS.find(x => x.id === rf.id);
+        const isCompact = f.html.includes('lp-compact') || f.html.includes('lp-trigger');
+        let style;
+        if (isCompact) {
+          style = 'flex:0 0 auto';
+        } else if (row.fields.length === 2 && row.fields.some(x => FIELDS.find(y => y.id === x.id)?.html.includes('lp-'))) {
+          style = 'flex:1';
+        } else {
+          const w = percs[i];
+          style = w === Math.round(100 / row.fields.length) ? 'flex:1' : `flex:0 0 ${w}%`;
+        }
+        lines.push(I + `  <div class="form-group" style="${style}">`);
+        f.html.split('\n').forEach(l => lines.push(I + '    ' + l));
+        lines.push(I + '  </div>');
+      });
+      lines.push(I + '</div>');
+    }
+  });
+  return lines.join('\n');
+}
+
+function updateCode() {
+  const el = document.getElementById('codeOutput');
+  el.innerHTML = highlightHTML(generateHTML());
+}
+
+function highlightHTML(code) {
+  let s = code.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  s = s.replace(/(&lt;!--.*?--&gt;)/g, '<span class="comment">$1</span>');
+  s = s.replace(/(&lt;\/?)([\w-]+)/g, '$1<span class="tag">$2</span>');
+  s = s.replace(/\s([\w-]+)(=)/g, ' <span class="attr">$1</span>$2');
+  s = s.replace(/=(&quot;|")(.*?)(\1)/g, '=<span class="val">"$2"</span>');
+  return s;
+}
+
+function resetLayout() { layout = INITIAL(); render(); showToast('Reset'); }
+function copyHTML() {
+  navigator.clipboard.writeText(generateHTML()).then(
+    () => showToast('Copied'),
+    () => showToast('Copy failed')
+  );
+}
+function showToast(msg) {
+  const t = document.getElementById('toast');
+  t.textContent = msg; t.classList.add('show');
+  clearTimeout(t._t); t._t = setTimeout(() => t.classList.remove('show'), 1500);
+}
+function setTheme(m) {
+  document.documentElement.dataset.mode = m;
+  document.getElementById('themeLight').classList.toggle('active', m==='light');
+  document.getElementById('themeDark').classList.toggle('active', m==='dark');
+}
+function toggleCodePanel() { document.getElementById('codePanel').classList.toggle('collapsed'); }
+if (window.matchMedia?.('(prefers-color-scheme: light)').matches) setTheme('light');
+
+function showPreview() {
+  const modal = document.getElementById('previewContent');
+  const html = generateHTML();
+  modal.innerHTML = '<button class="preview-close" onclick="closePreview()">&times;</button>' + html;
+  // Enable inputs in preview
+  modal.querySelectorAll('input,select,button:not(.preview-close)').forEach(el => {
+    el.style.pointerEvents = 'auto';
+  });
+  document.getElementById('previewOverlay').classList.add('open');
+}
+function closePreview() {
+  document.getElementById('previewOverlay').classList.remove('open');
+}
+
+render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a standalone `layout-editor.html` tool in `src/llm_rosetta/gateway/admin/` that lets developers visually rearrange the provider modal's common form fields (Provider Name, Base URL, API Key, Proxy URL, Timeout, Models Path, Logo URL)
- Supports drag-to-reorder and drag-onto-field to merge two fields into a side-by-side 2-column row, with a live HTML code output panel on the right that shows the resulting markup ready to copy-paste into `admin.html`
- Uses the existing admin CSS files (`base.css`, `components.css`) for accurate visual representation; pure vanilla HTML/CSS/JS with no external dependencies

## Test plan

- [ ] Open `layout-editor.html` in a browser (both via file:// and served locally)
- [ ] Verify all 7 form fields render with correct styling matching the admin modal
- [ ] Drag a field up/down to reorder — confirm the code panel updates
- [ ] Drag a field onto another field's center zone — confirm they merge into a 2-column row
- [ ] Click "Split" on a merged row — confirm fields separate back to individual rows
- [ ] Click "Copy HTML" — confirm clipboard contains valid HTML with correct class names/IDs
- [ ] Click "Reset" — confirm layout returns to original order
- [ ] Toggle Light/Dark theme — confirm both modes render correctly
- [ ] Verify no console errors