### PR TITLE
fix(google): plug integration gaps for google_interactions converter

### DIFF
--- a/src/llm_rosetta/converters/google_interactions/config_ops.py
+++ b/src/llm_rosetta/converters/google_interactions/config_ops.py
@@ -88,6 +88,9 @@ class GoogleInteractionsConfigOps(BaseConfigOps):
             if effort:
                 result["effort"] = effort
                 result["mode"] = "enabled"
+                # Interactions API always expects thought steps in the
+                # response when thinking is enabled
+                result["include_thoughts"] = True
         thinking_summaries = provider_config.get("thinking_summaries")
         if thinking_summaries in ("auto", "none"):
             result["summary"] = cast(IRVisibility, thinking_summaries)

--- a/src/llm_rosetta/converters/google_interactions/converter.py
+++ b/src/llm_rosetta/converters/google_interactions/converter.py
@@ -347,6 +347,13 @@ class GoogleInteractionsConverter(BaseConverter):
         if assistant_msg:
             steps = self.message_ops.ir_messages_to_p_steps([assistant_msg])
 
+        # Override status when steps contain function_call but finish_reason
+        # was "stop" (Google generateContent returns STOP for tool calls)
+        if status == "completed" and any(
+            s.get("type") == "function_call" for s in steps
+        ):
+            status = "requires_action"
+
         created_ts = ir_response.get("created", int(time.time()))
         created_iso = datetime.fromtimestamp(created_ts, tz=timezone.utc).isoformat()
 
@@ -522,3 +529,171 @@ class GoogleInteractionsConverter(BaseConverter):
             )
         events.append(StreamEndEvent(type="stream_end"))
         return events
+
+    # ── IR → Provider stream dispatch override ──────────────────────
+
+    def stream_response_to_provider(
+        self,
+        event: IRStreamEvent,
+        context: StreamContext | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        ctx = context or StreamContext()
+        result = super().stream_response_to_provider(event, ctx)
+
+        # Synthesize step.start before first delta when upstream skipped
+        # ContentBlockStartEvent (common for OpenAI Chat upstreams)
+        event_type = event.get("type", "")  # type: ignore[union-attr]
+        if event_type in ("text_delta", "reasoning_delta", "tool_call_delta"):
+            if not ctx.metadata.get("_interactions_step_started"):
+                ctx.metadata["_interactions_step_started"] = True
+                step_start = {
+                    "event_type": "step.start",
+                    "index": 0,
+                    "step": {"type": "model_output"},
+                }
+                chunks = [step_start]
+                if isinstance(result, list):
+                    chunks.extend(result)
+                elif result:
+                    chunks.append(result)
+                return chunks
+
+        # Synthesize step.stop before interaction.completed when missing
+        if event_type == "finish" and ctx.metadata.get("_interactions_step_started"):
+            if not ctx.metadata.get("_interactions_step_stopped"):
+                ctx.metadata["_interactions_step_stopped"] = True
+                step_stop = {"event_type": "step.stop", "index": 0}
+                chunks = [step_stop]
+                if isinstance(result, list):
+                    chunks.extend(result)
+                elif result:
+                    chunks.append(result)
+                return chunks
+
+        return result
+
+    # ── IR → Provider stream handlers (for response conversion) ────
+
+    def _handle_ir_stream_start_to_p(
+        self, event: StreamStartEvent, context: StreamContext | None
+    ) -> dict[str, Any]:
+        if context is not None:
+            context.response_id = event["response_id"]
+            context.model = event["model"]
+            context.mark_started()
+        return {
+            "event_type": "interaction.created",
+            "interaction": {
+                "id": event["response_id"],
+                "model": event["model"],
+                "status": "in_progress",
+            },
+        }
+
+    def _handle_ir_stream_end_to_p(
+        self, event: StreamEndEvent, context: StreamContext | None
+    ) -> dict[str, Any]:
+        reason = "stop"
+        interaction: dict[str, Any] = {"status": "completed"}
+        if context:
+            reason = context.metadata.get("_interactions_finish_reason", "stop")
+            interaction["id"] = getattr(context, "response_id", "")
+            interaction["model"] = getattr(context, "model", "")
+            stashed = context.metadata.get("_interactions_usage")
+            if stashed:
+                interaction["usage"] = stashed
+        interaction["status"] = _FINISH_REASON_TO_STATUS.get(reason, "completed")
+        return {
+            "event_type": "interaction.completed",
+            "interaction": interaction,
+        }
+
+    def _handle_ir_content_block_start_to_p(
+        self, event: ContentBlockStartEvent, context: StreamContext | None
+    ) -> dict[str, Any]:
+        block_type = event["block_type"]
+        step_type = {v: k for k, v in _STEP_TYPE_TO_BLOCK_TYPE.items()}.get(
+            block_type, block_type
+        )
+        return {
+            "event_type": "step.start",
+            "index": event["block_index"],
+            "step": {"type": step_type},
+        }
+
+    def _handle_ir_content_block_end_to_p(
+        self, event: ContentBlockEndEvent, context: StreamContext | None
+    ) -> dict[str, Any]:
+        return {
+            "event_type": "step.stop",
+            "index": event["block_index"],
+        }
+
+    def _handle_ir_text_delta_to_p(
+        self, event: TextDeltaEvent, context: StreamContext | None
+    ) -> dict[str, Any]:
+        return {
+            "event_type": "step.delta",
+            "index": event.get("block_index", 0),
+            "delta": {"type": "text", "text": event["text"]},
+        }
+
+    def _handle_ir_reasoning_delta_to_p(
+        self, event: ReasoningDeltaEvent, context: StreamContext | None
+    ) -> dict[str, Any]:
+        if event.get("signature"):
+            return {
+                "event_type": "step.delta",
+                "index": event.get("block_index", 0),
+                "delta": {"type": "thought_signature", "signature": event["signature"]},
+            }
+        return {
+            "event_type": "step.delta",
+            "index": event.get("block_index", 0),
+            "delta": {"type": "thought_summary", "text": event["reasoning"]},
+        }
+
+    def _handle_ir_tool_call_start_to_p(
+        self, event: ToolCallStartEvent, context: StreamContext | None
+    ) -> dict[str, Any]:
+        return {
+            "event_type": "step.start",
+            "index": event.get("tool_call_index", 0),
+            "step": {
+                "type": "function_call",
+                "id": event["tool_call_id"],
+                "name": event["tool_name"],
+            },
+        }
+
+    def _handle_ir_tool_call_delta_to_p(
+        self, event: ToolCallDeltaEvent, context: StreamContext | None
+    ) -> dict[str, Any]:
+        return {
+            "event_type": "step.delta",
+            "index": event.get("block_index", 0),
+            "delta": {
+                "type": "arguments",
+                "call_id": event["tool_call_id"],
+                "arguments": event["arguments_delta"],
+            },
+        }
+
+    def _handle_ir_finish_to_p(
+        self, event: FinishEvent, context: StreamContext | None
+    ) -> dict[str, Any]:
+        # Stash finish reason; defer interaction.completed to stream_end
+        # so usage (which may arrive after finish) is included
+        reason = event["finish_reason"]["reason"]
+        if context:
+            context.metadata["_interactions_finish_reason"] = reason
+        return {}
+
+    def _handle_ir_usage_to_p(
+        self, event: UsageEvent, context: StreamContext | None
+    ) -> dict[str, Any]:
+        usage = self._build_ir_usage_to_p(event["usage"])
+        # Stash for injection into interaction.completed
+        if context is not None:
+            context.metadata["_interactions_usage"] = usage
+        return {}

--- a/src/llm_rosetta/gateway/transport/sse_format.py
+++ b/src/llm_rosetta/gateway/transport/sse_format.py
@@ -43,12 +43,20 @@ def _format_sse_google(chunk: dict[str, Any]) -> str:
     return f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n"
 
 
+def _format_sse_google_interactions(chunk: dict[str, Any]) -> str:
+    """Format a chunk as Google Interactions SSE (``event: type\\ndata: json``)."""
+    event_type = chunk.get("event_type", "unknown")
+    return f"event: {event_type}\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+
+
 SSE_FORMATTERS: dict[str, Any] = {
     "openai_chat": _format_sse_openai_chat,
     "openai_responses": _format_sse_openai_responses,
     "open_responses": _format_sse_openai_responses,
     "anthropic": _format_sse_anthropic,
     "google": _format_sse_google,
+    "google_generate": _format_sse_google,
+    "google_interactions": _format_sse_google_interactions,
 }
 
 
@@ -102,8 +110,20 @@ def build_stream_error_events(
     if source_provider == "anthropic":
         return [{"type": "error", "error": {"type": "api_error", "message": message}}]
 
-    if source_provider == "google":
+    if source_provider in ("google", "google_generate"):
         return [{"error": {"code": 500, "message": message, "status": "INTERNAL"}}]
+
+    if source_provider == "google_interactions":
+        return [
+            {
+                "event_type": "interaction.completed",
+                "interaction": {
+                    "id": response_id,
+                    "status": "failed",
+                    "errors": [{"message": message}],
+                },
+            }
+        ]
 
     return []
 

--- a/tests/converters/google_interactions/test_roundtrip.py
+++ b/tests/converters/google_interactions/test_roundtrip.py
@@ -1,0 +1,266 @@
+"""Cross-format round-trip tests for Google Interactions converter.
+
+Tests A→IR→B→IR→A fidelity for request and response conversion
+across all supported provider pairs involving google_interactions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from llm_rosetta import get_converter_for_provider
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+
+def roundtrip_request(
+    body: dict[str, Any],
+    src: str,
+    via: str,
+) -> dict[str, Any]:
+    """A→IR→B→IR→A request round-trip."""
+    src_conv = get_converter_for_provider(src)
+    via_conv = get_converter_for_provider(via)
+
+    ir = src_conv.request_from_provider(body)
+    mid, _ = via_conv.request_to_provider(ir)
+    ir2 = via_conv.request_from_provider(mid)
+    back, _ = src_conv.request_to_provider(ir2)
+    return back
+
+
+def roundtrip_response(
+    body: dict[str, Any],
+    src: str,
+    via: str,
+) -> dict[str, Any]:
+    """A→IR→B→IR→A response round-trip."""
+    src_conv = get_converter_for_provider(src)
+    via_conv = get_converter_for_provider(via)
+
+    ir = src_conv.response_from_provider(body)
+    mid = via_conv.response_to_provider(ir)
+    ir2 = via_conv.response_from_provider(mid)
+    back = src_conv.response_to_provider(ir2)
+    return back
+
+
+# ── Fixtures ───────────────────────────────────────────────────────
+
+INTERACTIONS_REQUEST_SIMPLE = {
+    "model": "gemini-3.5-flash",
+    "input": "Say hello.",
+}
+
+INTERACTIONS_REQUEST_MULTI_TURN = {
+    "model": "gemini-3.5-flash",
+    "input": [
+        {
+            "type": "user_input",
+            "content": [{"type": "text", "text": "My name is Alice."}],
+        },
+        {"type": "model_output", "content": [{"type": "text", "text": "Hello Alice!"}]},
+        {
+            "type": "user_input",
+            "content": [{"type": "text", "text": "What is my name?"}],
+        },
+    ],
+}
+
+INTERACTIONS_REQUEST_WITH_TOOLS = {
+    "model": "gemini-3.5-flash",
+    "input": "What is the weather?",
+    "tools": [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"],
+            },
+        }
+    ],
+}
+
+INTERACTIONS_RESPONSE_SIMPLE = {
+    "id": "int_123",
+    "object": "interaction",
+    "model": "gemini-3.5-flash",
+    "status": "completed",
+    "created": "2025-12-04T15:01:45Z",
+    "steps": [
+        {"type": "model_output", "content": [{"type": "text", "text": "Hello!"}]},
+    ],
+    "usage": {
+        "total_input_tokens": 10,
+        "total_output_tokens": 5,
+        "total_tokens": 15,
+    },
+}
+
+INTERACTIONS_RESPONSE_WITH_THINKING = {
+    "id": "int_456",
+    "object": "interaction",
+    "model": "gemini-3.5-flash",
+    "status": "completed",
+    "created": "2025-12-04T15:01:45Z",
+    "steps": [
+        {
+            "type": "thought",
+            "signature": "sig_abc",
+            "summary": [{"type": "text", "text": "Thinking..."}],
+        },
+        {"type": "model_output", "content": [{"type": "text", "text": "42"}]},
+    ],
+    "usage": {
+        "total_input_tokens": 20,
+        "total_output_tokens": 10,
+        "total_tokens": 80,
+        "total_thought_tokens": 50,
+    },
+}
+
+INTERACTIONS_RESPONSE_TOOL_CALL = {
+    "id": "int_789",
+    "object": "interaction",
+    "model": "gemini-3.5-flash",
+    "status": "requires_action",
+    "created": "2025-12-04T15:01:45Z",
+    "steps": [
+        {
+            "type": "function_call",
+            "id": "call_1",
+            "name": "get_weather",
+            "arguments": {"location": "SF"},
+        },
+    ],
+}
+
+VIA_PROVIDERS = ["openai_chat", "anthropic", "google_generate"]
+
+
+# ── Request round-trip tests ───────────────────────────────────────
+
+
+class TestRequestRoundtrip:
+    @pytest.mark.parametrize("via", VIA_PROVIDERS)
+    def test_simple_request(self, via: str):
+        result = roundtrip_request(
+            INTERACTIONS_REQUEST_SIMPLE, "google_interactions", via
+        )
+        assert result["model"] == "gemini-3.5-flash"
+        if isinstance(result["input"], str):
+            assert "hello" in result["input"].lower()
+        else:
+            user_steps = [s for s in result["input"] if s.get("type") == "user_input"]
+            assert len(user_steps) >= 1
+
+    @pytest.mark.parametrize("via", VIA_PROVIDERS)
+    def test_multi_turn_request(self, via: str):
+        result = roundtrip_request(
+            INTERACTIONS_REQUEST_MULTI_TURN, "google_interactions", via
+        )
+        assert result["model"] == "gemini-3.5-flash"
+        inp = result["input"]
+        assert isinstance(inp, list)
+        types = [s.get("type") for s in inp]
+        assert "user_input" in types
+
+    @pytest.mark.parametrize("via", VIA_PROVIDERS)
+    def test_tools_preserved(self, via: str):
+        result = roundtrip_request(
+            INTERACTIONS_REQUEST_WITH_TOOLS, "google_interactions", via
+        )
+        assert "tools" in result
+        assert any(t.get("name") == "get_weather" for t in result["tools"])
+
+
+# ── Response round-trip tests ──────────────────────────────────────
+
+
+class TestResponseRoundtrip:
+    @pytest.mark.parametrize("via", VIA_PROVIDERS)
+    def test_simple_response(self, via: str):
+        result = roundtrip_response(
+            INTERACTIONS_RESPONSE_SIMPLE, "google_interactions", via
+        )
+        assert result["status"] == "completed"
+        model_outputs = [
+            s for s in result.get("steps", []) if s.get("type") == "model_output"
+        ]
+        assert len(model_outputs) >= 1
+        assert any(
+            "Hello" in c.get("text", "")
+            for s in model_outputs
+            for c in s.get("content", [])
+        )
+
+    @pytest.mark.parametrize("via", VIA_PROVIDERS)
+    def test_tool_call_response(self, via: str):
+        result = roundtrip_response(
+            INTERACTIONS_RESPONSE_TOOL_CALL, "google_interactions", via
+        )
+        assert result["status"] == "requires_action"
+        fc_steps = [
+            s for s in result.get("steps", []) if s.get("type") == "function_call"
+        ]
+        assert len(fc_steps) >= 1
+        assert fc_steps[0]["name"] == "get_weather"
+
+    @pytest.mark.parametrize("via", VIA_PROVIDERS)
+    def test_usage_preserved(self, via: str):
+        result = roundtrip_response(
+            INTERACTIONS_RESPONSE_SIMPLE, "google_interactions", via
+        )
+        usage = result.get("usage", {})
+        assert usage.get("total_input_tokens", 0) > 0
+        assert usage.get("total_output_tokens", 0) > 0
+
+
+# ── Reverse direction: other formats → Interactions → back ─────────
+
+
+OPENAI_CHAT_REQUEST = {
+    "model": "gemini-3.5-flash",
+    "messages": [
+        {"role": "user", "content": "Hello!"},
+    ],
+}
+
+OPENAI_CHAT_RESPONSE = {
+    "id": "chatcmpl-123",
+    "object": "chat.completion",
+    "created": 1733324505,
+    "model": "gemini-3.5-flash",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "Hi there!"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+}
+
+
+class TestReverseRoundtrip:
+    def test_openai_chat_via_interactions_request(self):
+        result = roundtrip_request(
+            OPENAI_CHAT_REQUEST, "openai_chat", "google_interactions"
+        )
+        assert "messages" in result
+        user_msgs = [m for m in result["messages"] if m.get("role") == "user"]
+        assert len(user_msgs) >= 1
+
+    def test_openai_chat_via_interactions_response(self):
+        result = roundtrip_response(
+            OPENAI_CHAT_RESPONSE, "openai_chat", "google_interactions"
+        )
+        assert "choices" in result
+        assert result["choices"][0]["message"]["content"] == "Hi there!"
+        assert result["choices"][0]["finish_reason"] == "stop"


### PR DESCRIPTION
## Summary

Three bugs found during live llm-comply testing against the dev gateway:

1. **Tool Calling status** — response had `status: "completed"` instead of `"requires_action"` when containing function_call steps. Root cause: Google generateContent returns `STOP` finish reason for tool calls, so the Interactions converter now detects function_call steps and overrides status.

2. **Streaming 500** — `KeyError: 'google_interactions'` in SSE formatter. Root cause: `SSE_FORMATTERS` and `build_stream_error_events` only had `"google"` entry, missing `google_generate` and `google_interactions`. Added both with appropriate SSE formats.

3. **Thinking missing** — no `thought` step in response despite `thinking_level: "low"`. Root cause: `include_thoughts` was not being set in IR `ReasoningConfig`, so the upstream Google API defaulted to hiding thought content. Now set `include_thoughts: True` whenever thinking is enabled.

## Test plan
- [x] 3226 tests pass
- [x] All pre-commit hooks pass
- [ ] Live llm-comply retest after deploy