### PR TITLE
feat(admin): migrate session auth to httponly cookie

### DIFF
--- a/src/llm_rosetta/gateway/admin/js/auth.js
+++ b/src/llm_rosetta/gateway/admin/js/auth.js
@@ -255,7 +255,7 @@ async function doExportDumps() {
   if (end) params.push('end=' + encodeURIComponent(end + 'T23:59:59Z'));
   if (params.length) url += '?' + params.join('&');
   try {
-    const r = await fetch(url, {headers: _adminHeaders()});
+    const r = await fetch(url, {headers: _adminHeaders(), credentials: 'include'});
     if (!r.ok) { showToast(t('toast.error'), 'error'); return; }
     const blob = await r.blob();
     const a = document.createElement('a');
@@ -317,9 +317,7 @@ async function _doTokenRotate() {
   try {
     const data = await api.post('/admin/api/token/rotate');
     // api.post returns parsed JSON directly, not a Response
-    if (data.token) {
-      localStorage.setItem('admin_token', data.token);
-    }
+    // Session cookie updated automatically by server response
     // Refresh internal token display
     const td = await api.get('/admin/api/internal-token');
     S.internalToken = td.token;
@@ -342,7 +340,7 @@ async function changeAdminPassword() {
   if (newPw.length < 4) { errEl.textContent = t('pw.tooShort'); return; }
   try {
     const data = await api.put('/admin/api/config/password', { current_password: current, new_password: newPw });
-    if (data.token) localStorage.setItem('admin_token', data.token);
+    // Session cookie updated automatically by server response
     ['settingsCurrentPw','settingsNewPw','settingsConfirmPw'].forEach(id => {
       const el = document.getElementById(id); if (el) el.value = '';
     });
@@ -353,7 +351,6 @@ async function changeAdminPassword() {
 }
 
 function showLoginOverlay() {
-  localStorage.removeItem('admin_token');
   document.body.classList.add('auth-pending');
   // Stop background polling timers to prevent repeated 401 → showLoginOverlay loops
   if (S.dashboardTimer) { clearInterval(S.dashboardTimer); S.dashboardTimer = null; }
@@ -375,10 +372,10 @@ async function doLogin() {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({password: pw}),
+      credentials: 'include',
     });
     const data = await r.json();
-    if (r.ok && data.token) {
-      localStorage.setItem('admin_token', data.token);
+    if (r.ok) {
       document.getElementById('loginOverlay').style.display = 'none';
       document.body.classList.remove('auth-pending');
       const btn = document.getElementById('logoutBtn');
@@ -398,22 +395,15 @@ async function checkAuthAndInit() {
     const r = await fetch('/admin/api/auth-check');
     const data = await r.json();
     if (data.requires_auth) {
-      // Check if we have a valid stored token
-      const token = localStorage.getItem('admin_token');
-      if (token) {
-        // Verify token by trying to load config
-        const test = await fetch('/admin/api/config', {headers: {'X-Admin-Token': token}});
-        if (test.status === 401) {
-          showLoginOverlay();
-          return;
-        }
-        const btn = document.getElementById('logoutBtn');
-        if (btn) btn.style.display = '';
-        _startInactivityTracking();
-      } else {
+      // Verify existing session cookie by trying to load config
+      const test = await fetch('/admin/api/config', {credentials: 'include'});
+      if (test.status === 401) {
         showLoginOverlay();
         return;
       }
+      const btn = document.getElementById('logoutBtn');
+      if (btn) btn.style.display = '';
+      _startInactivityTracking();
     }
     document.body.classList.remove('auth-pending');
     window.initApp();

--- a/src/llm_rosetta/gateway/admin/js/core.js
+++ b/src/llm_rosetta/gateway/admin/js/core.js
@@ -93,8 +93,10 @@ function _stopInactivityTracking() {
   if (_inactivityTimer) { clearTimeout(_inactivityTimer); _inactivityTimer = null; }
 }
 
-function doLogout() {
-  fetch('/admin/api/logout', {method: 'POST', credentials: 'include'}).catch(() => {});
+async function doLogout() {
+  try {
+    await fetch('/admin/api/logout', {method: 'POST', credentials: 'include'});
+  } catch (_) { /* network error — cookie may persist until next login */ }
   _stopInactivityTracking();
   const btn = document.getElementById('logoutBtn');
   if (btn) btn.style.display = 'none';

--- a/src/llm_rosetta/gateway/admin/js/core.js
+++ b/src/llm_rosetta/gateway/admin/js/core.js
@@ -41,15 +41,12 @@ function setTheme(name) {
 
 // ===================== API =====================
 function _adminHeaders(extra) {
-  const h = extra ? {...extra} : {};
-  const token = localStorage.getItem('admin_token');
-  if (token) h['X-Admin-Token'] = token;
-  return h;
+  return extra ? {...extra} : {};
 }
 
 const api = {
   async get(url) {
-    const r = await fetch(url, {headers: _adminHeaders(), cache: 'no-store'});
+    const r = await fetch(url, {headers: _adminHeaders(), cache: 'no-store', credentials: 'include'});
     if (r.status === 401) { window.showLoginOverlay?.(); throw new Error('Unauthorized'); }
     const data = await r.json().catch(() => null);
     if (!r.ok) throw new Error(data?.error || (r.status === 504 ? 'Request timed out — the upstream service may be unreachable' : `HTTP ${r.status}`));
@@ -57,12 +54,12 @@ const api = {
     return data;
   },
   async put(url, body) {
-    const r = await fetch(url, {method:'PUT', headers:_adminHeaders({'Content-Type':'application/json'}), body:JSON.stringify(body)});
+    const r = await fetch(url, {method:'PUT', headers:_adminHeaders({'Content-Type':'application/json'}), body:JSON.stringify(body), credentials: 'include'});
     if (r.status === 401) { window.showLoginOverlay?.(); throw new Error('Unauthorized'); }
     return r.json();
   },
   async del(url) {
-    const r = await fetch(url, {method:'DELETE', headers: _adminHeaders()});
+    const r = await fetch(url, {method:'DELETE', headers: _adminHeaders(), credentials: 'include'});
     if (r.status === 401) { window.showLoginOverlay?.(); throw new Error('Unauthorized'); }
     return r.json();
   },
@@ -70,6 +67,7 @@ const api = {
     const h = body !== undefined ? _adminHeaders({'Content-Type':'application/json'}) : _adminHeaders();
     const opts = {method:'POST', headers: h};
     if (body !== undefined) opts.body = JSON.stringify(body);
+    opts.credentials = 'include';
     const r = await fetch(url, opts);
     if (r.status === 401) { window.showLoginOverlay?.(); throw new Error('Unauthorized'); }
     return r.json();
@@ -96,7 +94,7 @@ function _stopInactivityTracking() {
 }
 
 function doLogout() {
-  localStorage.removeItem('admin_token');
+  fetch('/admin/api/logout', {method: 'POST', credentials: 'include'}).catch(() => {});
   _stopInactivityTracking();
   const btn = document.getElementById('logoutBtn');
   if (btn) btn.style.display = 'none';

--- a/src/llm_rosetta/gateway/admin/js/dashboard.js
+++ b/src/llm_rosetta/gateway/admin/js/dashboard.js
@@ -98,7 +98,7 @@ async function clearProfilingResults() {
 
 async function _fetchFlamegraphHtml(index) {
   const url = '/admin/api/profiling/results/' + index + '?format=html';
-  const r = await fetch(url, {headers: _adminHeaders(), cache: 'no-store'});
+  const r = await fetch(url, {headers: _adminHeaders(), cache: 'no-store', credentials: 'include'});
   if (!r.ok) throw new Error('HTTP ' + r.status);
   return r.text();
 }
@@ -126,7 +126,7 @@ async function downloadFlamegraph(index, model) {
 async function downloadAllFlamegraphs() {
   try {
     const url = '/admin/api/profiling/results/download';
-    const r = await fetch(url, {headers: _adminHeaders(), cache: 'no-store'});
+    const r = await fetch(url, {headers: _adminHeaders(), cache: 'no-store', credentials: 'include'});
     if (!r.ok) { showToast('Failed to download', 'error'); return; }
     const blob = await r.blob();
     const a = document.createElement('a');

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -29,8 +29,8 @@ from ._shared import (  # noqa: F401  (re-exported for backward compat)
 )
 from .auth import (
     admin_check,
-    admin_logout,
     admin_login,
+    admin_logout,
     change_password,
     rotate_token,
     serve_admin_html,

--- a/src/llm_rosetta/gateway/admin/routes/__init__.py
+++ b/src/llm_rosetta/gateway/admin/routes/__init__.py
@@ -29,6 +29,7 @@ from ._shared import (  # noqa: F401  (re-exported for backward compat)
 )
 from .auth import (
     admin_check,
+    admin_logout,
     admin_login,
     change_password,
     rotate_token,
@@ -136,6 +137,7 @@ def register_admin_routes(app: Any) -> None:
     # Admin auth
     app.route("/admin/api/login", methods=["POST"])(admin_login)
     app.route("/admin/api/auth-check", methods=["GET"])(admin_check)
+    app.route("/admin/api/logout", methods=["POST"])(admin_logout)
     app.route("/admin/api/config/password", methods=["PUT"])(change_password)
     app.route("/admin/api/token/rotate", methods=["POST"])(rotate_token)
     # Config CRUD (providers + models tabs)

--- a/src/llm_rosetta/gateway/admin/routes/auth.py
+++ b/src/llm_rosetta/gateway/admin/routes/auth.py
@@ -157,7 +157,13 @@ def _clear_login_failures(ip: str) -> None:
     _login_failures.pop(ip, None)
 
 
-def _set_session_cookie(resp: Response, token: str) -> None:
+def _is_secure_request(request: Any) -> bool:
+    """Check if the request arrived over HTTPS (direct or via reverse proxy)."""
+    proto = request.headers.get("x-forwarded-proto", "")
+    return proto.lower() == "https"
+
+
+def _set_session_cookie(resp: Response, token: str, *, secure: bool = False) -> None:
     """Set the admin session cookie on a response."""
     resp.set_cookie(
         ADMIN_COOKIE_NAME,
@@ -165,6 +171,7 @@ def _set_session_cookie(resp: Response, token: str) -> None:
         path="/admin",
         httponly=True,
         samesite="Lax",
+        secure=secure,
     )
 
 
@@ -202,7 +209,9 @@ async def admin_login(request: Any) -> Response:
 
     _clear_login_failures(ip)
     resp = JSONResponse({"ok": True})
-    _set_session_cookie(resp, auth_state.admin_token)
+    _set_session_cookie(
+        resp, auth_state.admin_token, secure=_is_secure_request(request)
+    )
     return resp
 
 
@@ -291,7 +300,9 @@ async def change_password(request: Any) -> Response:
 
     # Set new session cookie so browser stays authenticated
     resp = JSONResponse({"ok": True})
-    _set_session_cookie(resp, auth_state.admin_token)
+    _set_session_cookie(
+        resp, auth_state.admin_token, secure=_is_secure_request(request)
+    )
     return resp
 
 
@@ -309,5 +320,5 @@ async def rotate_token(request: Any) -> Response:
     request.app.internal_token = auth_state.internal_token
 
     resp = JSONResponse({"ok": True})
-    _set_session_cookie(resp, new_admin_token)
+    _set_session_cookie(resp, new_admin_token, secure=_is_secure_request(request))
     return resp

--- a/src/llm_rosetta/gateway/admin/routes/auth.py
+++ b/src/llm_rosetta/gateway/admin/routes/auth.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
+from llm_rosetta.gateway.auth import ADMIN_COOKIE_NAME
+
 from ..static import load_admin_html, load_static_file
 
 # Cached HTML — loaded once on first request, per custom_head value.
@@ -155,6 +157,17 @@ def _clear_login_failures(ip: str) -> None:
     _login_failures.pop(ip, None)
 
 
+def _set_session_cookie(resp: Response, token: str) -> None:
+    """Set the admin session cookie on a response."""
+    resp.set_cookie(
+        ADMIN_COOKIE_NAME,
+        token,
+        path="/admin",
+        httponly=True,
+        samesite="Lax",
+    )
+
+
 async def admin_login(request: Any) -> Response:
     """Validate admin password and return a session token."""
     auth_state = request.app.auth_state
@@ -188,7 +201,9 @@ async def admin_login(request: Any) -> Response:
         return JSONResponse(resp, status_code=401)
 
     _clear_login_failures(ip)
-    return JSONResponse({"ok": True, "token": auth_state.admin_token})
+    resp = JSONResponse({"ok": True})
+    _set_session_cookie(resp, auth_state.admin_token)
+    return resp
 
 
 async def admin_check(request: Any) -> Response:
@@ -196,6 +211,13 @@ async def admin_check(request: Any) -> Response:
     auth_state = request.app.auth_state
     requires_auth = bool(auth_state.admin_password)
     return JSONResponse({"requires_auth": requires_auth})
+
+
+async def admin_logout(request: Any) -> Response:
+    """Clear the admin session cookie."""
+    resp = JSONResponse({"ok": True})
+    resp.delete_cookie(ADMIN_COOKIE_NAME, path="/admin")
+    return resp
 
 
 async def change_password(request: Any) -> Response:
@@ -267,8 +289,10 @@ async def change_password(request: Any) -> Response:
     # Hot-reload config (syncs auth state via _sync_auth_middleware)
     _reload_gateway_config(request, config_path)
 
-    # Return the new admin token so frontend can swap immediately
-    return JSONResponse({"ok": True, "token": auth_state.admin_token})
+    # Set new session cookie so browser stays authenticated
+    resp = JSONResponse({"ok": True})
+    _set_session_cookie(resp, auth_state.admin_token)
+    return resp
 
 
 async def rotate_token(request: Any) -> Response:
@@ -284,4 +308,6 @@ async def rotate_token(request: Any) -> Response:
     # Also update the app-level internal_token reference
     request.app.internal_token = auth_state.internal_token
 
-    return JSONResponse({"ok": True, "token": new_admin_token})
+    resp = JSONResponse({"ok": True})
+    _set_session_cookie(resp, new_admin_token)
+    return resp

--- a/src/llm_rosetta/gateway/auth.py
+++ b/src/llm_rosetta/gateway/auth.py
@@ -25,6 +25,8 @@ from llm_rosetta._vendor.httpserver import JSONResponse, Response
 
 from .keystore import KeyContext, KeyStore
 
+ADMIN_COOKIE_NAME = "rosetta_admin_session"
+
 # Per-request auth context — set by auth hook, read by telemetry.
 api_key_context_var: contextvars.ContextVar[KeyContext | None] = contextvars.ContextVar(
     "api_key_context", default=None
@@ -138,13 +140,18 @@ def check_admin_auth(request: Any, auth_state: AuthState) -> Response | None:
 
     path = request.path
 
-    # Login and auth-check endpoints are always accessible
-    if path in ("/admin/api/login", "/admin/api/auth-check"):
+    # Login, logout, and auth-check endpoints are always accessible
+    if path in ("/admin/api/login", "/admin/api/logout", "/admin/api/auth-check"):
         return None
 
-    # Check X-Admin-Token header
+    # Check X-Admin-Token header (API clients, backward compat)
     admin_token = request.headers.get("x-admin-token", "")
     if admin_token and hmac.compare_digest(admin_token, auth_state.admin_token or ""):
+        return None
+
+    # Check session cookie (browser sessions)
+    cookie_token = request.cookies.get(ADMIN_COOKIE_NAME, "")
+    if cookie_token and hmac.compare_digest(cookie_token, auth_state.admin_token or ""):
         return None
 
     # Block unauthenticated API calls


### PR DESCRIPTION
## Summary

- Migrate admin panel auth from `localStorage` + `X-Admin-Token` header to `HttpOnly` + `SameSite=Lax` session cookies
- Server sets cookie on login/password-change/token-rotation, clears on logout
- `X-Admin-Token` header still accepted as fallback for API clients (curl, scripts)
- New `POST /admin/api/logout` endpoint to clear session cookie server-side
- Frontend simplified: removed all `localStorage` token management, all fetches use `credentials: 'include'`

Closes #659

## Test plan

- [x] `make test` — 3286 passed
- [x] Local Playwright test: login → cookie set (httponly, not visible to JS) → refresh persists session → logout clears cookie → refresh shows login
- [x] curl test: login sets Set-Cookie, authenticated request with cookie works, logout clears cookie, post-logout requests rejected
- [x] `X-Admin-Token` header fallback still works
- [ ] Dev deployment test on rosetta-dev.service.oaklight.top