### PR TITLE
fix(gateway): remove provider details from unauthenticated health endpoints

### DIFF
--- a/src/llm_rosetta/gateway/admin/css/components.css
+++ b/src/llm_rosetta/gateway/admin/css/components.css
@@ -57,7 +57,7 @@ tr:hover td { background: var(--bg-hover); }
 .cap-badge-rerank { background:color-mix(in srgb, var(--orange) 12%, transparent);color:var(--orange); }
 .cap-badge-text { background:color-mix(in srgb, var(--text-dim) 15%, transparent);color:var(--text-dim); }
 .cap-badge-vision { background:color-mix(in srgb, var(--purple) 12%, transparent);color:var(--purple); }
-.cap-badge-tools { background:color-mix(in srgb, var(--text) 8%, transparent);color:var(--text-dim); }
+.cap-badge-tools { background:color-mix(in srgb, var(--blue) 8%, var(--green) 4%);color:color-mix(in srgb, var(--blue) 50%, var(--green)); }
 .cap-badge-reasoning { background:color-mix(in srgb, var(--red) 8%, transparent);color:var(--red); }
 /* Provider-model cross-navigation */
 .provider-link { color:inherit;cursor:pointer;text-decoration:none; }
@@ -339,7 +339,7 @@ canvas { width: 100%; height: 160px; }
 /* Capability badges */
 .badge-cap { background: color-mix(in srgb, var(--text-dim) 15%, transparent); color: var(--text-dim); font-size: 10px; padding: 1px 5px; margin-right: 4px; display:inline-flex; align-items:center; gap:2px; }
 .badge-cap-vision { background: color-mix(in srgb, var(--purple) 12%, transparent); color: var(--purple); }
-.badge-cap-tools { background: color-mix(in srgb, var(--text) 8%, transparent); color: var(--text-dim); }
+.badge-cap-tools { background: color-mix(in srgb, var(--blue) 8%, var(--green) 4%); color: color-mix(in srgb, var(--blue) 50%, var(--green)); }
 .badge-cap-embed { background: color-mix(in srgb, var(--blue) 12%, transparent); color: var(--blue); }
 .badge-cap-reasoning { background: color-mix(in srgb, var(--red) 8%, transparent); color: var(--red); }
 
@@ -647,3 +647,6 @@ body { padding-bottom: 26px; }
 .provider-card.health-ok       { border-left: 3px solid var(--green, #22c55e); }
 .provider-card.health-warn     { border-left: 3px solid var(--yellow, #eab308); }
 .provider-card.health-critical { border-left: 3px solid var(--red, #ef4444); }
+
+/* Invert dark provider logos in dark mode for visibility */
+[data-mode="dark"] .pc-logo { filter: invert(1); }

--- a/src/llm_rosetta/gateway/admin/css/components.css
+++ b/src/llm_rosetta/gateway/admin/css/components.css
@@ -642,3 +642,8 @@ body { padding-bottom: 26px; }
   color:var(--text);font-family:var(--mono);
 }
 .lp-search-row input:focus { outline:none;border-color:var(--accent); }
+
+/* ── Provider health indicator (left border) ── */
+.provider-card.health-ok       { border-left: 3px solid var(--green, #22c55e); }
+.provider-card.health-warn     { border-left: 3px solid var(--yellow, #eab308); }
+.provider-card.health-critical { border-left: 3px solid var(--red, #ef4444); }

--- a/src/llm_rosetta/gateway/admin/css/components.css
+++ b/src/llm_rosetta/gateway/admin/css/components.css
@@ -52,13 +52,13 @@ tr:hover td { background: var(--bg-hover); }
    all three still fits its column without squeezing the base URL. */
 .cap-badge { display:inline-flex;align-items:center;gap:3px;padding:3px 7px;border-radius:10px;font-size:11px;font-weight:600;letter-spacing:.02em;margin:0 2px;vertical-align:middle; }
 .cap-badge svg { width:11px;height:11px;flex-shrink:0; }
-.cap-badge-llm { background:color-mix(in srgb, var(--accent) 15%, transparent);color:var(--accent); }
-.cap-badge-embedding { background:color-mix(in srgb, var(--green) 12%, transparent);color:var(--green); }
+.cap-badge-llm { background:color-mix(in srgb, var(--green) 12%, transparent);color:var(--green); }
+.cap-badge-embedding { background:color-mix(in srgb, var(--blue) 12%, transparent);color:var(--blue); }
 .cap-badge-rerank { background:color-mix(in srgb, var(--orange) 12%, transparent);color:var(--orange); }
 .cap-badge-text { background:color-mix(in srgb, var(--text-dim) 15%, transparent);color:var(--text-dim); }
-.cap-badge-vision { background:color-mix(in srgb, var(--orange) 12%, transparent);color:var(--orange); }
-.cap-badge-tools { background:color-mix(in srgb, var(--blue) 12%, transparent);color:var(--blue); }
-.cap-badge-reasoning { background:color-mix(in srgb, var(--purple) 12%, transparent);color:var(--purple); }
+.cap-badge-vision { background:color-mix(in srgb, var(--purple) 12%, transparent);color:var(--purple); }
+.cap-badge-tools { background:color-mix(in srgb, var(--text) 8%, transparent);color:var(--text-dim); }
+.cap-badge-reasoning { background:color-mix(in srgb, var(--red) 8%, transparent);color:var(--red); }
 /* Provider-model cross-navigation */
 .provider-link { color:inherit;cursor:pointer;text-decoration:none; }
 .provider-link:hover { text-decoration:underline;color:var(--accent); }
@@ -338,10 +338,10 @@ canvas { width: 100%; height: 160px; }
 
 /* Capability badges */
 .badge-cap { background: color-mix(in srgb, var(--text-dim) 15%, transparent); color: var(--text-dim); font-size: 10px; padding: 1px 5px; margin-right: 4px; display:inline-flex; align-items:center; gap:2px; }
-.badge-cap-vision { background: color-mix(in srgb, var(--orange) 12%, transparent); color: var(--orange); }
-.badge-cap-tools { background: color-mix(in srgb, var(--blue) 12%, transparent); color: var(--blue); }
-.badge-cap-embed { background: color-mix(in srgb, var(--green) 12%, transparent); color: var(--green); }
-.badge-cap-reasoning { background: color-mix(in srgb, var(--purple) 12%, transparent); color: var(--purple); }
+.badge-cap-vision { background: color-mix(in srgb, var(--purple) 12%, transparent); color: var(--purple); }
+.badge-cap-tools { background: color-mix(in srgb, var(--text) 8%, transparent); color: var(--text-dim); }
+.badge-cap-embed { background: color-mix(in srgb, var(--blue) 12%, transparent); color: var(--blue); }
+.badge-cap-reasoning { background: color-mix(in srgb, var(--red) 8%, transparent); color: var(--red); }
 
 /* Checkbox group */
 .checkbox-group { display: flex; gap: 14px; flex-wrap: wrap; align-items: center; }

--- a/src/llm_rosetta/gateway/admin/js/init.js
+++ b/src/llm_rosetta/gateway/admin/js/init.js
@@ -5,7 +5,7 @@ import {
   _startInactivityTracking, _stopInactivityTracking,
 } from './core.js';
 import { checkAuthAndInit, showLoginOverlay, openSettings } from './auth.js';
-import { loadConfig, renderProviders } from './providers.js';
+import { loadConfig, renderProviders, applyProviderHealth } from './providers.js';
 import { renderModels } from './models.js';
 import './fetch-models.js';
 import { loadKeys, loadLogKeyLabels, renderKeys } from './keys.js';
@@ -29,6 +29,7 @@ function initApp() {
   stopTimers();
   if (S.currentTab === 'dashboard' && _tabEnabled('dashboard')) { loadMetrics(); S.dashboardTimer = (S._dashboardRefreshMs > 0 ? setInterval(loadMetrics, S._dashboardRefreshMs) : null); }
   if (S.currentTab === 'logs' && _tabEnabled('logs')) { S.logOffset = 0; loadLogs(); S.logTimer = setInterval(loadLogs, 5000); }
+  if (S.currentTab === 'providers') { S.healthTimer = setInterval(applyProviderHealth, 30000); }
   if (location.hash === "#change-password") { openSettings(); history.replaceState(null, "", location.pathname); }
 }
 
@@ -52,6 +53,7 @@ function activateTab(tab) {
   if (id === 'dashboard' && _tabEnabled('dashboard')) { loadMetrics(); loadDumps(); S.dashboardTimer = (S._dashboardRefreshMs > 0 ? setInterval(loadMetrics, S._dashboardRefreshMs) : null); }
   if (id === 'logs' && _tabEnabled('logs')) { if (!S._keepLogOffset) S.logOffset = 0; S._keepLogOffset = false; loadLogs(); S.logTimer = setInterval(loadLogs, 5000); }
   if (id === 'providers' || id === 'models') { loadConfig(); }
+  if (id === 'providers') { S.healthTimer = setInterval(applyProviderHealth, 30000); }
   if (id === 'keys' && _tabEnabled('keys')) { loadKeys(); }
 }
 
@@ -86,6 +88,7 @@ window.goToTab = goToTab;
 function stopTimers() {
   if (S.dashboardTimer) { clearInterval(S.dashboardTimer); S.dashboardTimer = null; }
   if (S.logTimer) { clearInterval(S.logTimer); S.logTimer = null; }
+  if (S.healthTimer) { clearInterval(S.healthTimer); S.healthTimer = null; }
 }
 
 // Filter change handlers

--- a/src/llm_rosetta/gateway/admin/js/providers.js
+++ b/src/llm_rosetta/gateway/admin/js/providers.js
@@ -705,6 +705,7 @@ async function loadConfig() {
     cpEl.title = fullPath;
     document.getElementById('globalProxy').value = (S.configData.server && S.configData.server.proxy) || '';
     renderProviders();
+    applyProviderHealth();
     window.renderModels();
     // Detect host IP in background (for proxy placeholder hints)
     if (!window._detectedHostIp) {
@@ -733,7 +734,30 @@ Object.assign(window, {
   _activateSegChild,
 });
 
-export { renderProviders, loadConfig, _activateSegChild, _getProviderCaps };
+// ── Provider health indicators ───────────────────────────────────────
+
+async function applyProviderHealth() {
+  try {
+    const data = await api.get('/admin/api/metrics?seconds=60');
+    const health = data.providers || {};
+    document.querySelectorAll('.provider-card[data-provider]').forEach(card => {
+      card.classList.remove('health-ok', 'health-warn', 'health-critical', 'health-nodata');
+      const name = card.dataset.provider;
+      const stats = health[name];
+      if (!stats || stats.sample_size < 1) {
+        // No data — keep default border
+      } else if (stats.status === 'critical') {
+        card.classList.add('health-critical');
+      } else if (stats.success_rate < 0.9) {
+        card.classList.add('health-warn');
+      } else {
+        card.classList.add('health-ok');
+      }
+    });
+  } catch { /* metrics unavailable */ }
+}
+
+export { renderProviders, loadConfig, _activateSegChild, _getProviderCaps, applyProviderHealth };
 
 // ── Provider Connectivity Test ──────────────────────────────────────
 

--- a/src/llm_rosetta/gateway/admin/js/state.js
+++ b/src/llm_rosetta/gateway/admin/js/state.js
@@ -35,6 +35,7 @@ export const S = {
   logOffset: 0,
   dashboardTimer: null,
   logTimer: null,
+  healthTimer: null,
   expandedLogRows: new Set(),
   _dashboardRefreshMs: parseInt(localStorage.getItem('dashboardRefreshMs') || '3000', 10),
   _editingProviderName: null,

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -536,22 +536,24 @@ async def handle_list_models_google(request: Any) -> Response:
 
 
 async def handle_health(request: Any) -> Response:
-    """Return operational metrics and per-provider health status.
+    """Return aggregate health status without exposing provider details.
 
     Always returns HTTP 200. Use ``status: "degraded"`` in the payload
     to signal provider issues without breaking existing monitors.
     For a 503-on-unhealthy probe use ``/health/ready``.
+
+    Per-provider health details are available via the authenticated
+    admin metrics endpoint (``/admin/api/metrics``).
     """
     metrics = getattr(request.app, "metrics", None)
     if metrics is None:
         return JSONResponse({"status": "ok"})
 
-    snap = metrics.snapshot(series_seconds=3600)  # 1-hour window for errors_last_hour
+    snap = metrics.snapshot(series_seconds=3600)
     errors_last_hour = sum(
         pt["errors"] for pt in snap.get("series", []) if pt.get("errors", 0)
     )
 
-    provider_health = metrics.provider_health_snapshot()
     critical = metrics.any_critical_provider()
     overall_status = "degraded" if critical else "ok"
 
@@ -560,7 +562,6 @@ async def handle_health(request: Any) -> Response:
         "uptime_seconds": snap["uptime_seconds"],
         "requests_total": snap["total_requests"],
         "errors_last_hour": errors_last_hour,
-        "providers": provider_health,
     }
     return JSONResponse(payload, status_code=200)
 
@@ -578,9 +579,12 @@ async def handle_health_ready(request: Any) -> Response:
 
     critical = metrics.any_critical_provider()
     if critical:
-        provider_health = metrics.provider_health_snapshot()
+        health = metrics.provider_health_snapshot()
+        critical_count = sum(
+            1 for v in health.values() if v.get("status") == "critical"
+        )
         return JSONResponse(
-            {"status": "not_ready", "providers": provider_health},
+            {"status": "not_ready", "critical_providers": critical_count},
             status_code=503,
         )
     return JSONResponse({"status": "ready"})

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -562,6 +562,7 @@ async def handle_health(request: Any) -> Response:
         "uptime_seconds": snap["uptime_seconds"],
         "requests_total": snap["total_requests"],
         "errors_last_hour": errors_last_hour,
+        "detail_url": "/admin/api/metrics",
     }
     return JSONResponse(payload, status_code=200)
 

--- a/src/llm_rosetta/gateway/app.py
+++ b/src/llm_rosetta/gateway/app.py
@@ -577,12 +577,9 @@ async def handle_health_ready(request: Any) -> Response:
     if metrics is None:
         return JSONResponse({"status": "ok"})
 
-    critical = metrics.any_critical_provider()
-    if critical:
-        health = metrics.provider_health_snapshot()
-        critical_count = sum(
-            1 for v in health.values() if v.get("status") == "critical"
-        )
+    health = metrics.provider_health_snapshot()
+    critical_count = sum(1 for v in health.values() if v.get("status") == "critical")
+    if critical_count:
         return JSONResponse(
             {"status": "not_ready", "critical_providers": critical_count},
             status_code=503,

--- a/tests/gateway/test_health_endpoint.py
+++ b/tests/gateway/test_health_endpoint.py
@@ -237,8 +237,7 @@ class TestHandleHealthFunction:
         assert body["requests_total"] == 5
         assert "uptime_seconds" in body
         assert "errors_last_hour" in body
-        assert "providers" in body
-        assert "myargo" in body["providers"]
+        assert "providers" not in body
 
     def test_health_returns_200_degraded_for_critical_provider(self):
         import json
@@ -301,4 +300,4 @@ class TestHandleHealthFunction:
         body = json.loads(resp.body)
         assert resp.status_code == 503
         assert body["status"] == "not_ready"
-        assert "providers" in body
+        assert body["critical_providers"] >= 1


### PR DESCRIPTION
## Summary

- Remove `providers` field from `/health` response — leaks upstream infrastructure info to unauthenticated callers
- Replace `providers` object in `/health/ready` 503 response with `critical_providers` integer count (no names exposed)
- Per-provider health details remain available via authenticated `/admin/api/metrics`

## Test plan

- [x] `make test` passes (3382 passed, 0 failed)
- [x] Updated health endpoint tests to reflect new response shape
- [ ] Manual: verify `/health` no longer contains `providers` key
- [ ] Manual: verify `/admin/api/metrics` still shows per-provider health