### PR TITLE
fix: auto-rebuild metrics counters on startup when drift detected

### DIFF
--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -98,9 +98,11 @@ def _init_persistence(
             metrics.total_requests,
         )
 
-    # Auto-rebuild if persisted counters drifted from actual log entries
+    # Auto-rebuild if counters lag behind the log (ungraceful shutdown).
+    # Only rebuild when counters < log — the reverse (counters > log) is
+    # expected when log retention caps purge old entries.
     log_entries = persistence.count_log_entries()
-    if metrics.total_requests != log_entries:
+    if metrics.total_requests < log_entries:
         logger.warning(
             "Counter drift detected (counters=%d, log=%d), rebuilding from request log",
             metrics.total_requests,

--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -63,6 +63,55 @@ def _resolve_log_caps(config: GatewayConfig) -> tuple[int, int]:
 _VALID_TABS = frozenset({"providers", "models", "keys", "dashboard", "logs"})
 
 
+def _init_persistence(
+    config: Any,
+    config_path: str | None,
+    data_dir: str | None,
+    metrics: MetricsCollector,
+) -> PersistenceManager | None:
+    """Resolve data_dir, create PersistenceManager, and restore counters."""
+    resolved_data_dir: str | None = data_dir
+    if not resolved_data_dir:
+        configured = getattr(config, "data_dir", None)
+        if configured:
+            if config_path and not os.path.isabs(configured):
+                resolved_data_dir = os.path.join(
+                    os.path.dirname(config_path), configured
+                )
+            else:
+                resolved_data_dir = configured
+        elif config_path:
+            resolved_data_dir = os.path.join(os.path.dirname(config_path), "data")
+    if not resolved_data_dir:
+        return None
+
+    success_max, error_max = _resolve_log_caps(config)
+    persistence = PersistenceManager(
+        resolved_data_dir, success_max=success_max, error_max=error_max
+    )
+
+    saved_metrics = persistence.load_metrics()
+    if saved_metrics:
+        metrics.load_counters(saved_metrics)
+        logger.info(
+            "Loaded metrics from disk (total_requests=%d)",
+            metrics.total_requests,
+        )
+
+    # Auto-rebuild if persisted counters drifted from actual log entries
+    log_entries = persistence.count_log_entries()
+    if metrics.total_requests != log_entries:
+        logger.warning(
+            "Counter drift detected (counters=%d, log=%d), rebuilding from request log",
+            metrics.total_requests,
+            log_entries,
+        )
+        metrics.rebuild_counters(persistence.iter_log_rows_for_rebuild())
+        persistence.save_metrics(metrics.export_counters())
+
+    return persistence
+
+
 def setup_admin(
     app: Any,
     config: GatewayConfig,
@@ -122,34 +171,7 @@ def setup_admin(
         config_io = JsoncConfigIO()
     metrics = MetricsCollector()
 
-    # Set up SQLite persistence — explicit data_dir > config field > config-path default
-    persistence: PersistenceManager | None = None
-    resolved_data_dir: str | None = data_dir
-    if not resolved_data_dir:
-        configured = getattr(config, "data_dir", None)
-        if configured:
-            if config_path and not os.path.isabs(configured):
-                resolved_data_dir = os.path.join(
-                    os.path.dirname(config_path), configured
-                )
-            else:
-                resolved_data_dir = configured
-        elif config_path:
-            resolved_data_dir = os.path.join(os.path.dirname(config_path), "data")
-    if resolved_data_dir:
-        success_max, error_max = _resolve_log_caps(config)
-        persistence = PersistenceManager(
-            resolved_data_dir, success_max=success_max, error_max=error_max
-        )
-
-        # Restore persisted metrics counters
-        saved_metrics = persistence.load_metrics()
-        if saved_metrics:
-            metrics.load_counters(saved_metrics)
-            logger.info(
-                "Loaded metrics from disk (total_requests=%d)",
-                metrics.total_requests,
-            )
+    persistence = _init_persistence(config, config_path, data_dir, metrics)
 
     # Backfill target_provider_name for legacy log entries
     if persistence is not None:


### PR DESCRIPTION
## Summary
- Extract persistence initialization from `setup_admin()` into `_init_persistence()` helper (also fixes C901 complexity)
- After loading persisted counters, compare `total_requests` against actual `count_log_entries()`. If they differ, auto-rebuild from the request log and persist immediately
- Handles ungraceful shutdowns (kill -9, power loss, crash) where periodic flush didn't run

## Context
Originally fixed in argo-proxy (Oaklight/argo-proxy#167). This brings the same defensive logic into llm-rosetta so all downstream consumers benefit.

Closes #642

## Test plan
- [ ] Start gateway with existing `gateway.db` where counters are stale — verify "Counter drift detected" warning and auto-rebuild
- [ ] Start gateway with correct counters — verify no warning, no rebuild
- [ ] Start gateway without persistence (no data_dir) — verify no crash