### PR TITLE
feat(tool_ops): add google_interactions support and full lifecycle API

### DIFF
--- a/src/llm_rosetta/tool_ops.py
+++ b/src/llm_rosetta/tool_ops.py
@@ -96,7 +96,8 @@ def _get_tool_ops(provider: str) -> Any:
     raise ValueError(
         f"Unknown provider: {provider!r}. "
         f"Supported: openai_chat, openai_responses, anthropic, google, "
-        f"google_interactions"
+        f"google_interactions "
+        f"(aliases: openai-chat, openai-responses, google-genai, google-interactions)"
     )
 
 

--- a/src/llm_rosetta/tool_ops.py
+++ b/src/llm_rosetta/tool_ops.py
@@ -1,8 +1,10 @@
 """
-LLM-Rosetta - Tool Definition Convenience API
+LLM-Rosetta - Tool Conversion Convenience API
 
-Lightweight top-level API for converting tool definitions between IR and
+Lightweight top-level API for converting tool artifacts between IR and
 provider formats without instantiating full converter pipelines.
+
+Covers the full tool lifecycle: definition, choice, call, result, config.
 
 All imports are lazy to avoid pulling provider dependencies at import time.
 
@@ -17,20 +19,25 @@ Example usage::
         "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
     }
 
-    # Per-provider shortcuts
+    # Per-provider shortcuts (definitions only)
     openai_tool = tool_ops.to_openai_chat(ir_tool)
     anthropic_tool = tool_ops.to_anthropic(ir_tool)
 
-    # Unified dispatch
+    # Unified dispatch (definitions)
     gemini_tool = tool_ops.to_provider(ir_tool, provider="google")
 
     # Reverse direction
     recovered = tool_ops.from_provider(openai_tool, provider="openai_chat")
+
+    # Full lifecycle dispatch (choice, call, result, config)
+    provider_choice = tool_ops.choice_to_provider(ir_choice, provider="anthropic")
+    provider_call = tool_ops.call_to_provider(ir_call, provider="openai_chat")
 """
 
 from typing import Any, Literal
 
-from .types.ir.tools import ToolDefinition
+from .types.ir.tools import ToolCallConfig, ToolChoice, ToolDefinition
+from .types.ir.parts import ToolCallPart, ToolResultPart
 
 ToolProvider = Literal[
     # Canonical names (match ProviderType / internal module names)
@@ -38,12 +45,14 @@ ToolProvider = Literal[
     "openai_responses",
     "anthropic",
     "google",
+    "google_interactions",
     # Hyphenated aliases for ergonomic use
     "openai-chat",
     "openai-responses",
     "open_responses",
     "open-responses",
     "google-genai",
+    "google-interactions",
 ]
 
 _PROVIDER_ALIASES: dict[str, str] = {
@@ -52,6 +61,7 @@ _PROVIDER_ALIASES: dict[str, str] = {
     "open_responses": "openai_responses",
     "open-responses": "openai_responses",
     "google-genai": "google",
+    "google-interactions": "google_interactions",
 }
 
 
@@ -79,14 +89,18 @@ def _get_tool_ops(provider: str) -> Any:
         from .converters.google_generate import GoogleGenerateToolOps
 
         return GoogleGenerateToolOps
+    if canonical == "google_interactions":
+        from .converters.google_interactions import GoogleInteractionsToolOps
+
+        return GoogleInteractionsToolOps
     raise ValueError(
         f"Unknown provider: {provider!r}. "
-        f"Supported: openai_chat, openai_responses, anthropic, google "
-        f"(aliases: openai-chat, openai-responses, google-genai)"
+        f"Supported: openai_chat, openai_responses, anthropic, google, "
+        f"google_interactions"
     )
 
 
-# ==================== Unified dispatch ====================
+# ==================== Definition dispatch ====================
 
 
 def to_provider(ir_tool: ToolDefinition, provider: ToolProvider, **kwargs: Any) -> Any:
@@ -126,7 +140,75 @@ def from_provider(
     return _get_tool_ops(provider).p_tool_definition_to_ir(provider_tool, **kwargs)
 
 
-# ==================== Per-provider shortcuts ====================
+# ==================== Choice dispatch ====================
+
+
+def choice_to_provider(
+    ir_choice: ToolChoice, provider: ToolProvider, **kwargs: Any
+) -> Any:
+    """Convert an IR tool choice to provider-native format."""
+    return _get_tool_ops(provider).ir_tool_choice_to_p(ir_choice, **kwargs)
+
+
+def choice_from_provider(
+    provider_choice: Any, provider: ToolProvider, **kwargs: Any
+) -> ToolChoice:
+    """Convert a provider-native tool choice to IR format."""
+    return _get_tool_ops(provider).p_tool_choice_to_ir(provider_choice, **kwargs)
+
+
+# ==================== Call dispatch ====================
+
+
+def call_to_provider(
+    ir_call: ToolCallPart, provider: ToolProvider, **kwargs: Any
+) -> Any:
+    """Convert an IR tool call to provider-native format."""
+    return _get_tool_ops(provider).ir_tool_call_to_p(ir_call, **kwargs)
+
+
+def call_from_provider(
+    provider_call: Any, provider: ToolProvider, **kwargs: Any
+) -> ToolCallPart:
+    """Convert a provider-native tool call to IR format."""
+    return _get_tool_ops(provider).p_tool_call_to_ir(provider_call, **kwargs)
+
+
+# ==================== Result dispatch ====================
+
+
+def result_to_provider(
+    ir_result: ToolResultPart, provider: ToolProvider, **kwargs: Any
+) -> Any:
+    """Convert an IR tool result to provider-native format."""
+    return _get_tool_ops(provider).ir_tool_result_to_p(ir_result, **kwargs)
+
+
+def result_from_provider(
+    provider_result: Any, provider: ToolProvider, **kwargs: Any
+) -> ToolResultPart:
+    """Convert a provider-native tool result to IR format."""
+    return _get_tool_ops(provider).p_tool_result_to_ir(provider_result, **kwargs)
+
+
+# ==================== Config dispatch ====================
+
+
+def config_to_provider(
+    ir_config: ToolCallConfig, provider: ToolProvider, **kwargs: Any
+) -> Any:
+    """Convert an IR tool call config to provider-native format."""
+    return _get_tool_ops(provider).ir_tool_config_to_p(ir_config, **kwargs)
+
+
+def config_from_provider(
+    provider_config: Any, provider: ToolProvider, **kwargs: Any
+) -> ToolCallConfig:
+    """Convert a provider-native tool call config to IR format."""
+    return _get_tool_ops(provider).p_tool_config_to_ir(provider_config, **kwargs)
+
+
+# ==================== Per-provider definition shortcuts ====================
 
 
 def to_openai_chat(ir_tool: ToolDefinition, **kwargs: Any) -> dict[str, Any]:
@@ -151,10 +233,17 @@ def to_anthropic(ir_tool: ToolDefinition, **kwargs: Any) -> dict[str, Any]:
 
 
 def to_google_generate(ir_tool: ToolDefinition, **kwargs: Any) -> dict[str, Any]:
-    """Convert IR tool definition to Google GenAI format."""
+    """Convert IR tool definition to Google generateContent format."""
     from .converters.google_generate import GoogleGenerateToolOps
 
     return GoogleGenerateToolOps.ir_tool_definition_to_p(ir_tool, **kwargs)
+
+
+def to_google_interactions(ir_tool: ToolDefinition, **kwargs: Any) -> dict[str, Any]:
+    """Convert IR tool definition to Google Interactions format."""
+    from .converters.google_interactions import GoogleInteractionsToolOps
+
+    return GoogleInteractionsToolOps.ir_tool_definition_to_p(ir_tool, **kwargs)
 
 
 def from_openai_chat(provider_tool: Any, **kwargs: Any) -> ToolDefinition | None:
@@ -183,7 +272,16 @@ def from_anthropic(provider_tool: Any, **kwargs: Any) -> ToolDefinition | None:
 def from_google_generate(
     provider_tool: Any, **kwargs: Any
 ) -> ToolDefinition | list[ToolDefinition] | None:
-    """Convert Google GenAI tool definition to IR format."""
+    """Convert Google generateContent tool definition to IR format."""
     from .converters.google_generate import GoogleGenerateToolOps
 
     return GoogleGenerateToolOps.p_tool_definition_to_ir(provider_tool, **kwargs)
+
+
+def from_google_interactions(
+    provider_tool: Any, **kwargs: Any
+) -> ToolDefinition | list[ToolDefinition] | None:
+    """Convert Google Interactions tool definition to IR format."""
+    from .converters.google_interactions import GoogleInteractionsToolOps
+
+    return GoogleInteractionsToolOps.p_tool_definition_to_ir(provider_tool, **kwargs)

--- a/tests/test_tool_ops.py
+++ b/tests/test_tool_ops.py
@@ -17,6 +17,14 @@ IR_TOOL: ToolDefinition = {
     },
 }
 
+ALL_PROVIDERS = [
+    "openai_chat",
+    "openai_responses",
+    "anthropic",
+    "google",
+    "google_interactions",
+]
+
 
 # ==================== to_* shortcuts ====================
 
@@ -43,10 +51,13 @@ class TestToProvider:
 
     def test_to_google_generate(self):
         result = tool_ops.to_google_generate(IR_TOOL)
-        # Google wraps in function_declarations
         assert "function_declarations" in result
         decl = result["function_declarations"][0]
         assert decl["name"] == "get_weather"
+
+    def test_to_google_interactions(self):
+        result = tool_ops.to_google_interactions(IR_TOOL)
+        assert isinstance(result, dict)
 
 
 # ==================== from_* shortcuts ====================
@@ -78,7 +89,16 @@ class TestFromProvider:
     def test_from_google_generate(self):
         provider_tool = tool_ops.to_google_generate(IR_TOOL)
         recovered = tool_ops.from_google_generate(provider_tool)
-        # Google may return a list of ToolDefinitions
+        if isinstance(recovered, list):
+            assert len(recovered) >= 1
+            assert recovered[0]["name"] == "get_weather"
+        else:
+            assert recovered is not None
+            assert recovered["name"] == "get_weather"
+
+    def test_from_google_interactions(self):
+        provider_tool = tool_ops.to_google_interactions(IR_TOOL)
+        recovered = tool_ops.from_google_interactions(provider_tool)
         if isinstance(recovered, list):
             assert len(recovered) >= 1
             assert recovered[0]["name"] == "get_weather"
@@ -87,16 +107,13 @@ class TestFromProvider:
             assert recovered["name"] == "get_weather"
 
 
-# ==================== Unified dispatch ====================
+# ==================== Unified definition dispatch ====================
 
 
 class TestUnifiedDispatch:
     """Test to_provider / from_provider dispatch."""
 
-    @pytest.mark.parametrize(
-        "provider",
-        ["openai_chat", "openai_responses", "anthropic", "google"],
-    )
+    @pytest.mark.parametrize("provider", ALL_PROVIDERS)
     def test_to_provider_canonical(self, provider: str):
         result = tool_ops.to_provider(IR_TOOL, provider=provider)  # ty: ignore[invalid-argument-type]
         assert isinstance(result, dict)
@@ -107,6 +124,7 @@ class TestUnifiedDispatch:
             ("openai-chat", "openai_chat"),
             ("openai-responses", "openai_responses"),
             ("google-genai", "google"),
+            ("google-interactions", "google_interactions"),
         ],
     )
     def test_to_provider_aliases(self, alias: str, canonical: str):
@@ -122,26 +140,107 @@ class TestUnifiedDispatch:
         with pytest.raises(ValueError, match="Unknown provider"):
             tool_ops.from_provider({}, provider="not_a_provider")  # ty: ignore[invalid-argument-type]
 
-    @pytest.mark.parametrize(
-        "provider",
-        ["openai_chat", "openai_responses", "anthropic"],
-    )
+    @pytest.mark.parametrize("provider", ALL_PROVIDERS)
     def test_round_trip(self, provider: str):
         """to_provider then from_provider should recover the tool name."""
         provider_tool = tool_ops.to_provider(IR_TOOL, provider=provider)  # ty: ignore[invalid-argument-type]
         recovered = tool_ops.from_provider(provider_tool, provider=provider)  # ty: ignore[invalid-argument-type]
-        assert recovered is not None
-        if isinstance(recovered, list):
-            assert recovered[0]["name"] == "get_weather"
-        else:
-            assert recovered["name"] == "get_weather"
-
-    def test_round_trip_google(self):
-        """Google round-trip (may return list)."""
-        provider_tool = tool_ops.to_provider(IR_TOOL, provider="google")
-        recovered = tool_ops.from_provider(provider_tool, provider="google")
         if isinstance(recovered, list):
             assert any(t["name"] == "get_weather" for t in recovered)
         else:
             assert recovered is not None
             assert recovered["name"] == "get_weather"
+
+
+# ==================== Choice dispatch ====================
+
+
+class TestChoiceDispatch:
+    """Test tool choice conversion dispatch."""
+
+    @pytest.mark.parametrize("provider", ALL_PROVIDERS)
+    def test_choice_auto(self, provider: str):
+        ir_choice = {"mode": "auto"}
+        result = tool_ops.choice_to_provider(ir_choice, provider=provider)  # ty: ignore[invalid-argument-type]
+        assert result is not None
+
+    @pytest.mark.parametrize("provider", ALL_PROVIDERS)
+    def test_choice_none(self, provider: str):
+        ir_choice = {"mode": "none"}
+        result = tool_ops.choice_to_provider(ir_choice, provider=provider)  # ty: ignore[invalid-argument-type]
+        assert result is not None
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["openai_chat", "openai_responses", "anthropic"],
+    )
+    def test_choice_round_trip(self, provider: str):
+        ir_choice = {"mode": "auto"}
+        provider_choice = tool_ops.choice_to_provider(ir_choice, provider=provider)  # ty: ignore[invalid-argument-type]
+        recovered = tool_ops.choice_from_provider(provider_choice, provider=provider)  # ty: ignore[invalid-argument-type]
+        assert recovered["mode"] == "auto"
+
+
+# ==================== Call dispatch ====================
+
+
+class TestCallDispatch:
+    """Test tool call conversion dispatch."""
+
+    IR_CALL = {
+        "type": "tool_call",
+        "tool_call_id": "call_123",
+        "tool_name": "get_weather",
+        "arguments": '{"city": "London"}',
+    }
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["openai_chat", "openai_responses", "anthropic", "google"],
+    )
+    def test_call_to_provider(self, provider: str):
+        result = tool_ops.call_to_provider(self.IR_CALL, provider=provider)  # ty: ignore[invalid-argument-type]
+        assert result is not None
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["openai_chat", "openai_responses", "anthropic"],
+    )
+    def test_call_round_trip(self, provider: str):
+        provider_call = tool_ops.call_to_provider(self.IR_CALL, provider=provider)  # ty: ignore[invalid-argument-type]
+        recovered = tool_ops.call_from_provider(provider_call, provider=provider)  # ty: ignore[invalid-argument-type]
+        assert recovered["tool_name"] == "get_weather"
+
+
+# ==================== Result dispatch ====================
+
+
+class TestResultDispatch:
+    """Test tool result conversion dispatch."""
+
+    IR_RESULT = {
+        "type": "tool_result",
+        "tool_call_id": "call_123",
+        "content": "Sunny, 22°C",
+    }
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["openai_chat", "openai_responses", "anthropic"],
+    )
+    def test_result_to_provider(self, provider: str):
+        result = tool_ops.result_to_provider(self.IR_RESULT, provider=provider)  # ty: ignore[invalid-argument-type]
+        assert result is not None
+
+
+# ==================== Config dispatch ====================
+
+
+class TestConfigDispatch:
+    """Test tool config conversion dispatch."""
+
+    @pytest.mark.parametrize("provider", ALL_PROVIDERS)
+    def test_config_to_provider(self, provider: str):
+        ir_config = {"tool_choice": "auto"}
+        result = tool_ops.config_to_provider(ir_config, provider=provider)  # ty: ignore[invalid-argument-type]
+        assert isinstance(result, dict)

--- a/tests/test_tool_ops.py
+++ b/tests/test_tool_ops.py
@@ -5,7 +5,7 @@ import pytest
 from llm_rosetta import tool_ops
 from llm_rosetta.types.ir.tools import ToolDefinition
 
-# Shared fixture: a minimal IR tool definition
+# Shared fixtures
 IR_TOOL: ToolDefinition = {
     "type": "function",
     "name": "get_weather",
@@ -15,6 +15,19 @@ IR_TOOL: ToolDefinition = {
         "properties": {"city": {"type": "string", "description": "City name"}},
         "required": ["city"],
     },
+}
+
+IR_CALL = {
+    "type": "tool_call",
+    "tool_call_id": "call_123",
+    "tool_name": "get_weather",
+    "tool_input": {"city": "London"},
+}
+
+IR_RESULT = {
+    "type": "tool_result",
+    "tool_call_id": "call_123",
+    "result": "Sunny, 22°C",
 }
 
 ALL_PROVIDERS = [
@@ -58,6 +71,7 @@ class TestToProvider:
     def test_to_google_interactions(self):
         result = tool_ops.to_google_interactions(IR_TOOL)
         assert isinstance(result, dict)
+        assert result["name"] == "get_weather"
 
 
 # ==================== from_* shortcuts ====================
@@ -170,10 +184,7 @@ class TestChoiceDispatch:
         result = tool_ops.choice_to_provider(ir_choice, provider=provider)  # ty: ignore[invalid-argument-type]
         assert result is not None
 
-    @pytest.mark.parametrize(
-        "provider",
-        ["openai_chat", "openai_responses", "anthropic"],
-    )
+    @pytest.mark.parametrize("provider", ALL_PROVIDERS)
     def test_choice_round_trip(self, provider: str):
         ir_choice = {"mode": "auto"}
         provider_choice = tool_ops.choice_to_provider(ir_choice, provider=provider)  # ty: ignore[invalid-argument-type]
@@ -187,27 +198,14 @@ class TestChoiceDispatch:
 class TestCallDispatch:
     """Test tool call conversion dispatch."""
 
-    IR_CALL = {
-        "type": "tool_call",
-        "tool_call_id": "call_123",
-        "tool_name": "get_weather",
-        "arguments": '{"city": "London"}',
-    }
-
-    @pytest.mark.parametrize(
-        "provider",
-        ["openai_chat", "openai_responses", "anthropic", "google"],
-    )
+    @pytest.mark.parametrize("provider", ALL_PROVIDERS)
     def test_call_to_provider(self, provider: str):
-        result = tool_ops.call_to_provider(self.IR_CALL, provider=provider)  # ty: ignore[invalid-argument-type]
+        result = tool_ops.call_to_provider(IR_CALL, provider=provider)  # ty: ignore[invalid-argument-type]
         assert result is not None
 
-    @pytest.mark.parametrize(
-        "provider",
-        ["openai_chat", "openai_responses", "anthropic"],
-    )
+    @pytest.mark.parametrize("provider", ALL_PROVIDERS)
     def test_call_round_trip(self, provider: str):
-        provider_call = tool_ops.call_to_provider(self.IR_CALL, provider=provider)  # ty: ignore[invalid-argument-type]
+        provider_call = tool_ops.call_to_provider(IR_CALL, provider=provider)  # ty: ignore[invalid-argument-type]
         recovered = tool_ops.call_from_provider(provider_call, provider=provider)  # ty: ignore[invalid-argument-type]
         assert recovered["tool_name"] == "get_weather"
 
@@ -218,19 +216,19 @@ class TestCallDispatch:
 class TestResultDispatch:
     """Test tool result conversion dispatch."""
 
-    IR_RESULT = {
-        "type": "tool_result",
-        "tool_call_id": "call_123",
-        "content": "Sunny, 22°C",
-    }
+    @pytest.mark.parametrize("provider", ALL_PROVIDERS)
+    def test_result_to_provider(self, provider: str):
+        result = tool_ops.result_to_provider(IR_RESULT, provider=provider)  # ty: ignore[invalid-argument-type]
+        assert result is not None
 
     @pytest.mark.parametrize(
         "provider",
-        ["openai_chat", "openai_responses", "anthropic"],
+        ["openai_chat", "openai_responses", "anthropic", "google_interactions"],
     )
-    def test_result_to_provider(self, provider: str):
-        result = tool_ops.result_to_provider(self.IR_RESULT, provider=provider)  # ty: ignore[invalid-argument-type]
-        assert result is not None
+    def test_result_round_trip(self, provider: str):
+        provider_result = tool_ops.result_to_provider(IR_RESULT, provider=provider)  # ty: ignore[invalid-argument-type]
+        recovered = tool_ops.result_from_provider(provider_result, provider=provider)  # ty: ignore[invalid-argument-type]
+        assert recovered["tool_call_id"] == "call_123"
 
 
 # ==================== Config dispatch ====================
@@ -243,4 +241,10 @@ class TestConfigDispatch:
     def test_config_to_provider(self, provider: str):
         ir_config = {"tool_choice": "auto"}
         result = tool_ops.config_to_provider(ir_config, provider=provider)  # ty: ignore[invalid-argument-type]
+        assert isinstance(result, dict)
+
+    @pytest.mark.parametrize("provider", ALL_PROVIDERS)
+    def test_config_from_provider(self, provider: str):
+        provider_config = {"tool_choice": "auto"}
+        result = tool_ops.config_from_provider(provider_config, provider=provider)  # ty: ignore[invalid-argument-type]
         assert isinstance(result, dict)


### PR DESCRIPTION
## Summary

- Add `google_interactions` to the `tool_ops` convenience module — was the only converter missing from the convenience API
- Expand from definition-only to full `BaseToolOps` lifecycle: `choice_to_provider`/`choice_from_provider`, `call_to_provider`/`call_from_provider`, `result_to_provider`/`result_from_provider`, `config_to_provider`/`config_from_provider`
- Add `to_google_interactions()`/`from_google_interactions()` per-provider shortcuts
- 54 tests total (up from 21), covering all 5 providers and all lifecycle stages

## Test plan

- [x] `make lint` passes
- [x] `make test` — 3270 passed (net +33 new tests)
- [x] All 5 providers tested: `openai_chat`, `openai_responses`, `anthropic`, `google`, `google_interactions`
- [x] Round-trip tests for definitions, choices, and calls