### PR TITLE
feat(gateway): multi-provider routing with weighted round-robin

### DIFF
--- a/examples/gateway/config.jsonc
+++ b/examples/gateway/config.jsonc
@@ -75,6 +75,21 @@
     "gemini-2.0-flash": "google",
     "gemini-2.5-pro": "google",
     "gemini-2.5-flash": "google",
+
+    // Multi-provider: same model served by two providers (equal weight)
+    // "gpt-4o-multi": {
+    //   "providers": ["openai_chat", "openai_responses"],
+    //   "capabilities": ["text", "vision"]
+    // },
+
+    // Multi-provider: weighted distribution (3:1 ratio)
+    // "claude-sonnet-weighted": {
+    //   "providers": [
+    //     {"name": "anthropic", "weight": 3},
+    //     {"name": "anthropic_backup", "weight": 1}
+    //   ],
+    //   "strategy": "weighted_round_robin"
+    // },
     // Embedding models
     "text-embedding-3-small": { "provider": "openai_chat", "type": "embedding" },
     "jina-embeddings-v3": { "provider": "jina", "type": "embedding" },

--- a/src/llm_rosetta/gateway/admin/__init__.py
+++ b/src/llm_rosetta/gateway/admin/__init__.py
@@ -177,7 +177,9 @@ def setup_admin(
 
     # Backfill target_provider_name for legacy log entries
     if persistence is not None:
-        model_to_provider = {model: config.models[model] for model in config.models}
+        model_to_provider = {
+            model: route.provider_names[0] for model, route in config.models.items()
+        }
         backfilled = persistence.backfill_provider_names(model_to_provider)
         if backfilled:
             logger.info(

--- a/src/llm_rosetta/gateway/admin/routes/config.py
+++ b/src/llm_rosetta/gateway/admin/routes/config.py
@@ -103,9 +103,17 @@ def _normalize_model_entry(value: Any) -> dict[str, Any]:
     if isinstance(value, str):
         return {"provider": value, "capabilities": ["text"]}
     entry: dict[str, Any] = {
-        "provider": value.get("provider", ""),
         "capabilities": value.get("capabilities", ["text"]),
     }
+    if "providers" in value:
+        entry["providers"] = value["providers"]
+        if "strategy" in value:
+            entry["strategy"] = value["strategy"]
+        # For backward compat, set "provider" to the first entry
+        first = value["providers"][0] if value["providers"] else ""
+        entry["provider"] = first if isinstance(first, str) else first.get("name", "")
+    else:
+        entry["provider"] = value.get("provider", "")
     if value.get("type"):
         entry["type"] = value["type"]
     for key in (
@@ -289,10 +297,22 @@ async def delete_provider(request: Any, **kwargs: Any) -> Response:
 
         # Check if any model still references this provider
         models = data.get("models", {})
+
+        def _model_references_provider(model_cfg: Any, provider_name: str) -> bool:
+            if isinstance(model_cfg, str):
+                return model_cfg == provider_name
+            if isinstance(model_cfg, dict):
+                if "providers" in model_cfg:
+                    for entry in model_cfg["providers"]:
+                        pn = entry if isinstance(entry, str) else entry.get("name", "")
+                        if pn == provider_name:
+                            return True
+                    return False
+                return model_cfg.get("provider", "") == provider_name
+            return False
+
         referencing = [
-            m
-            for m, p in models.items()
-            if (p["provider"] if isinstance(p, dict) else p) == name
+            m for m, p in models.items() if _model_references_provider(p, name)
         ]
 
         from ._shared import _qp

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -490,19 +490,23 @@ async def handle_list_models(request: Any) -> Response:
         provider_name = model_route.providers[0].name
         api_standard = _config.provider_types.get(provider_name, "unknown")
         capabilities = _config.model_capabilities.get(name, ["text"])
-        data.append(
-            {
-                "id": name,
-                "object": "model",
-                "created": 0,
-                "owned_by": provider_name,
-                "api_standard": api_standard,
-                "capabilities": capabilities,
-                "type": "model",
-                "display_name": name,
-                "created_at": "1970-01-01T00:00:00Z",
-            }
-        )
+        entry: dict[str, Any] = {
+            "id": name,
+            "object": "model",
+            "created": 0,
+            "owned_by": provider_name,
+            "api_standard": api_standard,
+            "capabilities": capabilities,
+            "type": "model",
+            "display_name": name,
+            "created_at": "1970-01-01T00:00:00Z",
+        }
+        if model_route.is_multi:
+            entry["providers"] = [
+                {"name": p.name, "weight": p.weight} for p in model_route.providers
+            ]
+            entry["routing_strategy"] = "weighted_round_robin"
+        data.append(entry)
     return JSONResponse(
         {
             "object": "list",

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -486,7 +486,8 @@ async def handle_list_models(request: Any) -> Response:
     models = sorted(_config.models.keys())
     data = []
     for name in models:
-        provider_name = _config.models[name]
+        model_route = _config.models[name]
+        provider_name = model_route.provider_names[0]
         api_standard = _config.provider_types.get(provider_name, "unknown")
         capabilities = _config.model_capabilities.get(name, ["text"])
         data.append(

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -487,7 +487,7 @@ async def handle_list_models(request: Any) -> Response:
     data = []
     for name in models:
         model_route = _config.models[name]
-        provider_name = model_route.provider_names[0]
+        provider_name = model_route.providers[0].name
         api_standard = _config.provider_types.get(provider_name, "unknown")
         capabilities = _config.model_capabilities.get(name, ["text"])
         data.append(

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -15,6 +15,13 @@ from llm_rosetta._vendor import jsonx
 from llm_rosetta.auto_detect import ProviderType
 from llm_rosetta.routing import ResolvedRoute
 
+from .routing_strategy import (
+    DEFAULT_STRATEGY,
+    ModelRoute,
+    ProviderEntry,
+    create_strategy,
+)
+
 from .providers import build_provider_info
 from .transport import ProviderInfo
 
@@ -635,11 +642,12 @@ class GatewayConfig:
                 "config: no routable models — models may reference disabled providers"
             )
             return
-        for model, provider in self.models.items():
-            if provider not in self._raw_providers:
-                raise ValueError(
-                    f"config: model '{model}' references unknown provider '{provider}'"
-                )
+        for model, route in self.models.items():
+            for pname in route.provider_names:
+                if pname not in self._raw_providers:
+                    raise ValueError(
+                        f"config: model '{model}' references unknown provider '{pname}'"
+                    )
 
     @staticmethod
     def _resolve_provider_types(
@@ -676,48 +684,121 @@ class GatewayConfig:
         cls,
         raw_models: dict[str, Any],
         raw_providers: dict[str, dict[str, str]],
-    ) -> tuple[dict[str, ProviderType], dict[str, list[str]], dict[str, str]]:
+    ) -> tuple[dict[str, ModelRoute], dict[str, list[str]], dict[str, str]]:
         """Parse model routing entries from config.
 
-        Supports both string and dict formats:
+        Supports string, single-provider dict, and multi-provider formats:
           - ``"model": "provider"`` (legacy)
           - ``"model": {"provider": "p", "capabilities": [...]}``
-          - ``"model": {"provider": "p", "upstream_model": "actual_name"}``
+          - ``"model": {"providers": ["p1", "p2"]}`` (equal weight)
+          - ``"model": {"providers": [{"name": "p1", "weight": 3}, ...]}``
 
         Models referencing disabled/missing providers are silently skipped.
 
         Returns:
             Tuple of (models, model_capabilities, model_upstream_names).
         """
-        models: dict[str, ProviderType] = {}
+        models: dict[str, ModelRoute] = {}
         model_capabilities: dict[str, list[str]] = {}
         model_upstream_names: dict[str, str] = {}
         for name, value in raw_models.items():
-            if isinstance(value, str):
-                provider_name = value
-            elif isinstance(value, dict):
-                provider_name = value["provider"]
-            else:
-                raise ValueError(f"config: invalid model entry for '{name}'")
-
-            # Skip disabled models
-            if isinstance(value, dict) and value.get("enabled") is False:
+            route = cls._parse_model_route(name, value, raw_providers)
+            if route is None:
                 continue
-
-            if provider_name not in raw_providers:
-                continue
-
-            models[name] = provider_name
-            if isinstance(value, str):
-                model_capabilities[name] = list(cls.DEFAULT_CAPABILITIES)
-            else:
-                model_capabilities[name] = value.get(
-                    "capabilities", list(cls.DEFAULT_CAPABILITIES)
-                )
-                upstream = value.get("upstream_model")
-                if upstream:
-                    model_upstream_names[name] = upstream
+            models[name] = route
+            caps, upstream = cls._extract_model_metadata(value)
+            model_capabilities[name] = caps
+            if upstream:
+                model_upstream_names[name] = upstream
         return models, model_capabilities, model_upstream_names
+
+    @classmethod
+    def _parse_model_route(
+        cls,
+        name: str,
+        value: Any,
+        raw_providers: dict[str, dict[str, str]],
+    ) -> ModelRoute | None:
+        """Resolve a single model config entry to a :class:`ModelRoute`.
+
+        Returns ``None`` if the model should be skipped.
+        """
+        if isinstance(value, str):
+            if value not in raw_providers:
+                return None
+            return ModelRoute([ProviderEntry(value)])
+        if not isinstance(value, dict):
+            raise ValueError(f"config: invalid model entry for '{name}'")
+        if value.get("enabled") is False:
+            return None
+        if "provider" in value and "providers" in value:
+            raise ValueError(
+                f"config: model '{name}' has both 'provider' and "
+                f"'providers' — use one or the other"
+            )
+        if "providers" in value:
+            return cls._parse_multi_provider(name, value, raw_providers)
+        provider_name = value["provider"]
+        if provider_name not in raw_providers:
+            return None
+        return ModelRoute([ProviderEntry(provider_name)])
+
+    @classmethod
+    def _extract_model_metadata(cls, value: Any) -> tuple[list[str], str | None]:
+        """Extract capabilities and upstream_model from a model entry."""
+        if isinstance(value, str):
+            return list(cls.DEFAULT_CAPABILITIES), None
+        caps = value.get("capabilities", list(cls.DEFAULT_CAPABILITIES))
+        return caps, value.get("upstream_model")
+
+    @classmethod
+    def _parse_multi_provider(
+        cls,
+        model_name: str,
+        value: dict[str, Any],
+        raw_providers: dict[str, dict[str, str]],
+    ) -> ModelRoute | None:
+        """Parse a multi-provider model entry.
+
+        Returns ``None`` if no valid providers remain after filtering.
+        """
+        raw_list = value["providers"]
+        if not isinstance(raw_list, list) or not raw_list:
+            raise ValueError(
+                f"config: model '{model_name}' has empty or invalid 'providers' list"
+            )
+
+        entries: list[ProviderEntry] = []
+        for item in raw_list:
+            if isinstance(item, str):
+                pname, weight = item, 1
+            elif isinstance(item, dict):
+                pname = item.get("name", "")
+                weight = int(item.get("weight", 1))
+                if not pname:
+                    raise ValueError(
+                        f"config: model '{model_name}' has a provider entry "
+                        f"without a 'name' field"
+                    )
+            else:
+                raise ValueError(
+                    f"config: model '{model_name}' has invalid provider entry: {item}"
+                )
+            if pname not in raw_providers:
+                logger.warning(
+                    "Model %r: provider %r not found, skipping",
+                    model_name,
+                    pname,
+                )
+                continue
+            entries.append(ProviderEntry(pname, weight))
+
+        if not entries:
+            return None
+
+        strategy_name = value.get("strategy", DEFAULT_STRATEGY)
+        strategy = create_strategy(strategy_name)
+        return ModelRoute(entries, strategy)
 
     def resolve(
         self,
@@ -744,7 +825,7 @@ class GatewayConfig:
         """
         from typing import cast
 
-        provider_name = self.models[model]
+        provider_name = self.models[model].select()
         provider_type = self.provider_types[provider_name]
         shim_name = self.provider_shim_names.get(provider_name)
         upstream_model = self.model_upstream_names.get(model)

--- a/src/llm_rosetta/gateway/config.py
+++ b/src/llm_rosetta/gateway/config.py
@@ -15,14 +15,13 @@ from llm_rosetta._vendor import jsonx
 from llm_rosetta.auto_detect import ProviderType
 from llm_rosetta.routing import ResolvedRoute
 
+from .providers import build_provider_info
 from .routing_strategy import (
     DEFAULT_STRATEGY,
     ModelRoute,
     ProviderEntry,
     create_strategy,
 )
-
-from .providers import build_provider_info
 from .transport import ProviderInfo
 
 logger = logging.getLogger("llm-rosetta-gateway")
@@ -783,6 +782,11 @@ class GatewayConfig:
             else:
                 raise ValueError(
                     f"config: model '{model_name}' has invalid provider entry: {item}"
+                )
+            if weight < 1:
+                raise ValueError(
+                    f"config: model '{model_name}' provider '{pname}' "
+                    f"has invalid weight {weight} (must be >= 1)"
                 )
             if pname not in raw_providers:
                 logger.warning(

--- a/src/llm_rosetta/gateway/logging.py
+++ b/src/llm_rosetta/gateway/logging.py
@@ -107,6 +107,7 @@ _STRUCTURED_EXTRA_KEYS: frozenset[str] = frozenset(
         "label",
         "max_content_length",
         "model",
+        "provider_name",
         "request_id",
         "request_type",
         "source_provider",

--- a/src/llm_rosetta/gateway/proxy.py
+++ b/src/llm_rosetta/gateway/proxy.py
@@ -605,6 +605,7 @@ def _write_back_stream_usage(
     request_log: Any | None,
     metrics: Any | None,
     model: str,
+    provider_name: str | None = None,
 ) -> None:
     """Extract accumulated token usage from the stream processor and persist it."""
     usage = getattr(processor, "get_accumulated_usage", lambda: None)()
@@ -622,7 +623,12 @@ def _write_back_stream_usage(
     except Exception:
         logger.debug("Failed to write usage for %s", entry_id)
     if metrics is not None:
-        metrics.record_usage(model=model, input_tokens=inp, output_tokens=outp)
+        metrics.record_usage(
+            model=model,
+            input_tokens=inp,
+            output_tokens=outp,
+            provider_name=provider_name,
+        )
 
 
 async def _stream_event_generator(
@@ -729,7 +735,14 @@ async def _stream_event_generator(
             except Exception:
                 logger.debug("Failed to write stream profile for %s", entry_id)
 
-            _write_back_stream_usage(processor, entry_id, request_log, metrics, model)
+            _write_back_stream_usage(
+                processor,
+                entry_id,
+                request_log,
+                metrics,
+                model,
+                provider_name=dump_ctx.provider_name if dump_ctx else None,
+            )
 
         # Content capture (streaming): record accumulated upstream chunks
         if capture_record is not None and capture_state is not None:

--- a/src/llm_rosetta/gateway/routing_strategy.py
+++ b/src/llm_rosetta/gateway/routing_strategy.py
@@ -1,0 +1,114 @@
+"""Multi-provider routing strategies.
+
+Provides the :class:`RoutingStrategy` protocol, concrete strategy
+implementations, and the :class:`ModelRoute` container that pairs a
+list of provider entries with a strategy for selection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+@dataclass(slots=True)
+class ProviderEntry:
+    """A provider candidate with an associated weight."""
+
+    name: str
+    weight: int = 1
+
+
+class RoutingStrategy(Protocol):
+    """Interface for selecting a provider from a weighted list."""
+
+    def select(self, providers: list[ProviderEntry]) -> str:
+        """Return the name of the chosen provider."""
+        ...
+
+
+class WeightedRoundRobinStrategy:
+    """Smooth weighted round-robin (nginx-style).
+
+    Each provider tracks a ``current_weight``.  On every call the
+    effective weight is added, the highest-weight provider is chosen,
+    and the total weight is subtracted from the winner.  This produces
+    an even interleaving — e.g. weights [5, 1] yield the sequence
+    A A A A A B rather than bursting all A's then all B's.
+    """
+
+    def __init__(self) -> None:
+        self._current_weights: list[int] = []
+        self._initialized_for: int = 0
+
+    def select(self, providers: list[ProviderEntry]) -> str:
+        n = len(providers)
+        if n == 0:
+            raise ValueError("No providers configured")
+        if n == 1:
+            return providers[0].name
+
+        if self._initialized_for != id(providers):
+            self._current_weights = [0] * n
+            self._initialized_for = id(providers)
+
+        total = sum(p.weight for p in providers)
+        best_idx = 0
+        best_weight = -1
+        for i, p in enumerate(providers):
+            self._current_weights[i] += p.weight
+            if self._current_weights[i] > best_weight:
+                best_weight = self._current_weights[i]
+                best_idx = i
+
+        self._current_weights[best_idx] -= total
+        return providers[best_idx].name
+
+
+# Strategy registry
+_STRATEGIES: dict[str, type[RoutingStrategy]] = {
+    "weighted_round_robin": WeightedRoundRobinStrategy,
+}
+
+DEFAULT_STRATEGY = "weighted_round_robin"
+
+
+def create_strategy(name: str) -> RoutingStrategy:
+    """Instantiate a routing strategy by name.
+
+    Raises:
+        ValueError: If the strategy name is not recognized.
+    """
+    cls = _STRATEGIES.get(name)
+    if cls is None:
+        valid = ", ".join(sorted(_STRATEGIES))
+        raise ValueError(
+            f"Unknown routing strategy '{name}'. Valid strategies: {valid}"
+        )
+    return cls()
+
+
+@dataclass
+class ModelRoute:
+    """A model's provider list and routing strategy.
+
+    Wraps the provider selection so that callers simply call
+    :meth:`select` without knowing the strategy details.
+    """
+
+    providers: list[ProviderEntry]
+    strategy: RoutingStrategy = field(default_factory=WeightedRoundRobinStrategy)
+
+    def select(self) -> str:
+        """Pick the next provider according to the strategy."""
+        return self.strategy.select(self.providers)
+
+    @property
+    def provider_names(self) -> list[str]:
+        """All provider names in this route."""
+        return [p.name for p in self.providers]
+
+    @property
+    def is_multi(self) -> bool:
+        """Whether this route has more than one provider."""
+        return len(self.providers) > 1

--- a/src/llm_rosetta/gateway/routing_strategy.py
+++ b/src/llm_rosetta/gateway/routing_strategy.py
@@ -39,7 +39,7 @@ class WeightedRoundRobinStrategy:
 
     def __init__(self) -> None:
         self._current_weights: list[int] = []
-        self._initialized_for: int = 0
+        self._initialized_for: list[ProviderEntry] | None = None
 
     def select(self, providers: list[ProviderEntry]) -> str:
         n = len(providers)
@@ -48,9 +48,9 @@ class WeightedRoundRobinStrategy:
         if n == 1:
             return providers[0].name
 
-        if self._initialized_for != id(providers):
+        if self._initialized_for is not providers:
             self._current_weights = [0] * n
-            self._initialized_for = id(providers)
+            self._initialized_for = providers
 
         total = sum(p.weight for p in providers)
         best_idx = 0

--- a/src/llm_rosetta/observability/metrics.py
+++ b/src/llm_rosetta/observability/metrics.py
@@ -187,6 +187,7 @@ class MetricsCollector:
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     by_model_tokens: dict[str, dict[str, int]] = field(default_factory=dict)
+    by_provider_tokens: dict[str, dict[str, int]] = field(default_factory=dict)
 
     # Gauge
     active_streams: int = 0
@@ -252,6 +253,14 @@ class MetricsCollector:
             mt["input_tokens"] += input_tokens or 0
             mt["output_tokens"] += output_tokens or 0
 
+            if provider_name:
+                pt = self.by_provider_tokens.get(provider_name)
+                if pt is None:
+                    pt = {"input_tokens": 0, "output_tokens": 0}
+                    self.by_provider_tokens[provider_name] = pt
+                pt["input_tokens"] += input_tokens or 0
+                pt["output_tokens"] += output_tokens or 0
+
         self._window.record(duration_ms, is_error=is_error)
 
         # Per-provider stats (use provider_name if available, fall back to target)
@@ -266,6 +275,7 @@ class MetricsCollector:
         model: str,
         input_tokens: int | None = None,
         output_tokens: int | None = None,
+        provider_name: str | None = None,
     ) -> None:
         """Record token usage separately (for streaming write-back)."""
         if input_tokens is not None:
@@ -279,6 +289,14 @@ class MetricsCollector:
                 self.by_model_tokens[model] = mt
             mt["input_tokens"] += input_tokens or 0
             mt["output_tokens"] += output_tokens or 0
+
+            if provider_name:
+                pt = self.by_provider_tokens.get(provider_name)
+                if pt is None:
+                    pt = {"input_tokens": 0, "output_tokens": 0}
+                    self.by_provider_tokens[provider_name] = pt
+                pt["input_tokens"] += input_tokens or 0
+                pt["output_tokens"] += output_tokens or 0
 
     def provider_health_snapshot(self) -> dict[str, dict]:
         """Return a JSON-serializable per-provider health snapshot."""
@@ -310,6 +328,9 @@ class MetricsCollector:
             "total_input_tokens": self.total_input_tokens,
             "total_output_tokens": self.total_output_tokens,
             "by_model_tokens": {k: dict(v) for k, v in self.by_model_tokens.items()},
+            "by_provider_tokens": {
+                k: dict(v) for k, v in self.by_provider_tokens.items()
+            },
         }
 
     def load_counters(self, data: dict) -> None:
@@ -327,6 +348,9 @@ class MetricsCollector:
         self.total_output_tokens = data.get("total_output_tokens", 0)
         self.by_model_tokens = {
             k: dict(v) for k, v in data.get("by_model_tokens", {}).items()
+        }
+        self.by_provider_tokens = {
+            k: dict(v) for k, v in data.get("by_provider_tokens", {}).items()
         }
 
     def rebuild_counters(self, rows: Iterable[dict]) -> int:
@@ -364,6 +388,7 @@ class MetricsCollector:
         total_input_tokens = 0
         total_output_tokens = 0
         by_model_tokens: dict[str, dict[str, int]] = {}
+        by_provider_tokens: dict[str, dict[str, int]] = {}
 
         for r in rows:
             total_requests += 1
@@ -400,6 +425,16 @@ class MetricsCollector:
                 mt["input_tokens"] += inp or 0
                 mt["output_tokens"] += outp or 0
 
+                pn = r.get("target_provider_name") or r.get(
+                    "target_provider", "unknown"
+                )
+                pt = by_provider_tokens.get(pn)
+                if pt is None:
+                    pt = {"input_tokens": 0, "output_tokens": 0}
+                    by_provider_tokens[pn] = pt
+                pt["input_tokens"] += inp or 0
+                pt["output_tokens"] += outp or 0
+
         # Atomic swap — active_streams is live state, not rebuilt.
         self.total_requests = total_requests
         self.total_errors = total_errors
@@ -411,6 +446,7 @@ class MetricsCollector:
         self.total_input_tokens = total_input_tokens
         self.total_output_tokens = total_output_tokens
         self.by_model_tokens = by_model_tokens
+        self.by_provider_tokens = by_provider_tokens
 
         return total_requests
 
@@ -437,6 +473,9 @@ class MetricsCollector:
             "total_input_tokens": self.total_input_tokens,
             "total_output_tokens": self.total_output_tokens,
             "by_model_tokens": {k: dict(v) for k, v in self.by_model_tokens.items()},
+            "by_provider_tokens": {
+                k: dict(v) for k, v in self.by_provider_tokens.items()
+            },
             "series": self._window.get_series(series_seconds),
             "providers": self.provider_health_snapshot(),
         }

--- a/tests/gateway/test_multi_provider_config.py
+++ b/tests/gateway/test_multi_provider_config.py
@@ -221,3 +221,13 @@ class TestMultiProviderResolve:
             results.append(route.provider_name)
         assert results.count("openai_a") == 3
         assert results.count("openai_b") == 1
+
+    def test_zero_weight_raises(self):
+        with pytest.raises(ValueError, match="invalid weight 0"):
+            _make_config({"gpt-4o": {"providers": [{"name": "openai_a", "weight": 0}]}})
+
+    def test_negative_weight_raises(self):
+        with pytest.raises(ValueError, match="invalid weight -1"):
+            _make_config(
+                {"gpt-4o": {"providers": [{"name": "openai_a", "weight": -1}]}}
+            )

--- a/tests/gateway/test_multi_provider_config.py
+++ b/tests/gateway/test_multi_provider_config.py
@@ -1,0 +1,223 @@
+"""Tests for multi-provider model config parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_rosetta.gateway.config import GatewayConfig
+from llm_rosetta.gateway.routing_strategy import ModelRoute
+
+
+def _make_config(models: dict, providers: dict | None = None) -> GatewayConfig:
+    """Build a GatewayConfig from a minimal raw dict."""
+    if providers is None:
+        providers = {
+            "openai_a": {
+                "type": "openai_chat",
+                "api_key": "sk-a",
+                "base_url": "https://a.example.com",
+            },
+            "openai_b": {
+                "type": "openai_chat",
+                "api_key": "sk-b",
+                "base_url": "https://b.example.com",
+            },
+            "anthropic_a": {
+                "type": "anthropic",
+                "api_key": "sk-c",
+                "base_url": "https://c.example.com",
+            },
+        }
+    return GatewayConfig({"providers": providers, "models": models})
+
+
+class TestSingleProviderBackwardCompat:
+    """Existing single-provider config forms still work."""
+
+    def test_string_form(self):
+        config = _make_config({"gpt-4o": "openai_a"})
+        route = config.models["gpt-4o"]
+        assert isinstance(route, ModelRoute)
+        assert not route.is_multi
+        assert route.provider_names == ["openai_a"]
+        assert route.select() == "openai_a"
+
+    def test_dict_form(self):
+        config = _make_config({"gpt-4o": {"provider": "openai_a"}})
+        route = config.models["gpt-4o"]
+        assert not route.is_multi
+        assert route.select() == "openai_a"
+
+    def test_dict_with_capabilities(self):
+        config = _make_config(
+            {"gpt-4o": {"provider": "openai_a", "capabilities": ["text", "vision"]}}
+        )
+        assert config.model_capabilities["gpt-4o"] == ["text", "vision"]
+
+    def test_dict_with_upstream_model(self):
+        config = _make_config(
+            {"gpt-4o": {"provider": "openai_a", "upstream_model": "gpt-4o-2024-08-06"}}
+        )
+        assert config.model_upstream_names["gpt-4o"] == "gpt-4o-2024-08-06"
+
+
+class TestMultiProviderParsing:
+    """New multi-provider config forms."""
+
+    def test_providers_string_list(self):
+        config = _make_config({"gpt-4o": {"providers": ["openai_a", "openai_b"]}})
+        route = config.models["gpt-4o"]
+        assert route.is_multi
+        assert set(route.provider_names) == {"openai_a", "openai_b"}
+        # Equal weights
+        for p in route.providers:
+            assert p.weight == 1
+
+    def test_providers_dict_list_with_weights(self):
+        config = _make_config(
+            {
+                "gpt-4o": {
+                    "providers": [
+                        {"name": "openai_a", "weight": 3},
+                        {"name": "openai_b", "weight": 1},
+                    ],
+                }
+            }
+        )
+        route = config.models["gpt-4o"]
+        assert route.is_multi
+        assert route.providers[0].name == "openai_a"
+        assert route.providers[0].weight == 3
+        assert route.providers[1].name == "openai_b"
+        assert route.providers[1].weight == 1
+
+    def test_providers_mixed_list(self):
+        config = _make_config(
+            {
+                "gpt-4o": {
+                    "providers": [
+                        "openai_a",
+                        {"name": "openai_b", "weight": 2},
+                    ],
+                }
+            }
+        )
+        route = config.models["gpt-4o"]
+        assert route.providers[0].name == "openai_a"
+        assert route.providers[0].weight == 1
+        assert route.providers[1].name == "openai_b"
+        assert route.providers[1].weight == 2
+
+    def test_providers_with_strategy(self):
+        config = _make_config(
+            {
+                "gpt-4o": {
+                    "providers": ["openai_a", "openai_b"],
+                    "strategy": "weighted_round_robin",
+                }
+            }
+        )
+        route = config.models["gpt-4o"]
+        assert route.is_multi
+
+    def test_providers_with_capabilities(self):
+        config = _make_config(
+            {
+                "gpt-4o": {
+                    "providers": ["openai_a", "openai_b"],
+                    "capabilities": ["text", "vision"],
+                }
+            }
+        )
+        assert config.model_capabilities["gpt-4o"] == ["text", "vision"]
+
+    def test_provider_skipped_if_not_in_providers(self):
+        config = _make_config(
+            {
+                "gpt-4o": {
+                    "providers": ["openai_a", "nonexistent"],
+                }
+            }
+        )
+        route = config.models["gpt-4o"]
+        assert route.provider_names == ["openai_a"]
+
+    def test_model_skipped_if_all_providers_missing(self):
+        config = _make_config(
+            {"gpt-4o": {"providers": ["nonexistent_a", "nonexistent_b"]}}
+        )
+        assert "gpt-4o" not in config.models
+
+
+class TestMultiProviderValidation:
+    """Config validation for multi-provider."""
+
+    def test_provider_and_providers_mutually_exclusive(self):
+        with pytest.raises(ValueError, match="both 'provider' and 'providers'"):
+            _make_config(
+                {"gpt-4o": {"provider": "openai_a", "providers": ["openai_b"]}}
+            )
+
+    def test_empty_providers_list_raises(self):
+        with pytest.raises(ValueError, match="empty or invalid"):
+            _make_config({"gpt-4o": {"providers": []}})
+
+    def test_provider_entry_missing_name_raises(self):
+        with pytest.raises(ValueError, match="without a 'name' field"):
+            _make_config({"gpt-4o": {"providers": [{"weight": 3}]}})
+
+    def test_invalid_strategy_raises(self):
+        with pytest.raises(ValueError, match="Unknown routing strategy"):
+            _make_config(
+                {
+                    "gpt-4o": {
+                        "providers": ["openai_a"],
+                        "strategy": "does_not_exist",
+                    }
+                }
+            )
+
+
+class TestMultiProviderResolve:
+    """resolve() works with multi-provider models."""
+
+    def test_resolve_returns_route(self):
+        config = _make_config(
+            {
+                "gpt-4o": {
+                    "providers": [
+                        {"name": "openai_a", "weight": 3},
+                        {"name": "openai_b", "weight": 1},
+                    ],
+                }
+            }
+        )
+        route, pinfo = config.resolve("openai_chat", "gpt-4o")
+        assert route.provider_name in ("openai_a", "openai_b")
+        assert pinfo.name in ("openai_chat", "openai_chat")
+
+    def test_resolve_rotates_providers(self):
+        config = _make_config({"gpt-4o": {"providers": ["openai_a", "openai_b"]}})
+        providers_seen = set()
+        for _ in range(10):
+            route, _ = config.resolve("openai_chat", "gpt-4o")
+            providers_seen.add(route.provider_name)
+        assert providers_seen == {"openai_a", "openai_b"}
+
+    def test_resolve_weighted(self):
+        config = _make_config(
+            {
+                "gpt-4o": {
+                    "providers": [
+                        {"name": "openai_a", "weight": 3},
+                        {"name": "openai_b", "weight": 1},
+                    ],
+                }
+            }
+        )
+        results = []
+        for _ in range(4):
+            route, _ = config.resolve("openai_chat", "gpt-4o")
+            results.append(route.provider_name)
+        assert results.count("openai_a") == 3
+        assert results.count("openai_b") == 1

--- a/tests/gateway/test_routing_strategy.py
+++ b/tests/gateway/test_routing_strategy.py
@@ -1,0 +1,130 @@
+"""Tests for multi-provider routing strategies."""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_rosetta.gateway.routing_strategy import (
+    DEFAULT_STRATEGY,
+    ModelRoute,
+    ProviderEntry,
+    WeightedRoundRobinStrategy,
+    create_strategy,
+)
+
+
+class TestProviderEntry:
+    def test_defaults(self):
+        e = ProviderEntry("openai")
+        assert e.name == "openai"
+        assert e.weight == 1
+
+    def test_custom_weight(self):
+        e = ProviderEntry("openai", weight=5)
+        assert e.weight == 5
+
+
+class TestWeightedRoundRobinStrategy:
+    def test_single_provider(self):
+        s = WeightedRoundRobinStrategy()
+        providers = [ProviderEntry("a")]
+        assert s.select(providers) == "a"
+        assert s.select(providers) == "a"
+
+    def test_equal_weight_alternates(self):
+        s = WeightedRoundRobinStrategy()
+        providers = [ProviderEntry("a"), ProviderEntry("b")]
+        results = [s.select(providers) for _ in range(6)]
+        assert results.count("a") == 3
+        assert results.count("b") == 3
+
+    def test_weighted_distribution(self):
+        s = WeightedRoundRobinStrategy()
+        providers = [ProviderEntry("a", weight=3), ProviderEntry("b", weight=1)]
+        results = [s.select(providers) for _ in range(4)]
+        assert results.count("a") == 3
+        assert results.count("b") == 1
+
+    def test_weighted_interleaving(self):
+        """Smooth WRR should interleave, not burst."""
+        s = WeightedRoundRobinStrategy()
+        providers = [ProviderEntry("a", weight=2), ProviderEntry("b", weight=1)]
+        results = [s.select(providers) for _ in range(6)]
+        # Should produce a-a-b-a-a-b or a-b-a-a-b-a pattern, not a-a-a-a-b-b
+        # Key invariant: no more than 2 consecutive "a"s
+        for i in range(len(results) - 2):
+            if results[i] == results[i + 1] == results[i + 2] == "a":
+                pytest.fail(f"Three consecutive 'a' at index {i}: {results}")
+
+    def test_three_providers(self):
+        s = WeightedRoundRobinStrategy()
+        providers = [
+            ProviderEntry("a", weight=3),
+            ProviderEntry("b", weight=2),
+            ProviderEntry("c", weight=1),
+        ]
+        results = [s.select(providers) for _ in range(6)]
+        assert results.count("a") == 3
+        assert results.count("b") == 2
+        assert results.count("c") == 1
+
+    def test_empty_raises(self):
+        s = WeightedRoundRobinStrategy()
+        with pytest.raises(ValueError, match="No providers"):
+            s.select([])
+
+    def test_deterministic(self):
+        """Same sequence of selections every time."""
+        s1 = WeightedRoundRobinStrategy()
+        s2 = WeightedRoundRobinStrategy()
+        providers = [ProviderEntry("a", weight=3), ProviderEntry("b", weight=1)]
+        r1 = [s1.select(providers) for _ in range(8)]
+        r2 = [s2.select(providers) for _ in range(8)]
+        assert r1 == r2
+
+    def test_large_weight_ratio(self):
+        s = WeightedRoundRobinStrategy()
+        providers = [ProviderEntry("a", weight=99), ProviderEntry("b", weight=1)]
+        results = [s.select(providers) for _ in range(100)]
+        assert results.count("a") == 99
+        assert results.count("b") == 1
+
+
+class TestModelRoute:
+    def test_single_provider(self):
+        route = ModelRoute([ProviderEntry("openai")])
+        assert route.select() == "openai"
+        assert not route.is_multi
+        assert route.provider_names == ["openai"]
+
+    def test_multi_provider(self):
+        route = ModelRoute([ProviderEntry("a"), ProviderEntry("b")])
+        assert route.is_multi
+        assert set(route.provider_names) == {"a", "b"}
+        # Should return both over multiple calls
+        results = {route.select() for _ in range(10)}
+        assert results == {"a", "b"}
+
+    def test_custom_strategy(self):
+        strategy = WeightedRoundRobinStrategy()
+        route = ModelRoute(
+            [ProviderEntry("a", weight=1), ProviderEntry("b", weight=1)],
+            strategy=strategy,
+        )
+        results = [route.select() for _ in range(4)]
+        assert results.count("a") == 2
+        assert results.count("b") == 2
+
+
+class TestCreateStrategy:
+    def test_default_strategy(self):
+        s = create_strategy(DEFAULT_STRATEGY)
+        assert isinstance(s, WeightedRoundRobinStrategy)
+
+    def test_weighted_round_robin(self):
+        s = create_strategy("weighted_round_robin")
+        assert isinstance(s, WeightedRoundRobinStrategy)
+
+    def test_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unknown routing strategy"):
+            create_strategy("does_not_exist")

--- a/tests/gateway/test_token_tracking.py
+++ b/tests/gateway/test_token_tracking.py
@@ -464,3 +464,164 @@ class TestPassthroughZeroTokens:
         assert usage["prompt_tokens"] == 0
         assert usage["completion_tokens"] == 50
         assert usage["total_tokens"] == 50
+
+
+# ---- Provider-level token tracking (multi-provider support) ----
+
+
+class TestProviderTokenTracking:
+    """by_provider_tokens aggregation in MetricsCollector."""
+
+    def test_record_request_tracks_provider_tokens(self):
+        m = MetricsCollector()
+        m.record_request(
+            model="gpt-4o",
+            source="openai_chat",
+            target="openai_chat",
+            status_code=200,
+            duration_ms=100,
+            is_stream=False,
+            provider_name="openai_a",
+            input_tokens=100,
+            output_tokens=50,
+        )
+        assert m.by_provider_tokens["openai_a"]["input_tokens"] == 100
+        assert m.by_provider_tokens["openai_a"]["output_tokens"] == 50
+
+    def test_record_request_without_provider_name(self):
+        m = MetricsCollector()
+        m.record_request(
+            model="gpt-4o",
+            source="openai_chat",
+            target="openai_chat",
+            status_code=200,
+            duration_ms=100,
+            is_stream=False,
+            input_tokens=100,
+            output_tokens=50,
+        )
+        assert m.by_provider_tokens == {}
+
+    def test_provider_token_accumulation(self):
+        m = MetricsCollector()
+        for _ in range(3):
+            m.record_request(
+                model="gpt-4o",
+                source="openai_chat",
+                target="openai_chat",
+                status_code=200,
+                duration_ms=100,
+                is_stream=False,
+                provider_name="openai_a",
+                input_tokens=100,
+                output_tokens=50,
+            )
+        assert m.by_provider_tokens["openai_a"]["input_tokens"] == 300
+        assert m.by_provider_tokens["openai_a"]["output_tokens"] == 150
+
+    def test_multi_provider_separation(self):
+        m = MetricsCollector()
+        m.record_request(
+            model="gpt-4o",
+            source="openai_chat",
+            target="openai_chat",
+            status_code=200,
+            duration_ms=100,
+            is_stream=False,
+            provider_name="openai_a",
+            input_tokens=100,
+            output_tokens=50,
+        )
+        m.record_request(
+            model="gpt-4o",
+            source="openai_chat",
+            target="openai_chat",
+            status_code=200,
+            duration_ms=100,
+            is_stream=False,
+            provider_name="openai_b",
+            input_tokens=200,
+            output_tokens=100,
+        )
+        assert m.by_provider_tokens["openai_a"]["input_tokens"] == 100
+        assert m.by_provider_tokens["openai_b"]["input_tokens"] == 200
+
+    def test_record_usage_with_provider_name(self):
+        m = MetricsCollector()
+        m.record_usage(
+            model="gpt-4o",
+            input_tokens=500,
+            output_tokens=200,
+            provider_name="openai_a",
+        )
+        assert m.by_provider_tokens["openai_a"]["input_tokens"] == 500
+        assert m.by_provider_tokens["openai_a"]["output_tokens"] == 200
+
+    def test_record_usage_without_provider_name(self):
+        m = MetricsCollector()
+        m.record_usage(model="gpt-4o", input_tokens=500, output_tokens=200)
+        assert m.by_provider_tokens == {}
+
+    def test_snapshot_includes_provider_tokens(self):
+        m = MetricsCollector()
+        m.record_request(
+            model="gpt-4o",
+            source="openai_chat",
+            target="openai_chat",
+            status_code=200,
+            duration_ms=100,
+            is_stream=False,
+            provider_name="openai_a",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+        snap = m.snapshot()
+        assert snap["by_provider_tokens"]["openai_a"]["input_tokens"] == 1000
+
+    def test_export_load_preserves_provider_tokens(self):
+        m = MetricsCollector()
+        m.record_request(
+            model="gpt-4o",
+            source="openai_chat",
+            target="openai_chat",
+            status_code=200,
+            duration_ms=100,
+            is_stream=False,
+            provider_name="openai_a",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+        exported = m.export_counters()
+        m2 = MetricsCollector()
+        m2.load_counters(exported)
+        assert m2.by_provider_tokens["openai_a"]["input_tokens"] == 1000
+
+    def test_rebuild_counters_with_provider_tokens(self):
+        m = MetricsCollector()
+        rows = [
+            {
+                "model": "gpt-4o",
+                "source_provider": "openai_chat",
+                "target_provider": "openai_chat",
+                "target_provider_name": "openai_a",
+                "is_stream": False,
+                "status_code": 200,
+                "duration_ms": 100,
+                "input_tokens": 100,
+                "output_tokens": 50,
+            },
+            {
+                "model": "gpt-4o",
+                "source_provider": "openai_chat",
+                "target_provider": "openai_chat",
+                "target_provider_name": "openai_b",
+                "is_stream": False,
+                "status_code": 200,
+                "duration_ms": 100,
+                "input_tokens": 200,
+                "output_tokens": 100,
+            },
+        ]
+        m.rebuild_counters(rows)
+        assert m.by_provider_tokens["openai_a"]["input_tokens"] == 100
+        assert m.by_provider_tokens["openai_b"]["input_tokens"] == 200


### PR DESCRIPTION
## Summary

- Support configuring multiple upstream providers per model with weighted load distribution via a `"providers"` list in the models config block
- Add `RoutingStrategy` protocol and `WeightedRoundRobinStrategy` (nginx-style smooth WRR) for pluggable routing strategies
- Add `by_provider_tokens` metrics dimension for per-provider token usage tracking
- Add `provider_name` to stderr structured log keys for better observability
- Update admin routes to handle multi-provider cascade delete and normalization
- Backward compatible: existing single-provider string and dict forms work unchanged

### Config example

```jsonc
"models": {
  // Existing forms (unchanged)
  "gpt-4o-mini": "openai_a",

  // Multi-provider with weights
  "gpt-4o": {
    "providers": [
      {"name": "openai_a", "weight": 3},
      {"name": "openai_b", "weight": 1}
    ],
    "strategy": "weighted_round_robin"
  },

  // Multi-provider shorthand (equal weight)
  "claude-sonnet": {
    "providers": ["anthropic_a", "anthropic_b"]
  }
}
```

### Coordination with recent PRs

- Builds on #662 (token tracking) — adds `by_provider_tokens` alongside `by_model_tokens`
- Orthogonal to #663 (key affinity) — affinity operates after routing selects a provider
- Phase 2 (per-key weight within a provider) will be a separate PR

Closes #664

## Test plan

- [x] `make lint` passes (ruff check + format + ty check + complexipy)
- [x] `make test` passes (3380 passed, 0 failed)
- [x] 43 new tests: routing strategy (16), multi-provider config parsing (18), provider token tracking (9)
- [x] All existing tests pass unchanged (backward compatibility verified)
- [ ] Manual: deploy and verify weighted round-robin distributes requests across providers
- [ ] Manual: verify admin dashboard shows provider name in request logs