### PR TITLE
feat(admin): cross-link request log and error dump entries

### DIFF
--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -198,6 +198,29 @@ def setup_admin(
 
     capture_state = CaptureState()
 
+    # Backfill last_used for API keys from request log history
+    keystore = getattr(app, "keystore", None)
+    if keystore is not None and persistence is not None:
+        backfilled_keys = keystore.backfill_last_used(persistence.db_path)
+        if backfilled_keys:
+            logger.info(
+                "Backfilled last_used for %d API key(s) from request log",
+                backfilled_keys,
+            )
+
+    # Backfill request_log_id for error dumps missing the link
+    if persistence is not None:
+        gateway_config = getattr(app, "gateway_config", None)
+        aliases = gateway_config.model_upstream_names if gateway_config else {}
+        backfilled_dumps = persistence.backfill_error_dump_log_ids(
+            model_aliases=aliases
+        )
+        if backfilled_dumps:
+            logger.info(
+                "Backfilled request_log_id for %d error dump(s)",
+                backfilled_dumps,
+            )
+
     app.metrics = metrics
     app.request_log = request_log
     app.persistence = persistence

--- a/src/llm_rosetta/gateway/admin/admin.html
+++ b/src/llm_rosetta/gateway/admin/admin.html
@@ -47,7 +47,7 @@
   </div>
   <div class="header-right">
     <span style="font-size:12px;color:var(--text-dim);margin-right:8px"><span style="margin-right:4px" data-i18n="label.systemTime">System Time</span><span id="systemClock" style="font-family:var(--mono)"></span></span>
-    <button class="btn btn-sm" onclick="openSettings()" data-i18n-title="modal.settings" title="Settings"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></button>
+    <button class="btn btn-sm" onclick="openSettings()" data-i18n-title="modal.settings" title="Settings" style="display:inline-flex;align-items:center;justify-content:center;padding:4px 8px"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></button>
     <button id="logoutBtn" class="btn btn-sm" onclick="doLogout()" style="display:none" data-i18n="btn.logout">Logout</button>
   </div>
 </div>
@@ -144,9 +144,9 @@
       <div class="table-scroll"><table>
         <thead><tr>
           <th style="width:3%"><input type="checkbox" class="row-check" onchange="selectAllModels(this)"></th>
-          <th class="sortable" onclick="sortModels('name')" id="sortName" data-i18n="col.model" style="width:28%">Model</th>
-          <th style="width:9%;text-align:center" data-i18n="col.type">Type</th>
-          <th style="width:20%;text-align:center" data-i18n="col.capabilities">Capabilities</th>
+          <th class="sortable" onclick="sortModels('name')" id="sortName" data-i18n="col.model" style="width:19%">Model</th>
+          <th style="width:15%;text-align:center" data-i18n="col.type">Type</th>
+          <th style="width:23%" data-i18n="col.capabilities">Capabilities</th>
           <th class="sortable" onclick="sortModels('provider')" id="sortProvider" data-i18n="col.provider" style="width:13%">Provider</th>
           <th style="width:22%;text-align:right" data-i18n="col.actions"></th>
         </tr></thead>
@@ -160,14 +160,15 @@
     <div class="section">
       <div class="section-header">
         <h2 data-i18n="section.apiKeys">API Keys</h2>
-        <button class="btn btn-primary btn-sm" onclick="openKeyModal()" data-i18n="btn.generateKey">+ Generate Key</button>
+<button class="btn btn-primary btn-sm" onclick="openKeyModal()" data-i18n="btn.generateKey">+ Generate Key</button>
       </div>
-      <p style="font-size:13px;color:var(--text-dim);margin-bottom:16px" data-i18n="keys.description">Manage gateway API keys used to authenticate requests to /v1/* endpoints.</p>
+      <p style="font-size:13px;color:var(--text-dim);margin-bottom:16px"><span data-i18n="keys.description">Manage gateway API keys used to authenticate requests to /v1/* endpoints.</span> <button onclick="backfillKeysLastUsed()" data-i18n-title="hint.refreshLastUsed" title="Refresh last-used timestamps from request log" style="background:none;border:none;cursor:pointer;color:var(--text-dim);padding:2px;vertical-align:middle;transition:color 0.15s" onmouseenter="this.style.color='var(--accent)'" onmouseleave="this.style.color='var(--text-dim)'"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 4v6h6"/><path d="M23 20v-6h-6"/><path d="M20.49 9A9 9 0 005.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 013.51 15"/></svg></button></p>
       <div class="table-scroll"><table>
         <thead><tr>
-          <th data-i18n="col.label">Label</th>
-          <th data-i18n="col.created">Created</th>
-          <th></th>
+          <th style="width:30%" data-i18n="col.label">Label</th>
+          <th style="width:15%" data-i18n="col.created">Created</th>
+          <th style="width:15%" data-i18n="col.lastUsed">Last Used</th>
+          <th style="text-align:right"></th>
         </tr></thead>
         <tbody id="keysTable"></tbody>
       </table></div>
@@ -270,6 +271,7 @@
         <div style="display:flex;align-items:center;gap:8px">
           <span style="font-size:12px;color:var(--text-dim)" id="dumpCount"></span>
           <button class="btn btn-sm" onclick="downloadAllDumps()" id="dumpDownloadAllBtn" style="display:none" data-i18n="btn.downloadAll">Download All</button>
+          <button class="btn btn-sm" onclick="backfillDumpLogIds()" title="Link unmatched error dumps to their request log entries by timestamp and provider" data-i18n="btn.matchLogs">Match Logs</button>
           <div style="display:inline-block;position:relative">
             <button class="btn btn-sm" onclick="toggleDumpMoreMenu(this)" style="padding:3px 8px">⋯</button>
             <div id="dumpMoreMenu" style="display:none;position:absolute;right:0;top:calc(100% + 4px);min-width:140px;background:var(--bg-card);border:1px solid var(--border);border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.3);z-index:10;overflow:hidden">

--- a/src/llm_rosetta/gateway/admin/css/components.css
+++ b/src/llm_rosetta/gateway/admin/css/components.css
@@ -50,11 +50,15 @@ tr:hover td { background: var(--bg-hover); }
 /* Capability badges for provider cards */
 /* Capability badges are secondary metadata — kept small so a provider with
    all three still fits its column without squeezing the base URL. */
-.cap-badge { display:inline-flex;align-items:center;gap:2px;padding:1px 5px;border-radius:10px;font-size:9px;font-weight:600;letter-spacing:.02em;margin-left:4px;vertical-align:middle; }
-.cap-badge svg { width:9px;height:9px;flex-shrink:0; }
+.cap-badge { display:inline-flex;align-items:center;gap:3px;padding:3px 7px;border-radius:10px;font-size:11px;font-weight:600;letter-spacing:.02em;margin:0 2px;vertical-align:middle; }
+.cap-badge svg { width:11px;height:11px;flex-shrink:0; }
 .cap-badge-llm { background:color-mix(in srgb, var(--accent) 15%, transparent);color:var(--accent); }
 .cap-badge-embedding { background:color-mix(in srgb, var(--green) 12%, transparent);color:var(--green); }
 .cap-badge-rerank { background:color-mix(in srgb, var(--orange) 12%, transparent);color:var(--orange); }
+.cap-badge-text { background:color-mix(in srgb, var(--text-dim) 15%, transparent);color:var(--text-dim); }
+.cap-badge-vision { background:color-mix(in srgb, var(--orange) 12%, transparent);color:var(--orange); }
+.cap-badge-tools { background:color-mix(in srgb, var(--blue) 12%, transparent);color:var(--blue); }
+.cap-badge-reasoning { background:color-mix(in srgb, var(--purple) 12%, transparent);color:var(--purple); }
 /* Provider-model cross-navigation */
 .provider-link { color:inherit;cursor:pointer;text-decoration:none; }
 .provider-link:hover { text-decoration:underline;color:var(--accent); }
@@ -333,7 +337,7 @@ canvas { width: 100%; height: 160px; }
 .badge-stream { background: color-mix(in srgb, var(--accent) 15%, transparent); color: var(--accent); }
 
 /* Capability badges */
-.badge-cap { background: color-mix(in srgb, var(--text-dim) 15%, transparent); color: var(--text-dim); font-size: 10px; padding: 1px 6px; margin-right: 3px; }
+.badge-cap { background: color-mix(in srgb, var(--text-dim) 15%, transparent); color: var(--text-dim); font-size: 10px; padding: 1px 5px; margin-right: 4px; display:inline-flex; align-items:center; gap:2px; }
 .badge-cap-vision { background: color-mix(in srgb, var(--orange) 12%, transparent); color: var(--orange); }
 .badge-cap-tools { background: color-mix(in srgb, var(--blue) 12%, transparent); color: var(--blue); }
 .badge-cap-embed { background: color-mix(in srgb, var(--green) 12%, transparent); color: var(--green); }
@@ -432,7 +436,7 @@ th.sortable.desc::after { content:'\25BC';opacity:.8; }
 .model-toolbar input, .provider-toolbar input { flex:1;min-width:180px;max-width:300px;padding:6px 10px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);color:var(--text);font-size:13px;font-family:var(--mono); }
 .model-toolbar select { padding:6px 10px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);color:var(--text);font-size:13px; }
 #tab-models table { table-layout:fixed; }
-#tab-keys .table-scroll { max-width:80%;margin:0 auto; }
+
 
 /* Provider breakdown grid */
 .pb-grid { column-count:2;column-gap:32px; }

--- a/src/llm_rosetta/gateway/admin/js/dashboard.js
+++ b/src/llm_rosetta/gateway/admin/js/dashboard.js
@@ -359,7 +359,8 @@ async function renderDumps() {
       }
       const did = esc(e.dump_id||e.id||'');
       const chk = S._selectedDumpIds && S._selectedDumpIds.has(did) ? ' checked' : '';
-      return `<tr>
+      const dumpHlStyle = S._highlightDumpId === did ? ' style="background:color-mix(in srgb, var(--accent) 20%, transparent)"' : '';
+      return `<tr${dumpHlStyle}>
         <td><input type="checkbox" class="row-check" data-id="${did}" onchange="updateDumpBulk()"${chk}></td>
         <td>${time}</td>
         <td><code>${esc(e.model||'-')}</code></td>
@@ -369,7 +370,7 @@ async function renderDumps() {
         <td><span style="font-size:11px;color:var(--red);font-family:var(--mono);max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:block" title="${esc(e.response_text||'')}">${esc(errPreview)}</span></td>
         <td style="white-space:nowrap">
           <button class="btn btn-sm" onclick="viewDump('${esc(e.dump_id||e.id)}')" title="View"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></button>
-          <button class="btn btn-sm" onclick="downloadDump('${esc(e.dump_id||e.id)}')" title="Download"><svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5" style="vertical-align:middle"><path d="M8 2v8m0 0l-3-3m3 3l3-3M3 12h10"/></svg></button>
+          <button class="btn btn-sm" onclick="downloadDump('${esc(e.dump_id||e.id)}')" title="Download"><svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5" style="vertical-align:middle"><path d="M8 2v8m0 0l-3-3m3 3l3-3M3 12h10"/></svg></button>${e.request_log_id ? ` <button class="btn btn-sm" onclick="jumpToRequestLog('${esc(e.request_log_id)}')" title="View in request log"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></button>` : ''}
         </td>
       </tr>`;
     }).join('');
@@ -583,6 +584,7 @@ function renderProviderBreakdown(d) {
     grid.innerHTML = `<div style="color:var(--text-dim);padding:10px">${t('empty.data')}</div>`;
     return;
   }
+  grid.style.columnCount = 2;
   grid.innerHTML = entries.map(([p,c], i) => `<div class="pb-item"><span class="pb-rank">${i+1}</span><span class="pb-name">${esc(p)}</span><span class="pb-count">${c}</span></div>`).join('');
 }
 
@@ -737,6 +739,43 @@ function drawLatencyChart(canvasId, series) {
 }
 
 
+// ===================== Cross-linking =====================
+
+async function backfillDumpLogIds() {
+  try {
+    const res = await api.post('/admin/api/error-dumps/backfill-log-ids');
+    if (res && res.error) { showToast(res.error, 'error'); return; }
+    showToast('Matched ' + (res.updated || 0) + ' error dump(s) with request logs');
+    if (res.updated > 0) { S._dumpAllEntries = []; renderDumps(); }
+  } catch(e) { showToast('Backfill failed', 'error'); }
+}
+
+
+
+function jumpToRequestLog(requestLogId) {
+  api.get('/admin/api/requests/' + requestLogId).then(function(entry) {
+    if (!entry || entry.error) { showToast('Request log entry not found', 'error'); return; }
+    S._highlightLogId = requestLogId;
+    if (!S._highlightLogIdTimer) {
+      S._highlightLogIdTimer = setTimeout(function() {
+        S._highlightLogId = null;
+        S._highlightLogIdTimer = null;
+      }, 10000);
+    }
+    const offset = entry._offset || 0;
+    const pageSize = 30;
+    S.logOffset = Math.floor(offset / pageSize) * pageSize;
+    S._keepLogOffset = true;
+    goToTab('logs', function() {
+      ['filterModel','filterProvider','filterStatus','filterApiKey'].forEach(function(id) {
+        const el = document.getElementById(id);
+        if (el) el.value = '';
+      });
+      setTimeout(function() { loadLogs(); }, 300);
+    });
+  }, function() { showToast('Failed to load request log entry', 'error'); });
+}
+
 // ===================== Bulk Select =====================
 
 if (!S._selectedDumpIds) S._selectedDumpIds = new Set();
@@ -835,6 +874,7 @@ Object.assign(window, {
   onDumpModelFilterChange, closeDumpModelSearch,
   onDumpTimeRangeChange, closeDumpTimeCustom, resetDumpFilters,
   renderPersistence, renderStats, renderProviderBreakdown,
+  jumpToRequestLog, backfillDumpLogIds,
   selectAllProfiling, updateProfilingBulk, bulkDownloadProfiling,
   selectAllCapture, updateCaptureBulk, bulkDownloadCapture,
   selectAllDumps, updateDumpBulk, bulkDownloadDumps, bulkDeleteDumps,
@@ -842,6 +882,7 @@ Object.assign(window, {
 });
 
 export { loadMetrics, loadDumps, renderPersistence, renderStats, renderProviderBreakdown,
+  jumpToRequestLog, backfillDumpLogIds,
   selectAllProfiling, updateProfilingBulk, bulkDownloadProfiling,
   selectAllCapture, updateCaptureBulk, bulkDownloadCapture,
   selectAllDumps, updateDumpBulk, bulkDownloadDumps, bulkDeleteDumps, rebuildMetrics };

--- a/src/llm_rosetta/gateway/admin/js/dashboard.js
+++ b/src/llm_rosetta/gateway/admin/js/dashboard.js
@@ -3,7 +3,7 @@
  * and canvas charts.
  */
 
-import { S, DUMP_PAGE_SIZE } from './state.js';
+import { S, DUMP_PAGE_SIZE, LOG_LIMIT } from './state.js';
 import { t } from './i18n.js';
 import { api, _adminHeaders, showToast, esc, formatDuration, closeModal, fmtBytesShort, fmtBytesLong } from './core.js';
 
@@ -756,14 +756,13 @@ function jumpToRequestLog(requestLogId) {
   api.get('/admin/api/requests/' + requestLogId).then(function(entry) {
     if (!entry || entry.error) { showToast('Request log entry not found', 'error'); return; }
     S._highlightLogId = requestLogId;
-    if (!S._highlightLogIdTimer) {
-      S._highlightLogIdTimer = setTimeout(function() {
-        S._highlightLogId = null;
-        S._highlightLogIdTimer = null;
-      }, 10000);
-    }
+    if (S._highlightLogIdTimer) clearTimeout(S._highlightLogIdTimer);
+    S._highlightLogIdTimer = setTimeout(function() {
+      S._highlightLogId = null;
+      S._highlightLogIdTimer = null;
+    }, 10000);
     const offset = entry._offset || 0;
-    const pageSize = 30;
+    const pageSize = LOG_LIMIT;
     S.logOffset = Math.floor(offset / pageSize) * pageSize;
     S._keepLogOffset = true;
     goToTab('logs', function() {

--- a/src/llm_rosetta/gateway/admin/js/i18n.js
+++ b/src/llm_rosetta/gateway/admin/js/i18n.js
@@ -54,7 +54,7 @@ export const I18N = {
     'profiling.remaining':'{n} remaining',
     'profiling.downloadAll':'Download All', 'profiling.hint':'Results are in-memory only and will be lost on restart. Download important results.',
     'section.capture':'Content Capture',
-    'section.errorDumps':'Error Dumps', 'dump.empty':'No error dumps recorded.', 'confirm.clearDumps':'Clear All Error Dumps', 'confirm.clearDumpsHint':'This will permanently delete all error dump records. Type <strong style="color:var(--red)">CLEAR</strong> to confirm.', 'filter.allPhases':'All Phases', 'filter.allStatus':'All Status', 'filter.allTime':'All Time', 'btn.downloadAll':'Download All', 'btn.downloadSelected':'Download Selected', 'btn.deleteSelected':'Delete Selected', 'btn.clearAll':'Clear All', 'btn.resetFilters':'✕ Reset',
+    'section.errorDumps':'Error Dumps', 'dump.empty':'No error dumps recorded.', 'confirm.clearDumps':'Clear All Error Dumps', 'confirm.clearDumpsHint':'This will permanently delete all error dump records. Type <strong style="color:var(--red)">CLEAR</strong> to confirm.', 'filter.allPhases':'All Phases', 'filter.allStatus':'All Status', 'filter.allTime':'All Time', 'btn.downloadAll':'Download All', 'btn.downloadSelected':'Download Selected', 'btn.deleteSelected':'Delete Selected', 'btn.matchLogs':'Match Logs', 'btn.clearAll':'Clear All', 'btn.resetFilters':'✕ Reset',
     'capture.enable':'Enable', 'capture.disable':'Disable', 'capture.clear':'Clear',
     'capture.requests':'Requests:', 'capture.detail':'Detail', 'capture.mode':'Mode',
     'capture.empty':'No captures. Enable capture and send requests.',
@@ -96,8 +96,8 @@ export const I18N = {
     'provider.countTotal':'{total} providers',
     'empty.searchResults':'No matching results.',
     'section.apiKeys':'API Keys',
-    'btn.generateKey':'+ Generate Key', 'btn.generate':'Generate', 'btn.copy':'Copy', 'btn.clone':'Clone',
-    'col.label':'Label', 'col.created':'Created',
+    'btn.generateKey':'+ Generate Key', 'btn.refreshLastUsed':'Refresh Last Used', 'hint.refreshLastUsed':'Refresh last-used timestamps from request log', 'btn.generate':'Generate', 'btn.copy':'Copy', 'btn.clone':'Clone',
+    'col.label':'Label', 'col.created':'Created', 'col.lastUsed':'Last Used',
     'col.apiKey':'API Key', 'col.clientIp':'Client IP',
     'modal.generateKey':'Generate API Key',
     'modal.keyCreated':'Key Created',
@@ -106,7 +106,7 @@ export const I18N = {
     'keys.description':'Manage gateway API keys used to authenticate requests to /v1/* endpoints.',
     'keys.copyWarning':'Copy this key now. It will not be shown again in full.',
     'keys.noKeys':'No API keys configured. Endpoints are open without authentication.',
-    'toast.keySaved':'API key created', 'toast.keyRotated':'API key \'{label}\' rotated',
+    'toast.keySaved':'API key created', 'toast.keysBackfilled':'Refreshed last-used for {n} key(s)', 'toast.keyRotated':'API key \'{label}\' rotated',
     'toast.keyDeleted':'API key deleted',
     'toast.keyLabelUpdated':'Label updated',
     'toast.keyCopied':'Key copied to clipboard',
@@ -142,7 +142,7 @@ export const I18N = {
     'login.btn':'Login',
     'login.error':'Invalid password',
     'btn.logout':'Logout',
-    'label.systemTime':'System Time',
+    'label.systemTime':'Server Time',
     'footer.db':'DB', 'footer.ok':'ok', 'footer.err':'err', 'footer.req':'Req',
     'footer.tip.req':'Total requests since server start (lifetime counter, never reset by log clearing)',
     'footer.tip.ok':'Logged success entries / retention cap (status < 400)',
@@ -195,7 +195,7 @@ export const I18N = {
     'profiling.remaining':'\u5269\u4f59 {n} \u4e2a',
     'profiling.downloadAll':'\u5168\u90e8\u4e0b\u8f7d', 'profiling.hint':'\u7ed3\u679c\u4ec5\u5b58\u4e8e\u5185\u5b58\uff0c\u91cd\u542f\u540e\u4e22\u5931\u3002\u8bf7\u53ca\u65f6\u4e0b\u8f7d\u91cd\u8981\u7ed3\u679c\u3002',
     'section.capture':'\u5185\u5bb9\u6355\u83b7',
-    'section.errorDumps':'\u9519\u8bef\u8bb0\u5f55', 'dump.empty':'\u6682\u65e0\u9519\u8bef\u8bb0\u5f55\u3002', 'confirm.clearDumps':'\u6e05\u7a7a\u6240\u6709\u9519\u8bef\u8bb0\u5f55', 'confirm.clearDumpsHint':'\u6b64\u64cd\u4f5c\u5c06\u6c38\u4e45\u5220\u9664\u6240\u6709\u9519\u8bef\u8bb0\u5f55\u3002\u8f93\u5165 <strong style="color:var(--red)">CLEAR</strong> \u786e\u8ba4\u3002', 'filter.allPhases':'\u6240\u6709\u9636\u6bb5', 'filter.allStatus':'\u6240\u6709\u72b6\u6001', 'filter.allTime':'\u6240\u6709\u65f6\u95f4', 'btn.downloadAll':'\u5168\u90e8\u4e0b\u8f7d', 'btn.downloadSelected':'\u4e0b\u8f7d\u6240\u9009', 'btn.deleteSelected':'\u5220\u9664\u6240\u9009', 'btn.clearAll':'\u6e05\u7a7a\u6240\u6709', 'btn.resetFilters':'✕ \u91cd\u7f6e',
+    'section.errorDumps':'\u9519\u8bef\u8bb0\u5f55', 'dump.empty':'\u6682\u65e0\u9519\u8bef\u8bb0\u5f55\u3002', 'confirm.clearDumps':'\u6e05\u7a7a\u6240\u6709\u9519\u8bef\u8bb0\u5f55', 'confirm.clearDumpsHint':'\u6b64\u64cd\u4f5c\u5c06\u6c38\u4e45\u5220\u9664\u6240\u6709\u9519\u8bef\u8bb0\u5f55\u3002\u8f93\u5165 <strong style="color:var(--red)">CLEAR</strong> \u786e\u8ba4\u3002', 'filter.allPhases':'\u6240\u6709\u9636\u6bb5', 'filter.allStatus':'\u6240\u6709\u72b6\u6001', 'filter.allTime':'\u6240\u6709\u65f6\u95f4', 'btn.downloadAll':'\u5168\u90e8\u4e0b\u8f7d', 'btn.downloadSelected':'\u4e0b\u8f7d\u6240\u9009', 'btn.deleteSelected':'\u5220\u9664\u6240\u9009', 'btn.matchLogs':'\u5339\u914d\u65e5\u5fd7', 'btn.clearAll':'\u6e05\u7a7a\u6240\u6709', 'btn.resetFilters':'✕ \u91cd\u7f6e',
     'capture.enable':'\u542f\u7528', 'capture.disable':'\u505c\u6b62', 'capture.clear':'\u6e05\u7a7a',
     'capture.requests':'\u8bf7\u6c42\u6570\uff1a', 'capture.detail':'\u8be6\u60c5', 'capture.mode':'\u6a21\u5f0f',
     'capture.empty':'\u6682\u65e0\u6355\u83b7\u7ed3\u679c\u3002\u542f\u7528\u540e\u53d1\u9001\u8bf7\u6c42\u5373\u53ef\u91c7\u96c6\u3002',
@@ -236,8 +236,8 @@ export const I18N = {
     'provider.countTotal':'{total} \u4e2a\u670d\u52a1\u65b9',
     'empty.searchResults':'\u65e0\u5339\u914d\u7ed3\u679c\u3002',
     'section.apiKeys':'API \u5bc6\u94a5',
-    'btn.generateKey':'+ \u751f\u6210\u5bc6\u94a5', 'btn.generate':'\u751f\u6210', 'btn.copy':'\u590d\u5236', 'btn.clone':'\u514b\u9686',
-    'col.label':'\u6807\u7b7e', 'col.key':'\u5bc6\u94a5', 'col.created':'\u521b\u5efa\u65f6\u95f4',
+    'btn.generateKey':'+ \u751f\u6210\u5bc6\u94a5', 'btn.refreshLastUsed':'\u5237\u65b0\u6700\u540e\u4f7f\u7528', 'hint.refreshLastUsed':'\u4ece\u8bf7\u6c42\u65e5\u5fd7\u5237\u65b0\u6700\u540e\u4f7f\u7528\u65f6\u95f4', 'btn.generate':'\u751f\u6210', 'btn.copy':'\u590d\u5236', 'btn.clone':'\u514b\u9686',
+    'col.label':'\u6807\u7b7e', 'col.key':'\u5bc6\u94a5', 'col.created':'\u521b\u5efa\u65f6\u95f4', 'col.lastUsed':'\u6700\u540e\u4f7f\u7528',
     'col.apiKey':'API \u5bc6\u94a5', 'col.clientIp':'\u5ba2\u6237\u7aef IP',
     'modal.generateKey':'\u751f\u6210 API \u5bc6\u94a5',
     'modal.keyCreated':'\u5bc6\u94a5\u5df2\u521b\u5efa',
@@ -246,7 +246,7 @@ export const I18N = {
     'keys.description':'\u7ba1\u7406\u7f51\u5173 API \u5bc6\u94a5\uff0c\u7528\u4e8e\u8ba4\u8bc1 /v1/* \u7aef\u70b9\u7684\u8bf7\u6c42\u3002',
     'keys.copyWarning':'\u8bf7\u7acb\u5373\u590d\u5236\u6b64\u5bc6\u94a5\u3002\u5b8c\u6574\u5bc6\u94a5\u4ec5\u663e\u793a\u4e00\u6b21\u3002',
     'keys.noKeys':'\u672a\u914d\u7f6e API \u5bc6\u94a5\u3002\u7aef\u70b9\u5f00\u653e\u65e0\u9700\u8ba4\u8bc1\u3002',
-    'toast.keySaved':'API \u5bc6\u94a5\u5df2\u521b\u5efa', 'toast.keyRotated':'API \u5bc6\u94a5 \'{label}\' \u5df2\u8f6e\u6362',
+    'toast.keySaved':'API \u5bc6\u94a5\u5df2\u521b\u5efa', 'toast.keysBackfilled':'\u5df2\u5237\u65b0 {n} \u4e2a\u5bc6\u94a5\u7684\u6700\u540e\u4f7f\u7528\u65f6\u95f4', 'toast.keyRotated':'API \u5bc6\u94a5 \'{label}\' \u5df2\u8f6e\u6362',
     'toast.keyDeleted':'API \u5bc6\u94a5\u5df2\u5220\u9664',
     'toast.keyLabelUpdated':'\u6807\u7b7e\u5df2\u66f4\u65b0',
     'toast.keyCopied':'\u5bc6\u94a5\u5df2\u590d\u5236\u5230\u526a\u8d34\u677f',
@@ -281,7 +281,7 @@ export const I18N = {
     'login.subtitle':'Admin \u9762\u677f\u5df2\u542f\u7528\u5bc6\u7801\u4fdd\u62a4',
     'login.btn':'\u767b\u5f55',
     'login.error':'\u5bc6\u7801\u9519\u8bef',
-    'label.systemTime':'\u7cfb\u7edf\u65f6\u95f4',
+    'label.systemTime':'\u670d\u52a1\u5668\u65f6\u95f4',
     'footer.db':'DB', 'footer.ok':'\u6b63\u5e38', 'footer.err':'\u9519\u8bef', 'footer.req':'\u8bf7\u6c42',
     'footer.tip.req':'\u670d\u52a1\u542f\u52a8\u4ee5\u6765\u7684\u603b\u8bf7\u6c42\u6570\uff08\u7d2f\u8ba1\u8ba1\u6570\u5668\uff0c\u6e05\u9664\u65e5\u5fd7\u4e0d\u4f1a\u91cd\u7f6e\uff09',
     'footer.tip.ok':'\u5df2\u8bb0\u5f55\u7684\u6210\u529f\u6761\u76ee / \u4fdd\u7559\u4e0a\u9650\uff08\u72b6\u6001\u7801 < 400\uff09',
@@ -323,6 +323,9 @@ export function applyI18n() {
   });
   document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
     el.placeholder = t(el.dataset.i18nPlaceholder);
+  });
+  document.querySelectorAll('[data-i18n-title]').forEach(el => {
+    el.title = t(el.dataset.i18nTitle);
   });
   // Re-render dynamic content via window.* to break circular deps
   if (S.configData) { window.renderProviders?.(); window.renderModels?.(); }

--- a/src/llm_rosetta/gateway/admin/js/init.js
+++ b/src/llm_rosetta/gateway/admin/js/init.js
@@ -50,7 +50,7 @@ function activateTab(tab) {
   localStorage.setItem('llm-rosetta-tab', id);
   stopTimers();
   if (id === 'dashboard' && _tabEnabled('dashboard')) { loadMetrics(); loadDumps(); S.dashboardTimer = (S._dashboardRefreshMs > 0 ? setInterval(loadMetrics, S._dashboardRefreshMs) : null); }
-  if (id === 'logs' && _tabEnabled('logs')) { S.logOffset = 0; loadLogs(); S.logTimer = setInterval(loadLogs, 5000); }
+  if (id === 'logs' && _tabEnabled('logs')) { if (!S._keepLogOffset) S.logOffset = 0; S._keepLogOffset = false; loadLogs(); S.logTimer = setInterval(loadLogs, 5000); }
   if (id === 'providers' || id === 'models') { loadConfig(); }
   if (id === 'keys' && _tabEnabled('keys')) { loadKeys(); }
 }
@@ -73,6 +73,15 @@ if (S.currentTab !== 'providers') {
   const savedTab = document.querySelector(`.tab[data-tab="${S.currentTab}"]`);
   if (savedTab) activateTab(savedTab);
 }
+
+function goToTab(tabId, callback) {
+  const tab = document.querySelector('.tab[data-tab="' + tabId + '"]');
+  if (tab) {
+    activateTab(tab);
+    if (callback) setTimeout(callback, 300);
+  }
+}
+window.goToTab = goToTab;
 
 function stopTimers() {
   if (S.dashboardTimer) { clearInterval(S.dashboardTimer); S.dashboardTimer = null; }
@@ -106,7 +115,7 @@ document.addEventListener('keydown', e => {
   function tick() {
     const now = new Date();
     const time = now.toLocaleTimeString();
-    const tz = now.toLocaleTimeString('en-US', { timeZoneName: 'short' }).split(' ').pop();
+    const tz = 'GMT' + (now.getTimezoneOffset() > 0 ? '-' : '+') + String(Math.abs(Math.floor(now.getTimezoneOffset()/60))).padStart(1,'0') + (now.getTimezoneOffset()%60 ? ':' + String(Math.abs(now.getTimezoneOffset()%60)).padStart(2,'0') : '');
     el.textContent = time + ' ' + tz;
   }
   tick();

--- a/src/llm_rosetta/gateway/admin/js/keys.js
+++ b/src/llm_rosetta/gateway/admin/js/keys.js
@@ -28,16 +28,20 @@ function renderKeys() {
   const tbody = document.getElementById('keysTable');
   const keys = (S.keysData && S.keysData.keys) || [];
   if (keys.length === 0) {
-    tbody.innerHTML = `<tr><td colspan="3" style="color:var(--text-dim)">${t('keys.noKeys')}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="4" style="color:var(--text-dim)">${t('keys.noKeys')}</td></tr>`;
     return;
   }
   tbody.innerHTML = keys.map(k => {
     const created = k.created ? new Date(k.created).toLocaleDateString() : '—';
+    const createdFull = k.created ? new Date(k.created).toLocaleString(undefined, {year:'numeric',month:'2-digit',day:'2-digit',hour:'2-digit',minute:'2-digit',second:'2-digit',timeZoneName:'shortOffset'}) : '';
+    const lastUsed = k.last_used ? new Date(k.last_used).toLocaleDateString() : '—';
+    const lastUsedFull = k.last_used ? new Date(k.last_used).toLocaleString(undefined, {year:'numeric',month:'2-digit',day:'2-digit',hour:'2-digit',minute:'2-digit',second:'2-digit',timeZoneName:'shortOffset'}) : '';
     return `<tr>
       <td><span class="key-label-text" id="label-${k.id}">${esc(k.label || '—')}</span>
         <button class="key-btn" style="margin-left:4px" onclick="editKeyLabel('${k.id}','${esc(k.label || '')}')" title="Edit"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg></button></td>
-      <td>${created}</td>
-      <td style="white-space:nowrap"><button class="btn btn-sm" onclick="rotateKey('${k.id}','${esc(k.label || k.id)}', this)">${t('btn.rotate')}</button> <button class="btn btn-sm btn-danger" onclick="deleteKey('${k.id}','${esc(k.label || k.id)}', this)">${t('btn.delete')}</button></td>
+      <td title="${createdFull}">${created}</td>
+      <td title="${lastUsedFull}">${lastUsed}</td>
+      <td style="white-space:nowrap;text-align:right"><button class="btn btn-sm" onclick="rotateKey('${k.id}','${esc(k.label || k.id)}', this)">${t('btn.rotate')}</button> <button class="btn btn-sm btn-danger" onclick="deleteKey('${k.id}','${esc(k.label || k.id)}', this)">${t('btn.delete')}</button></td>
     </tr>`;
   }).join('');
 }
@@ -110,9 +114,19 @@ function rotateKey(id, label, btn) {
   });
 }
 
+async function backfillKeysLastUsed() {
+  try {
+    const res = await api.post('/admin/api/keys/backfill-last-used');
+    if (res && res.error) { showToast(res.error, 'error'); return; }
+    showToast(t('toast.keysBackfilled').replace('{n}', res.updated || 0));
+    if (res.updated > 0) loadKeys();
+  } catch(e) { showToast('Backfill failed', 'error'); }
+}
+
 Object.assign(window, {
   loadKeys, loadLogKeyLabels, renderKeys, openKeyModal,
   generateKey, copyCreatedKey, deleteKey, rotateKey, editKeyLabel,
+  backfillKeysLastUsed,
 });
 
 export { loadKeys, loadLogKeyLabels, renderKeys };

--- a/src/llm_rosetta/gateway/admin/js/logs.js
+++ b/src/llm_rosetta/gateway/admin/js/logs.js
@@ -73,12 +73,11 @@ function renderLogs(entries, total) {
   if (S._highlightLogId) {
     const hlRow = document.querySelector('#logTable tr[data-log-id="' + S._highlightLogId + '"]');
     if (hlRow) hlRow.scrollIntoView({behavior:'smooth', block:'center'});
-    if (!S._highlightLogIdTimer) {
-      S._highlightLogIdTimer = setTimeout(function() {
-        S._highlightLogId = null;
-        S._highlightLogIdTimer = null;
-      }, 10000);
-    }
+    if (S._highlightLogIdTimer) clearTimeout(S._highlightLogIdTimer);
+    S._highlightLogIdTimer = setTimeout(function() {
+      S._highlightLogId = null;
+      S._highlightLogIdTimer = null;
+    }, 10000);
   }
 
   // Pagination
@@ -157,12 +156,11 @@ function jumpToErrorDump(requestLogId) {
       if (match) {
         const dumpId = match.dump_id || match.id;
         S._highlightDumpId = dumpId;
-        if (!S._highlightDumpIdTimer) {
-          S._highlightDumpIdTimer = setTimeout(function() {
-            S._highlightDumpId = null;
-            S._highlightDumpIdTimer = null;
-          }, 10000);
-        }
+        if (S._highlightDumpIdTimer) clearTimeout(S._highlightDumpIdTimer);
+        S._highlightDumpIdTimer = setTimeout(function() {
+          S._highlightDumpId = null;
+          S._highlightDumpIdTimer = null;
+        }, 10000);
         const idx = entries.indexOf(match);
         S._dumpPage = Math.floor(idx / 20);
         renderDumps();

--- a/src/llm_rosetta/gateway/admin/js/logs.js
+++ b/src/llm_rosetta/gateway/admin/js/logs.js
@@ -46,17 +46,20 @@ function renderLogs(entries, total) {
       const hasError = !!e.error_detail;
       const rowId = e.timestamp + '_' + e.model;
       const isExpanded = S.expandedLogRows.has(rowId);
-      const rowStyle = hasError ? ` style="cursor:pointer" onclick="toggleLogRow('${rowId}',this)"` : '';
       const expandHint = hasError ? ' title="Click to expand error"' : '';
       const clientIp = e.client_ip || '—';
-      let rows = `<tr${rowStyle}${expandHint}>
+      const hlBg = S._highlightLogId === e.id ? 'background:color-mix(in srgb, var(--accent) 20%, transparent);' : '';
+      const rowCursor = hasError ? 'cursor:pointer;' : '';
+      const styleAttr = (hlBg || rowCursor) ? ` style="${hlBg}${rowCursor}"` : '';
+      const rowClick = hasError ? ` onclick="toggleLogRow('${rowId}',this)"` : '';
+      let rows = `<tr data-log-id="${esc(e.id)}"${styleAttr}${rowClick}${expandHint}>
         <td>${time}</td>
         <td><code>${esc(e.model)}</code></td>
         <td>${esc(e.source_provider)} &rarr; ${esc(e.target_provider_name || resolveProviderName(e.target_provider))}</td>
         <td>${modeBadge}</td>
         <td style="font-size:12px;color:var(--text-dim)">${esc(keyLabel)}</td>
         <td style="font-size:12px;color:var(--text-dim)">${esc(clientIp)}</td>
-        <td><span class="badge ${statusCls}">${e.status_code}${hasError ? ' ▸' : ''}</span></td>
+        <td><span class="badge ${statusCls}">${e.status_code}${hasError ? ' ▸' : ''}</span>${e.status_code >= 400 ? ` <button class="btn btn-sm" onclick="event.stopPropagation();jumpToErrorDump('${esc(e.id)}')" title="View error dump" style="padding:2px 4px;margin-left:2px"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></button>` : ''}</td>
         <td>${e.duration_ms.toFixed(0)} ms</td>
       </tr>`;
       if (hasError) {
@@ -64,6 +67,18 @@ function renderLogs(entries, total) {
       }
       return rows;
     }).join('');
+  }
+
+  // Auto-highlight and scroll
+  if (S._highlightLogId) {
+    const hlRow = document.querySelector('#logTable tr[data-log-id="' + S._highlightLogId + '"]');
+    if (hlRow) hlRow.scrollIntoView({behavior:'smooth', block:'center'});
+    if (!S._highlightLogIdTimer) {
+      S._highlightLogIdTimer = setTimeout(function() {
+        S._highlightLogId = null;
+        S._highlightLogIdTimer = null;
+      }, 10000);
+    }
   }
 
   // Pagination
@@ -134,8 +149,44 @@ function updateKeyFilterOptions() {
 
 // ===================== Window globals =====================
 
+function jumpToErrorDump(requestLogId) {
+  goToTab('dashboard', function() {
+    function tryFind(attempts) {
+      const entries = S._dumpAllEntries || [];
+      const match = entries.find(e => e.request_log_id === requestLogId);
+      if (match) {
+        const dumpId = match.dump_id || match.id;
+        S._highlightDumpId = dumpId;
+        if (!S._highlightDumpIdTimer) {
+          S._highlightDumpIdTimer = setTimeout(function() {
+            S._highlightDumpId = null;
+            S._highlightDumpIdTimer = null;
+          }, 10000);
+        }
+        const idx = entries.indexOf(match);
+        S._dumpPage = Math.floor(idx / 20);
+        renderDumps();
+        setTimeout(function() {
+          const section = document.getElementById('errorDumpSection');
+          if (section) section.scrollIntoView({behavior:'smooth', block:'start'});
+          setTimeout(function() {
+            const btn = document.querySelector('#dumpTable tr [onclick*="' + dumpId + '"]');
+            if (btn) btn.closest('tr').scrollIntoView({behavior:'smooth', block:'center'});
+          }, 300);
+        }, 200);
+      } else if (attempts < 5) {
+        setTimeout(function() { tryFind(attempts + 1); }, 500);
+      } else {
+        const section = document.getElementById('errorDumpSection');
+        if (section) section.scrollIntoView({behavior:'smooth', block:'start'});
+      }
+    }
+    setTimeout(function() { tryFind(0); }, 600);
+  });
+}
+
 Object.assign(window, {
-  loadLogs, renderLogs, toggleLogRow, changePage,
+  loadLogs, renderLogs, toggleLogRow, changePage, jumpToErrorDump,
   resetLogFilters, updateFilterOptions, updateKeyFilterOptions,
   deleteModel,
 });

--- a/src/llm_rosetta/gateway/admin/js/models.js
+++ b/src/llm_rosetta/gateway/admin/js/models.js
@@ -221,6 +221,13 @@ function goToProviderFromModel(provName) {
 
 // ── Model rendering ──
 
+const _capIcons = {
+  text: '<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7V4h16v3"/><path d="M12 4v16"/><path d="M8 20h8"/></svg>',
+  vision: '<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>',
+  tools: '<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>',
+  reasoning: '<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M12 2a7 7 0 00-4 12.7V17h8v-2.3A7 7 0 0012 2z"/></svg>',
+};
+
 function renderModels() {
   const tbody = document.getElementById('modelTable');
   const models = S.configData.models || {};
@@ -299,12 +306,6 @@ function renderModels() {
     const rowDimmed = provDisabled || !modelEnabled;
     const caps = typeof info === 'string' ? ['text'] : (info.capabilities || ['text']);
     const modelType = _getModelType(info);
-    const _capIcons = {
-      text: '<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7V4h16v3"/><path d="M12 4v16"/><path d="M8 20h8"/></svg>',
-      vision: '<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>',
-      tools: '<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>',
-      reasoning: '<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M12 2a7 7 0 00-4 12.7V17h8v-2.3A7 7 0 0012 2z"/></svg>',
-    };
     const capBadges = modelType === 'llm' ? caps.map(c => {
       const cls = 'cap-badge-' + c;
       const icon = _capIcons[c] || '';

--- a/src/llm_rosetta/gateway/admin/js/models.js
+++ b/src/llm_rosetta/gateway/admin/js/models.js
@@ -299,9 +299,16 @@ function renderModels() {
     const rowDimmed = provDisabled || !modelEnabled;
     const caps = typeof info === 'string' ? ['text'] : (info.capabilities || ['text']);
     const modelType = _getModelType(info);
+    const _capIcons = {
+      text: '<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7V4h16v3"/><path d="M12 4v16"/><path d="M8 20h8"/></svg>',
+      vision: '<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>',
+      tools: '<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>',
+      reasoning: '<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M12 2a7 7 0 00-4 12.7V17h8v-2.3A7 7 0 0012 2z"/></svg>',
+    };
     const capBadges = modelType === 'llm' ? caps.map(c => {
-      const cls = c === 'vision' ? 'badge-cap-vision' : c === 'tools' ? 'badge-cap-tools' : c === 'embedding' ? 'badge-cap-embed' : c === 'reasoning' ? 'badge-cap-reasoning' : 'badge-cap';
-      return `<span class="badge ${cls}">${esc(c)}</span>`;
+      const cls = 'cap-badge-' + c;
+      const icon = _capIcons[c] || '';
+      return `<span class="cap-badge ${cls}">${icon}${esc(c)}</span>`;
     }).join('') : '';
     const hasVision = caps.includes('vision');
     const hasTools = caps.includes('tools');
@@ -320,7 +327,7 @@ function renderModels() {
         ${upstreamTag || urlTplTag ? `<div style="margin-top:2px">${upstreamTag}${urlTplTag}</div>` : ''}
       </td>
       <td style="text-align:center">${typeBadge}</td>
-      <td style="text-align:center">${capBadges || '<span style="color:var(--text-dim);font-size:11px">—</span>'}</td>
+      <td>${capBadges || '<span style="color:var(--text-dim);font-size:11px">—</span>'}</td>
       <td><span class="provider-link" onclick="goToProviderFromModel('${esc(prov)}')">${esc(prov)}</span>${provDisabled ? ` <span style="color:var(--text-dim);font-size:11px">(${t('provider.disabled')})</span>` : ''}</td>
       <td style="text-align:right;white-space:nowrap;position:relative">
         <div class="pill-toggle ${modelEnabled ? 'is-on' : 'is-off'}" role="switch" tabindex="0" aria-checked="${modelEnabled}" aria-label="${esc(name)}" onclick="toggleModel('${esc(name)}')" onkeydown="if(event.key===' '||event.key==='Enter'){event.preventDefault();toggleModel('${esc(name)}')}" title="${modelEnabled ? t('model.enabled') : t('model.disabled')}" style="vertical-align:middle;margin-right:4px"><span class="pill-on">${t('label.on')}</span><span class="pill-off">${t('label.off')}</span></div>

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -51,6 +51,7 @@ from .config import (
     toggle_provider,
 )
 from .keys import (
+    backfill_keys_last_used,
     create_api_key,
     delete_api_key,
     get_api_keys,
@@ -72,6 +73,8 @@ from .observability import (
     get_metrics,
     get_provider_key,
     get_request_key_labels,
+    backfill_dump_log_ids,
+    get_request_by_id,
     get_requests,
     network_diagnostics,
     rebuild_metrics,
@@ -175,7 +178,13 @@ def register_admin_routes(app: Any) -> None:
     )
     # Request log (logs tab)
     app.route("/admin/api/requests", methods=["GET"])(_guard("logs", get_requests))
+    app.route("/admin/api/error-dumps/backfill-log-ids", methods=["POST"])(
+        _guard("logs", backfill_dump_log_ids)
+    )
     app.route("/admin/api/requests/key-labels", methods=["GET"])(get_request_key_labels)
+    app.route("/admin/api/requests/<entry_id>", methods=["GET"])(
+        _guard("logs", get_request_by_id)
+    )
     app.route("/admin/api/requests", methods=["DELETE"])(_guard("logs", clear_requests))
     # Network diagnostics
     app.route("/admin/api/diagnostics/network", methods=["GET"])(network_diagnostics)
@@ -198,6 +207,9 @@ def register_admin_routes(app: Any) -> None:
     # API key management (keys tab)
     app.route("/admin/api/keys", methods=["GET"])(_guard("keys", get_api_keys))
     app.route("/admin/api/keys", methods=["POST"])(_guard("keys", create_api_key))
+    app.route("/admin/api/keys/backfill-last-used", methods=["POST"])(
+        _guard("keys", backfill_keys_last_used)
+    )
     app.route("/admin/api/keys/<key_id>", methods=["PUT"])(
         _guard("keys", update_api_key)
     )

--- a/src/llm_rosetta/gateway/admin/routes/keys.py
+++ b/src/llm_rosetta/gateway/admin/routes/keys.py
@@ -97,6 +97,16 @@ async def rotate_api_key(request: Any, **kwargs: Any) -> Response:
     return JSONResponse({"ok": True, "id": key_id, "key": new_key})
 
 
+async def backfill_keys_last_used(request: Any, **kwargs: Any) -> Response:
+    """Backfill last_used from request log for keys missing the value."""
+    keystore = _get_keystore(request)
+    persistence = getattr(request.app, "persistence", None)
+    if persistence is None:
+        return JSONResponse({"error": "No persistence configured"}, status_code=400)
+    updated = keystore.backfill_last_used(persistence.db_path)
+    return JSONResponse({"updated": updated})
+
+
 async def get_internal_token(request: Any) -> Response:
     """Return the ephemeral internal token for admin panel test requests."""
     token = getattr(request.app, "internal_token", None)

--- a/src/llm_rosetta/gateway/admin/routes/observability.py
+++ b/src/llm_rosetta/gateway/admin/routes/observability.py
@@ -157,6 +157,27 @@ async def get_requests(request: Any) -> Response:
     return JSONResponse({"entries": entries, "total": total})
 
 
+async def backfill_dump_log_ids(request: Any, **kwargs: Any) -> Response:
+    """Backfill NULL request_log_id in error_dumps by matching timestamps."""
+    persistence = getattr(request.app, "persistence", None)
+    if persistence is None:
+        return JSONResponse({"error": "No persistence configured"}, status_code=400)
+    config = getattr(request.app, "gateway_config", None)
+    aliases = config.model_upstream_names if config else {}
+    updated = persistence.backfill_error_dump_log_ids(model_aliases=aliases)
+    return JSONResponse({"updated": updated})
+
+
+async def get_request_by_id(request: Any, **kwargs: Any) -> Response:
+    """Return a single request log entry by ID."""
+    log = request.app.request_log
+    entry_id = kwargs.get("entry_id") or request.path_params["entry_id"]
+    entry = log.get_entry(entry_id)
+    if entry is None:
+        return JSONResponse({"error": "Not found"}, status_code=404)
+    return JSONResponse(entry)
+
+
 async def clear_requests(request: Any) -> Response:
     """Clear the request log."""
     log = request.app.request_log

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -311,7 +311,7 @@ async def _proxy_handler(
                 preflight_token_count=preflight,
             )
         else:
-            pre_entry_id = None
+            pre_entry_id = uuid.uuid4().hex
             response, profile = await handle_non_streaming(
                 route,
                 provider_info,
@@ -320,6 +320,7 @@ async def _proxy_handler(
                 metadata_store=store,
                 extra_headers=extra_headers,
                 persistence=persistence,
+                entry_id=pre_entry_id,
             )
         status_code = response.status_code
         if status_code >= 400 and hasattr(response, "body"):
@@ -360,7 +361,6 @@ async def _proxy_handler(
         error_detail = str(exc)
         logger.exception("[%s] unhandled error in proxy handler", request_id)
         status_code = 500
-        pre_entry_id = None
         dump_error(
             persistence,
             request_body=body,
@@ -371,6 +371,7 @@ async def _proxy_handler(
             provider_name=route.provider_name,
             status_code=500,
             error_phase="conversion",
+            request_log_id=pre_entry_id,
         )
         resp = error_response_for_source(
             source_provider, 500, f"Internal server error: {exc}"

--- a/src/llm_rosetta/gateway/auth.py
+++ b/src/llm_rosetta/gateway/auth.py
@@ -264,7 +264,12 @@ def create_auth_hook(auth_state: AuthState) -> Any:
         if not key:
             return _error_for_path(path, 401, "Invalid or missing API key")
 
-        ctx = auth_state.keystore.validate(key) if auth_state.keystore else None
+        ctx: KeyContext | None = None
+        if auth_state.keystore:
+            result = auth_state.keystore.validate(key)
+            if result is not None:
+                key_id, ctx = result
+                auth_state.keystore.touch(key_id)
         if ctx is None:
             return _error_for_path(path, 401, "Invalid or missing API key")
 

--- a/src/llm_rosetta/gateway/keystore.py
+++ b/src/llm_rosetta/gateway/keystore.py
@@ -12,6 +12,7 @@ import json
 import logging
 import secrets
 import sqlite3
+import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -66,8 +67,18 @@ class KeyStore:
             )"""
         )
         self._conn.commit()
+        self._migrate_last_used()
         self._cache: dict[str, tuple[str, KeyContext]] = {}
+        self._last_touch: dict[str, float] = {}
         self._refresh_cache()
+
+    def _migrate_last_used(self) -> None:
+        cols = {
+            r[1] for r in self._conn.execute("PRAGMA table_info(api_keys)").fetchall()
+        }
+        if "last_used" not in cols:
+            self._conn.execute("ALTER TABLE api_keys ADD COLUMN last_used TEXT")
+            self._conn.commit()
 
     def _refresh_cache(self) -> None:
         """Rebuild the in-memory hash → (id, KeyContext) lookup."""
@@ -83,10 +94,52 @@ class KeyStore:
             cache[key_hash] = (row_id, KeyContext(label=label, allowed_shims=shims))
         self._cache = cache
 
-    def validate(self, raw_key: str) -> KeyContext | None:
-        """Validate a raw API key and return its context, or None."""
-        entry = self._cache.get(_hash_key(raw_key))
-        return entry[1] if entry else None
+    def validate(self, raw_key: str) -> tuple[str, KeyContext] | None:
+        """Validate a raw API key and return ``(key_id, context)``, or None."""
+        return self._cache.get(_hash_key(raw_key))
+
+    def touch(self, key_id: str, interval: float = 300.0) -> None:
+        """Record a last-used timestamp, throttled to one write per *interval* seconds."""
+        now = time.monotonic()
+        if now - self._last_touch.get(key_id, 0) < interval:
+            return
+        self._last_touch[key_id] = now
+        from datetime import datetime, timezone
+
+        ts = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            "UPDATE api_keys SET last_used = ? WHERE id = ?", (ts, key_id)
+        )
+        self._conn.commit()
+
+    def backfill_last_used(self, request_log_db_path: str | Path) -> int:
+        """Backfill last_used from request log for keys that have no value yet."""
+        import sqlite3 as _sqlite3
+
+        try:
+            log_conn = _sqlite3.connect(str(request_log_db_path))
+        except Exception:
+            return 0
+        updated = 0
+        for row_id, label, last_used in self._conn.execute(
+            "SELECT id, label, last_used FROM api_keys"
+        ).fetchall():
+            if last_used or not label:
+                continue
+            r = log_conn.execute(
+                "SELECT MAX(timestamp) FROM request_log WHERE api_key_label = ?",
+                (label,),
+            ).fetchone()
+            if r and r[0]:
+                self._conn.execute(
+                    "UPDATE api_keys SET last_used = ? WHERE id = ?",
+                    (r[0], row_id),
+                )
+                updated += 1
+        if updated:
+            self._conn.commit()
+        log_conn.close()
+        return updated
 
     def has_keys(self) -> bool:
         return bool(self._cache)
@@ -121,10 +174,10 @@ class KeyStore:
     def list_keys(self) -> list[dict[str, Any]]:
         """List all keys without secrets."""
         rows = self._conn.execute(
-            "SELECT id, label, allowed_shims, created, rotated FROM api_keys"
+            "SELECT id, label, allowed_shims, created, rotated, last_used FROM api_keys"
         ).fetchall()
         result = []
-        for row_id, label, shims_json, created, rotated in rows:
+        for row_id, label, shims_json, created, rotated, last_used in rows:
             try:
                 shims = json.loads(shims_json)
             except (json.JSONDecodeError, TypeError):
@@ -137,6 +190,8 @@ class KeyStore:
             }
             if rotated:
                 entry["rotated"] = rotated
+            if last_used:
+                entry["last_used"] = last_used
             result.append(entry)
         return result
 
@@ -195,6 +250,39 @@ class KeyStore:
         self._conn.commit()
         self._refresh_cache()
         return new_key
+
+    def import_from_config(self, config_keys: list[dict[str, str]]) -> int:
+        """Import plaintext keys from config into SQLite (idempotent).
+
+        Returns the number of keys newly imported.
+        """
+        imported = 0
+        for entry in config_keys:
+            raw_key = entry.get("key", "")
+            if not raw_key:
+                continue
+            key_hash = _hash_key(raw_key)
+            try:
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO api_keys "
+                    "(id, key_hash, label, allowed_shims, created) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (
+                        entry.get("id", _generate_id()),
+                        key_hash,
+                        entry.get("label", ""),
+                        '["*"]',
+                        entry.get("created", ""),
+                    ),
+                )
+                if self._conn.execute("SELECT changes()").fetchone()[0]:
+                    imported += 1
+            except sqlite3.IntegrityError:
+                pass
+        if imported:
+            self._conn.commit()
+            self._refresh_cache()
+        return imported
 
     def close(self) -> None:
         self._conn.close()

--- a/src/llm_rosetta/gateway/keystore.py
+++ b/src/llm_rosetta/gateway/keystore.py
@@ -15,6 +15,7 @@ import sqlite3
 import time
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -104,8 +105,6 @@ class KeyStore:
         if now - self._last_touch.get(key_id, 0) < interval:
             return
         self._last_touch[key_id] = now
-        from datetime import datetime, timezone
-
         ts = datetime.now(timezone.utc).isoformat()
         self._conn.execute(
             "UPDATE api_keys SET last_used = ? WHERE id = ?", (ts, key_id)
@@ -121,24 +120,26 @@ class KeyStore:
         except Exception:
             return 0
         updated = 0
-        for row_id, label, last_used in self._conn.execute(
-            "SELECT id, label, last_used FROM api_keys"
-        ).fetchall():
-            if last_used or not label:
-                continue
-            r = log_conn.execute(
-                "SELECT MAX(timestamp) FROM request_log WHERE api_key_label = ?",
-                (label,),
-            ).fetchone()
-            if r and r[0]:
-                self._conn.execute(
-                    "UPDATE api_keys SET last_used = ? WHERE id = ?",
-                    (r[0], row_id),
-                )
-                updated += 1
-        if updated:
-            self._conn.commit()
-        log_conn.close()
+        try:
+            for row_id, label, last_used in self._conn.execute(
+                "SELECT id, label, last_used FROM api_keys"
+            ).fetchall():
+                if last_used or not label:
+                    continue
+                r = log_conn.execute(
+                    "SELECT MAX(timestamp) FROM request_log WHERE api_key_label = ?",
+                    (label,),
+                ).fetchone()
+                if r and r[0]:
+                    self._conn.execute(
+                        "UPDATE api_keys SET last_used = ? WHERE id = ?",
+                        (r[0], row_id),
+                    )
+                    updated += 1
+            if updated:
+                self._conn.commit()
+        finally:
+            log_conn.close()
         return updated
 
     def has_keys(self) -> bool:

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -314,6 +314,7 @@ async def handle_non_streaming(
     extra_headers: dict[str, str] | None = None,
     persistence: Any | None = None,
     capture_state: CaptureState | None = None,
+    entry_id: str | None = None,
 ) -> tuple[Response, dict[str, Any]]:
     """Non-streaming proxy: convert -> forward -> convert back -> respond.
 
@@ -356,6 +357,7 @@ async def handle_non_streaming(
             status_code=400,
             error_phase="conversion",
             upstream_url=str(provider_info.base_url),
+            request_log_id=entry_id,
         )
         return error_response_for_source(route.source_provider, 400, str(exc)), profile
 
@@ -398,6 +400,7 @@ async def handle_non_streaming(
             status_code=502,
             error_phase="upstream",
             upstream_url=str(provider_info.base_url),
+            request_log_id=entry_id,
         )
         if capture_state is not None:
             capture_state.record(
@@ -441,6 +444,7 @@ async def handle_non_streaming(
             status_code=resp.status_code,
             error_phase="upstream",
             upstream_url=str(provider_info.base_url),
+            request_log_id=entry_id,
         )
         if capture_state is not None:
             capture_state.record(
@@ -488,6 +492,7 @@ async def handle_non_streaming(
             status_code=502,
             error_phase="response",
             upstream_url=str(provider_info.base_url),
+            request_log_id=entry_id,
         )
         return error_response_for_source(route.source_provider, 502, str(exc)), profile
 
@@ -836,6 +841,7 @@ async def handle_streaming(
             status_code=400,
             error_phase="conversion",
             upstream_url=str(provider_info.base_url),
+            request_log_id=entry_id,
         )
         return error_response_for_source(route.source_provider, 400, str(exc)), profile
 

--- a/src/llm_rosetta/observability/persistence.py
+++ b/src/llm_rosetta/observability/persistence.py
@@ -343,7 +343,80 @@ class PersistenceManager:
         ).fetchone()
         if row is None:
             return None
-        return self._row_to_dict(row)
+        d = self._row_to_dict(row)
+        offset_row = self._conn.execute(
+            "SELECT COUNT(*) FROM request_log WHERE timestamp > ?",
+            (d["timestamp"],),
+        ).fetchone()
+        d["_offset"] = offset_row[0] if offset_row else 0
+        return d
+
+    def backfill_error_dump_log_ids(
+        self,
+        window_seconds: float = 0.1,
+        model_aliases: dict[str, str] | None = None,
+    ) -> int:
+        """Match error dumps with NULL request_log_id to request_log entries.
+
+        Uses timestamp proximity, source/target provider, status code, and
+        model name to find the best match.  *model_aliases* maps
+        ``request_model -> upstream_model`` (from gateway config) so that
+        dump model names (which use upstream names) can be matched against
+        request log entries (which use request names).
+
+        Returns the number of rows updated.
+        """
+        reverse_aliases: dict[str, list[str]] = {}
+        for req_name, up_name in (model_aliases or {}).items():
+            reverse_aliases.setdefault(up_name, []).append(req_name)
+
+        cur = self._conn.execute(
+            "SELECT id, timestamp, model, status_code, source_provider, target_provider "
+            "FROM error_dumps WHERE request_log_id IS NULL OR request_log_id = ''"
+        )
+        unmatched = cur.fetchall()
+        if not unmatched:
+            return 0
+        updated = 0
+        for dump_id, ts, dump_model, status, source, target in unmatched:
+            if not ts:
+                continue
+            candidate_models = [dump_model] if dump_model else []
+            for alias in reverse_aliases.get(dump_model or "", []):
+                if alias not in candidate_models:
+                    candidate_models.append(alias)
+            row = None
+            for m in candidate_models:
+                row = self._conn.execute(
+                    "SELECT id FROM request_log "
+                    "WHERE source_provider = ? AND target_provider = ? "
+                    "AND status_code = ? AND model = ? "
+                    "AND abs(julianday(timestamp) - julianday(?)) * 86400 < ? "
+                    "ORDER BY abs(julianday(timestamp) - julianday(?)) "
+                    "LIMIT 1",
+                    (source, target, status, m, ts, window_seconds, ts),
+                ).fetchone()
+                if row:
+                    break
+            if not row and dump_model:
+                row = self._conn.execute(
+                    "SELECT id FROM request_log "
+                    "WHERE source_provider = ? AND target_provider = ? "
+                    "AND status_code = ? "
+                    "AND abs(julianday(timestamp) - julianday(?)) * 86400 < ? "
+                    "ORDER BY abs(julianday(timestamp) - julianday(?)) "
+                    "LIMIT 1",
+                    (source, target, status, ts, window_seconds, ts),
+                ).fetchone()
+            if row:
+                self._conn.execute(
+                    "UPDATE error_dumps SET request_log_id = ? WHERE id = ?",
+                    (row[0], dump_id),
+                )
+                updated += 1
+        if updated:
+            self._conn.commit()
+        return updated
 
     def get_api_key_labels(self) -> list[str]:
         """Return distinct API key labels seen in request logs."""

--- a/src/llm_rosetta/observability/persistence.py
+++ b/src/llm_rosetta/observability/persistence.py
@@ -337,7 +337,13 @@ class PersistenceManager:
         return entries, total
 
     def get_log_entry(self, entry_id: str) -> dict[str, Any] | None:
-        """Return a single log entry by id, or ``None``."""
+        """Return a single log entry by id, or ``None``.
+
+        Includes ``_offset`` — the entry's position in the newest-first
+        list — so the admin UI can jump directly to the correct page.
+        Uses an indexed timestamp comparison; acceptable for single-entry
+        lookups (not called in hot paths).
+        """
         row = self._conn.execute(
             "SELECT * FROM request_log WHERE id = ?", (entry_id,)
         ).fetchone()
@@ -399,6 +405,8 @@ class PersistenceManager:
                 if row:
                     break
             if not row and dump_model:
+                # Fallback: match without model constraint. May mis-link if
+                # two different models error with the same status in the window.
                 row = self._conn.execute(
                     "SELECT id FROM request_log "
                     "WHERE source_provider = ? AND target_provider = ? "

--- a/tests/gateway/test_keystore.py
+++ b/tests/gateway/test_keystore.py
@@ -29,23 +29,25 @@ class TestKeyStoreCreate:
         key_id, raw_key = keystore.create(
             label="limited", allowed_shims=["openai", "anthropic"]
         )
-        ctx = keystore.validate(raw_key)
-        assert ctx is not None
+        result = keystore.validate(raw_key)
+        assert result is not None
+        _, ctx = result
         assert ctx.allowed_shims == frozenset({"openai", "anthropic"})
 
     def test_default_allowed_shims_is_star(self, keystore):
         _, raw_key = keystore.create(label="default")
-        ctx = keystore.validate(raw_key)
-        assert ctx is not None
+        result = keystore.validate(raw_key)
+        assert result is not None
+        _, ctx = result
         assert ctx.allowed_shims == frozenset({"*"})
 
 
 class TestKeyStoreValidate:
     def test_validate_valid_key(self, keystore):
         _, raw_key = keystore.create(label="valid")
-        ctx = keystore.validate(raw_key)
-        assert ctx is not None
-        assert isinstance(ctx, KeyContext)
+        result = keystore.validate(raw_key)
+        assert result is not None
+        _, ctx = result
         assert ctx.label == "valid"
 
     def test_validate_invalid_key(self, keystore):
@@ -78,15 +80,17 @@ class TestKeyStoreUpdate:
     def test_update_label(self, keystore):
         key_id, raw_key = keystore.create(label="old")
         assert keystore.update(key_id, label="new")
-        ctx = keystore.validate(raw_key)
-        assert ctx is not None
+        result = keystore.validate(raw_key)
+        assert result is not None
+        _, ctx = result
         assert ctx.label == "new"
 
     def test_update_allowed_shims(self, keystore):
         key_id, raw_key = keystore.create(label="x")
         assert keystore.update(key_id, allowed_shims=["google"])
-        ctx = keystore.validate(raw_key)
-        assert ctx is not None
+        result = keystore.validate(raw_key)
+        assert result is not None
+        _, ctx = result
         assert ctx.allowed_shims == frozenset({"google"})
 
     def test_update_nonexistent(self, keystore):
@@ -129,8 +133,9 @@ class TestKeyStoreRotate:
     def test_rotate_new_key_validates(self, keystore):
         key_id, _ = keystore.create(label="rotate")
         new_key = keystore.rotate(key_id)
-        ctx = keystore.validate(new_key)
-        assert ctx is not None
+        result = keystore.validate(new_key)
+        assert result is not None
+        _, ctx = result
         assert ctx.label == "rotate"
 
     def test_rotate_sets_rotated_timestamp(self, keystore):


### PR DESCRIPTION
## Summary

- **Request log ↔ Error dump cross-linking**: 4xx/5xx request log entries show a jump-to-dump button; error dump rows with `request_log_id` show a jump-to-log button. Jumps clear filters, calculate correct page offset, and highlight the target row for 10 seconds.
- **Backfill matching**: "Match Logs" button and auto-run on startup link unlinked error dumps to request log entries via timestamp (±0.1s), source/target provider, status code, and model alias resolution from gateway config.
- **API key last-used tracking**: New `last_used` column auto-migrated on startup, updated in auth hook with 5-min throttle. "Refresh Last Used" icon button backfills from request log history.
- **UI improvements**: capability badge SVG icons using `cap-badge` class, model table column width tuning (Model 19%, Type 15% center, Capabilities 23%), `data-i18n-title` support, "Server Time" label, GMT±N timezone format throughout.

## Test plan

- [ ] Deploy dev build, verify cross-link buttons appear on both request log and error dump entries
- [ ] Click jump buttons in both directions, verify tab switch + row highlight
- [ ] Click "Match Logs" on error dumps, verify unlinked entries get matched
- [ ] Verify API keys Last Used column populates after making requests
- [ ] Click refresh icon on API keys, verify backfill from request log
- [ ] Verify capability badge icons render correctly on models tab
- [ ] Verify GMT±N timezone in server clock and hover timestamps
- [ ] `make test` passes