### PR TITLE
fix(google): plug integration gaps for google_interactions converter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
             extras: ""
             check: |
               python -c "from llm_rosetta import get_converter_for_provider; print('core import OK')"
-              python -c "from llm_rosetta.converters.google_generate.content_ops import GoogleGenerateContentOps; print('google converter OK')"
+              python -c "from llm_rosetta.converters.google_generate.content_ops import GoogleGenerateContentOps; print('google generate converter OK')"
+              python -c "from llm_rosetta import GoogleInteractionsConverter; print('google interactions converter OK')"
           - name: gateway
             extras: "[gateway]"
             check: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,14 +24,15 @@ Zero required dependencies at its core; provider SDKs are optional extras.
 Provider A ──→ IR ──→ Provider B
 ```
 
-Four converters, one per API standard:
+Five converters, one per API standard:
 
 | Converter | API Standard | Module |
 |-----------|-------------|--------|
 | `openai_chat` | OpenAI Chat Completions | `converters/openai_chat/` |
 | `openai_responses` | OpenAI Responses API | `converters/openai_responses/` |
 | `anthropic` | Anthropic Messages API | `converters/anthropic/` |
-| `google` | Google GenAI API | `converters/google_genai/` |
+| `google_generate` | Google generateContent API | `converters/google_generate/` |
+| `google_interactions` | Google Interactions API | `converters/google_interactions/` |
 
 Each converter implements bidirectional conversion (request/response) and
 streaming. Converters are provider-agnostic — provider-specific quirks are
@@ -76,12 +77,13 @@ src/llm_rosetta/
 ├── __init__.py              # Public API: convert(), get_converter_for_provider()
 ├── auto_detect.py           # Provider auto-detection from request body
 ├── tool_ops.py              # Cross-provider tool call utilities
-├── converters/              # 4 bidirectional converters
+├── converters/              # 5 bidirectional converters
 │   ├── base/                # Abstract base + ConversionContext
 │   ├── openai_chat/
 │   ├── openai_responses/
 │   ├── anthropic/
-│   └── google_genai/
+│   ├── google_generate/
+│   └── google_interactions/
 ├── shims/                   # Provider/model identity cards + transforms
 │   ├── provider_shim.py
 │   ├── transforms.py
@@ -294,6 +296,40 @@ allowed — it leads to drift and missed pages.
 
 Commits in doc worktrees use `PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit` since
 those branches have no `.pre-commit-config.yaml`.
+
+## Adding a new converter (checklist)
+
+When adding a converter for a new API standard, **every** item below
+must be completed before the work is considered done.  Use this as a
+gate — missing any item means the converter is not fully integrated.
+
+1. **Converter module** — `converters/<name>/` with `__init__.py`,
+   `converter.py`, `content_ops.py`, `tool_ops.py`, `config_ops.py`,
+   `message_ops.py`.  Converter class extends `BaseConverter` and
+   implements all abstract hooks.
+2. **Unit tests** — `tests/converters/<name>/` mirroring the ops modules.
+   Must include round-trip tests (provider→IR→provider).
+3. **Public API exports** — add the converter class to both
+   `converters/__init__.py` and the top-level `__init__.py` `__all__`.
+4. **Auto-detect** — add detection function and wire into
+   `detect_provider()` in `auto_detect.py`.  Add the name to
+   `ProviderType` literal.  Add to `converter_map` in
+   `get_converter_for_provider()`.
+5. **Provider shim** — create `shims/providers/<name>/provider.yaml`.
+   Add the base type to `_BASE_TYPES` in `provider_shim.py`.
+6. **Gateway route** — register a route handler in `gateway/app.py`.
+   Update `gateway/proxy.py` for error responses, stream detection,
+   stream flag injection, preflight body, and usage extraction.
+7. **CLAUDE.md** — update the converter table and repository layout
+   in this file.
+8. **Documentation** — update `docs_en/` and `docs_zh/` (both in the
+   same task): changelog, converters guide, API reference.  Push both
+   worktrees.
+9. **CI smoke test** — if applicable, add an import check in
+   `.github/workflows/ci.yml`.
+10. **`test_public_api.py`** — add the new class to `EXPECTED_EXPORTS`.
+11. **`test_shim_loader.py`** — add to expected shim set and base-type
+    mapping.
 
 ## Escalation
 

--- a/src/llm_rosetta/__init__.py
+++ b/src/llm_rosetta/__init__.py
@@ -19,6 +19,7 @@ from .converters import (
     GoogleConverter,
     GoogleGenerateConverter,
     GoogleGenAIConverter,  # deprecated alias
+    GoogleInteractionsConverter,
     OpenAIChatConverter,
     OpenAIResponsesConverter,
 )
@@ -48,6 +49,7 @@ __all__ = [
     "GoogleGenerateConverter",
     "GoogleGenAIConverter",  # deprecated alias
     "GoogleConverter",
+    "GoogleInteractionsConverter",
     "OpenAIResponsesConverter",
     # Conversion context
     "ConversionContext",

--- a/src/llm_rosetta/converters/__init__.py
+++ b/src/llm_rosetta/converters/__init__.py
@@ -17,6 +17,7 @@ from .google_generate import GoogleConverter, GoogleGenerateConverter
 from .google_generate import (
     GoogleGenerateConverter as GoogleGenAIConverter,
 )  # deprecated alias
+from .google_interactions import GoogleInteractionsConverter
 from .openai_chat import OpenAIChatConverter
 from .openai_responses import OpenAIResponsesConverter
 from .rerank import CohereRerankConverter, JinaRerankConverter, VoyageRerankConverter
@@ -34,6 +35,7 @@ __all__ = [
     "GoogleGenerateConverter",
     "GoogleGenAIConverter",  # deprecated alias,
     "GoogleConverter",
+    "GoogleInteractionsConverter",
     "OpenAIResponsesConverter",
     "JinaRerankConverter",
     "CohereRerankConverter",

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -456,6 +456,12 @@ async def handle_google_generate(
         )
 
 
+async def handle_google_interactions(
+    request: Any,
+) -> Response | StreamingResponse:
+    return await _proxy_handler(request, source_provider="google_interactions")
+
+
 async def handle_list_models(request: Any) -> Response:
     """List configured models in a format compatible with OpenAI and Anthropic SDKs."""
     assert _config is not None
@@ -865,6 +871,7 @@ def create_app(
         app.route("/v1beta/models/<path:model_path>", methods=["POST"])(
             handle_google_generate
         )
+        app.route("/v1beta/interactions", methods=["POST"])(handle_google_interactions)
         app.route("/health", methods=["GET"])(handle_health)
         app.route("/health/live", methods=["GET"])(handle_health_live)
         app.route("/health/ready", methods=["GET"])(handle_health_ready)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -28,9 +28,9 @@ EXPECTED_EXPORTS: dict[str, _ModuleSpec] = {
             "OpenAIChatConverter",
             "AnthropicConverter",
             "GoogleGenerateConverter",
-            "GoogleConverter",
-            "GoogleGenerateConverter",
             "GoogleGenAIConverter",
+            "GoogleConverter",
+            "GoogleInteractionsConverter",
             "OpenAIResponsesConverter",
             # Conversion context
             "ConversionContext",


### PR DESCRIPTION
## Summary

Fixes integration gaps missed during the initial google_interactions converter landing.

- **Public API exports** (#644): `GoogleInteractionsConverter` now importable from `llm_rosetta` and `llm_rosetta.converters`
- **Gateway route** (#645): `/v1beta/interactions` POST handler registered in `app.py`
- **CLAUDE.md** (#646): converter table and repo layout updated; new "Adding a new converter" checklist added to prevent future gaps
- **CI smoke test**: import check for `GoogleInteractionsConverter`
- **test_public_api.py**: fixed duplicate entry, added `GoogleInteractionsConverter`

## Why these were missed

No checklist existed for "what must be done when adding a new converter." The checklist is now in CLAUDE.md § "Adding a new converter" — 11 items covering module → tests → exports → auto-detect → shim → gateway → docs → CI.

## Closes

- #644, #645, #646

## Test plan

- [x] 3226 tests pass, 0 failures
- [x] All pre-commit hooks pass