### PR TITLE
feat(gateway): API key affinity for prompt cache optimization

### DIFF
--- a/src/llm_rosetta/gateway/affinity.py
+++ b/src/llm_rosetta/gateway/affinity.py
@@ -1,0 +1,65 @@
+"""API key affinity — deterministic key selection for prompt cache locality.
+
+Instead of round-robin, selects an upstream key based on
+``hash(client_token + message_prefix) % num_keys`` so the same
+conversation from the same client always hits the same upstream key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def extract_prefix_from_ir(
+    ir_request: dict[str, Any],
+    max_messages: int = 2,
+) -> str:
+    """Extract a stable string prefix from an IR request.
+
+    Builds a fingerprint from ``system_instruction`` plus the first
+    *max_messages* entries in ``messages``.  Returns ``""`` when the
+    IR is empty or extraction fails (e.g. passthrough mode produces
+    ``{}``).
+    """
+    if not ir_request:
+        return ""
+
+    parts: list[str] = []
+
+    # system_instruction is list[TextPart] in canonical IR
+    sys_instr = ir_request.get("system_instruction")
+    if sys_instr:
+        parts.append(_stable_str(sys_instr))
+
+    messages = ir_request.get("messages")
+    if messages:
+        for msg in messages[:max_messages]:
+            parts.append(_stable_str(msg))
+
+    return "\n".join(parts) if parts else ""
+
+
+def compute_affinity_index(
+    client_key_hash: str,
+    message_prefix: str,
+    num_keys: int,
+) -> int | None:
+    """Compute a deterministic key index from client identity + message prefix.
+
+    Returns ``None`` when affinity cannot be determined (missing inputs
+    or single key), signalling the caller to fall back to round-robin.
+    """
+    if num_keys <= 1 or not client_key_hash or not message_prefix:
+        return None
+    combined = f"{client_key_hash}\n{message_prefix}"
+    h = hashlib.sha256(combined.encode()).digest()
+    return int.from_bytes(h[:4], "big") % num_keys
+
+
+def _stable_str(value: Any) -> str:
+    """Convert a value to a stable string for hashing."""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, sort_keys=True, ensure_ascii=False)

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -297,22 +297,20 @@ async def _proxy_handler(
     persistence = _raw_persistence if _config.error_dumps_enabled else None
     deep_profiler = _try_start_profiler(request.app)
 
+    # Shared across streaming / non-streaming paths
+    pre_entry_id = uuid.uuid4().hex
+    _kctx = api_key_context_var.get()
+    _client_key_hash = _kctx.key_hash if _kctx else ""
+    _key_affinity = _config.provider_key_affinity.get(route.provider_name, True)
+
     try:
         if is_stream:
-            # For streaming, we pre-generate the entry_id so the stream
-            # generator can write back stream-phase profile after completion.
-            pre_entry_id = uuid.uuid4().hex
-
             preflight_override = get_preflight_tokens_override(request)
             preflight = (
                 preflight_override
                 if preflight_override is not None
                 else route.preflight_token_count
             )
-
-            _kctx = api_key_context_var.get()
-            _client_key_hash = _kctx.key_hash if _kctx else ""
-            _key_affinity = _config.provider_key_affinity.get(route.provider_name, True)
 
             response, profile = await handle_streaming(
                 route,
@@ -330,11 +328,6 @@ async def _proxy_handler(
                 key_affinity=_key_affinity,
             )
         else:
-            pre_entry_id = uuid.uuid4().hex
-            _kctx = api_key_context_var.get()
-            _client_key_hash = _kctx.key_hash if _kctx else ""
-            _key_affinity = _config.provider_key_affinity.get(route.provider_name, True)
-
             response, profile = await handle_non_streaming(
                 route,
                 provider_info,

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -310,6 +310,10 @@ async def _proxy_handler(
                 else route.preflight_token_count
             )
 
+            _kctx = api_key_context_var.get()
+            _client_key_hash = _kctx.key_hash if _kctx else ""
+            _key_affinity = _config.provider_key_affinity.get(route.provider_name, True)
+
             response, profile = await handle_streaming(
                 route,
                 provider_info,
@@ -322,9 +326,15 @@ async def _proxy_handler(
                 metrics=getattr(request.app, "metrics", None),
                 persistence=persistence,
                 preflight_token_count=preflight,
+                client_key_hash=_client_key_hash,
+                key_affinity=_key_affinity,
             )
         else:
             pre_entry_id = uuid.uuid4().hex
+            _kctx = api_key_context_var.get()
+            _client_key_hash = _kctx.key_hash if _kctx else ""
+            _key_affinity = _config.provider_key_affinity.get(route.provider_name, True)
+
             response, profile = await handle_non_streaming(
                 route,
                 provider_info,
@@ -334,6 +344,8 @@ async def _proxy_handler(
                 extra_headers=extra_headers,
                 persistence=persistence,
                 entry_id=pre_entry_id,
+                client_key_hash=_client_key_hash,
+                key_affinity=_key_affinity,
             )
         status_code = response.status_code
         if status_code >= 400 and hasattr(response, "body"):

--- a/src/llm_rosetta/gateway/auth.py
+++ b/src/llm_rosetta/gateway/auth.py
@@ -17,6 +17,7 @@ When no keys are configured, behavior depends on ``open_on_no_keys``:
 from __future__ import annotations
 
 import contextvars
+import dataclasses
 import hashlib
 import hmac
 from typing import Any
@@ -285,11 +286,7 @@ def create_auth_hook(auth_state: AuthState) -> Any:
             return _error_for_path(path, 401, "Invalid or missing API key")
 
         api_key_context_var.set(
-            KeyContext(
-                label=ctx.label,
-                allowed_shims=ctx.allowed_shims,
-                key_hash=hashlib.sha256(key.encode()).hexdigest(),
-            )
+            dataclasses.replace(ctx, key_hash=hashlib.sha256(key.encode()).hexdigest())
         )
         return None
 

--- a/src/llm_rosetta/gateway/auth.py
+++ b/src/llm_rosetta/gateway/auth.py
@@ -264,7 +264,11 @@ def create_auth_hook(auth_state: AuthState) -> Any:
         # Check internal token first (admin panel test requests)
         if key and auth_state.internal_token and key == auth_state.internal_token:
             api_key_context_var.set(
-                KeyContext(label="internal", allowed_shims=frozenset({"*"}))
+                KeyContext(
+                    label="internal",
+                    allowed_shims=frozenset({"*"}),
+                    key_hash=hashlib.sha256(key.encode()).hexdigest(),
+                )
             )
             return None
 
@@ -280,7 +284,13 @@ def create_auth_hook(auth_state: AuthState) -> Any:
         if ctx is None:
             return _error_for_path(path, 401, "Invalid or missing API key")
 
-        api_key_context_var.set(ctx)
+        api_key_context_var.set(
+            KeyContext(
+                label=ctx.label,
+                allowed_shims=ctx.allowed_shims,
+                key_hash=hashlib.sha256(key.encode()).hexdigest(),
+            )
+        )
         return None
 
     return auth_hook

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -279,6 +279,10 @@ class GatewayConfig:
             self._parse_max_tool_description_length_overrides(self._raw_providers)
         )
 
+        self.provider_key_affinity = self._parse_key_affinity_overrides(
+            self._raw_providers
+        )
+
         self.models, self.model_capabilities, self.model_upstream_names = (
             self._parse_models(raw.get("models", {}), self._raw_providers)
         )
@@ -441,6 +445,17 @@ class GatewayConfig:
         for pname, pcfg in raw_providers.items():
             if isinstance(pcfg, dict) and "preflight_token_count" in pcfg:
                 result[pname] = bool(pcfg["preflight_token_count"])
+        return result
+
+    @staticmethod
+    def _parse_key_affinity_overrides(
+        raw_providers: dict[str, dict[str, str]],
+    ) -> dict[str, bool]:
+        """Extract per-provider key_affinity overrides."""
+        result: dict[str, bool] = {}
+        for pname, pcfg in raw_providers.items():
+            if isinstance(pcfg, dict) and "key_affinity" in pcfg:
+                result[pname] = bool(pcfg["key_affinity"])
         return result
 
     @staticmethod

--- a/src/llm_rosetta/gateway/keystore.py
+++ b/src/llm_rosetta/gateway/keystore.py
@@ -30,6 +30,7 @@ class KeyContext:
 
     label: str
     allowed_shims: frozenset[str]
+    key_hash: str = ""
 
 
 def _hash_key(raw_key: str) -> str:

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -38,9 +38,8 @@ from .logging import (
     log_stream_summary,
     log_upstream_error,
 )
-from .sanitize import sanitize_upstream_error
-
 from .affinity import compute_affinity_index, extract_prefix_from_ir
+from .sanitize import sanitize_upstream_error
 from .transport import (
     ProviderInfo,
     UpstreamConnectionError,
@@ -305,6 +304,23 @@ def _strip_internal_metadata(obj: dict | list) -> None:
             _strip_internal_metadata(item)
 
 
+def _maybe_apply_affinity(
+    provider_info: ProviderInfo,
+    ir_request: dict,
+    client_key_hash: str,
+    key_affinity: bool,
+) -> ProviderInfo:
+    """Apply key affinity if conditions are met, otherwise return unchanged."""
+    if key_affinity and client_key_hash and len(provider_info.key_ring) > 1:
+        prefix = extract_prefix_from_ir(ir_request)
+        idx = compute_affinity_index(
+            client_key_hash, prefix, len(provider_info.key_ring)
+        )
+        if idx is not None:
+            return provider_info.with_affinity(idx)
+    return provider_info
+
+
 async def handle_non_streaming(
     route: ResolvedRoute,
     provider_info: ProviderInfo,
@@ -380,13 +396,9 @@ async def handle_non_streaming(
     _strip_internal_metadata(target_body)
 
     # Key affinity: deterministic key selection for prompt cache locality
-    if key_affinity and client_key_hash and len(provider_info.key_ring) > 1:
-        _prefix = extract_prefix_from_ir(pipeline.ir_request)
-        _key_idx = compute_affinity_index(
-            client_key_hash, _prefix, len(provider_info.key_ring)
-        )
-        if _key_idx is not None:
-            provider_info = provider_info.with_affinity(_key_idx)
+    provider_info = _maybe_apply_affinity(
+        provider_info, pipeline.ir_request, client_key_hash, key_affinity
+    )
 
     # Phase 3: Forward to upstream via transport
     upstream_url = provider_info.upstream_url(model)
@@ -913,13 +925,9 @@ async def handle_streaming(
     _strip_internal_metadata(target_body)
 
     # Key affinity: deterministic key selection for prompt cache locality
-    if key_affinity and client_key_hash and len(provider_info.key_ring) > 1:
-        _prefix = extract_prefix_from_ir(pipeline.ir_request)
-        _key_idx = compute_affinity_index(
-            client_key_hash, _prefix, len(provider_info.key_ring)
-        )
-        if _key_idx is not None:
-            provider_info = provider_info.with_affinity(_key_idx)
+    provider_info = _maybe_apply_affinity(
+        provider_info, pipeline.ir_request, client_key_hash, key_affinity
+    )
 
     # Preflight: get exact input_tokens before streaming (opt-in)
     _preflight_input_tokens: int | None = None

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -40,6 +40,7 @@ from .logging import (
 )
 from .sanitize import sanitize_upstream_error
 
+from .affinity import compute_affinity_index, extract_prefix_from_ir
 from .transport import (
     ProviderInfo,
     UpstreamConnectionError,
@@ -315,6 +316,8 @@ async def handle_non_streaming(
     persistence: Any | None = None,
     capture_state: CaptureState | None = None,
     entry_id: str | None = None,
+    client_key_hash: str = "",
+    key_affinity: bool = True,
 ) -> tuple[Response, dict[str, Any]]:
     """Non-streaming proxy: convert -> forward -> convert back -> respond.
 
@@ -375,6 +378,15 @@ async def handle_non_streaming(
 
     log_converted_request(target_body)
     _strip_internal_metadata(target_body)
+
+    # Key affinity: deterministic key selection for prompt cache locality
+    if key_affinity and client_key_hash and len(provider_info.key_ring) > 1:
+        _prefix = extract_prefix_from_ir(pipeline.ir_request)
+        _key_idx = compute_affinity_index(
+            client_key_hash, _prefix, len(provider_info.key_ring)
+        )
+        if _key_idx is not None:
+            provider_info = provider_info.with_affinity(_key_idx)
 
     # Phase 3: Forward to upstream via transport
     upstream_url = provider_info.upstream_url(model)
@@ -831,6 +843,8 @@ async def handle_streaming(
     persistence: Any | None = None,
     capture_state: CaptureState | None = None,
     preflight_token_count: bool = False,
+    client_key_hash: str = "",
+    key_affinity: bool = True,
 ) -> tuple[Response | StreamingResponse, dict[str, Any]]:
     """Streaming proxy: convert -> forward -> stream-convert back -> SSE.
 
@@ -897,6 +911,15 @@ async def handle_streaming(
 
     log_converted_request(target_body)
     _strip_internal_metadata(target_body)
+
+    # Key affinity: deterministic key selection for prompt cache locality
+    if key_affinity and client_key_hash and len(provider_info.key_ring) > 1:
+        _prefix = extract_prefix_from_ir(pipeline.ir_request)
+        _key_idx = compute_affinity_index(
+            client_key_hash, _prefix, len(provider_info.key_ring)
+        )
+        if _key_idx is not None:
+            provider_info = provider_info.with_affinity(_key_idx)
 
     # Preflight: get exact input_tokens before streaming (opt-in)
     _preflight_input_tokens: int | None = None

--- a/src/llm_rosetta/gateway/transport/provider_info.py
+++ b/src/llm_rosetta/gateway/transport/provider_info.py
@@ -45,6 +45,17 @@ class KeyRing:
         self._idx = (self._idx + 1) % len(self._keys)
         return key
 
+    def select(self, index: int) -> str:
+        """Return the key at *index* (mod key count).
+
+        Unlike :meth:`next`, this does not advance the round-robin
+        counter — it is a pure lookup used by affinity-based key
+        selection.
+        """
+        if not self._keys:
+            raise ValueError("No API keys configured")
+        return self._keys[index % len(self._keys)]
+
     def __len__(self) -> int:
         return len(self._keys)
 
@@ -116,11 +127,14 @@ class ProviderInfo:
         self._stream_url_template = stream_url_template
         self.proxy_url = proxy_url
         self.timeout = timeout
+        self._affinity_key_index: int | None = None
 
     # -- public helpers used by the proxy -----------------------------------
 
     def auth_headers(self) -> dict[str, str]:
-        """Return auth headers using the next rotated key."""
+        """Return auth headers using the next rotated or affinity-selected key."""
+        if self._affinity_key_index is not None:
+            return self._auth_header_fn(self.key_ring.select(self._affinity_key_index))
         return self._auth_header_fn(self.key_ring.next())
 
     def upstream_url(self, model: str, *, stream: bool = False) -> str:
@@ -164,6 +178,22 @@ class ProviderInfo:
 
         clone = copy.copy(self)
         clone.timeout = timeout
+        return clone
+
+    def with_affinity(self, key_index: int | None) -> ProviderInfo:
+        """Return a shallow copy with affinity-based key selection.
+
+        When *key_index* is set, :meth:`auth_headers` uses
+        :meth:`KeyRing.select` instead of round-robin :meth:`KeyRing.next`.
+        The new instance shares the same :class:`KeyRing`.
+        Returns ``self`` unchanged if *key_index* is ``None``.
+        """
+        if key_index is None:
+            return self
+        import copy
+
+        clone = copy.copy(self)
+        clone._affinity_key_index = key_index
         return clone
 
 

--- a/tests/gateway/test_app_headers.py
+++ b/tests/gateway/test_app_headers.py
@@ -37,6 +37,7 @@ def test_proxy_handler_forwards_user_agent_to_non_streaming_proxy(monkeypatch):
     class _Config:
         models = {"gpt-test": "test-provider"}
         error_dumps_enabled = False
+        provider_key_affinity: dict[str, bool] = {}
 
         def resolve(self, source_provider, model):
             return (

--- a/tests/gateway/test_key_affinity.py
+++ b/tests/gateway/test_key_affinity.py
@@ -1,0 +1,245 @@
+"""Tests for API key affinity — deterministic key selection for cache locality.
+
+Covers:
+- KeyRing.select() — positional lookup without advancing round-robin
+- extract_prefix_from_ir() — stable fingerprint from IR request
+- compute_affinity_index() — deterministic hash-based key index
+- ProviderInfo.with_affinity() — shallow-copy with pinned key index
+- KeyContext.key_hash — client identity field
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_rosetta.gateway.affinity import compute_affinity_index, extract_prefix_from_ir
+from llm_rosetta.gateway.transport.provider_info import KeyRing, ProviderInfo
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider_info(
+    *,
+    api_key: str = "test-key",
+    base_url: str = "https://api.example.com",
+    url_template: str = "{base_url}/v1/chat/completions",
+) -> ProviderInfo:
+    return ProviderInfo(
+        "test",
+        api_key=api_key,
+        base_url=base_url,
+        auth_header_fn=lambda key: {"Authorization": f"Bearer {key}"},
+        url_template=url_template,
+    )
+
+
+# ---------------------------------------------------------------------------
+# KeyRing.select()
+# ---------------------------------------------------------------------------
+
+
+class TestKeyRingSelect:
+    def test_select_returns_correct_key(self):
+        ring = KeyRing("key-a,key-b,key-c")
+        assert ring.select(0) == "key-a"
+        assert ring.select(1) == "key-b"
+        assert ring.select(2) == "key-c"
+
+    def test_select_wraps_around(self):
+        ring = KeyRing("key-a,key-b,key-c")
+        assert ring.select(3) == "key-a"
+        assert ring.select(4) == "key-b"
+
+    def test_select_does_not_affect_round_robin(self):
+        ring = KeyRing("key-a,key-b")
+        ring.select(0)  # should not change _idx
+        ring.select(1)
+        assert ring.next() == "key-a"  # still starts from 0
+        assert ring.next() == "key-b"
+
+    def test_select_single_key(self):
+        ring = KeyRing("only-key")
+        assert ring.select(0) == "only-key"
+        assert ring.select(42) == "only-key"
+
+    def test_select_empty_raises(self):
+        ring = KeyRing("")
+        with pytest.raises(ValueError):
+            ring.select(0)
+
+
+# ---------------------------------------------------------------------------
+# extract_prefix_from_ir()
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPrefixFromIR:
+    def test_system_and_messages(self):
+        ir = {
+            "system_instruction": [{"type": "text", "text": "You are helpful."}],
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
+                {"role": "assistant", "content": [{"type": "text", "text": "Hi"}]},
+                {"role": "user", "content": [{"type": "text", "text": "Bye"}]},
+            ],
+        }
+        prefix = extract_prefix_from_ir(ir)
+        assert "You are helpful." in prefix
+        assert "Hello" in prefix
+        assert "Hi" in prefix
+        # third message should NOT be included (max_messages=2 default)
+        assert "Bye" not in prefix
+
+    def test_no_system(self):
+        ir = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
+            ],
+        }
+        prefix = extract_prefix_from_ir(ir)
+        assert "Hello" in prefix
+        assert prefix  # not empty
+
+    def test_empty_ir(self):
+        assert extract_prefix_from_ir({}) == ""
+
+    def test_none_like_ir(self):
+        assert extract_prefix_from_ir({}) == ""
+
+    def test_custom_max_messages(self):
+        ir = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "msg1"}]},
+                {"role": "assistant", "content": [{"type": "text", "text": "msg2"}]},
+                {"role": "user", "content": [{"type": "text", "text": "msg3"}]},
+            ],
+        }
+        prefix = extract_prefix_from_ir(ir, max_messages=1)
+        assert "msg1" in prefix
+        assert "msg2" not in prefix
+
+    def test_determinism(self):
+        ir = {
+            "system_instruction": [{"type": "text", "text": "system"}],
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+            ],
+        }
+        assert extract_prefix_from_ir(ir) == extract_prefix_from_ir(ir)
+
+    def test_system_only(self):
+        ir = {"system_instruction": [{"type": "text", "text": "Be concise."}]}
+        prefix = extract_prefix_from_ir(ir)
+        assert "Be concise." in prefix
+
+
+# ---------------------------------------------------------------------------
+# compute_affinity_index()
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAffinityIndex:
+    def test_deterministic(self):
+        idx1 = compute_affinity_index("hash123", "prefix", 5)
+        idx2 = compute_affinity_index("hash123", "prefix", 5)
+        assert idx1 == idx2
+
+    def test_in_range(self):
+        for n in [2, 3, 5, 10, 100]:
+            idx = compute_affinity_index("test-hash", "test-prefix", n)
+            assert idx is not None
+            assert 0 <= idx < n
+
+    def test_different_clients(self):
+        idx_a = compute_affinity_index("client-a", "same-prefix", 100)
+        idx_b = compute_affinity_index("client-b", "same-prefix", 100)
+        # with 100 keys, different clients should (almost certainly) get
+        # different indices — collision probability ~1%
+        assert idx_a != idx_b
+
+    def test_different_prefixes(self):
+        idx_a = compute_affinity_index("same-client", "prefix-alpha", 100)
+        idx_b = compute_affinity_index("same-client", "prefix-beta", 100)
+        # with 100 keys, different prefixes should (almost certainly) get
+        # different indices — collision probability ~1%
+        assert idx_a != idx_b
+
+    def test_returns_none_single_key(self):
+        assert compute_affinity_index("hash", "prefix", 1) is None
+
+    def test_returns_none_empty_hash(self):
+        assert compute_affinity_index("", "prefix", 5) is None
+
+    def test_returns_none_empty_prefix(self):
+        assert compute_affinity_index("hash", "", 5) is None
+
+
+# ---------------------------------------------------------------------------
+# ProviderInfo.with_affinity()
+# ---------------------------------------------------------------------------
+
+
+class TestProviderInfoWithAffinity:
+    def test_returns_clone(self):
+        pi = _make_provider_info(api_key="key-a,key-b,key-c")
+        clone = pi.with_affinity(1)
+        assert clone is not pi
+
+    def test_shares_key_ring(self):
+        pi = _make_provider_info(api_key="key-a,key-b,key-c")
+        clone = pi.with_affinity(1)
+        assert clone.key_ring is pi.key_ring
+
+    def test_uses_select(self):
+        pi = _make_provider_info(api_key="key-a,key-b,key-c")
+        clone = pi.with_affinity(1)
+        headers = clone.auth_headers()
+        assert headers == {"Authorization": "Bearer key-b"}
+
+    def test_none_returns_self(self):
+        pi = _make_provider_info(api_key="key-a,key-b")
+        result = pi.with_affinity(None)
+        assert result is pi
+
+    def test_original_unaffected(self):
+        pi = _make_provider_info(api_key="key-a,key-b")
+        _clone = pi.with_affinity(1)
+        # original should still use round-robin
+        assert pi.auth_headers() == {"Authorization": "Bearer key-a"}
+        assert pi.auth_headers() == {"Authorization": "Bearer key-b"}
+
+    def test_affinity_is_idempotent(self):
+        pi = _make_provider_info(api_key="key-a,key-b,key-c")
+        clone = pi.with_affinity(2)
+        # calling auth_headers multiple times should return same key
+        h1 = clone.auth_headers()
+        h2 = clone.auth_headers()
+        assert h1 == h2 == {"Authorization": "Bearer key-c"}
+
+    def test_chaining_with_timeout(self):
+        pi = _make_provider_info(api_key="key-a,key-b")
+        clone = pi.with_affinity(1).with_timeout(30.0)
+        assert clone.timeout == 30.0
+        assert clone.auth_headers() == {"Authorization": "Bearer key-b"}
+
+
+# ---------------------------------------------------------------------------
+# KeyContext.key_hash
+# ---------------------------------------------------------------------------
+
+
+class TestKeyContextKeyHash:
+    def test_default_empty(self):
+        from llm_rosetta.gateway.keystore import KeyContext
+
+        ctx = KeyContext(label="test", allowed_shims=frozenset())
+        assert ctx.key_hash == ""
+
+    def test_explicit_hash(self):
+        from llm_rosetta.gateway.keystore import KeyContext
+
+        ctx = KeyContext(label="test", allowed_shims=frozenset(), key_hash="abc123")
+        assert ctx.key_hash == "abc123"


### PR DESCRIPTION
## Summary

- Add deterministic upstream API key selection based on `hash(client_token + message_prefix)` instead of round-robin, so the same conversation from the same client always hits the same upstream key — maximizing provider-side prompt cache hits (Anthropic, OpenAI, Google all cache by key + prefix)
- Extract message prefix from the unified IR (`system_instruction` + first N messages), avoiding per-provider parsing logic
- Fall back to round-robin when: single key, no client auth, prefix extraction fails, or `key_affinity: false` in provider config
- Stateless design — pure hash, no TTL, no cache storage

Closes #661

## Changes

| File | Change |
|------|--------|
| `gateway/transport/provider_info.py` | `KeyRing.select(index)` + `ProviderInfo.with_affinity()` |
| `gateway/affinity.py` | New module: `extract_prefix_from_ir()`, `compute_affinity_index()` |
| `gateway/keystore.py` | `KeyContext.key_hash` field |
| `gateway/auth.py` | Populate `key_hash` from client token SHA-256 |
| `gateway/config.py` | Per-provider `key_affinity` config flag |
| `gateway/proxy.py` | Apply affinity after `convert_request()`, before `transport.send()` |
| `gateway/app.py` | Thread `client_key_hash` and `key_affinity` to proxy handlers |
| `tests/gateway/test_key_affinity.py` | 28 unit + integration tests |

## Test plan

- [ ] `make test` passes (3314 passed, 4 skipped)
- [ ] `make lint` passes (ruff check + format)
- [ ] `KeyRing.select()` does not affect round-robin state
- [ ] Same client + same prefix → same key (deterministic)
- [ ] Different clients or prefixes → different keys (probabilistic)
- [ ] Single key / no auth / empty IR → falls back to round-robin
- [ ] `with_affinity()` clone shares `KeyRing` with original
- [ ] `key_affinity: false` config disables the feature