### PR TITLE
fix(shims): load max_tool_description_length from provider YAML

### DIFF
--- a/src/llm_rosetta/shims/providers/__init__.py
+++ b/src/llm_rosetta/shims/providers/__init__.py
@@ -270,6 +270,7 @@ def _load_single_provider(
         model_reasoning=model_reasoning,
         response_id_prefix=cfg.get("response_id_prefix", ""),
         supports_custom_tools=cfg.get("supports_custom_tools", False),
+        max_tool_description_length=cfg.get("max_tool_description_length"),
         multimodal_tool_result=cfg.get("multimodal_tool_result"),
         tool_search_mode=cfg.get("tool_search_mode", "disabled"),
     )

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -195,6 +195,25 @@ class TestBuiltinShims:
         assert shim is not None
         assert shim.base == "google_generate"
 
+    def test_max_tool_description_length_loaded_from_yaml(self):
+        """The YAML threshold must reach the shim object.
+
+        Regression: the field existed on ProviderShim and was consumed by
+        the route resolver, but the YAML loader never read the key, so the
+        declared value was silently dropped and relocation never fired.
+        """
+        for name in ("openai", "argo--openai_chat"):
+            shim = get_shim(name)
+            assert shim is not None
+            assert shim.max_tool_description_length == 1024, (
+                f"{name} should load max_tool_description_length from YAML"
+            )
+
+    def test_max_tool_description_length_absent_stays_none(self):
+        shim = get_shim("anthropic")
+        assert shim is not None
+        assert shim.max_tool_description_length is None
+
 
 # ---------------------------------------------------------------------------
 # Integration: shim → converter


### PR DESCRIPTION
## Problem

`max_tool_description_length` is declared in two shipped provider YAMLs
(`openai/provider.yaml`, `argo/openai_chat/provider.yaml`), but the loader in
`shims/providers/__init__.py` builds `ProviderShim(...)` from an explicit list
of keys and that key is not in the list. The declared value is silently dropped
and the field falls back to its dataclass default of `None`.

Observed on current master:

| | declared in `provider.yaml` | value on the shim object |
|---|---|---|
| `supports_custom_tools` | `true` | `True` ✅ |
| `max_tool_description_length` | `1024` | `None` ❌ |

`supports_custom_tools` loading correctly is the control — the loader works, it
just skips this one key.

Everything downstream is wired correctly: the dataclass field, the resolution
order in `gateway/config.py` (model → provider → shim), and the call site at
`pipeline.py:540`. But `relocate_oversized_tool_descriptions` no-ops on its
first line when `max_description_length is None`, so the relocation never runs.
The oversized description goes upstream unchanged and ARGO rejects it:

```
Invalid 'tools[0].custom.description': string too long.
Expected a string with maximum length 4096, but got a string with length 13457 instead.
```

## Scope

The provider-level override added alongside the feature (admin UI →
`_parse_max_tool_description_length_overrides` → `provider_max_tool_description_length`)
is **unaffected and still works** — I verified a provider-level `4096` resolves
to the route correctly. That is why the gap is invisible when the threshold is
set through the admin UI.

It only affects consumers relying on the shipped YAML default. argo-proxy is
one: its `_build_providers` sets no provider override, so it depends entirely
on the shim value.

## Fix

One line, matching the surrounding `cfg.get(...)` style:

```python
max_tool_description_length=cfg.get("max_tool_description_length"),
```

## Verification

- **End-to-end**: identical request carrying a 13,457-character custom tool
  description, same model and upstream — **HTTP 400** (`string_above_max_length`)
  before, **HTTP 200** after.
- **Unit**: `get_shim("openai")` and `get_shim("argo--openai_chat")` now report
  `1024`; `get_shim("anthropic")`, which declares no limit, still reports `None`.
- `make lint` clean (ruff check + ruff format --check).
- Full suite: **3367 passed, 21 skipped**.

## Tests

Two regression tests in `tests/test_shims.py::TestBuiltinShims`. They fail on
master and pass with the fix (confirmed by stashing only the source change).

The existing `tests/test_tool_description_relocation.py` calls the transform
directly with the `max_description_length` **parameter** and contains zero
references to the `max_tool_description_length` **config key**, so nothing
previously exercised the YAML → shim path. These tests close that gap.

## Note on docs

No `docs_en/` / `docs_zh/` changes here, following the precedent of #625, which
shipped none — the docs orphan branches aren't pushable from a fork. This is
probably worth an `[Unreleased]` changelog line under bug fixes; happy to
supply the wording if you'd like it, or leave it to you when you next touch the
worktrees.

## Context

Found while debugging why relocation stopped firing for argo-proxy after #625
landed. Comparing the merged implementation against the original commit on the
same branch, the only file present in one and not the other is this loader —
the rewrite reproduced every other link in the chain, so the missing line does
not show up when diffing against master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
