### PR TITLE
feat(ci): configurable Nuitka flags for binary size experiments

### DIFF
--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -130,6 +130,7 @@ jobs:
         shell: bash
         run: |
           BINARY=$(ls build/llm-rosetta-gateway-* 2>/dev/null | head -1)
+          [ -z "$BINARY" ] && exit 0
           PRE_SIZE=$(stat --format=%s "$BINARY" 2>/dev/null || python -c "import os; print(os.path.getsize('$BINARY'))")
           PRE_MB=$(python -c "print(f'{int($PRE_SIZE)/1048576:.1f}')")
 
@@ -152,6 +153,8 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
+          EXTRA_FLAGS: ${{ inputs.nuitka_extra_flags || '(none)' }}
+          UPX_ENABLED: ${{ inputs.upx }}
         run: |
           END=$(date +%s)
           ELAPSED=$((END - NUITKA_START))
@@ -168,8 +171,8 @@ jobs:
           echo "  Platform:     ${{ matrix.platform }}"
           echo "  Ref:          ${{ inputs.ref }}"
           echo "  Version:      $VERSION"
-          echo "  Extra flags:  ${{ inputs.nuitka_extra_flags || '(none)' }}"
-          echo "  UPX:          ${{ inputs.upx }}"
+          echo "  Extra flags:  $EXTRA_FLAGS"
+          echo "  UPX:          $UPX_ENABLED"
           echo "  Build time:   ${MINS}m ${SECS}s (${ELAPSED}s total)"
           echo "  Binary size:  ${BINARY_SIZE_MB} MB (${BINARY_SIZE} bytes)"
           echo "--------------------------------------------"
@@ -194,8 +197,8 @@ jobs:
             echo "|--------|-------|"
             echo "| Binary size | ${BINARY_SIZE_MB} MB (${BINARY_SIZE} bytes) |"
             echo "| Build time | ${MINS}m ${SECS}s |"
-            echo "| Extra flags | \`${{ inputs.nuitka_extra_flags || '(none)' }}\` |"
-            echo "| UPX | ${{ inputs.upx }} |"
+            echo "| Extra flags | \`${EXTRA_FLAGS}\` |"
+            echo "| UPX | ${UPX_ENABLED} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Smoke test (non-Windows)
@@ -249,6 +252,7 @@ jobs:
         if: inputs.upx
         run: |
           BINARY=$(ls build/llm-rosetta-gateway-*-musl 2>/dev/null | head -1)
+          [ -z "$BINARY" ] && exit 0
           PRE_SIZE=$(stat --format=%s "$BINARY")
           PRE_MB=$(python3 -c "print(f'{int($PRE_SIZE)/1048576:.1f}')")
 
@@ -263,6 +267,8 @@ jobs:
       - name: Build statistics
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
+          EXTRA_FLAGS: ${{ inputs.nuitka_extra_flags || '(none)' }}
+          UPX_ENABLED: ${{ inputs.upx }}
         run: |
           END=$(date +%s)
           ELAPSED=$((END - NUITKA_START))
@@ -279,8 +285,8 @@ jobs:
           echo "  Platform:     ${{ matrix.platform }}"
           echo "  Ref:          ${{ inputs.ref }}"
           echo "  Version:      $VERSION"
-          echo "  Extra flags:  ${{ inputs.nuitka_extra_flags || '(none)' }}"
-          echo "  UPX:          ${{ inputs.upx }}"
+          echo "  Extra flags:  $EXTRA_FLAGS"
+          echo "  UPX:          $UPX_ENABLED"
           echo "  Build time:   ${MINS}m ${SECS}s (${ELAPSED}s total)"
           echo "  Binary size:  ${BINARY_SIZE_MB} MB (${BINARY_SIZE} bytes)"
           echo "--------------------------------------------"
@@ -297,8 +303,8 @@ jobs:
             echo "|--------|-------|"
             echo "| Binary size | ${BINARY_SIZE_MB} MB (${BINARY_SIZE} bytes) |"
             echo "| Build time | ${MINS}m ${SECS}s |"
-            echo "| Extra flags | \`${{ inputs.nuitka_extra_flags || '(none)' }}\` |"
-            echo "| UPX | ${{ inputs.upx }} |"
+            echo "| Extra flags | \`${EXTRA_FLAGS}\` |"
+            echo "| UPX | ${UPX_ENABLED} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Smoke test

--- a/.github/workflows/nuitka.yml
+++ b/.github/workflows/nuitka.yml
@@ -13,6 +13,16 @@ on:
         required: true
         type: string
         default: "all"
+      nuitka_extra_flags:
+        description: "Extra Nuitka flags for experimentation (e.g. '--lto=yes --python-flag=no_docstrings')"
+        required: false
+        type: string
+        default: ""
+      upx:
+        description: "Apply UPX compression after build (Linux/Windows only, breaks macOS code signing)"
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       ref:
@@ -22,6 +32,14 @@ on:
         required: false
         type: string
         default: "all"
+      nuitka_extra_flags:
+        required: false
+        type: string
+        default: ""
+      upx:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   prepare:
@@ -103,7 +121,32 @@ jobs:
 
       - name: Build binary
         shell: bash
+        env:
+          NUITKA_EXTRA_FLAGS: ${{ inputs.nuitka_extra_flags }}
         run: make build-binary
+
+      - name: UPX compression (Linux/Windows)
+        if: inputs.upx && matrix.os != 'macos'
+        shell: bash
+        run: |
+          BINARY=$(ls build/llm-rosetta-gateway-* 2>/dev/null | head -1)
+          PRE_SIZE=$(stat --format=%s "$BINARY" 2>/dev/null || python -c "import os; print(os.path.getsize('$BINARY'))")
+          PRE_MB=$(python -c "print(f'{int($PRE_SIZE)/1048576:.1f}')")
+
+          if [ "${{ matrix.os }}" = "linux" ]; then
+            sudo apt-get install -y upx-ucl 2>/dev/null || sudo apt-get install -y upx
+          fi
+          # Windows runners have choco; install if needed
+          if [ "${{ matrix.os }}" = "windows" ]; then
+            choco install upx -y 2>/dev/null || true
+          fi
+
+          upx --best "$BINARY" || echo "UPX compression failed (non-fatal)"
+
+          POST_SIZE=$(stat --format=%s "$BINARY" 2>/dev/null || python -c "import os; print(os.path.getsize('$BINARY'))")
+          POST_MB=$(python -c "print(f'{int($POST_SIZE)/1048576:.1f}')")
+          RATIO=$(python -c "print(f'{int($POST_SIZE)/int($PRE_SIZE)*100:.0f}')")
+          echo "UPX: ${PRE_MB} MB → ${POST_MB} MB (${RATIO}% of original)"
 
       - name: Build statistics
         shell: bash
@@ -125,6 +168,8 @@ jobs:
           echo "  Platform:     ${{ matrix.platform }}"
           echo "  Ref:          ${{ inputs.ref }}"
           echo "  Version:      $VERSION"
+          echo "  Extra flags:  ${{ inputs.nuitka_extra_flags || '(none)' }}"
+          echo "  UPX:          ${{ inputs.upx }}"
           echo "  Build time:   ${MINS}m ${SECS}s (${ELAPSED}s total)"
           echo "  Binary size:  ${BINARY_SIZE_MB} MB (${BINARY_SIZE} bytes)"
           echo "--------------------------------------------"
@@ -141,6 +186,17 @@ jobs:
           echo "  Peak memory (build dir):"
           du -sh build/ 2>/dev/null || true
           echo "============================================"
+
+          # Structured summary for cross-run comparison
+          {
+            echo "### ${{ matrix.platform }}"
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| Binary size | ${BINARY_SIZE_MB} MB (${BINARY_SIZE} bytes) |"
+            echo "| Build time | ${MINS}m ${SECS}s |"
+            echo "| Extra flags | \`${{ inputs.nuitka_extra_flags || '(none)' }}\` |"
+            echo "| UPX | ${{ inputs.upx }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Smoke test (non-Windows)
         if: matrix.os != 'windows'
@@ -185,7 +241,24 @@ jobs:
         run: echo "NUITKA_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - name: Build musl binary
+        env:
+          NUITKA_EXTRA_FLAGS: ${{ inputs.nuitka_extra_flags }}
         run: make build-binary-musl
+
+      - name: UPX compression (musl)
+        if: inputs.upx
+        run: |
+          BINARY=$(ls build/llm-rosetta-gateway-*-musl 2>/dev/null | head -1)
+          PRE_SIZE=$(stat --format=%s "$BINARY")
+          PRE_MB=$(python3 -c "print(f'{int($PRE_SIZE)/1048576:.1f}')")
+
+          sudo apt-get install -y upx-ucl 2>/dev/null || sudo apt-get install -y upx
+          upx --best "$BINARY" || echo "UPX compression failed (non-fatal)"
+
+          POST_SIZE=$(stat --format=%s "$BINARY")
+          POST_MB=$(python3 -c "print(f'{int($POST_SIZE)/1048576:.1f}')")
+          RATIO=$(python3 -c "print(f'{int($POST_SIZE)/int($PRE_SIZE)*100:.0f}')")
+          echo "UPX: ${PRE_MB} MB → ${POST_MB} MB (${RATIO}% of original)"
 
       - name: Build statistics
         env:
@@ -206,6 +279,8 @@ jobs:
           echo "  Platform:     ${{ matrix.platform }}"
           echo "  Ref:          ${{ inputs.ref }}"
           echo "  Version:      $VERSION"
+          echo "  Extra flags:  ${{ inputs.nuitka_extra_flags || '(none)' }}"
+          echo "  UPX:          ${{ inputs.upx }}"
           echo "  Build time:   ${MINS}m ${SECS}s (${ELAPSED}s total)"
           echo "  Binary size:  ${BINARY_SIZE_MB} MB (${BINARY_SIZE} bytes)"
           echo "--------------------------------------------"
@@ -215,6 +290,16 @@ jobs:
           echo "  Peak memory (build dir):"
           du -sh build/ 2>/dev/null || true
           echo "============================================"
+
+          {
+            echo "### ${{ matrix.platform }}"
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            echo "| Binary size | ${BINARY_SIZE_MB} MB (${BINARY_SIZE} bytes) |"
+            echo "| Build time | ${MINS}m ${SECS}s |"
+            echo "| Extra flags | \`${{ inputs.nuitka_extra_flags || '(none)' }}\` |"
+            echo "| UPX | ${{ inputs.upx }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Smoke test
         run: |

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ BINARY_NAME_MUSL = llm-rosetta-gateway-$(VERSION)-linux-$(BINARY_ARCH)-musl
 BINARY_DIR := build
 NUITKA_ENTRY := _nuitka_entry.py
 NUITKA_JOBS := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
+NUITKA_EXTRA_FLAGS ?=
 
 NUITKA_FLAGS = \
 	--standalone \
@@ -133,7 +134,8 @@ NUITKA_FLAGS = \
 	--nofollow-import-to=setuptools \
 	--nofollow-import-to=pip \
 	--nofollow-import-to=_pytest \
-	--assume-yes-for-downloads
+	--assume-yes-for-downloads \
+	$(NUITKA_EXTRA_FLAGS)
 
 # Build native binary (glibc on Linux, system libc on macOS, MSVC on Windows)
 build-binary:
@@ -177,6 +179,7 @@ build-binary-musl:
 				--nofollow-import-to=pip \
 				--nofollow-import-to=_pytest \
 				--assume-yes-for-downloads \
+				$(NUITKA_EXTRA_FLAGS) \
 				/tmp/_entry.py && \
 			rm -rf /output/_entry.* '
 	@ls -lh $(BINARY_DIR)/$(BINARY_NAME_MUSL)


### PR DESCRIPTION
## Summary

- Add `NUITKA_EXTRA_FLAGS` variable to Makefile, appended to both native and musl Nuitka build commands
- Add `nuitka_extra_flags` and `upx` workflow dispatch inputs to `nuitka.yml`
- Add UPX post-build compression step (Linux/Windows only, skipped on macOS)
- Add structured step summary with size, build time, and flags for cross-run comparison

## Why

Binary sizes range from 10-21 MB across platforms. We want to systematically test flag combinations to reduce size. This PR adds the infrastructure — experiments tracked in #638.

## Test plan

- [x] Baseline run triggered (no extra flags): https://github.com/Oaklight/llm-rosetta/actions/runs/33934782019
- [ ] After merge, trigger experiment with `--python-flag=no_docstrings` to validate flag passing