### PR TITLE
fix(google): add google_generate and google_interactions to provider URL registry

### DIFF
--- a/src/llm_rosetta/gateway/providers.py
+++ b/src/llm_rosetta/gateway/providers.py
@@ -61,6 +61,20 @@ _PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
         "url_template": "{base_url}/v1beta/models/{model}:generateContent",
         "stream_url_template": "{base_url}/v1beta/models/{model}:streamGenerateContent?alt=sse",
     },
+    "google_generate": {
+        "default_base_url": "https://generativelanguage.googleapis.com",
+        "default_api_key_env": "GOOGLE_API_KEY",
+        "auth_header_fn": google_auth,
+        "url_template": "{base_url}/v1beta/models/{model}:generateContent",
+        "stream_url_template": "{base_url}/v1beta/models/{model}:streamGenerateContent?alt=sse",
+    },
+    "google_interactions": {
+        "default_base_url": "https://generativelanguage.googleapis.com",
+        "default_api_key_env": "GOOGLE_API_KEY",
+        "auth_header_fn": google_auth,
+        "url_template": "{base_url}/v1beta/interactions",
+        "stream_url_template": "{base_url}/v1beta/interactions?alt=sse",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

The gateway provider URL registry only had a `"google"` entry. After the rename to `google_generate` and the new `google_interactions` type, the proxy had no URL templates for either — falling back to the base URL root, causing 404s from Google.

- `google_generate`: same templates as `"google"` (generateContent)
- `google_interactions`: `/v1beta/interactions` and `?alt=sse` for streaming

Found during live testing with llm-comply against the dev gateway.

## Test plan
- [x] 3226 tests pass
- [x] All hooks pass